### PR TITLE
Allow buck to run when watchman isn't installed

### DIFF
--- a/bin/buck_common
+++ b/bin/buck_common
@@ -60,14 +60,16 @@ function killBuckd() {
       fi
     done
   fi
-  rm -rf "${BUCKD_DIR}"
-  HAS_TRIGGERS=$(python <<-EOT
+  if [ $(which watchman) ]; then
+    rm -rf "${BUCKD_DIR}"
+    HAS_TRIGGERS=$(python <<-EOT
 import json
 print bool(json.loads("""$(watchman trigger-list $PWD)""").get("triggers", None))
 EOT
 )
-  if [ "${HAS_TRIGGERS}" != "True" ]; then
-    watchman watch-del "$PROJECT_ROOT" > /dev/null || true
+    if [ "${HAS_TRIGGERS}" != "True" ]; then
+      watchman watch-del "$PROJECT_ROOT" > /dev/null || true
+    fi
   fi
   setBuckdRunning
 }


### PR DESCRIPTION
This only runs the watchman command if watchman is on the PATH.

Buck was giving me:

~/gitroot/buck (master)$ bin/buck --help
/home/kchodorow/gitroot/buck/bin/buck_common: line 68: watchman: command not found
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/usr/lib/python2.7/json/**init**.py", line 326, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 384, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
