### PR TITLE
Remove `@Nullable` annotation from `escapeJavaType` method

### DIFF
--- a/src/com/facebook/buck/parcelable/Parser.java
+++ b/src/com/facebook/buck/parcelable/Parser.java
@@ -87,7 +87,7 @@ public class Parser {
    * We allow { and } to be used in place of &lt; and &gt; for Java generics in our XML
    * descriptor files.
    */
-  private static String escapeJavaType(@Nullable String type) {
+  private static String escapeJavaType(String type) {
     return type.replace('{', '<').replace('}', '>');
   }
 


### PR DESCRIPTION
Summary:
The `type` parameter is annotated with `@Nullable`, but the parameter
should not actually be null because it is being dereferenced within
the method.

Remove the annotation.

Test Plan:
Run some test builds.

Change-Id: I0605bea537a60525921c4d9f5d162e8702d2ed0c
