### PR TITLE
Add ability to use a .src.zip as a python_library source.

### DIFF
--- a/src/com/facebook/buck/cli/BUCK
+++ b/src/com/facebook/buck/cli/BUCK
@@ -55,6 +55,7 @@ java_library(
     '//src/com/facebook/buck/parser:config',
     '//src/com/facebook/buck/parser:parser',
     '//src/com/facebook/buck/python:config',
+    '//src/com/facebook/buck/python:rules',
     '//src/com/facebook/buck/rules:types',
     '//src/com/facebook/buck/thrift:rules',
     '//test/com/facebook/buck/...',

--- a/src/com/facebook/buck/python/BUCK
+++ b/src/com/facebook/buck/python/BUCK
@@ -34,6 +34,7 @@ java_immutables_library(
   srcs = glob(['*.java'], excludes=CONFIG_SRCS + SUPPORT_SRCS),
   deps = [
     ':support',
+    '//src/com/facebook/buck/cli:config',
     '//src/com/facebook/buck/cxx:platform',
     '//src/com/facebook/buck/graph:graph',
     '//src/com/facebook/buck/io:io',
@@ -49,6 +50,7 @@ java_immutables_library(
     '//src/com/facebook/buck/util:exceptions',
     '//src/com/facebook/buck/test:test',
     '//src/com/facebook/buck/test/selectors:selectors',
+    '//src/com/facebook/buck/zip:unzip',
     '//third-party/java/guava:guava',
     '//third-party/java/infer-annotations:infer-annotations',
     '//third-party/java/jsr:jsr305',

--- a/src/com/facebook/buck/python/PexStep.java
+++ b/src/com/facebook/buck/python/PexStep.java
@@ -16,8 +16,10 @@
 
 package com.facebook.buck.python;
 
+import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.shell.ShellStep;
 import com.facebook.buck.step.ExecutionContext;
+import com.facebook.buck.zip.Unzip;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
@@ -28,6 +30,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 public class PexStep extends ShellStep {
+  private static final String SRC_ZIP = ".src.zip";
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -46,6 +49,7 @@ public class PexStep extends ShellStep {
   // The map of resources to include in the PEX.
   private final ImmutableMap<Path, Path> resources;
   private final Path pythonPath;
+  private final Path tempDir;
 
   // The map of native libraries to include in the PEX.
   private final ImmutableMap<Path, Path> nativeLibraries;
@@ -53,6 +57,7 @@ public class PexStep extends ShellStep {
   public PexStep(
       Path pathToPex,
       Path pythonPath,
+      Path tempDir,
       Path destination,
       String entry,
       ImmutableMap<Path, Path> modules,
@@ -60,6 +65,7 @@ public class PexStep extends ShellStep {
       ImmutableMap<Path, Path> nativeLibraries) {
     this.pathToPex = pathToPex;
     this.pythonPath = pythonPath;
+    this.tempDir = tempDir;
     this.destination = destination;
     this.entry = entry;
     this.modules = modules;
@@ -79,10 +85,16 @@ public class PexStep extends ShellStep {
    * limits on arguments.
    */
   @Override
-  protected Optional<String> getStdin() {
+  protected Optional<String> getStdin(ExecutionContext context) {
     // Convert the map of paths to a map of strings before converting to JSON.
     ImmutableMap.Builder<String, String> modulesBuilder = ImmutableMap.builder();
-    for (ImmutableMap.Entry<Path, Path> ent : modules.entrySet()) {
+    ImmutableMap<Path, Path> resolvedModules;
+    try {
+      resolvedModules = getExpandedSourcePaths(context, modules);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    for (ImmutableMap.Entry<Path, Path> ent : resolvedModules.entrySet()) {
       modulesBuilder.put(ent.getKey().toString(), ent.getValue().toString());
     }
     ImmutableMap.Builder<String, String> resourcesBuilder = ImmutableMap.builder();
@@ -113,4 +125,33 @@ public class PexStep extends ShellStep {
         destination.toString());
   }
 
+  private ImmutableMap<Path, Path> getExpandedSourcePaths(
+      ExecutionContext context,
+      ImmutableMap<Path, Path> paths) throws IOException {
+    ProjectFilesystem projectFilesystem = context.getProjectFilesystem();
+    ImmutableMap.Builder<Path, Path> sources = ImmutableMap.builder();
+
+    for (ImmutableMap.Entry<Path, Path> ent : paths.entrySet()) {
+      if (ent.getValue().toString().endsWith(SRC_ZIP)) {
+        Path destinationDirectory = projectFilesystem.resolve(
+            tempDir.resolve(ent.getKey()));
+        destinationDirectory.toFile().mkdirs();
+
+        ImmutableList<Path> zipPaths = Unzip.extractZipFile(
+            projectFilesystem.resolve(ent.getValue()),
+            destinationDirectory,
+            /* overwriteExistingFiles */ true);
+        for (Path path : zipPaths) {
+          Path modulePath = destinationDirectory.relativize(path);
+          sources.put(modulePath, path);
+        }
+      } else {
+        sources.put(ent.getKey(), ent.getValue());
+      }
+    }
+
+    return sources.build();
+  }
+
+  
 }

--- a/src/com/facebook/buck/python/PythonBinary.java
+++ b/src/com/facebook/buck/python/PythonBinary.java
@@ -30,6 +30,7 @@ import com.facebook.buck.rules.RuleKey;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.step.Step;
+import com.facebook.buck.step.fs.MakeCleanDirectoryStep;
 import com.facebook.buck.step.fs.MkdirStep;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -132,10 +133,15 @@ public class PythonBinary extends AbstractBuildRule implements BinaryBuildRule {
     // Make sure the parent directory exists.
     steps.add(new MkdirStep(binPath.getParent()));
 
+    Path workingDirectory = BuildTargets.getGenPath(
+        getBuildTarget(), "__%s__working_directory");
+    steps.add(new MakeCleanDirectoryStep(workingDirectory));
+
     // Generate and return the PEX build step.
     steps.add(new PexStep(
         pathToPex,
         pythonEnvironment.getPythonPath(),
+        workingDirectory,
         binPath,
         PythonUtil.toModuleName(getBuildTarget(), main.toString()),
         getResolver().getMappedPaths(components.getModules()),

--- a/src/com/facebook/buck/python/pex.py
+++ b/src/com/facebook/buck/python/pex.py
@@ -108,7 +108,10 @@ def main():
             # Linux behave different when hard-linking a source that is a
             # symbolic link (Linux does *not* follow symlinks), resolve any
             # layers of symlinks here to get consistent behavior.
-            pex_builder.add_source(dereference_symlinks(src), dst)
+            try:
+                pex_builder.add_source(dereference_symlinks(src), dst)
+            except OSError as e:
+                raise Exception("Failed to add {}: {}".format(src, e))
 
         # Add resources listed in the manifest.
         for dst, src in manifest['resources'].iteritems():

--- a/src/com/facebook/buck/shell/ShellStep.java
+++ b/src/com/facebook/buck/shell/ShellStep.java
@@ -109,7 +109,7 @@ public abstract class ShellStep implements Step {
       builder.setDirectory(context.getProjectDirectoryRoot().toAbsolutePath().toFile());
     }
 
-    Optional<String> stdin = getStdin();
+    Optional<String> stdin = getStdin(context);
     if (stdin.isPresent()) {
       builder.setRedirectInput(ProcessBuilder.Redirect.PIPE);
     }
@@ -160,7 +160,7 @@ public abstract class ShellStep implements Step {
     ProcessExecutor.Result result = executor.launchAndExecute(
         params,
         options.build(),
-        getStdin(),
+        getStdin(context),
         getTimeout());
     stdout = result.getStdout();
     stderr = result.getStderr();
@@ -206,7 +206,8 @@ public abstract class ShellStep implements Step {
     return shellCommandArgs;
   }
 
-  protected Optional<String> getStdin() {
+  @SuppressWarnings("unused")
+  protected Optional<String> getStdin(ExecutionContext context) {
     return Optional.absent();
   }
 

--- a/test/com/facebook/buck/python/PythonSrcZipIntegrationTest.java
+++ b/test/com/facebook/buck/python/PythonSrcZipIntegrationTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.python;
+
+import com.facebook.buck.testutil.integration.DebuggableTemporaryFolder;
+import com.facebook.buck.testutil.integration.ProjectWorkspace;
+import com.facebook.buck.testutil.integration.ProjectWorkspace.ProcessResult;
+import com.facebook.buck.testutil.integration.TestDataHelper;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Properties;
+
+public class PythonSrcZipIntegrationTest {
+
+  @Rule
+  public DebuggableTemporaryFolder tmp = new DebuggableTemporaryFolder();
+  public ProjectWorkspace workspace;
+
+  @Before
+  public void setUp() throws IOException {
+    Properties props = System.getProperties();
+    props.setProperty(
+        "buck.path_to_python_test_main",
+        Paths.get("src/com/facebook/buck/python/__test_main__.py").toAbsolutePath().toString());
+    props.setProperty(
+        "buck.path_to_pex",
+        Paths.get("src/com/facebook/buck/python/pex.py").toAbsolutePath().toString());
+
+    workspace = TestDataHelper.createProjectWorkspaceForScenario(
+        this, "src_zip", tmp);
+    workspace.setUp();
+  }
+
+  @Test
+  public void testDependingOnSrcZipWorks() throws IOException {
+    // This test should pass.
+    ProcessResult result1 = workspace.runBuckCommand("test", "//:test");
+    result1.assertSuccess();
+  }
+
+}

--- a/test/com/facebook/buck/python/testdata/src_zip/BUCK
+++ b/test/com/facebook/buck/python/testdata/src_zip/BUCK
@@ -1,0 +1,34 @@
+python_binary(
+    name='zip',
+    main='zip.py',
+)
+
+genrule(
+    name='file.src.zip',
+    out='file.src.zip',
+    cmd='$(exe :zip) mod $OUT $SRCS',
+    srcs=[
+       'file.py',
+    ],
+    deps=[
+       ':zip',
+    ],
+)
+
+python_library(
+    name='file_zip_lib',
+    base_module='',
+    srcs=[
+        ':file.src.zip',
+    ],
+)
+
+python_test(
+    name='test',
+    srcs=[
+        'test.py',
+    ],
+    deps=[
+        ':file_zip_lib',
+    ],
+)

--- a/test/com/facebook/buck/python/testdata/src_zip/file.py
+++ b/test/com/facebook/buck/python/testdata/src_zip/file.py
@@ -1,0 +1,1 @@
+print "I'm a file. A lonely, lonely file."

--- a/test/com/facebook/buck/python/testdata/src_zip/test.py
+++ b/test/com/facebook/buck/python/testdata/src_zip/test.py
@@ -1,0 +1,3 @@
+from mod import file
+
+print 'Yay'

--- a/test/com/facebook/buck/python/testdata/src_zip/zip.py
+++ b/test/com/facebook/buck/python/testdata/src_zip/zip.py
@@ -1,0 +1,15 @@
+import os.path
+import sys
+import zipfile
+
+def main():
+    root_dir, output_file = sys.argv[1:3]
+    input_files = sys.argv[3:]
+
+    f = zipfile.ZipFile(output_file, 'w')
+    for input_file in input_files:
+        f.write(input_file, os.path.join(root_dir, os.path.basename(input_file)))
+    f.close()
+
+if __name__ == '__main__':
+    main()

--- a/test/com/facebook/buck/shell/ShellStepTest.java
+++ b/test/com/facebook/buck/shell/ShellStepTest.java
@@ -134,7 +134,7 @@ public class ShellStepTest {
          return cmd.get(0);
       }
       @Override
-      protected Optional<String> getStdin() {
+      protected Optional<String> getStdin(ExecutionContext context) {
         return stdin;
       }
       @Override


### PR DESCRIPTION
The intention is to allow genrules to generate > 1 file worth of code (or some directory structure) that can be used in a python_library. For example, you could write a small wrapper around genrule to take a PyPI package name & version, download it & repackage it to include certain directories as a python_library (similar to, but slightly more involved than maven_jar in bucklets).