### PR TITLE
Reset compressed size when combining JAR/ZIP archives

### DIFF
--- a/src/com/facebook/buck/shell/JarDirectoryCommand.java
+++ b/src/com/facebook/buck/shell/JarDirectoryCommand.java
@@ -201,7 +201,9 @@ public class JarDirectoryCommand implements Command {
         continue;
       }
 
-      jar.putNextEntry(entry);
+      ZipEntry newEntry = new ZipEntry(entry);
+      newEntry.setCompressedSize(-1);
+      jar.putNextEntry(newEntry);
       InputStream inputStream = zip.getInputStream(entry);
       ByteStreams.copy(inputStream, jar);
       jar.closeEntry();


### PR DESCRIPTION
zlib does not always deflate a resource to the same compressed size as
the original input.  The input resource may have been compressed using
a different version of libz, or different compression settings.

Before adding each entry to the ZIP, clone the entry and reinitialize
the compressed field to -1 as is done by the more commonly used
ZipEntry(String) constructor.

This fixes a rare case where including a JAR in a java_binary() may
throw an error such as:

  invalid entry compressed size (expected 4271 but got 4275 bytes)
