### PR TITLE
force usage of python2

### DIFF
--- a/bin/buck
+++ b/bin/buck
@@ -9,4 +9,9 @@ while [ -h "$BUCK_PATH" ]; do
 done
 BUCK_DIR=$(dirname "$BUCK_PATH")
 
-exec python "$BUCK_DIR"/../programs/buck.py "$@"
+PYTHON=python
+ret=`python -c 'import sys; print("%i" % (sys.hexversion<0x03000000))'`
+if [ $ret -eq 0 ]; then
+  PYTHON=python2
+fi
+exec $PYTHON "$BUCK_DIR"/../programs/buck.py "$@"


### PR DESCRIPTION
Summary:
Buck fails to run under python3.  Test the version of the default python
interpreter before launching it, and use the python2 binary if the
default version on the system is python3.

Test plan: buck test, run buck on system with python3 as default