### PR TITLE
Implement a build_config generator.

### DIFF
--- a/src/com/facebook/buck/android/BUCK
+++ b/src/com/facebook/buck/android/BUCK
@@ -55,6 +55,8 @@ RULES_SRCS = [
   'AndroidLibraryRule.java',
   'AndroidManifest.java',
   'AndroidManifestDescription.java',
+  'BuildConfig.java',
+  'BuildConfigDescription.java',
   'AndroidResourceBuildRuleFactory.java',
   'AndroidResourceDepsFinder.java',
   'AndroidResourceDetails.java',

--- a/src/com/facebook/buck/android/BuildConfig.java
+++ b/src/com/facebook/buck/android/BuildConfig.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2014-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.android;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
+
+import com.facebook.buck.model.BuildTarget;
+import com.facebook.buck.rules.AbstractBuildable;
+import com.facebook.buck.rules.BuildContext;
+import com.facebook.buck.rules.Buildable;
+import com.facebook.buck.rules.BuildableContext;
+import com.facebook.buck.rules.RuleKey;
+import com.facebook.buck.step.Step;
+import com.facebook.buck.step.fs.MkdirStep;
+import com.facebook.buck.step.fs.RmStep;
+import com.facebook.buck.util.BuckConstant;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * {@link BuildConfig} is a {@link Buildable} that can generate a BuildConfig.java file.
+ * <pre>
+ * build_config(
+ *   name = 'debug_build_config',
+ *   package = 'com.example.package',
+ *   debug = 'true',
+ * )
+ * </pre>
+ * This will produce a genfile that will be parameterized by the name of the
+ * {@code build_config} rule.
+ * This can be used as a dependency for example
+ * for an android library:
+ * <pre>
+ * android_library(
+ *  name = 'my-app-lib',
+ *  srcs = [genfile('__debug_build_config__/BuildConfig.java')] + glob(['src/**\/*.java']),
+ *  deps = [
+ *   ':debug_build_config',
+ *  ],
+ * )
+ * </pre>
+ */
+public class BuildConfig extends AbstractBuildable {
+
+  private final BuildTarget buildTarget;
+  private final String appPackage;
+  private final boolean debug;
+
+  private final Path pathToOutputFile;
+
+  protected BuildConfig(BuildTarget buildTarget,
+      String appPackage, boolean debug) {
+    this.buildTarget = Preconditions.checkNotNull(buildTarget);
+    this.appPackage = appPackage;
+    this.debug = debug;
+    this.pathToOutputFile = Paths.get(
+        BuckConstant.GEN_DIR,
+        buildTarget.getBasePath(),
+	"__" + buildTarget.getShortName() + "__",
+	"BuildConfig.java");
+  }
+
+  @Override
+  public Collection<Path> getInputsToCompareToOutput() {
+    return ImmutableList.<Path>builder().build();
+  }
+
+  @Override
+  public RuleKey.Builder appendDetailsToRuleKey(RuleKey.Builder builder) throws IOException {
+    return builder;
+  }
+
+  public BuildTarget getBuildTarget() {
+    return buildTarget;
+  }
+
+  public boolean getDebug() {
+    return debug;
+  }
+
+  public String getAppPackage() {
+    return appPackage;
+  }
+
+  @Override
+  public List<Step> getBuildSteps(BuildContext context, BuildableContext buildableContext)
+      throws IOException {
+    ImmutableList.Builder<Step> commands = ImmutableList.builder();
+
+    // Clear out the old file, if it exists.
+    commands.add(new RmStep(pathToOutputFile,
+        /* shouldForceDeletion */ true,
+        /* shouldRecurse */ false));
+
+    // Make sure the directory for the output file exists.
+    commands.add(new MkdirStep(pathToOutputFile.getParent()));
+
+    commands.add(new GenerateBuildConfigStep(
+        getAppPackage(), getDebug(),
+        getPathToOutputFile()));
+
+    buildableContext.recordArtifact(pathToOutputFile);
+    return commands.build();
+  }
+
+  @Override
+  public Path getPathToOutputFile() {
+    return pathToOutputFile;
+  }
+
+}

--- a/src/com/facebook/buck/android/BuildConfigDescription.java
+++ b/src/com/facebook/buck/android/BuildConfigDescription.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.android;
+
+import com.facebook.buck.rules.BuildRuleParams;
+import com.facebook.buck.rules.BuildRuleType;
+import com.facebook.buck.rules.Buildable;
+import com.facebook.buck.rules.Description;
+import com.facebook.buck.rules.Hint;
+
+public class BuildConfigDescription implements Description<BuildConfigDescription.Arg> {
+
+  public static final BuildRuleType TYPE = new BuildRuleType("build_config");
+
+  @Override
+  public BuildRuleType getBuildRuleType() {
+    return TYPE;
+  }
+
+  @Override
+  public Arg createUnpopulatedConstructorArg() {
+    return new Arg();
+  }
+
+  @Override
+  public Buildable createBuildable(BuildRuleParams params, Arg args) {
+    return new BuildConfig(params.getBuildTarget(), args.appPackage, args.debug);
+  }
+
+  public static class Arg {
+    @Hint(name = "package")
+    public String appPackage;
+    public boolean debug;
+  }
+
+}

--- a/src/com/facebook/buck/android/GenerateBuildConfigStep.java
+++ b/src/com/facebook/buck/android/GenerateBuildConfigStep.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2014-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.android;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.file.Path;
+
+import com.facebook.buck.step.ExecutionContext;
+import com.facebook.buck.step.Step;
+import com.facebook.buck.util.HumanReadableException;
+import com.facebook.buck.util.environment.Platform;
+import com.google.common.base.Charsets;
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+import com.google.common.io.Files;
+
+public class GenerateBuildConfigStep implements Step {
+
+  private String configPackage;
+  private boolean debug;
+  private Path outBuildConfigPath;
+
+  public GenerateBuildConfigStep(
+      String configPackage, boolean debug,
+      Path outBuildConfigPath) {
+    this.configPackage = Preconditions.checkNotNull(configPackage);
+    this.debug = debug;
+    this.outBuildConfigPath = Preconditions.checkNotNull(outBuildConfigPath);
+  }
+
+  @Override
+  public int execute(ExecutionContext context) {
+
+    if (outBuildConfigPath.getNameCount() == 0) {
+      throw new HumanReadableException("Output BuildConfig.java filepath is missing");
+    }
+
+    try {
+      Files.createParentDirs(outBuildConfigPath.toFile());
+    } catch (IOException e) {
+      e.printStackTrace(context.getStdErr());
+      return 1;
+    }
+
+    File outManifestFile = outBuildConfigPath.toFile();
+    try {
+      OutputStreamWriter out = new OutputStreamWriter(new FileOutputStream(outManifestFile));
+      out.write("package ");
+      out.write(configPackage);
+      out.write(";\n");
+      out.write("public final class BuildConfig {\n");
+      out.write("  public final static boolean DEBUG = ");
+      out.write(String.valueOf(debug));
+      out.write(";\n");
+      out.write("}");
+      out.flush();
+      out.close();
+    } catch (IOException e) {
+      throw new HumanReadableException("Error writing BuildConfig.java");
+    }
+
+    if (context.getPlatform() == Platform.WINDOWS) {
+      // Convert line endings to Lf on Windows.
+      try {
+        String xmlText = Files.toString(outManifestFile, Charsets.UTF_8);
+        xmlText = xmlText.replace("\r\n", "\n");
+        Files.write(xmlText.getBytes(Charsets.UTF_8), outManifestFile);
+      } catch (IOException e) {
+        throw new HumanReadableException("Error converting line endings of manifest file");
+      }
+    }
+
+    return 0;
+  }
+
+  @Override
+  public String getDescription(ExecutionContext context) {
+    return String.format("generate_build_config %s %s", configPackage, String.valueOf(debug));
+  }
+
+  @Override
+  public String getShortName() {
+    return "generate_build_config";
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof GenerateBuildConfigStep)) {
+      return false;
+    }
+
+    GenerateBuildConfigStep that = (GenerateBuildConfigStep)obj;
+    return Objects.equal(this.configPackage, that.configPackage)
+        && Objects.equal(this.debug, that.debug)
+        && Objects.equal(this.outBuildConfigPath, that.outBuildConfigPath);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(
+        configPackage,
+        debug,
+        outBuildConfigPath);
+  }
+}

