### PR TITLE
skip parsing android 'tools' attributes in layout

### DIFF
--- a/src/com/facebook/buck/android/aapt/MiniAapt.java
+++ b/src/com/facebook/buck/android/aapt/MiniAapt.java
@@ -411,7 +411,8 @@ public class MiniAapt implements Step {
         String rawRType = resourceName.substring(1, slashPosition);
         String name = resourceName.substring(slashPosition + 1);
 
-        if (name.startsWith("android:")) {
+        String nodeName = nodesUsingIds.item(i).getNodeName();
+        if (name.startsWith("android:") || nodeName.startsWith("tools:")) {
           continue;
         }
         if (!RESOURCE_TYPES.containsKey(rawRType)) {

--- a/test/com/facebook/buck/android/aapt/MiniAaptTest.java
+++ b/test/com/facebook/buck/android/aapt/MiniAaptTest.java
@@ -52,7 +52,7 @@ public class MiniAaptTest {
         "<Button android:id=\"@+id/button3\" ",
         "style:attribute=\"@style/Buck.Theme\" ",
         "android:background=\"@drawable/some_image\" />",
-        "<TextView android:id=\"@id/android:empty\" />",
+        "<TextView tools:showIn=\"@layout/some_layout\" android:id=\"@id/android:empty\" />",
         "</LinearLayout>")
         .build();
 


### PR DESCRIPTION
The 'tools' is a special attribute handled by android build tool. It aims to give designer a chance to see the display with specific resources but they don't need to be packaged with application.