### PR TITLE
Fix exit code for usage with --help

### DIFF
--- a/bin/buck
+++ b/bin/buck
@@ -14,7 +14,11 @@ def main():
         buck_repo = BuckRepo(THIS_DIR, project)
         if 'clean' in sys.argv:
             buck_repo.kill_buckd()
-        exit_code = buck_repo.launch_buck()
+        if '--help' in sys.argv:
+            buck_repo.launch_buck()
+            exit_code = 0
+        else:
+            exit_code = buck_repo.launch_buck()
         sys.exit(exit_code)
 
 if __name__ == "__main__":


### PR DESCRIPTION
When I use buck with option `--help` it exits with non-zero code.

```
bayandin@mbp:~/repos/buck$ bin/buck --version
Not using buckd because watchman isn't installed.
buck version e2f2eec283d05ea117c983030a9f0b359127bb27

bayandin@mbp:~/repos/buck$ bin/buck --help
Not using buckd because watchman isn't installed.
buck build tool
usage:
  buck [options]
  buck command --help
  buck command [command-options]
available commands:
  audit       lists the inputs for the specified target
  build       builds the specified target
  cache       makes calls to the artifact cache
  clean       deletes any generated files
  install     builds and installs an APK
  project     generates project configuration files for an IDE
  quickstart  generates a default project directory
  run         runs a target as a command
  targets     prints the list of buildable targets
  test        builds and runs the tests for the specified target
  uninstall   uninstalls an APK
options:
 --help         : Shows this screen and exits.
 --version (-V) : Show version number.

bayandin@mbp:~/repos/buck$ echo $?
1
```

This PR fixes this unexpected behaviour.