### PR TITLE
Old trace files not being deleted because the filename format has changed

### DIFF
--- a/src/com/facebook/buck/event/listener/ChromeTraceBuildListener.java
+++ b/src/com/facebook/buck/event/listener/ChromeTraceBuildListener.java
@@ -59,7 +59,7 @@ import java.util.concurrent.TimeUnit;
  * Logs events to a json file formatted to be viewed in Chrome Trace View (chrome://tracing).
  */
 public class ChromeTraceBuildListener implements BuckEventListener {
-  private static final String TRACE_FILE_PATTERN = "build\\.\\d*\\.trace";
+  private static final String TRACE_FILE_PATTERN = "build\\..+\\.trace";
 
   private final ProjectFilesystem projectFilesystem;
   private final int tracesToKeep;

--- a/test/com/facebook/buck/event/listener/ChromeTraceBuildListenerTest.java
+++ b/test/com/facebook/buck/event/listener/ChromeTraceBuildListenerTest.java
@@ -91,7 +91,7 @@ public class ChromeTraceBuildListenerTest {
 
     for (int i = 0; i < 10; ++i) {
       File oldResult = new File(tmpDir.getRoot(),
-          String.format("%s/build.100%d.trace", BuckConstant.BUCK_TRACE_DIR, i));
+          String.format("%s/build.b7d3bf7e-%d.trace", BuckConstant.BUCK_TRACE_DIR, i));
       oldResult.createNewFile();
       oldResult.setLastModified(TimeUnit.SECONDS.toMillis(i));
     }
@@ -111,9 +111,9 @@ public class ChromeTraceBuildListenerTest {
         }).toList();
     assertEquals(4, files.size());
     assertEquals(ImmutableSortedSet.of("build.trace",
-                                       "build.1009.trace",
-                                       "build.1008.trace",
-                                       "build.1007.trace"),
+                                       "build.b7d3bf7e-7.trace",
+                                       "build.b7d3bf7e-8.trace",
+                                       "build.b7d3bf7e-9.trace"),
         ImmutableSortedSet.copyOf(files));
   }
 


### PR DESCRIPTION
The regex for matching trace files for deletion from buck-out/log/traces was not updated when the filename format changed.

Old format example:

```
build.1009.trace
```

New format example:

```
build.9e4e8dda-fab4-6f83-308d-803a3a1850dc.trace
```
