### PR TITLE
Add support for user home in cache directory name

### DIFF
--- a/src/com/facebook/buck/cli/BuckConfig.java
+++ b/src/com/facebook/buck/cli/BuckConfig.java
@@ -601,8 +601,12 @@ public class BuckConfig {
   @VisibleForTesting
   Path getCacheDir() {
     String cacheDir = getValue("cache", "dir").or(DEFAULT_CACHE_DIR);
-    if (!cacheDir.isEmpty() && cacheDir.charAt(0) == '/') {
-      return Paths.get(cacheDir);
+    if (!cacheDir.isEmpty()) {
+      if (cacheDir.charAt(0) == '/') {
+        return Paths.get(cacheDir);
+      } else if (cacheDir.charAt(0) == '~') {
+        return Paths.get(cacheDir.replace("~", System.getProperty("user.home")));
+      }
     }
     return projectFilesystem.getAbsolutifier().apply(Paths.get(cacheDir));
   }

--- a/test/com/facebook/buck/cli/BuckConfigTest.java
+++ b/test/com/facebook/buck/cli/BuckConfigTest.java
@@ -443,6 +443,31 @@ public class BuckConfigTest {
   }
 
   @Test
+  public void testIgnorePathsWithUserHomeCacheDir() throws IOException {
+
+    ProjectFilesystem filesystem = EasyMock.createMock(ProjectFilesystem.class);
+    BuildTargetParser parser = EasyMock.createMock(BuildTargetParser.class);
+    EasyMock.replay(filesystem, parser);
+    Reader reader = new StringReader(Joiner.on('\n').join(
+        "[cache]",
+        "dir = ~/cache_dir"));
+    BuckConfig config = BuckConfig.createFromReader(
+        reader,
+        filesystem,
+        parser,
+        Platform.detect(),
+        ImmutableMap.copyOf(System.getenv()));
+
+    ImmutableSet<Path> ignorePaths = config.getIgnorePaths();
+    assertFalse("User home cache directory should not be in set of ignored paths",
+        ignorePaths.contains(System.getProperty("user.home")
+            + File.separator
+            + "cache_dir"));
+
+    EasyMock.verify(filesystem, parser);
+  }
+
+  @Test
   public void testBuckPyIgnorePaths() throws IOException {
     ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(
         this, "buck_py_ignore_paths", temporaryFolder);


### PR DESCRIPTION
Make it possible to provide the following cache directory name
in .buckconfig file:

  dir = ~/.gerritcodereview/buck-cache

This allows to share the same Buck cache directory for multiple
source trees.
