### PR TITLE
Add 'check_linear_alloc_limit' and 'primary_dex_patterns_excluded' arguments in android_binary Rule

### DIFF
--- a/src/com/facebook/buck/android/AndroidBinaryDescription.java
+++ b/src/com/facebook/buck/android/AndroidBinaryDescription.java
@@ -209,10 +209,10 @@ public class AndroidBinaryDescription implements Description<AndroidBinaryDescri
   }
 
   private DexSplitMode createDexSplitMode(Arg args) {
-    // Exopackage builds default to JAR, otherwise, default to RAW.
-    DexStore defaultDexStore = args.exopackage.or(false)
-        ? DexStore.JAR
-        : DexStore.RAW;
+    // Exopackage or isPrimaryDexPatternsExcluded builds default to JAR,otherwise, default to RAW.
+    DexStore defaultDexStore = (args.exopackage.or(false) || args.primaryDexPatternsExcluded.or(false))
+       ? DexStore.JAR
+       : DexStore.RAW;
     DexSplitStrategy dexSplitStrategy = args.minimizePrimaryDexSize.or(false)
         ? DexSplitStrategy.MINIMIZE_PRIMARY_DEX_SIZE
         : DexSplitStrategy.MAXIMIZE_PRIMARY_DEX_SIZE;
@@ -225,7 +225,9 @@ public class AndroidBinaryDescription implements Description<AndroidBinaryDescri
         args.primaryDexPatterns.or(ImmutableList.<String>of()),
         args.primaryDexClassesFile,
         args.primaryDexScenarioFile,
-        args.primaryDexScenarioOverflowAllowed.or(false));
+        args.primaryDexScenarioOverflowAllowed.or(false),
+        args.checkLinearAllocLimit.or(true),
+        args.primaryDexPatternsExcluded.or(false));
   }
 
   private PackageType getPackageType(Arg args) {
@@ -275,6 +277,12 @@ public class AndroidBinaryDescription implements Description<AndroidBinaryDescri
     public Optional<BuildConfigFields> buildConfigValues;
 
     public Optional<SourcePath> buildConfigValuesFile;
+
+    /** Exclude primaryDexPatterns in primary dex*/
+    public Optional<Boolean> primaryDexPatternsExcluded;
+
+    /** whether check linearAllocLimit or not */
+    public Optional<Boolean> checkLinearAllocLimit;
 
     public Optional<ImmutableSortedSet<BuildTarget>> deps;
   }

--- a/src/com/facebook/buck/android/DexSplitMode.java
+++ b/src/com/facebook/buck/android/DexSplitMode.java
@@ -43,7 +43,9 @@ class DexSplitMode {
       /* primaryDexPatterns */ ImmutableSet.<String>of(),
       /* primaryDexClassesFile */ Optional.<SourcePath>absent(),
       /* primaryDexScenarioFile */ Optional.<SourcePath>absent(),
-      /* isPrimaryDexScenarioOverflowAllowed */ false);
+      /* isPrimaryDexScenarioOverflowAllowed */ false,
+      /* isCheckLinearAllocLimit */ true,
+      /* isPrimaryDexPatternsExcluded */ false);
 
   private final boolean shouldSplitDex;
   private final DexStore dexStore;
