### PR TITLE
Add zip_safe flag to all python targets & set it to False on cxx_python_extension

### DIFF
--- a/src/com/facebook/buck/cxx/CxxLibrary.java
+++ b/src/com/facebook/buck/cxx/CxxLibrary.java
@@ -195,7 +195,8 @@ public class CxxLibrary extends AbstractCxxLibrary {
     return PythonPackageComponents.of(
         /* modules */ ImmutableMap.<Path, SourcePath>of(),
         /* resources */ ImmutableMap.<Path, SourcePath>of(),
-        /* nativeLibraries */ libs.build());
+        /* nativeLibraries */ libs.build(),
+        /* zipSafe */ Optional.<Boolean>absent());
   }
 
   @Override

--- a/src/com/facebook/buck/cxx/CxxPythonExtension.java
+++ b/src/com/facebook/buck/cxx/CxxPythonExtension.java
@@ -25,6 +25,7 @@ import com.facebook.buck.rules.BuildTargetSourcePath;
 import com.facebook.buck.rules.NoopBuildRule;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
 import java.nio.file.Path;
@@ -60,7 +61,8 @@ public class CxxPythonExtension extends NoopBuildRule implements PythonPackagabl
     return PythonPackageComponents.of(
         ImmutableMap.of(module, output),
         ImmutableMap.<Path, SourcePath>of(),
-        ImmutableMap.<Path, SourcePath>of());
+        ImmutableMap.<Path, SourcePath>of(),
+        Optional.of(false));
   }
 
 }

--- a/src/com/facebook/buck/cxx/PrebuiltCxxLibrary.java
+++ b/src/com/facebook/buck/cxx/PrebuiltCxxLibrary.java
@@ -192,7 +192,8 @@ public class PrebuiltCxxLibrary extends AbstractCxxLibrary {
     return PythonPackageComponents.of(
         /* modules */ ImmutableMap.<Path, SourcePath>of(),
         /* resources */ ImmutableMap.<Path, SourcePath>of(),
-        nativeLibraries);
+        nativeLibraries,
+        /* zipSafe */ Optional.<Boolean>absent());
   }
 
   @Override

--- a/src/com/facebook/buck/python/PexStep.java
+++ b/src/com/facebook/buck/python/PexStep.java
@@ -55,6 +55,8 @@ public class PexStep extends ShellStep {
   // The map of native libraries to include in the PEX.
   private final ImmutableMap<Path, Path> nativeLibraries;
 
+  private final boolean zipSafe;
+
   public PexStep(
       Path pathToPex,
       Path pythonPath,
@@ -63,7 +65,8 @@ public class PexStep extends ShellStep {
       String entry,
       ImmutableMap<Path, Path> modules,
       ImmutableMap<Path, Path> resources,
-      ImmutableMap<Path, Path> nativeLibraries) {
+      ImmutableMap<Path, Path> nativeLibraries,
+      boolean zipSafe) {
     this.pathToPex = pathToPex;
     this.pythonPath = pythonPath;
     this.tempDir = tempDir;
@@ -72,6 +75,7 @@ public class PexStep extends ShellStep {
     this.modules = modules;
     this.resources = resources;
     this.nativeLibraries = nativeLibraries;
+    this.zipSafe = zipSafe;
   }
 
   @Override
@@ -118,12 +122,20 @@ public class PexStep extends ShellStep {
 
   @Override
   protected ImmutableList<String> getShellCommandInternal(ExecutionContext context) {
-    return ImmutableList.of(
-        pythonPath.toString(),
-        pathToPex.toString(),
-        "--python", pythonPath.toString(),
-        "--entry-point", entry,
-        destination.toString());
+    ImmutableList.Builder<String> builder = ImmutableList.builder();
+    builder.add(pythonPath.toString());
+    builder.add(pathToPex.toString());
+    builder.add("--python");
+    builder.add(pythonPath.toString());
+    builder.add("--entry-point");
+    builder.add(entry);
+
+    if (!zipSafe) {
+      builder.add("--no-zip-safe");
+    }
+
+    builder.add(destination.toString());
+    return builder.build();
   }
 
   private ImmutableMap<Path, Path> getExpandedSourcePaths(

--- a/src/com/facebook/buck/python/PythonBinary.java
+++ b/src/com/facebook/buck/python/PythonBinary.java
@@ -123,7 +123,8 @@ public class PythonBinary extends AbstractBuildRule implements BinaryBuildRule {
         mainModule,
         getResolver().getMappedPaths(components.getModules()),
         getResolver().getMappedPaths(components.getResources()),
-        getResolver().getMappedPaths(components.getNativeLibraries())));
+        getResolver().getMappedPaths(components.getNativeLibraries()),
+        components.isZipSafe().or(true)));
 
     // Record the executable package for caching.
     buildableContext.recordArtifact(getBinPath());

--- a/src/com/facebook/buck/python/PythonBinaryDescription.java
+++ b/src/com/facebook/buck/python/PythonBinaryDescription.java
@@ -118,7 +118,8 @@ public class PythonBinaryDescription implements Description<PythonBinaryDescript
     PythonPackageComponents binaryPackageComponents = PythonPackageComponents.of(
         modules.build(),
         /* resources */ ImmutableMap.<Path, SourcePath>of(),
-        /* nativeLibraries */ ImmutableMap.<Path, SourcePath>of());
+        /* nativeLibraries */ ImmutableMap.<Path, SourcePath>of(),
+        /* zipSafe */ args.zipSafe);
     PythonPackageComponents allPackageComponents = PythonUtil.getAllComponents(
         params,
         binaryPackageComponents,
@@ -145,6 +146,7 @@ public class PythonBinaryDescription implements Description<PythonBinaryDescript
     public Optional<String> mainModule;
     public Optional<ImmutableSortedSet<BuildTarget>> deps;
     public Optional<String> baseModule;
+    public Optional<Boolean> zipSafe;
   }
 
 }

