### PR TITLE
Error in aapt_package when prebuilt AAR does not include any `res` files

### DIFF
--- a/src/com/facebook/buck/android/AndroidPrebuiltAarGraphEnhancer.java
+++ b/src/com/facebook/buck/android/AndroidPrebuiltAarGraphEnhancer.java
@@ -205,6 +205,7 @@ class AndroidPrebuiltAarGraphEnhancer {
       steps.add(new MakeCleanDirectoryStep(unpackDirectory));
       steps.add(new UnzipStep(getResolver().getPath(aarFile), unpackDirectory));
       steps.add(new TouchStep(getProguardConfig()));
+      steps.add(new MkdirStep(getResDirectory()));
       steps.add(new MkdirStep(getAssetsDirectory()));
 
       // We take the classes.jar file that is required to exist in an .aar and merge it with any


### PR DESCRIPTION
If a prebuild AAR file contains an *empty* `res/` directory, the
directory does not get created in the `__unpack_*#aar_unzip__/res/`
location.  This causes the `aapt` tool to fail with error:

    ERROR: resource directory 'buck-out/bin/__unpack_<prebuilt_aar_name>#aar_unzip__/res' does not exist

In the `AndroidPrebuiltAarGraphEnhancer` class, there is a step
that accounts for a similar error on the `assets` directory:

    steps.add(new MkdirStep(getAssetsDirectory()));

Adding a similar step for the `res` directory resolves the error.