### PR TITLE
java_library: provide a way to specify non transitive dependencies

### DIFF
--- a/src/com/facebook/buck/android/AndroidLibraryRule.java
+++ b/src/com/facebook/buck/android/AndroidLibraryRule.java
@@ -61,6 +61,7 @@ public class AndroidLibraryRule extends DefaultJavaLibraryRule {
       Optional<String> manifestFile) {
     super(buildRuleParams,
         srcs,
+        ImmutableSortedSet.<BuildRule>of(),
         resources,
         proguardConfig,
         /* exportedDeps */ ImmutableSortedSet.<BuildRule>of(),

--- a/src/com/facebook/buck/java/JavaLibraryBuildRuleFactory.java
+++ b/src/com/facebook/buck/java/JavaLibraryBuildRuleFactory.java
@@ -41,7 +41,6 @@ public class JavaLibraryBuildRuleFactory extends AbstractBuildRuleFactory<Defaul
     builder.setProguardConfig(
         proguardConfig.transform(params.getResolveFilePathRelativeToBuildFileDirectoryTransform()));
 
-
     for (String exportedDep : params.getOptionalListAttribute("exported_deps")) {
       BuildTarget buildTarget = params.resolveBuildTarget(exportedDep);
       builder.addExportedDep(buildTarget);
@@ -53,6 +52,11 @@ public class JavaLibraryBuildRuleFactory extends AbstractBuildRuleFactory<Defaul
     Optional<String> sourceLevel = params.getOptionalStringAttribute("source");
     if (sourceLevel.isPresent()) {
       builder.setSourceLevel(sourceLevel.get());
+    }
+
+    for (String dep : params.getOptionalListAttribute("compile_deps")) {
+      BuildTarget buildTarget = params.resolveBuildTarget(dep);
+      builder.addCompileDep(buildTarget);
     }
 
     Optional<String> targetLevel = params.getOptionalStringAttribute("target");

--- a/src/com/facebook/buck/java/JavaTestRule.java
+++ b/src/com/facebook/buck/java/JavaTestRule.java
@@ -89,6 +89,7 @@ public class JavaTestRule extends DefaultJavaLibraryRule implements TestRule {
       ImmutableSet<JavaLibraryRule> sourceUnderTest) {
     super(buildRuleParams,
         srcs,
+        ImmutableSortedSet.<BuildRule>of(),
         resources,
         proguardConfig,
         /* exportDeps */ ImmutableSortedSet.<BuildRule>of(),

--- a/src/com/facebook/buck/parser/buck.py
+++ b/src/com/facebook/buck/parser/buck.py
@@ -216,6 +216,7 @@ def java_library(
     target='6',
     proguard_config=None,
     deps=[],
+    compile_deps=[],
     visibility=[],
     build_env=None):
   add_rule({
@@ -229,6 +230,7 @@ def java_library(
     'target' : target,
     'proguard_config' : proguard_config,
     'deps' : deps + exported_deps,
+    'compile_deps' : compile_deps,
     'visibility' : visibility,
   }, build_env)
 


### PR DESCRIPTION
Add compile_deps parameter to java_library function to specify the non
transitive dependencies. Because of the way how dependency graph is
implemented the deps parameter must still list all dependencies:

``` python
  java_binary(
    name = 'plugin',
    manifest_file = 'resources/MANIFEST.MF',
    deps = ['//:plugin-library'],
  )

  java_library(
    name = 'plugin-library',
    srcs = glob(...),
    deps = ['//lib:plugin-api'],
    compile_deps = ['//lib:plugin-api'],
  )
```

JAR file plugin.jar doesn't include the content of plugin-api.

Test Plan: https://github.com/davido/buck_test

fixes: #63
