### PR TITLE
Fetch from all remotes when trying to get the required revision

### DIFF
--- a/bin/buck_common
+++ b/bin/buck_common
@@ -33,7 +33,7 @@ if [ -e "${PROJECT_ROOT}/.buckversion" ] && [ ! -e "${PROJECT_ROOT}/.nobuckcheck
 
   # If the hash is in not in the user's repository, do a `git fetch`.
   if ! git cat-file -e "$BUCK_REQUIRED_VERSION"; then
-    git fetch
+    git fetch --all
   fi
 
 


### PR DESCRIPTION
Summary:
If the required revision is not in the local repository, Buck tries to
get it by running `git fetch`.  However this only works if the revision
is on the default remote, i.e. the one originally cloned from.  If the
required revision is on another remote, i.e. a forked version, it will not
be fetched.  Adding the `--all` option to `git fetch` fixes this.

Test Plan:
1. Clone buck from github.
2. Add another remote with `git remote add`.
3. In the test project set .buckversion to point to a revision that is only
   on the other remote.
4. Build the test project with `buck build`.

Signed-off-by: David Pursehouse david.pursehouse@sonymobile.com
