### PR TITLE
Pass system property to test runner containing the module base directory

### DIFF
--- a/src/com/facebook/buck/java/JUnitStep.java
+++ b/src/com/facebook/buck/java/JUnitStep.java
@@ -54,10 +54,14 @@ public class JUnitStep extends ShellStep {
   @VisibleForTesting
   public static final String BUILD_ID_PROPERTY = "com.facebook.buck.buildId";
 
+  @VisibleForTesting
+  public static final String MODULE_PATH_PROPERTY = "com.facebook.buck.modulePath";
+
   private final ImmutableSet<Path> classpathEntries;
   private final Iterable<String> testClassNames;
   private final List<String> vmArgs;
   private final Path directoryForTestResults;
+  private final Path modulePath;
   private final Path tmpDirectory;
   private final Path testRunnerClasspath;
   private final boolean isCodeCoverageEnabled;
@@ -93,6 +97,7 @@ public class JUnitStep extends ShellStep {
       Iterable<String> testClassNames,
       List<String> vmArgs,
       Path directoryForTestResults,
+      Path modulePath,
       Path tmpDirectory,
       boolean isCodeCoverageEnabled,
       boolean isDebugEnabled,
@@ -104,6 +109,7 @@ public class JUnitStep extends ShellStep {
         testClassNames,
         vmArgs,
         directoryForTestResults,
+        modulePath,
         tmpDirectory,
         isCodeCoverageEnabled,
         isDebugEnabled,
@@ -120,6 +126,7 @@ public class JUnitStep extends ShellStep {
       Iterable<String> testClassNames,
       List<String> vmArgs,
       Path directoryForTestResults,
+      Path modulePath,
       Path tmpDirectory,
       boolean isCodeCoverageEnabled,
       boolean isDebugEnabled,
@@ -131,6 +138,7 @@ public class JUnitStep extends ShellStep {
     this.classpathEntries = ImmutableSet.copyOf(classpathEntries);
     this.testClassNames = Iterables.unmodifiableIterable(testClassNames);
     this.vmArgs = ImmutableList.copyOf(vmArgs);
+    this.modulePath = modulePath;
     this.directoryForTestResults = directoryForTestResults;
     this.tmpDirectory = tmpDirectory;
     this.isCodeCoverageEnabled = isCodeCoverageEnabled;
@@ -169,6 +177,9 @@ public class JUnitStep extends ShellStep {
 
     // Include the buildId
     args.add(String.format("-D%s=%s", BUILD_ID_PROPERTY, buildId));
+
+    // Include the baseDir
+    args.add(String.format("-D%s=%s", MODULE_PATH_PROPERTY, modulePath));
 
     if (isDebugEnabled) {
       // This is the default config used by IntelliJ. By doing this, all a user

--- a/src/com/facebook/buck/java/JavaTest.java
+++ b/src/com/facebook/buck/java/JavaTest.java
@@ -197,6 +197,7 @@ public class JavaTest extends DefaultJavaLibrary implements TestRule {
         reorderedTestClasses,
         amendVmArgs(vmArgs, executionContext.getTargetDeviceOptional()),
         pathToTestOutput,
+        getBuildTarget().getBasePath(),
         tmpDirectory,
         executionContext.isCodeCoverageEnabled(),
         executionContext.isDebugEnabled(),

--- a/test/com/facebook/buck/java/JUnitStepTest.java
+++ b/test/com/facebook/buck/java/JUnitStepTest.java
@@ -57,6 +57,9 @@ public class JUnitStepTest {
     BuildId pretendBuildId = new BuildId("pretend-build-id");
     String buildIdArg = String.format("-D%s=%s", JUnitStep.BUILD_ID_PROPERTY, pretendBuildId);
 
+    Path modulePath = Paths.get("module/submodule");
+    String modulePathArg = String.format("-D%s=%s", JUnitStep.MODULE_PATH_PROPERTY, modulePath);
+
     Path directoryForTestResults = Paths.get("buck-out/gen/theresults/");
     Path directoryForTemp = Paths.get("buck-out/gen/thetmp/");
     boolean isCodeCoverageEnabled = false;
@@ -68,6 +71,7 @@ public class JUnitStepTest {
         testClassNames,
         vmArgs,
         directoryForTestResults,
+        modulePath,
         directoryForTemp,
         isCodeCoverageEnabled,
         isDebugEnabled,
@@ -89,6 +93,7 @@ public class JUnitStepTest {
             "-Djava.io.tmpdir=" + directoryForTemp,
             "-Dbuck.testrunner_classes=" + testRunnerClasspath,
             buildIdArg,
+            modulePathArg,
             vmArg1,
             vmArg2,
             "-verbose",
@@ -123,6 +128,9 @@ public class JUnitStepTest {
     BuildId pretendBuildId = new BuildId("pretend-build-id");
     String buildIdArg = String.format("-D%s=%s", JUnitStep.BUILD_ID_PROPERTY, pretendBuildId);
 
+    Path modulePath = Paths.get("module/submodule");
+    String modulePathArg = String.format("-D%s=%s", JUnitStep.MODULE_PATH_PROPERTY, modulePath);
+
     Path directoryForTestResults = Paths.get("buck-out/gen/theresults/");
     Path directoryForTemp = Paths.get("buck-out/gen/thetmp/");
     boolean isCodeCoverageEnabled = false;
@@ -134,6 +142,7 @@ public class JUnitStepTest {
         testClassNames,
         vmArgs,
         directoryForTestResults,
+        modulePath,
         directoryForTemp,
         isCodeCoverageEnabled,
         isDebugEnabled,
@@ -157,6 +166,7 @@ public class JUnitStepTest {
             "-Djava.io.tmpdir=" + directoryForTemp,
             "-Dbuck.testrunner_classes=" + testRunnerClasspath,
             buildIdArg,
+            modulePathArg,
             "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005",
             vmArg1,
             vmArg2,


### PR DESCRIPTION
We're doing a big migration from an old build structure to buck and have too many tests that make assumptions about the location of the filesystem. This patch may help others in a similar situation or maybe provoke discussion on a better solution.

It allows a test to call the following to find out what the module root is:
System.getProperty("com.facebook.buck.modulePath")