--- a/src/com/facebook/buck/python/PythonLibrary.java
+++ b/src/com/facebook/buck/python/PythonLibrary.java
@@ -24,6 +24,7 @@ import com.facebook.buck.rules.BuildableProperties;
 import com.facebook.buck.rules.NoopBuildRule;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
 import java.nio.file.Path;
@@ -34,15 +35,18 @@ public class PythonLibrary extends NoopBuildRule implements PythonPackagable {
 
   private final ImmutableMap<Path, SourcePath> srcs;
   private final ImmutableMap<Path, SourcePath> resources;
+  private final Optional<Boolean> zipSafe;
 
   public PythonLibrary(
       BuildRuleParams params,
       SourcePathResolver resolver,
       ImmutableMap<Path, SourcePath> srcs,
-      ImmutableMap<Path, SourcePath> resources) {
+      ImmutableMap<Path, SourcePath> resources,
+      Optional<Boolean> zipSafe) {
     super(params, resolver);
     this.srcs = srcs;
     this.resources = resources;
+    this.zipSafe = zipSafe;
   }
 
   /**
@@ -53,7 +57,8 @@ public class PythonLibrary extends NoopBuildRule implements PythonPackagable {
     return PythonPackageComponents.of(
         srcs,
         resources,
-        ImmutableMap.<Path, SourcePath>of());
+        ImmutableMap.<Path, SourcePath>of(),
+        zipSafe);
   }
 
   @Override

--- a/src/com/facebook/buck/python/PythonLibraryDescription.java
+++ b/src/com/facebook/buck/python/PythonLibraryDescription.java
@@ -48,6 +48,7 @@ public class PythonLibraryDescription implements Description<Arg> {
             resources;
     public Optional<ImmutableSortedSet<BuildTarget>> deps;
     public Optional<String> baseModule;
+    public Optional<Boolean> zipSafe;
   }
 
   @Override
@@ -79,7 +80,8 @@ public class PythonLibraryDescription implements Description<Arg> {
             params.getBuildTarget(),
             pathResolver,
             "resources",
-            baseModule, args.resources));
+            baseModule, args.resources),
+        args.zipSafe);
   }
 
 }

--- a/src/com/facebook/buck/python/PythonTestDescription.java
+++ b/src/com/facebook/buck/python/PythonTestDescription.java
@@ -217,7 +217,8 @@ public class PythonTestDescription implements Description<PythonTestDescription.
             .putAll(srcs)
             .build(),
         resources,
-        ImmutableMap.<Path, SourcePath>of());
+        ImmutableMap.<Path, SourcePath>of(),
+        args.zipSafe);
     PythonPackageComponents allComponents =
         PythonUtil.getAllComponents(params, testComponents, cxxPlatform);
 

--- a/src/com/facebook/buck/python/pex.py
+++ b/src/com/facebook/buck/python/pex.py
@@ -56,6 +56,7 @@ def dereference_symlinks(src):
 def main():
     parser = optparse.OptionParser(usage="usage: %prog [options] output")
     parser.add_option('--entry-point', default='__main__')
+    parser.add_option('--no-zip-safe', action='store_false', dest='zip_safe', default=True)
     parser.add_option('--python', default=sys.executable)
     options, args = parser.parse_args()
     if len(args) == 1:
@@ -86,12 +87,11 @@ def main():
             interpreter=interpreter,
         )
 
-        # Mark this PEX as zip-safe, meaning everything will stayed zipped up
+        # Set whether this PEX as zip-safe, meaning everything will stayed zipped up
         # and we'll rely on python's zip-import mechanism to load modules from
         # the PEX.  This may not work in some situations (e.g. native
-        # libraries, libraries that want to find resources via the FS), so
-        # we'll want to revisit this.
-        pex_builder.info.zip_safe = True
+        # libraries, libraries that want to find resources via the FS).
+        pex_builder.info.zip_safe = options.zip_safe
 
         # Set the starting point for this PEX.
         pex_builder.info.entry_point = options.entry_point

--- a/src/com/facebook/buck/thrift/ThriftPythonEnhancer.java
+++ b/src/com/facebook/buck/thrift/ThriftPythonEnhancer.java
@@ -139,7 +139,8 @@ public class ThriftPythonEnhancer implements ThriftLanguageSpecificEnhancer {
         langParams,
         new SourcePathResolver(resolver),
         modules,
-        ImmutableMap.<Path, SourcePath>of());
+        ImmutableMap.<Path, SourcePath>of(),
+        Optional.of(true));
   }
 
   private ImmutableSet<BuildTarget> getImplicitDeps() {

--- a/test/com/facebook/buck/cxx/CxxBinaryDescriptionTest.java
+++ b/test/com/facebook/buck/cxx/CxxBinaryDescriptionTest.java
@@ -132,7 +132,8 @@ public class CxxBinaryDescriptionTest {
         return PythonPackageComponents.of(
             ImmutableMap.<Path, SourcePath>of(),
             ImmutableMap.<Path, SourcePath>of(),
-            ImmutableMap.<Path, SourcePath>of());
+            ImmutableMap.<Path, SourcePath>of(),
+            Optional.<Boolean>absent());
       }
 
       @Override

--- a/test/com/facebook/buck/cxx/CxxLibraryDescriptionTest.java
+++ b/test/com/facebook/buck/cxx/CxxLibraryDescriptionTest.java
@@ -157,7 +157,8 @@ public class CxxLibraryDescriptionTest {
         return PythonPackageComponents.of(
             ImmutableMap.<Path, SourcePath>of(),
             ImmutableMap.<Path, SourcePath>of(),
-            ImmutableMap.<Path, SourcePath>of());
+            ImmutableMap.<Path, SourcePath>of(),
+            Optional.<Boolean>absent());
       }
 
       @Override
@@ -551,7 +552,8 @@ public class CxxLibraryDescriptionTest {
             ImmutableMap.<Path, SourcePath>of(),
             ImmutableMap.<Path, SourcePath>of(
                 Paths.get(sharedLibrarySoname),
-                new PathSourcePath(getProjectFilesystem(), sharedLibraryOutput)));
+                new PathSourcePath(getProjectFilesystem(), sharedLibraryOutput)),
+            Optional.<Boolean>absent());
       }
 
       @Override
@@ -837,7 +839,8 @@ public class CxxLibraryDescriptionTest {
         ImmutableMap.<Path, SourcePath>of(),
         ImmutableMap.<Path, SourcePath>of(
             Paths.get(CxxDescriptionEnhancer.getSharedLibrarySoname(target, cxxPlatform)),
-            new BuildTargetSourcePath(projectFilesystem, sharedRule.getBuildTarget())));
+            new BuildTargetSourcePath(projectFilesystem, sharedRule.getBuildTarget())),
+        Optional.<Boolean>absent());
     assertEquals(
         expectedPythonPackageComponents,
         rule.getPythonPackageComponents(cxxPlatform));

--- a/test/com/facebook/buck/cxx/CxxLibraryTest.java
+++ b/test/com/facebook/buck/cxx/CxxLibraryTest.java
@@ -35,9 +35,9 @@ import com.facebook.buck.rules.PathSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.step.Step;
+import com.google.common.base.Optional;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
 import com.google.common.base.Functions;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
@@ -146,7 +146,8 @@ public class CxxLibraryTest {
         ImmutableMap.<Path, SourcePath>of(),
         ImmutableMap.<Path, SourcePath>of(
             Paths.get(sharedLibrarySoname),
-            new PathSourcePath(projectFilesystem, sharedLibraryOutput)));
+            new PathSourcePath(projectFilesystem, sharedLibraryOutput)),
+        Optional.<Boolean>absent());
     assertEquals(
         expectedPythonPackageComponents,
         cxxLibrary.getPythonPackageComponents(cxxPlatform));

--- a/test/com/facebook/buck/cxx/CxxPythonExtensionDescriptionTest.java
+++ b/test/com/facebook/buck/cxx/CxxPythonExtensionDescriptionTest.java
@@ -170,7 +170,8 @@ public class CxxPythonExtensionDescriptionTest {
             ImmutableMap.<Path, SourcePath>of(),
             ImmutableMap.<Path, SourcePath>of(
                 Paths.get(sharedLibrarySoname),
-                new PathSourcePath(getProjectFilesystem(), sharedLibraryOutput)));
+                new PathSourcePath(getProjectFilesystem(), sharedLibraryOutput)),
+            Optional.<Boolean>absent());
       }
 
       @Override
@@ -234,7 +235,8 @@ public class CxxPythonExtensionDescriptionTest {
             target.getBasePath().resolve(desc.getExtensionName(target)),
             new BuildTargetSourcePath(projectFilesystem, rule.getBuildTarget())),
         ImmutableMap.<Path, SourcePath>of(),
-        ImmutableMap.<Path, SourcePath>of());
+        ImmutableMap.<Path, SourcePath>of(),
+        Optional.of(false));
     assertEquals(
         expectedComponents,
         actualComponent);

--- a/test/com/facebook/buck/cxx/FakeCxxLibrary.java
+++ b/test/com/facebook/buck/cxx/FakeCxxLibrary.java
@@ -129,7 +129,8 @@ public final class FakeCxxLibrary extends AbstractCxxLibrary {
         ImmutableMap.<Path, SourcePath>of(),
         ImmutableMap.<Path, SourcePath>of(
             Paths.get(sharedLibrarySoname),
-            new PathSourcePath(getProjectFilesystem(), sharedLibraryOutput)));
+            new PathSourcePath(getProjectFilesystem(), sharedLibraryOutput)),
+        Optional.<Boolean>absent());
   }
 
   @Override

--- a/test/com/facebook/buck/cxx/PrebuiltCxxLibraryDescriptionTest.java
+++ b/test/com/facebook/buck/cxx/PrebuiltCxxLibraryDescriptionTest.java
@@ -121,7 +121,8 @@ public class PrebuiltCxxLibraryDescriptionTest {
         ImmutableMap.<Path, SourcePath>of(),
         ImmutableMap.<Path, SourcePath>of(
             Paths.get(getSharedLibrarySoname(arg)),
-            new PathSourcePath(filesystem, getSharedLibraryPath(arg))));
+            new PathSourcePath(filesystem, getSharedLibraryPath(arg))),
+        Optional.<Boolean>absent());
     assertEquals(
         expectedComponents,
         lib.getPythonPackageComponents(CXX_PLATFORM));
@@ -166,7 +167,8 @@ public class PrebuiltCxxLibraryDescriptionTest {
     PythonPackageComponents expectedComponents = PythonPackageComponents.of(
         ImmutableMap.<Path, SourcePath>of(),
         ImmutableMap.<Path, SourcePath>of(),
-        ImmutableMap.<Path, SourcePath>of());
+        ImmutableMap.<Path, SourcePath>of(),
+        Optional.<Boolean>absent());
     assertEquals(
         expectedComponents,
         lib.getPythonPackageComponents(CXX_PLATFORM));
@@ -211,7 +213,8 @@ public class PrebuiltCxxLibraryDescriptionTest {
     PythonPackageComponents expectedComponents = PythonPackageComponents.of(
         ImmutableMap.<Path, SourcePath>of(),
         ImmutableMap.<Path, SourcePath>of(),
-        ImmutableMap.<Path, SourcePath>of());
+        ImmutableMap.<Path, SourcePath>of(),
+        Optional.<Boolean>absent());
     assertEquals(
         expectedComponents,
         lib.getPythonPackageComponents(CXX_PLATFORM));
@@ -258,7 +261,8 @@ public class PrebuiltCxxLibraryDescriptionTest {
         ImmutableMap.<Path, SourcePath>of(),
         ImmutableMap.<Path, SourcePath>of(
             Paths.get(getSharedLibrarySoname(arg)),
-            new PathSourcePath(filesystem, getSharedLibraryPath(arg))));
+            new PathSourcePath(filesystem, getSharedLibraryPath(arg))),
+        Optional.<Boolean>absent());
     assertEquals(
         expectedComponents,
         lib.getPythonPackageComponents(CXX_PLATFORM));

--- a/test/com/facebook/buck/python/BUCK
+++ b/test/com/facebook/buck/python/BUCK
@@ -25,6 +25,7 @@ java_test(
     '//src/com/facebook/buck/util:exceptions',
     '//src/com/facebook/buck/util:util',
     '//src/com/facebook/buck/shell:rules',
+    '//src/com/facebook/buck/shell:steps',
     '//test/com/facebook/buck/cli:FakeBuckConfig',
     '//test/com/facebook/buck/io:testutil',
     '//test/com/facebook/buck/java:testutil',

--- a/test/com/facebook/buck/python/PexStepTest.java
+++ b/test/com/facebook/buck/python/PexStepTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.python;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.endsWith;
+
+import com.facebook.buck.step.TestExecutionContext;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class PexStepTest {
+  private static final Path PYTHON_PATH = Paths.get("/usr/local/bin/python");
+  private static final Path PEXPY_PATH = Paths.get("pex.py");
+  private static final Path TEMP_PATH = Paths.get("/tmp/");
+  private static final Path DEST_PATH = Paths.get("/dest");
+  private static final String ENTRY_POINT = "entry_point.main";
+
+  @Test
+  public void testCommandLine() {
+    PexStep step = new PexStep(
+        PEXPY_PATH, PYTHON_PATH, TEMP_PATH, DEST_PATH, ENTRY_POINT,
+        /* modules */ ImmutableMap.<Path, Path>of(),
+        /* resources */ ImmutableMap.<Path, Path>of(),
+        /* nativeLibraries */ ImmutableMap.<Path, Path>of(),
+        /* zipSafe */ true);
+    String command = Joiner.on(" ").join(
+        step.getShellCommandInternal(TestExecutionContext.newInstance()));
+
+    assertThat(command, startsWith(PYTHON_PATH + " " + PEXPY_PATH));
+    assertThat(command, containsString("--python " + PYTHON_PATH));
+    assertThat(command, containsString("--entry-point " + ENTRY_POINT));
+    assertThat(command, endsWith(" " + DEST_PATH));
+  }
+
+  @Test
+  public void testCommandLineNoZipSafe() {
+    PexStep step = new PexStep(
+        PEXPY_PATH, PYTHON_PATH, TEMP_PATH, DEST_PATH, ENTRY_POINT,
+        /* modules */ ImmutableMap.<Path, Path>of(),
+        /* resources */ ImmutableMap.<Path, Path>of(),
+        /* nativeLibraries */ ImmutableMap.<Path, Path>of(),
+        /* zipSafe */ false);
+    String command = Joiner.on(" ").join(
+        step.getShellCommandInternal(TestExecutionContext.newInstance()));
+
+    assertThat(command, containsString("--no-zip-safe"));
+  }
+
+}

