### PR TITLE
Ensure onCreate calls through to super onCreate

### DIFF
--- a/docs/setup/quickstart.soy
+++ b/docs/setup/quickstart.soy
@@ -86,7 +86,7 @@ public class MyFirstActivity extends Activity {
   
   @Override
   public void onCreate(Bundle savedInstanceState) {
-
+    super.onCreate(savedInstanceState);
   }
 }" > java/com/example/activity/MyFirstActivity.java
 </pre>{/literal}


### PR DESCRIPTION
Quick start doco creates an activity which does not call through to super.onCreate and causes the sample Hello World app to crash.  