@@ -87,6 +89,17 @@ class DexSplitMode {
   private final boolean isPrimaryDexScenarioOverflowAllowed;
 
   /**
+   * Boolean identifying whether check linearAllocLimit forcibly or not.
+   */
+  private final boolean isCheckLinearAllocLimit;
+
+  /**
+   * Boolean identifying whether we should allow the primaryDexPatterns 
+   * excluded in primary dex.
+   */
+  private final boolean isPrimaryDexPatternsExcluded;
+
+  /**
    *
    * @param primaryDexPatterns Set of substrings that, when matched, will cause individual input
    *     class or resource files to be placed into the primary jar (and thus the primary dex
@@ -102,6 +115,10 @@ class DexSplitMode {
    *     to proceed on a best-effort basis (true).
    * @param useLinearAllocSplitDex If true, {@link com.facebook.buck.dalvik.DalvikAwareZipSplitter}
    *     will be used. Also, {@code linearAllocHardLimit} must have a positive value in this case.
+   * @param isCheckLinarAllocLimit A boolean indicating whether check linearAllocLimit forcibly or not.
+   * @param isPrimaryDexPatternsExcluded A boolean indicating whether exclude the primaryDexPatterns in
+   *     primary dex file. If true, the class match patterns in primaryDexPatterns will be built in 
+   *     secondary dexs in split-dex case.
    */
   public DexSplitMode(
       boolean shouldSplitDex,
@@ -112,7 +129,9 @@ class DexSplitMode {
       Collection<String> primaryDexPatterns,
       Optional<SourcePath> primaryDexClassesFile,
       Optional<SourcePath> primaryDexScenarioFile,
-      boolean isPrimaryDexScenarioOverflowAllowed) {
+      boolean isPrimaryDexScenarioOverflowAllowed,
+      boolean isCheckLinarAllocLimit,
+      boolean isPrimaryDexPatternsExcluded) {
     this.shouldSplitDex = shouldSplitDex;
     this.dexSplitStrategy = Preconditions.checkNotNull(dexSplitStrategy);
     this.dexStore = Preconditions.checkNotNull(dexStore);
@@ -122,6 +141,8 @@ class DexSplitMode {
     this.primaryDexClassesFile = Preconditions.checkNotNull(primaryDexClassesFile);
     this.primaryDexScenarioFile = Preconditions.checkNotNull(primaryDexScenarioFile);
     this.isPrimaryDexScenarioOverflowAllowed = isPrimaryDexScenarioOverflowAllowed;
+    this.isCheckLinearAllocLimit = isCheckLinarAllocLimit;
+    this.isPrimaryDexPatternsExcluded = isPrimaryDexPatternsExcluded;
   }
 
   public DexStore getDexStore() {
@@ -143,6 +164,14 @@ class DexSplitMode {
 
   public long getLinearAllocHardLimit() {
     return linearAllocHardLimit;
+  }
+
+  public boolean getCheckLinearAllocLimit() {
+    return isCheckLinearAllocLimit;
+  }
+
+  public boolean getPrimaryDexPatternsExcluded() {
+    return isPrimaryDexPatternsExcluded;
   }
 
   public ImmutableSet<String> getPrimaryDexPatterns() {
@@ -182,6 +211,8 @@ class DexSplitMode {
     builder.set(
         prefix + ".isPrimaryDexScenarioOverflowAllowed",
         isPrimaryDexScenarioOverflowAllowed);
+    builder.set(prefix + ".isCheckLinearAllocLimit", isCheckLinearAllocLimit);
+    builder.set(prefix + ".isPrimaryDexPatternsExcluded", isPrimaryDexPatternsExcluded);
     return builder;
   }
 }

--- a/src/com/facebook/buck/android/PreDexMerge.java
+++ b/src/com/facebook/buck/android/PreDexMerge.java
@@ -203,7 +203,9 @@ public class PreDexMerge extends AbstractBuildRule implements InitializableFromD
         paths.scratchDir,
         dexSplitMode.getLinearAllocHardLimit(),
         dexSplitMode.getDexStore(),
-        paths.jarfilesSubdir);
+        paths.jarfilesSubdir,
+        dexSplitMode.getCheckLinearAllocLimit(),
+        dexSplitMode.getPrimaryDexPatternsExcluded());
     final PreDexedFilesSorter.Result sortResult =
         preDexedFilesSorter.sortIntoPrimaryAndSecondaryDexes(context, steps);
 

--- a/test/com/facebook/buck/android/SplitZipStepTest.java
+++ b/test/com/facebook/buck/android/SplitZipStepTest.java
@@ -116,7 +116,9 @@ public class SplitZipStepTest {
             /* primaryDexPatterns */ ImmutableSet.of("List"),
             Optional.<SourcePath>of(new TestSourcePath("the/manifest.txt")),
             /* primaryDexScenarioFile */ Optional.<SourcePath>absent(),
-            /* isPrimaryDexScenarioOverflowAllowed */ false),
+            /* isPrimaryDexScenarioOverflowAllowed */ false,
+            /* isCheckLinearAllocLimit */ true,
+            /* isPrimaryDexPatternsExcluded */ false),
         Optional.<Path>absent(),
         Optional.of(Paths.get("the/manifest.txt")),
         /* pathToReportDir */ Paths.get(""));
@@ -187,7 +189,9 @@ public class SplitZipStepTest {
             /* primaryDexPatterns */ ImmutableSet.of("/primary/", "x/"),
             Optional.<SourcePath>of(new TestSourcePath("the/manifest.txt")),
             /* primaryDexScenarioFile */ Optional.<SourcePath>absent(),
-            /* isPrimaryDexScenarioOverflowAllowed */ false),
+            /* isPrimaryDexScenarioOverflowAllowed */ false,
+            /* isCheckLinearAllocLimit */ true,
+            /* isPrimaryDexPatternsExcluded */ false),
         Optional.<Path>absent(),
         Optional.of(Paths.get("the/manifest.txt")),
         /* pathToReportDir */ Paths.get(""));
@@ -272,7 +276,9 @@ public class SplitZipStepTest {
             /* primaryDexPatterns */ ImmutableSet.of("primary"),
             /* primaryDexClassesFile */ Optional.<SourcePath>absent(),
             /* primaryDexScenarioFile */ Optional.<SourcePath>absent(),
-            /* isPrimaryDexScenarioOverflowAllowed */ false),
+            /* isPrimaryDexScenarioOverflowAllowed */ false,
+            /* isCheckLinearAllocLimit */ true,
+            /* isPrimaryDexPatternsExcluded */ false),
         Optional.<Path>absent(),
         Optional.<Path>absent(),
         /* pathToReportDir */ Paths.get(""));


### PR DESCRIPTION
In `android_binary` rule, I add two boolean arguments: `check_linear_alloc_limit` and `primary_dex_patterns_excluded`.

If `check_linear_alloc_limit` is False, it will not check the linear alloc limit. The default value is False.

if `primary_dex_patterns_excluded` is True, the classes match `primary_dex_patterns` will be excluded in primary dex file. They will be included in secondary dex files. 

Refer to issue #202 