### PR TITLE
Improve the messages printed when buck self-updates

### DIFF
--- a/programs/buck_repo.py
+++ b/programs/buck_repo.py
@@ -116,6 +116,13 @@ class BuckRepo(BuckTool):
     def _checkout_and_clean(self, revision, branch):
         with Tracing('BuckRepo._checkout_and_clean'):
             if not self._revision_exists(revision):
+                print(textwrap.dedent("""\
+                    Required revision {0} is not
+                    available in the local repository.
+                    Buck is fetching updates from git. You can disable this by creating
+                    a '.nobuckcheck' file in your repository, but this might lead to
+                    strange bugs or build failures.""".format(revision)),
+                    file=sys.stderr)
                 git_command = ['git', 'fetch']
                 git_command.extend(['--all'] if not branch else ['origin', branch])
                 try:
@@ -125,10 +132,7 @@ class BuckRepo(BuckTool):
                         cwd=self._buck_dir)
                 except subprocess.CalledProcessError:
                     raise BuckToolException(textwrap.dedent("""\
-                          Failed to fetch Buck updates from git.
-                          You can disable this by creating a '.nobuckcheck' file in
-                          your repository, but this might lead to strange bugs or
-                          build failures."""))
+                          Failed to fetch Buck updates from git."""))
 
             current_revision = self._get_git_revision()
 
@@ -141,9 +145,13 @@ class BuckRepo(BuckTool):
                     current_revision, revision)),
                     file=sys.stderr)
 
-                subprocess.check_call(
-                    ['git', 'checkout', '--quiet', revision],
-                    cwd=self._buck_dir)
+                try:
+                    subprocess.check_call(
+                        ['git', 'checkout', '--quiet', revision],
+                        cwd=self._buck_dir)
+                except subprocess.CalledProcessError:
+                    raise BuckToolException(textwrap.dedent("""\
+                          Failed to update Buck to revision {0}.""".format(revision)))
                 if os.path.exists(self._build_success_file):
                     os.remove(self._build_success_file)
 


### PR DESCRIPTION
Summary:

(1.) When the .buckversion file specifies a revision that is not present
in the current repository, print a message stating that Buck is fetching
updates.

(2.) When the git fetch fails, only display a "failed" message.  Move the
bit about how the user can disable the update into the informational
message that was already displayed as described in (1.).

(3.) If the revision specified in .buckversion does not exist on the
remote, either because it's plain wrong or because the revision is on a
remote that is not configured in the local repository, the git checkout
fails. Catch the exception and display a message rather than a Python
Traceback.

Test Plan:

Set .buckversion to a revision that does not exist. Run `buck clean` and
observe that it prints the message in (1.), then runs git fetch, and then
fails to check out the revision and fails with an error message.