### PR TITLE
Fix buck build on Java 8

### DIFF
--- a/src/com/facebook/buck/rules/BUCK
+++ b/src/com/facebook/buck/rules/BUCK
@@ -34,6 +34,7 @@ java_immutables_library(
     '//src/com/facebook/buck/cxx:rules',
     '//src/com/facebook/buck/rules/macros:macros',
     '//src/com/facebook/buck/shell:rules',
+    '//src/com/facebook/buck/step:step',
     '//src/com/facebook/buck/thrift:rules',
     '//src/com/facebook/buck/util:constants',
     '//src/com/facebook/buck/util:exceptions',


### PR DESCRIPTION
Buck, by default, builds java_library targets with first order deps
only, so that transitive dependencies don't considered.

So the target '//src/com/facebook/buck/rules:types' is using
SmartDexingStep class that implements Step class. Step class is not
used directly by this target and Java 7 compiler is happy about it.
However Java8 compiler needs to touch Step class because of default
methods and cannot reach it, even though it's contained in the
transitive dependency chain:

  rules:types => rules:build_rule => step:step

To verify this, the following command can be used

  $ buck build  --build-dependencies=TRANSITIVE \
//src/com/facebook/buck/rules:types

To fix the problem for both compilers, add step:step as direct
dependency to the rules:types target.

TEST PLAN:

  $ buck build //src/com/facebook/buck/rules:types

on both Java 7 and java 8 should succeed.

This addresses an issue raised in #312.