--- a/test/com/facebook/buck/python/PythonBinaryDescriptionTest.java
+++ b/test/com/facebook/buck/python/PythonBinaryDescriptionTest.java
@@ -75,7 +75,8 @@ public class PythonBinaryDescriptionTest {
         ImmutableMap.<Path, SourcePath>of(
             Paths.get("hello"),
             new BuildTargetSourcePath(PROJECT_FILESYSTEM, genrule.getBuildTarget())),
-        ImmutableMap.<Path, SourcePath>of());
+        ImmutableMap.<Path, SourcePath>of(),
+        Optional.<Boolean>absent());
 
     BuildRuleParams params =
         new FakeBuildRuleParamsBuilder(BuildTargetFactory.newInstance("//:bin"))
@@ -92,6 +93,7 @@ public class PythonBinaryDescriptionTest {
     arg.mainModule = Optional.absent();
     arg.main = Optional.<SourcePath>of(new TestSourcePath("blah.py"));
     arg.baseModule = Optional.absent();
+    arg.zipSafe = Optional.absent();
     BuildRule rule = desc.createBuildRule(params, resolver, arg);
 
     assertEquals(
@@ -122,6 +124,7 @@ public class PythonBinaryDescriptionTest {
         Optional.<SourcePath>of(
             new BuildTargetSourcePath(PROJECT_FILESYSTEM, genrule.getBuildTarget()));
     arg.baseModule = Optional.absent();
+    arg.zipSafe = Optional.absent();
     BuildRule rule = desc.createBuildRule(params, resolver, arg);
     assertEquals(
         ImmutableSortedSet.<BuildRule>of(genrule),
@@ -145,6 +148,7 @@ public class PythonBinaryDescriptionTest {
     arg.deps = Optional.of(ImmutableSortedSet.<BuildTarget>of());
     arg.mainModule = Optional.absent();
     arg.main = Optional.<SourcePath>of(new TestSourcePath("foo/" + mainName));
+    arg.zipSafe = Optional.absent();
 
     // Run without a base module set and verify it defaults to using the build target
     // base name.
@@ -181,6 +185,7 @@ public class PythonBinaryDescriptionTest {
     arg.mainModule = Optional.of(mainModule);
     arg.main = Optional.absent();
     arg.baseModule = Optional.absent();
+    arg.zipSafe = Optional.absent();
     PythonBinary rule = desc.createBuildRule(params, resolver, arg);
     assertEquals(mainModule, rule.getMainModule());
   }

--- a/test/com/facebook/buck/python/PythonBinaryTest.java
+++ b/test/com/facebook/buck/python/PythonBinaryTest.java
@@ -33,6 +33,7 @@ import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.keys.DefaultRuleKeyBuilderFactory;
 import com.facebook.buck.testutil.FakeFileHashCache;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
+import com.google.common.base.Optional;
 import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
@@ -74,7 +75,8 @@ public class PythonBinaryTest {
                 Paths.get(mod1), new PathSourcePath(projectFilesystem, src1),
                 Paths.get(mod2), new PathSourcePath(projectFilesystem, src2)),
             ImmutableMap.<Path, SourcePath>of(),
-            ImmutableMap.<Path, SourcePath>of()));
+            ImmutableMap.<Path, SourcePath>of(),
+            Optional.<Boolean>absent()));
 
     // Calculate and return the rule key.
     RuleKey.Builder builder = ruleKeyBuilderFactory.newInstance(binary, resolver);

--- a/test/com/facebook/buck/python/PythonLibraryTest.java
+++ b/test/com/facebook/buck/python/PythonLibraryTest.java
@@ -25,6 +25,7 @@ import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.TestSourcePath;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
 import org.junit.Rule;
@@ -51,7 +52,8 @@ public class PythonLibraryTest {
             .build(),
         new SourcePathResolver(new BuildRuleResolver()),
         srcs,
-        ImmutableMap.<Path, SourcePath>of());
+        ImmutableMap.<Path, SourcePath>of(),
+        Optional.<Boolean>absent());
 
     assertTrue(pythonLibrary.getProperties().is(LIBRARY));
   }

