### PR TITLE
Have aapt ignore BUCK files in res/ directories.

### DIFF
--- a/src/com/facebook/buck/android/AaptStep.java
+++ b/src/com/facebook/buck/android/AaptStep.java
@@ -99,6 +99,10 @@ public class AaptStep extends ShellStep {
     builder.add("-I", androidPlatformTarget.getAndroidJar().getAbsolutePath());
     builder.add("-F", pathToOutputApkFile);
 
+    // Ignore BUCK files in addition to the other files that are ignored by default.
+    // Otherwise, having a BUCK file in a res/ directory will cause a build failure.
+    builder.add("--ignore-assets", "BUCK:!.svn:!.git:!.ds_store:!*.scc:.*:<dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~");
+
     builder.addAll(pathsToRawFilesDirs);
 
     return builder.build();

--- a/src/com/facebook/buck/android/GenRDotJavaStep.java
+++ b/src/com/facebook/buck/android/GenRDotJavaStep.java
@@ -129,6 +129,10 @@ public class GenRDotJavaStep extends ShellStep {
     builder.add("--auto-add-overlay");
     builder.add("-I").add(androidPlatformTarget.getAndroidJar().getAbsolutePath());
 
+    // Ignore BUCK files in addition to the other files that are ignored by default.
+    // Otherwise, having a BUCK file in a res/ directory will cause a build failure.
+    builder.add("--ignore-assets", "BUCK:!.svn:!.git:!.ds_store:!*.scc:.*:<dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~");
+
     return builder.build();
   }
 


### PR DESCRIPTION
Summary:
aapt will fail if it detects extra files and folders that are not
explicitly ignored. Therefore, it was previously impossible to put a
BUCK file in a res/ directory.

The motivating reason for allowing BUCK files in res/ directories is
to allow targets such as:

  # in //src/com/example/res/BUCK
  android_library(
    name = 'res',
    res = '.',
    deps = [],
    visibility = ['PUBLIC'],
  )

which could be referenced from the command line like so:
  buck build src/com/example/res

Test Plan:
Successfully ran `buck build src/com/example/res` on a project where
//src/com/example/res/ contained a BUCK file.
