### PR TITLE
Improve error messages when build target parse preconditions fail

### DIFF
--- a/src/com/facebook/buck/parser/BuildTargetPatternParser.java
+++ b/src/com/facebook/buck/parser/BuildTargetPatternParser.java
@@ -39,7 +39,7 @@ public class BuildTargetPatternParser {
   }
 
   /**
-   * 1. //src/com/facebook/buck/cli:cli will be convert to a single build target
+   * 1. //src/com/facebook/buck/cli:cli will be converted to a single build target
    * 2. //src/com/facebook/buck/cli: will match all in the same directory.
    * 3. //src/com/facebook/buck/cli/... will match all in or under that directory.
    * For case 2 and 3, parseContext is expected to be {@link ParseContext#forVisibilityArgument()}.
@@ -60,17 +60,17 @@ public class BuildTargetPatternParser {
     }
 
     Preconditions.checkArgument(buildTargetPattern.startsWith(BUILD_RULE_PREFIX),
-        "buildTargetPattern must start with //");
+        String.format("'%s' must start with '//'", buildTargetPattern));
     Preconditions.checkNotNull(parseContext);
 
     if (buildTargetPattern.endsWith(WILDCARD_BUILD_RULE_SUFFIX)) {
       if (parseContext.getType() != ParseContext.Type.VISIBILITY) {
         throw new BuildTargetParseException(
-            String.format("%s cannot end with ...", buildTargetPattern));
+            String.format("'%s' cannot end with '...'", buildTargetPattern));
       } else {
         if (buildTargetPattern.contains(BUILD_RULE_SEPARATOR)) {
           throw new BuildTargetParseException(String.format(
-              "%s cannot contain colon", buildTargetPattern));
+              "'%s' cannot contain colon", buildTargetPattern));
         }
         String basePathWithSlash = buildTargetPattern.substring(
             BUILD_RULE_PREFIX.length(),


### PR DESCRIPTION
Summary:

When a build target pattern does not begin with '//', the build
fails with the error:

 java.lang.IllegalArgumentException: buildTargetPattern must start with //

Change this error message to include the name of the target that
caused the failure, making it easier to find and fix it.

Also, add quote marks in appropriate places in the error messages.

Test Plan:
1. Build Gerrit containing a broken maven_jar definition
   
   maven_jar(
    name = 'objenesis',
   id = 'org.objenesis:objenesis:1.2',
   sha1 = 'bfcb0539a071a4c5a30690388903ac48c0667f2a',
   license = 'DO_NOT_DISTRIBUTE',
   visibility = [':easymock', '//lib/powermock:powermock-reflect'],
   attach_source = False,
   )
2. Observe the error message:
   
   java.lang.IllegalArgumentException: ':easymock' must start with '//'
3. Don't spend ages tearing out hair trying to figure out where the
   error is coming from.
