### PR TITLE
java_binary: optionally suppress manifest merging from dependent JARs

### DIFF
--- a/src/com/facebook/buck/java/DefaultJavaLibraryRule.java
+++ b/src/com/facebook/buck/java/DefaultJavaLibraryRule.java
@@ -623,7 +623,8 @@ public class DefaultJavaLibraryRule extends DoNotUseAbstractBuildable
           outputJar.get(),
           Collections.singleton(outputDirectory),
           /* mainClass */ null,
-          /* manifestFile */ null));
+          /* manifestFile */ null,
+          /* manifestPristine */ null));
     }
 
     Preconditions.checkNotNull(abiKeySupplier,

--- a/src/com/facebook/buck/java/JavaBinaryBuildRuleFactory.java
+++ b/src/com/facebook/buck/java/JavaBinaryBuildRuleFactory.java
@@ -49,6 +49,13 @@ public class JavaBinaryBuildRuleFactory extends AbstractBuildRuleFactory<JavaBin
       builder.setManifest(manifestFilePath);
     }
 
+    // manifest_pristine
+    Optional<String> manifestPristine = params.getOptionalStringAttribute("manifest_pristine");
+    if (manifestPristine.isPresent()) {
+      Path manifestPristinePath = params.resolveFilePathRelativeToBuildFileDirectory(
+          manifestPristine.get());
+      builder.setManifestPristine(manifestPristinePath);
+    }
   }
 
 }

--- a/src/com/facebook/buck/java/JavaBinaryRule.java
+++ b/src/com/facebook/buck/java/JavaBinaryRule.java
@@ -68,7 +68,11 @@ public class JavaBinaryRule extends DoNotUseAbstractBuildable implements BinaryB
   private final Path manifestFile;
 
   @Nullable
+  private final Path manifestPristine;
+
+  @Nullable
   private final Path metaInfDirectory;
+
 
   private final DirectoryTraverser directoryTraverser;
 
@@ -76,11 +80,13 @@ public class JavaBinaryRule extends DoNotUseAbstractBuildable implements BinaryB
       BuildRuleParams buildRuleParams,
       @Nullable String mainClass,
       @Nullable Path manifestFile,
+      @Nullable Path manifestPristine,
       @Nullable Path metaInfDirectory,
       DirectoryTraverser directoryTraverser) {
     super(buildRuleParams);
     this.mainClass = mainClass;
     this.manifestFile = manifestFile;
+    this.manifestPristine = manifestPristine;
     this.metaInfDirectory = metaInfDirectory;
 
     this.directoryTraverser = Preconditions.checkNotNull(directoryTraverser);
@@ -147,7 +153,8 @@ public class JavaBinaryRule extends DoNotUseAbstractBuildable implements BinaryB
     }
 
     Path outputFile = getOutputFile();
-    Step jar = new JarDirectoryStep(outputFile, includePaths, mainClass, manifestFile);
+    Step jar = new JarDirectoryStep(outputFile, includePaths, mainClass, manifestFile,
+        manifestPristine);
     commands.add(jar);
 
     return commands.build();
@@ -190,6 +197,7 @@ public class JavaBinaryRule extends DoNotUseAbstractBuildable implements BinaryB
 
     private String mainClass;
     private Path manifestFile;
+    private Path manifestPristine;
     private Path metaInfDirectory;
 
     private Builder(AbstractBuildRuleBuilderParams params) {
@@ -201,6 +209,7 @@ public class JavaBinaryRule extends DoNotUseAbstractBuildable implements BinaryB
       return new JavaBinaryRule(createBuildRuleParams(ruleResolver),
           mainClass,
           manifestFile,
+          manifestPristine,
           metaInfDirectory,
           new DefaultDirectoryTraverser());
     }
@@ -224,6 +233,11 @@ public class JavaBinaryRule extends DoNotUseAbstractBuildable implements BinaryB
 
     public Builder setManifest(Path manifestFile) {
       this.manifestFile = manifestFile;
+      return this;
+    }
+
+    public Builder setManifestPristine(Path manifestPristine) {
+      this.manifestPristine = manifestPristine;
       return this;
     }
 

--- a/src/com/facebook/buck/parser/buck.py
+++ b/src/com/facebook/buck/parser/buck.py
@@ -319,6 +319,7 @@ def java_binary(
   name,
   main_class=None,
   manifest_file=None,
+  manifest_pristine=None,
   deps=[],
   visibility=[],
   build_env=None):
@@ -327,6 +328,7 @@ def java_binary(
     'type' : 'java_binary',
     'name' : name,
     'manifest_file': manifest_file,
+    'manifest_pristine': manifest_pristine,
     'main_class' : main_class,
     'deps' : deps,
     'visibility' : visibility,

--- a/test/com/facebook/buck/java/DefaultJavaLibraryRuleTest.java
+++ b/test/com/facebook/buck/java/DefaultJavaLibraryRuleTest.java
@@ -1305,6 +1305,7 @@ public class DefaultJavaLibraryRuleTest {
             "com.facebook.Main",
             null,
             null,
+            null,
             new DefaultDirectoryTraverser());
       }
     },

--- a/test/com/facebook/buck/java/JarDirectoryStepTest.java
+++ b/test/com/facebook/buck/java/JarDirectoryStepTest.java
@@ -56,7 +56,8 @@ public class JarDirectoryStepTest {
     JarDirectoryStep step = new JarDirectoryStep(Paths.get("output.jar"),
         ImmutableSet.of(Paths.get(first.getName()), Paths.get(second.getName())),
         "com.example.Main",
-        /* manifest file */ null);
+        /* manifest file */ null,
+        /* manifest pristine */ null);
     ExecutionContext context = TestExecutionContext.newBuilder()
         .setProjectFilesystem(new ProjectFilesystem(zipup))
         .build();
@@ -83,7 +84,8 @@ public class JarDirectoryStepTest {
     JarDirectoryStep step = new JarDirectoryStep(Paths.get("output.jar"),
         ImmutableSet.of(Paths.get(first.getName()), Paths.get(second.getName())),
         "com.example.Main",
-        /* manifest file */ null);
+        /* manifest file */ null,
+        /* manifest pristine */ null);
 
     ExecutionContext context = TestExecutionContext.newBuilder()
         .setProjectFilesystem(new ProjectFilesystem(zipup))
@@ -131,7 +133,8 @@ public class JarDirectoryStepTest {
         Paths.get("output.jar"),
         ImmutableSet.of(Paths.get("input.jar")),
         /* main class */ null,
-        Paths.get("manifest"));
+        Paths.get("manifest"),
+        /* manifest pristine */ null);
     ExecutionContext context = TestExecutionContext.newBuilder()
         .setProjectFilesystem(new ProjectFilesystem(tmp))
         .build();


### PR DESCRIPTION
For core/plugin pattern MANIFEST.MF file is used to define meta information
used by core system to load the plugin.  In this scenario is important to
have only manifest entries in the resulting artifact that were provided in
manifest_file paramter to java_binary() function.

This change extends java_binary() with additional parameter:

  manifest_pristine

If this parameter is passed, then no merging take place.

This fixes bug #86.

Test plans: https://github.com/davido/buck_test
