### PR TITLE
Add explicit case statements for JsonToken enum constants

### DIFF
--- a/src/com/facebook/buck/util/WatchmanWatcher.java
+++ b/src/com/facebook/buck/util/WatchmanWatcher.java
@@ -167,6 +167,19 @@ public class WatchmanWatcher implements ProjectFilesystemWatcher {
           }
           builder = new PathEventBuilder();
           break;
+        case END_ARRAY:
+        case NOT_AVAILABLE:
+        case START_ARRAY:
+        case START_OBJECT:
+        case VALUE_EMBEDDED_OBJECT:
+        case VALUE_FALSE:
+        case VALUE_NULL:
+        case VALUE_NUMBER_FLOAT:
+        case VALUE_NUMBER_INT:
+        case VALUE_STRING:
+        case VALUE_TRUE:
+        default:
+          break;
       }
       token = jsonParser.nextToken();
     }


### PR DESCRIPTION
Summary: Eclipse warns:

  The enum constant [name] needs a corresponding case label in
  this enum switch on JsonToken

Add the missing cases, and a default, to prevent the warnings.

Test plan: Build

Change-Id: Ic3276831a1648a5986588a3a5b2c7ae16951343b
