### PR TITLE
Prebuilt libraries should default to the native extension for the platform

### DIFF
--- a/src/com/facebook/buck/cxx/CxxPythonExtensionDescription.java
+++ b/src/com/facebook/buck/cxx/CxxPythonExtensionDescription.java
@@ -82,6 +82,7 @@ public class CxxPythonExtensionDescription implements
 
   @VisibleForTesting
   protected String getExtensionName(BuildTarget target) {
+    // .so is used on OS X too (as opposed to dylib).
     return String.format("%s.so", target.getShortName());
   }
 

--- a/src/com/facebook/buck/cxx/PrebuiltCxxLibraryDescription.java
+++ b/src/com/facebook/buck/cxx/PrebuiltCxxLibraryDescription.java
@@ -135,11 +135,12 @@ public class PrebuiltCxxLibraryDescription
       CxxPlatform cxxPlatform,
       Optional<String> soname,
       Optional<String> libName) {
+    String extension = cxxPlatform.getSharedLibraryExtension();
     return getOptionalArg(
         target,
         cxxPlatform,
         soname,
-        String.format("lib%s.so", getLibName(target, cxxPlatform, libName)));
+        String.format("lib%s.%s", getLibName(target, cxxPlatform, libName), extension));
   }
 
   private static Path getLibraryPath(
@@ -158,7 +159,8 @@ public class PrebuiltCxxLibraryDescription
       CxxPlatform cxxPlatform,
       Optional<String> libDir,
       Optional<String> libName) {
-    return getLibraryPath(target, cxxPlatform, libDir, libName, ".so");
+    return getLibraryPath(target, cxxPlatform, libDir, libName,
+                          String.format(".%s", cxxPlatform.getSharedLibraryExtension()));
   }
 
   public static Path getStaticLibraryPath(

--- a/test/com/facebook/buck/cxx/PrebuiltCxxLibraryDescriptionTest.java
+++ b/test/com/facebook/buck/cxx/PrebuiltCxxLibraryDescriptionTest.java
@@ -60,12 +60,12 @@ public class PrebuiltCxxLibraryDescriptionTest {
     String libDir = arg.libDir.or("lib");
     String libName = arg.libName.or(TARGET.getShortName());
     return TARGET.getBasePath().resolve(libDir).resolve(
-        String.format("lib%s.so", libName));
+        String.format("lib%s.%s", libName, CXX_PLATFORM.getSharedLibraryExtension()));
   }
 
   private static String getSharedLibrarySoname(PrebuiltCxxLibraryDescription.Arg arg) {
     String libName = arg.libName.or(TARGET.getShortName());
-    return arg.soname.or(String.format("lib%s.so", libName));
+    return arg.soname.or(String.format("lib%s.%s", libName, CXX_PLATFORM.getSharedLibraryExtension()));
   }
 
   private static ImmutableList<Path> getIncludeDirs(PrebuiltCxxLibraryDescription.Arg arg) {
@@ -320,19 +320,20 @@ public class PrebuiltCxxLibraryDescriptionTest {
             .withFlavor(ImmutableFlavor.of("PLATFORM2"));
 
     assertEquals(
-        "libtest-PLATFORM1.so",
+        String.format("libtest-PLATFORM1.%s", platform1.getSharedLibraryExtension()),
         PrebuiltCxxLibraryDescription.getSoname(
             TARGET,
             platform1, soname, libName));
     assertEquals(
-        "libtest-PLATFORM2.so",
+        String.format("libtest-PLATFORM2.%s", platform2.getSharedLibraryExtension()),
         PrebuiltCxxLibraryDescription.getSoname(
             TARGET,
             platform2, soname, libName));
 
     assertEquals(
         TARGET.getBasePath()
-            .resolve("libs/PLATFORM1/libtest-PLATFORM1.so"),
+            .resolve(String.format("libs/PLATFORM1/libtest-PLATFORM1.%s",
+                                   platform1.getSharedLibraryExtension())),
         PrebuiltCxxLibraryDescription.getSharedLibraryPath(TARGET, platform1, libDir, libName));
     assertEquals(
         TARGET.getBasePath()
@@ -341,7 +342,8 @@ public class PrebuiltCxxLibraryDescriptionTest {
 
     assertEquals(
         TARGET.getBasePath()
-            .resolve("libs/PLATFORM2/libtest-PLATFORM2.so"),
+            .resolve(String.format("libs/PLATFORM2/libtest-PLATFORM2.%s",
+                                   platform2.getSharedLibraryExtension())),
         PrebuiltCxxLibraryDescription.getSharedLibraryPath(TARGET, platform2, libDir, libName));
     assertEquals(
         TARGET.getBasePath()


### PR DESCRIPTION
Also allows you to do something like (albeit ugly, but working):

```python
import subprocess
import collections

# A small amount of magic to get cxx_python_extension working.
python_ldflags = subprocess.check_output('python-config --ldflags', shell=True).split()
prebuilt_cxx_library(
    name='pylib',
    provided=True,
    lib_name='python2.7',
    lib_dir=[v[len('-L'):] for v in python_ldflags if v.startswith('-L')][0],
    include_dirs=[v[len('-I'):] for v in
                  subprocess.check_output('python-config --includes', shell=True).split()],
    linker_flags=python_ldflags,
    visibility=['PUBLIC']
)
```