### PR TITLE
Add support for tab completion in bash

### DIFF
--- a/scripts/bash_completion
+++ b/scripts/bash_completion
@@ -1,0 +1,45 @@
+# #########################################################################
+# This bash script adds tab-completion to buck.
+#
+# Testing it out without installing
+# =================================
+#
+# To test out the completion without "installing" this, just run this file
+# directly, like so:
+#
+#     . ~/path/to/bash_completion
+#
+# Note: There's a dot ('.') at the beginning of that command.
+#
+# After you do that, tab completion will immediately be made available in your
+# current Bash shell. It will not, however, be available next time you log in.
+#
+# Installing
+# ==========
+#
+# To install the completion, point to this file from your .bash_profile, like so:
+#
+#     . ~/path/to/bash_completion
+#
+# Do the same in your .bashrc if .bashrc doesn't invoke .bash_profile.
+#
+# The settings will take effect the next time you log in.
+#
+# Uninstalling
+# ============
+#
+# To uninstall, just remove the line from your .bash_profile and .bashrc.
+# #########################################################################
+
+_buck_sh()
+{
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    opts="audit build cache clean install project targets test uninstall"
+
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+}
+complete -F _buck_sh buck
+


### PR DESCRIPTION
Summary: when the bash_completion script is loaded, the user
can use the tab key to automatically complete the name of the
buck command, or if there are multiple commands beginning with
the same letter(s) suggest commands to use.

Test:

Install the completion script:

  $ ./scripts/bash_completion

Suggestion of all available commands:

  $ buck <TAB>
  audit build cache clean install project targets test uninstall

Suggestion of available commands with given starting letter:

  $ buck c<TAB>
  cache clean

Completion of command with given starting letter

  $ buck b<TAB>

("b" is auto-completed to "build")

Change-Id: I573808900811ed79733895f34cccb388535c80b0
