### PR TITLE
Allow to specify the title of the code coverage report

### DIFF
--- a/src/com/facebook/buck/cli/AbstractTestRunningOptions.java
+++ b/src/com/facebook/buck/cli/AbstractTestRunningOptions.java
@@ -78,4 +78,9 @@ abstract class AbstractTestRunningOptions {
   public CoverageReportFormat getCoverageReportFormat() {
     return CoverageReportFormat.HTML;
   }
+
+  @Value.Default
+  public String getCoverageReportTitle() {
+    return "Code-Coverage Analysis";
+  }
 }

--- a/src/com/facebook/buck/cli/TestCommand.java
+++ b/src/com/facebook/buck/cli/TestCommand.java
@@ -80,6 +80,9 @@ public class TestCommand extends BuildCommand {
   @Option(name = "--code-coverage-format", usage = "Format to be used for coverage")
   private CoverageReportFormat coverageReportFormat = CoverageReportFormat.HTML;
 
+  @Option(name = "--code-coverage-title", usage = "Title used for coverage")
+  private String coverageReportTitle = "Code-Coverage Analysis";
+
   @Option(name = "--debug",
           usage = "Whether the test will start suspended with a JDWP debug port of 5005")
   private boolean isDebugEnabled = false;
@@ -374,6 +377,7 @@ public class TestCommand extends BuildCommand {
               .setShufflingTests(isShufflingTests)
               .setPathToXmlTestOutput(Optional.fromNullable(pathToXmlTestOutput))
               .setCoverageReportFormat(coverageReportFormat)
+              .setCoverageReportTitle(coverageReportTitle)
               .build();
           return TestRunning.runTests(
               params,

--- a/src/com/facebook/buck/cli/TestRunning.java
+++ b/src/com/facebook/buck/cli/TestRunning.java
@@ -426,7 +426,8 @@ public class TestRunning {
                 defaultJavaPackageFinderOptional,
                 params.getRepository().getFilesystem(),
                 JUnitStep.JACOCO_OUTPUT_DIR,
-                options.getCoverageReportFormat()),
+                options.getCoverageReportFormat(),
+                options.getCoverageReportTitle()),
             Optional.<BuildTarget>absent());
       } catch (StepFailedException e) {
         params.getConsole().printBuildFailureWithoutStacktrace(e);
@@ -712,7 +713,8 @@ public class TestRunning {
       Optional<DefaultJavaPackageFinder> defaultJavaPackageFinderOptional,
       ProjectFilesystem filesystem,
       Path outputDirectory,
-      CoverageReportFormat format) {
+      CoverageReportFormat format,
+      String title) {
     ImmutableSet.Builder<String> srcDirectories = ImmutableSet.builder();
     ImmutableSet.Builder<Path> pathsToClasses = ImmutableSet.builder();
 
@@ -734,7 +736,8 @@ public class TestRunning {
         srcDirectories.build(),
         pathsToClasses.build(),
         outputDirectory,
-        format);
+        format,
+        title);
   }
 
   /**

--- a/src/com/facebook/buck/java/GenerateCodeCoverageReportStep.java
+++ b/src/com/facebook/buck/java/GenerateCodeCoverageReportStep.java
@@ -33,16 +33,19 @@ public class GenerateCodeCoverageReportStep extends ShellStep {
   private final Set<Path> classesDirectories;
   private final Path outputDirectory;
   private CoverageReportFormat format;
+  private final String title;
 
   public GenerateCodeCoverageReportStep(
       Set<String> sourceDirectories,
       Set<Path> classesDirectories,
       Path outputDirectory,
-      CoverageReportFormat format) {
+      CoverageReportFormat format,
+      String title) {
     this.sourceDirectories = ImmutableSet.copyOf(sourceDirectories);
     this.classesDirectories = ImmutableSet.copyOf(classesDirectories);
     this.outputDirectory = outputDirectory;
     this.format = format;
+    this.title = title;
   }
 
   @Override
@@ -60,6 +63,8 @@ public class GenerateCodeCoverageReportStep extends ShellStep {
     args.add(String.format("-Djacoco.exec.data.file=%s", JUnitStep.JACOCO_EXEC_COVERAGE_FILE));
 
     args.add(String.format("-Djacoco.format=%s", format.toString().toLowerCase()));
+
+    args.add(String.format("-Djacoco.title=%s", title));
 
     args.add(String.format("-Dclasses.dir=%s",
         Joiner.on(":").join(Iterables.transform(classesDirectories,

--- a/src/com/facebook/buck/java/ReportGenerator.java
+++ b/src/com/facebook/buck/java/ReportGenerator.java
@@ -56,7 +56,7 @@ public class ReportGenerator {
          */
         public ReportGenerator() {
                 String jacocoOutputDir = System.getProperty("jacoco.output.dir");
-                this.title = "Code-Coverage Analysis";
+                this.title = System.getProperty("jacoco.title");
                 this.executionDataFile = new File(
                     jacocoOutputDir, System.getProperty("jacoco.exec.data.file"));
                 this.execFileLoader = new ExecFileLoader();

--- a/test/com/facebook/buck/java/GenerateCodeCoverageReportStepTest.java
+++ b/test/com/facebook/buck/java/GenerateCodeCoverageReportStepTest.java
@@ -57,7 +57,7 @@ public class GenerateCodeCoverageReportStepTest {
       String outputDirectory) {
     GenerateCodeCoverageReportStep step = new GenerateCodeCoverageReportStep(
         sourceDirectories, classesDirectories,
-        Paths.get(outputDirectory), CoverageReportFormat.HTML);
+        Paths.get(outputDirectory), CoverageReportFormat.HTML, "TitleFoo");
 
     ExecutionContext context = createMock(ExecutionContext.class);
     expect(
@@ -77,6 +77,7 @@ public class GenerateCodeCoverageReportStepTest {
         String.format("-Djacoco.output.dir=%s", outputDirectory),
         String.format("-Djacoco.exec.data.file=%s", JUnitStep.JACOCO_EXEC_COVERAGE_FILE),
         "-Djacoco.format=html",
+        "-Djacoco.title=TitleFoo",
         String.format("-Dclasses.dir=%s",
             String.format("%s%c%s:%s%c%s",
                 new File(".").getAbsoluteFile().toPath().normalize(),


### PR DESCRIPTION
When generating code coverage reports for different targets, it was
hard to see which report belonged to what target. Hence, we allow the
caller to specify a title for the report.