--- a/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
+++ b/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
@@ -22,6 +22,7 @@ import com.facebook.buck.android.AndroidLibraryBuildRuleFactory;
 import com.facebook.buck.android.AndroidManifestDescription;
 import com.facebook.buck.android.AndroidResourceBuildRuleFactory;
 import com.facebook.buck.android.ApkGenruleBuildRuleFactory;
+import com.facebook.buck.android.BuildConfigDescription;
 import com.facebook.buck.android.GenAidlDescription;
 import com.facebook.buck.android.NdkLibraryBuildRuleFactory;
 import com.facebook.buck.android.PrebuiltNativeLibraryBuildRuleFactory;
@@ -110,6 +111,7 @@ public class KnownBuildRuleTypes {
     Builder builder = builder();
 
     builder.register(new AndroidManifestDescription());
+    builder.register(new BuildConfigDescription());
     builder.register(new ExportFileDescription());
     builder.register(new GenAidlDescription());
     builder.register(new IosBinaryDescription());

--- a/test/com/facebook/buck/android/BuildConfigTest.java
+++ b/test/com/facebook/buck/android/BuildConfigTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2014-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.android;
+
+import static org.junit.Assert.assertEquals;
+
+import com.facebook.buck.model.BuildTarget;
+import com.facebook.buck.rules.BuildContext;
+import com.facebook.buck.rules.BuildRule;
+import com.facebook.buck.rules.BuildRuleParams;
+import com.facebook.buck.rules.BuildRuleParamsFactory;
+import com.facebook.buck.rules.BuildRuleType;
+import com.facebook.buck.rules.Buildable;
+import com.facebook.buck.rules.FakeBuildRule;
+import com.facebook.buck.rules.FakeBuildableContext;
+import com.facebook.buck.rules.FileSourcePath;
+import com.facebook.buck.step.Step;
+import com.facebook.buck.util.BuckConstant;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+/**
+ * Unit test for {@link BuildConfig}.
+ */
+public class BuildConfigTest {
+
+  /**
+   * Tests the following methods:
+   * <ul>
+   *   <li>{@link Buildable#getInputsToCompareToOutput()}
+   *   <li>{@link BuildConfig#getPathToOutputFile()}
+   * </ul>
+   */
+  @Test
+  public void testSimpleObserverMethods() {
+    BuildRule buildRule = createSimpleBuildConfigRule();
+    BuildConfig buildConfigRule = (BuildConfig) buildRule.getBuildable();
+
+    assertEquals(
+        BuckConstant.GEN_PATH.resolve("java/com/example/__build_config__/BuildConfig.java"),
+        buildConfigRule.getPathToOutputFile());
+  }
+
+  @Test
+  public void testBuildInternal() throws IOException {
+    BuildRule buildRule = createSimpleBuildConfigRule();
+    BuildConfig buildConfigRule = (BuildConfig) buildRule.getBuildable();
+
+    // Mock out a BuildContext whose DependencyGraph will be traversed.
+    BuildContext buildContext = EasyMock.createMock(BuildContext.class);
+    EasyMock.replay(buildContext);
+
+    List<Step> steps = buildConfigRule.getBuildSteps(buildContext, new FakeBuildableContext());
+    Step generateBuildConfigStep = steps.get(2);
+    assertEquals(
+        new GenerateBuildConfigStep("com.example", true,
+            BuckConstant.GEN_PATH.resolve("java/com/example/__build_config__/BuildConfig.java")),
+        generateBuildConfigStep);
+
+    EasyMock.verify(buildContext);
+  }
+
+  @Test
+  public void testGetTypeMethodOfBuilder() {
+    assertEquals("build_config", BuildConfigDescription.TYPE.getName());
+  }
+
+  private BuildRule createSimpleBuildConfigRule() {
+    // First, create the BuildConfig object.
+    BuildRuleParams buildRuleParams = BuildRuleParamsFactory.createTrivialBuildRuleParams(
+        new BuildTarget("//java/com/example", "build_config"));
+    BuildConfigDescription description = new BuildConfigDescription();
+    BuildConfigDescription.Arg arg = description.createUnpopulatedConstructorArg();
+    arg.appPackage = "com.example";
+    arg.debug = true;
+    final Buildable buildConfig = description.createBuildable(buildRuleParams, arg);
+
+    // Then create a BuildRule whose Buildable is the BuildConfig.
+    return new FakeBuildRule(BuildRuleType.ANDROID_MANIFEST, buildRuleParams) {
+      @Override
+      public Buildable getBuildable() {
+        return buildConfig;
+      }
+    };
+  }
+
+  // TODO(user): Add another unit test that passes in a non-trivial DependencyGraph and verify that
+  // the resulting set of libraryManifestPaths is computed correctly.
+}


### PR DESCRIPTION
Summary:
This change set adds a build_config generator that knows how to
generate the BuildConfig.java files generated by existing build tools.
This addresses issue: https://github.com/facebook/buck/issues/3
and is based on the strategy proposed in the comment on that issue.

Test Plan:
There are already unit tests in place which verify all but the
contents of the generated file. To verify contents add a build_config
rule to a project and dig into buck-out to verify the contents
of the file are correct.
