### PR TITLE
Update addon-google_apis-google-19 to 19-1

### DIFF
--- a/scripts/travisci_install_android_sdk.sh
+++ b/scripts/travisci_install_android_sdk.sh
@@ -15,5 +15,5 @@ addon-google_apis-google-16,\
 android-18,\
 addon-google_apis-google-18,\
 android-19,\
-addon-google_apis-google-19,\
+addon-google_apis-google-19-1,\
 extra-android-support


### PR DESCRIPTION
Fixes https://github.com/facebook/buck/issues/105

tools/eclipse/project.py
resulted in 

BUILD FAILED: Google APIs not found in /Users/jjennings/adt-bundle-mac-x86_64-20131030/sdk/add-ons/addon-google_apis-google-19/libs.
Please run '/Users/jjennings/adt-bundle-mac-x86_64-20131030/sdk/tools/android sdk' and select both 'SDK Platform' and 'Google APIs' under Android (API 19)

even though everything was installed. Turns out, 19 was replaced by 19-1 in the android sdk.
