### PR TITLE
Improve the bash completion script installation instructions

### DIFF
--- a/scripts/bash_completion
+++ b/scripts/bash_completion
@@ -17,7 +17,12 @@
 # Installing
 # ==========
 #
-# To install the completion, point to this file from your .bash_profile, like so:
+# To install the completion, copy this file to the appropriate folder for
+# your distribution, for example:
+#
+#     cp ~/path/to/bash_completion /etc/bash_completion.d/buck
+#
+# Alternatively you can invoke this file from your .bash_profile, like so:
 #
 #     . ~/path/to/bash_completion
 #


### PR DESCRIPTION
Summary:
On some distributions there is a specific folder in which the
script should be placed, rather than adding the `source` command
in the user profile.

Test Plan:
Follow the instructions and make sure it works as expected.

Change-Id: I4fcd9c8c16c06b2a3428c4130d6a389ab37ebf26
