### PR TITLE
Redundant format arg in resolveFilePathRelativeToBuildFileDirectory

### DIFF
--- a/src/com/facebook/buck/parser/BuildRuleFactoryParams.java
+++ b/src/com/facebook/buck/parser/BuildRuleFactoryParams.java
@@ -143,8 +143,7 @@ public final class BuildRuleFactoryParams {
       path = path.substring(GENFILE_PREFIX.length());
       return String.format("%s/%s",
           BuckConstant.GEN_DIR,
-          resolvePathAgainstBuildTargetBase(path),
-          path);
+          resolvePathAgainstBuildTargetBase(path));
     } else {
       String fullPath = resolvePathAgainstBuildTargetBase(path);
       File file = filesystem.getFileForRelativePath(fullPath);


### PR DESCRIPTION
Summary:
In method resolveFilePathRelativeToBuildFileDirectory, String.format
is called with 3 arguments, but the string format only expects 2.

Remove the redundant one.

Test Plan:
Run some test builds.

Change-Id: If284a8c5cf0c6b00e6a65f68181e4dc803e00b57
