### PR TITLE
Prevent passing of MaxPermSize on OpenJDK 1.8

### DIFF
--- a/programs/buck_tool.py
+++ b/programs/buck_tool.py
@@ -457,4 +457,4 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None):
 def is_java8():
     output = check_output(['java', '-version'], stderr=subprocess.STDOUT)
     version_line = output.strip().splitlines()[0]
-    return re.compile('java version "1\.8\..*').match(version_line)
+    return re.compile('(openjdk|java) version "1\.8\..*').match(version_line)


### PR DESCRIPTION
This addresses an issue raised in #313.

TEST PLAN:

Set up OpenJDK 1.8 and run:

  $ buck build buck

and confirm that "MaxPermSize=256m" is not passed to Java process.