### PR TITLE
Make test coverage report with JaCoCo work in the wild

### DIFF
--- a/bin/buck_common
+++ b/bin/buck_common
@@ -437,6 +437,7 @@ BUCK_JAVA_ARGS=( \
   -Dbuck.abi_processor_classes="${BUCK_DIRECTORY}"/build/abi_processor/classes \
   -Dbuck.path_to_emma_jar="${BUCK_DIRECTORY}"/third-party/java/emma-2.0.5312/out/emma-2.0.5312.jar \
   -Dbuck.path_to_asm_jar="${BUCK_DIRECTORY}"/third-party/java/asm/asm-debug-all-4.1.jar \
+  -Dbuck.path_to_jacoco_jars="${BUCK_DIRECTORY}"/third-party/java/jacoco-0.6.4/out \
   -Dbuck.test_util_no_tests_dir=true \
   -Dbuck.logging_config_file="${BUCK_DIRECTORY}"/config/logging.properties \
   -Dbuck.path_to_python_interp="${PYTHON_INTERP_FALLBACK}" \


### PR DESCRIPTION
EMMA coverage report invocation is working, but it is somehow flaky.
Test coverage report with JaCoCo is looking very promising but it
seems to only work for Buck project itself because some paths are
hard coded and other paths are customizable but still not exposed
in buck_common script as it's the case with broken EMMA.

Make hard coded path customizable and expose the paths in buck_common
so that folks in the wild can use it.

Test Plan:
Clone Gerrit Code Review project and issue this command:
buck test --all --code-coverage --code-coverage-format html --no-results-cache
Enjoy the report in buck-out/gen/jacoco/code-coverage/index.html