--- a/test/com/facebook/buck/python/PythonPackageableComponentsTest.java
+++ b/test/com/facebook/buck/python/PythonPackageableComponentsTest.java
@@ -24,6 +24,7 @@ import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.util.HumanReadableException;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
 import org.junit.Test;
@@ -32,6 +33,27 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class PythonPackageableComponentsTest {
+
+  @Test
+  public void testMergeZipSafe() {
+    PythonPackageComponents compA = PythonPackageComponents.of(
+        ImmutableMap.<Path, SourcePath>of(Paths.get("test"), new TestSourcePath("sourceA")),
+        ImmutableMap.<Path, SourcePath>of(),
+        ImmutableMap.<Path, SourcePath>of(),
+        Optional.of(true));
+    PythonPackageComponents compB = PythonPackageComponents.of(
+        ImmutableMap.<Path, SourcePath>of(Paths.get("test2"), new TestSourcePath("sourceB")),
+        ImmutableMap.<Path, SourcePath>of(),
+        ImmutableMap.<Path, SourcePath>of(),
+        Optional.of(false));
+
+    BuildTarget me = BuildTargetFactory.newInstance("//:me");
+    BuildTarget them = BuildTargetFactory.newInstance("//:them");
+    PythonPackageComponents.Builder builder = new PythonPackageComponents.Builder(me);
+    builder.addComponent(compB, them);
+    builder.addComponent(compA, them);
+    assertTrue(!builder.build().isZipSafe().get());
+  }
 
   @Test
   public void testDuplicateSourcesThrowsException() {
@@ -56,11 +78,13 @@ public class PythonPackageableComponentsTest {
     PythonPackageComponents compA = PythonPackageComponents.of(
         ImmutableMap.<Path, SourcePath>of(dest, new TestSourcePath("sourceA")),
         ImmutableMap.<Path, SourcePath>of(),
-        ImmutableMap.<Path, SourcePath>of());
+        ImmutableMap.<Path, SourcePath>of(),
+        Optional.<Boolean>absent());
     PythonPackageComponents compB = PythonPackageComponents.of(
         ImmutableMap.<Path, SourcePath>of(dest, new TestSourcePath("sourceB")),
         ImmutableMap.<Path, SourcePath>of(),
-        ImmutableMap.<Path, SourcePath>of());
+        ImmutableMap.<Path, SourcePath>of(),
+        Optional.<Boolean>absent());
     PythonPackageComponents.Builder builder = new PythonPackageComponents.Builder(me);
     builder.addComponent(compA, them);
     try {

--- a/test/com/facebook/buck/python/PythonTestDescriptionTest.java
+++ b/test/com/facebook/buck/python/PythonTestDescriptionTest.java
@@ -82,6 +82,7 @@ public class PythonTestDescriptionTest {
     arg.contacts = Optional.absent();
     arg.labels = Optional.absent();
     arg.sourceUnderTest = Optional.absent();
+    arg.zipSafe = Optional.absent();
     PythonTest testRule = desc.createBuildRule(params, resolver, arg);
 
     PythonBinary binRule = (PythonBinary) resolver.getRule(
@@ -122,6 +123,7 @@ public class PythonTestDescriptionTest {
     arg.srcs = Optional.of(
         Either.<ImmutableSortedSet<SourcePath>, ImmutableMap<String, SourcePath>>ofLeft(
             ImmutableSortedSet.of(source)));
+    arg.zipSafe = Optional.absent();
 
     // Run without a base module set and verify it defaults to using the build target
     // base name.


### PR DESCRIPTION
Native libraries are not zipsafe (see https://docs.python.org/2/library/zipimport.html "only files .py and .py[co] are available for import. ZIP import of dynamic modules (.pyd, .so) is disallowed"). This change introduces the zip_safe flag on all python targets that can potentially be not-zip-safe, and marks cxx_python_extension as definitely-not zip safe.

I made it a tristate in PythonPackageComponents mostly to keep the default from being hardcoded in every python rule.