### PR TITLE
Handle KeyboardInterrupt in buck.py

### DIFF
--- a/src/com/facebook/buck/parser/buck.py
+++ b/src/com/facebook/buck/parser/buck.py
@@ -845,4 +845,7 @@ def main():
 
 
 if __name__ == '__main__':
-  main()
+  try:
+    main()
+  except KeyboardInterrupt:
+    pass


### PR DESCRIPTION
Summary:
Terminating a buck build with CTRL-C sometimes results in a Python
Traceback being shown on the terminal.

Fix this by catching KeyboardInterrupt in the main() method.  Don't
do anything with the caught exception; just pass.

Test Plan:
Build something.  Terminate it with CTRL-C.  Don't see a TraceBack.

Change-Id: I3e84d7056c43df0db7a2acf7fd8aed7472d058ce
