### PR TITLE
Remove second definition of buf

### DIFF
--- a/third-party/nailgun/nailgun-client/ng.c
+++ b/third-party/nailgun/nailgun-client/ng.c
@@ -54,8 +54,6 @@
 	#define FILE_SEPARATOR '/'
 	typedef int HANDLE;
 	typedef unsigned int SOCKET;
-	/* buffer used for reading an writing chunk data */
-	char buf[BUFSIZE];
 #endif
 
 #ifndef MIN


### PR DESCRIPTION
     [exec] third-party/nailgun/nailgun-client/ng.c:115:17: error: redefinition of 'char buf [2048]'
     [exec]  char buf[BUFSIZE];
     [exec]                  ^
     [exec] third-party/nailgun/nailgun-client/ng.c:58:7: note: 'char buf [2048]' previously declared here
     [exec]   char buf[BUFSIZE];
     [exec]        ^