### PR TITLE
Pass system property to test runner containing the base dir of the test module

### DIFF
--- a/src/com/facebook/buck/java/JUnitStep.java
+++ b/src/com/facebook/buck/java/JUnitStep.java
@@ -59,10 +59,14 @@ public class JUnitStep extends ShellStep {
   @VisibleForTesting
   public static final String BUILD_ID_PROPERTY = "com.facebook.buck.buildId";
 
+  @VisibleForTesting
+  public static final String MODULE_PATH_PROPERTY = "com.facebook.buck.modulePath";
+
   private final ImmutableSet<Path> classpathEntries;
   private final Iterable<String> testClassNames;
   private final List<String> vmArgs;
   private final Path directoryForTestResults;
+  private final Path modulePath;
   private final Path tmpDirectory;
   private final Path testRunnerClasspath;
   private final boolean isCodeCoverageEnabled;
@@ -102,6 +106,7 @@ public class JUnitStep extends ShellStep {
       Iterable<String> testClassNames,
       List<String> vmArgs,
       Path directoryForTestResults,
+      Path modulePath,
       Path tmpDirectory,
       boolean isCodeCoverageEnabled,
       boolean isDebugEnabled,
@@ -114,6 +119,7 @@ public class JUnitStep extends ShellStep {
         testClassNames,
         vmArgs,
         directoryForTestResults,
+        modulePath,
         tmpDirectory,
         isCodeCoverageEnabled,
         isDebugEnabled,
@@ -131,6 +137,7 @@ public class JUnitStep extends ShellStep {
       Iterable<String> testClassNames,
       List<String> vmArgs,
       Path directoryForTestResults,
+      Path modulePath,
       Path tmpDirectory,
       boolean isCodeCoverageEnabled,
       boolean isDebugEnabled,
@@ -145,6 +152,7 @@ public class JUnitStep extends ShellStep {
     this.vmArgs = ImmutableList.copyOf(vmArgs);
     this.directoryForTestResults = directoryForTestResults;
     this.tmpDirectory = tmpDirectory;
+    this.modulePath = modulePath;
     this.isCodeCoverageEnabled = isCodeCoverageEnabled;
     this.isDebugEnabled = isDebugEnabled;
     this.buildId = buildId;
@@ -185,6 +193,9 @@ public class JUnitStep extends ShellStep {
 
     // Include the buildId
     args.add(String.format("-D%s=%s", BUILD_ID_PROPERTY, buildId));
+
+    // Include the baseDir
+    args.add(String.format("-D%s=%s", MODULE_PATH_PROPERTY, modulePath));
 
     if (isDebugEnabled) {
       // This is the default config used by IntelliJ. By doing this, all a user

--- a/src/com/facebook/buck/java/JavaTest.java
+++ b/src/com/facebook/buck/java/JavaTest.java
@@ -196,6 +196,7 @@ public class JavaTest extends DefaultJavaLibrary implements TestRule {
         reorderedTestClasses,
         amendVmArgs(vmArgs, executionContext.getTargetDeviceOptional()),
         pathToTestOutput,
+        getBuildTarget().getBasePath(),
         tmpDirectory,
         executionContext.isCodeCoverageEnabled(),
         executionContext.isDebugEnabled(),

--- a/test/com/facebook/buck/java/JUnitStepTest.java
+++ b/test/com/facebook/buck/java/JUnitStepTest.java
@@ -61,6 +61,9 @@ public class JUnitStepTest {
     BuildId pretendBuildId = new BuildId("pretend-build-id");
     String buildIdArg = String.format("-D%s=%s", JUnitStep.BUILD_ID_PROPERTY, pretendBuildId);
 
+    Path modulePath = Paths.get("module/submodule");
+    String modulePathArg = String.format("-D%s=%s", JUnitStep.MODULE_PATH_PROPERTY, modulePath);
+
     Path directoryForTestResults = Paths.get("buck-out/gen/theresults/");
     Path directoryForTemp = Paths.get("buck-out/gen/thetmp/");
     boolean isCodeCoverageEnabled = false;
@@ -73,6 +76,7 @@ public class JUnitStepTest {
         testClassNames,
         vmArgs,
         directoryForTestResults,
+        modulePath,
         directoryForTemp,
         isCodeCoverageEnabled,
         isDebugEnabled,
@@ -96,6 +100,7 @@ public class JUnitStepTest {
             "-Djava.io.tmpdir=" + filesystem.resolve(directoryForTemp),
             "-Dbuck.testrunner_classes=" + testRunnerClasspath,
             buildIdArg,
+            modulePathArg,
             vmArg1,
             vmArg2,
             "-verbose",
@@ -133,6 +138,9 @@ public class JUnitStepTest {
     BuildId pretendBuildId = new BuildId("pretend-build-id");
     String buildIdArg = String.format("-D%s=%s", JUnitStep.BUILD_ID_PROPERTY, pretendBuildId);
 
+    Path modulePath = Paths.get("module/submodule");
+    String modulePathArg = String.format("-D%s=%s", JUnitStep.MODULE_PATH_PROPERTY, modulePath);
+
     Path directoryForTestResults = Paths.get("buck-out/gen/theresults/");
     Path directoryForTemp = Paths.get("buck-out/gen/thetmp/");
     boolean isCodeCoverageEnabled = false;
@@ -144,6 +152,7 @@ public class JUnitStepTest {
         testClassNames,
         vmArgs,
         directoryForTestResults,
+        modulePath,
         directoryForTemp,
         isCodeCoverageEnabled,
         isDebugEnabled,
@@ -167,6 +176,7 @@ public class JUnitStepTest {
             "-Djava.io.tmpdir=" + directoryForTemp,
             "-Dbuck.testrunner_classes=" + testRunnerClasspath,
             buildIdArg,
+            modulePathArg,
             "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005",
             vmArg1,
             vmArg2,


### PR DESCRIPTION
This helps with legacy code migrations that open files in locations relative to the root of the test module.