### PR TITLE
Resolve the source jar path before converting it to a string.

### DIFF
--- a/src/com/facebook/buck/java/intellij/Project.java
+++ b/src/com/facebook/buck/java/intellij/Project.java
@@ -972,10 +972,9 @@ public class Project {
       PrebuiltJar prebuiltJar = (PrebuiltJar) libraryJar;
 
       String binaryJar = resolver.getPath(prebuiltJar.getBinaryJar()).toString();
-      String sourceJar = null;
-      if (prebuiltJar.getSourceJar().isPresent()) {
-        sourceJar = prebuiltJar.getSourceJar().get().toString();
-      }
+      String sourceJar = prebuiltJar.getSourceJar().isPresent()
+          ? resolver.getPath(prebuiltJar.getSourceJar().get()).toString()
+          : null;
       String javadocUrl = prebuiltJar.getJavadocUrl().orNull();
       libraries.add(new SerializablePrebuiltJarRule(name, binaryJar, sourceJar, javadocUrl));
     }

--- a/test/com/facebook/buck/java/intellij/ProjectIntegrationTest.java
+++ b/test/com/facebook/buck/java/intellij/ProjectIntegrationTest.java
@@ -104,7 +104,6 @@ public class ProjectIntegrationTest {
     workspace.verify();
   }
 
-
   @Test
   public void testBuckProjectDryRun() throws IOException {
     ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(
@@ -119,6 +118,7 @@ public class ProjectIntegrationTest {
         "//:root_module",
         "//libs:generated",
         "//libs:generated_jar",
+        "//libs:generated_source_jar",
         "//libs:guava",
         "//libs:jsr305",
         "//libs:junit",

--- a/test/com/facebook/buck/java/intellij/testdata/project1/.idea/libraries/buck_out_gen_libs_generated_jar.xml.expected
+++ b/test/com/facebook/buck/java/intellij/testdata/project1/.idea/libraries/buck_out_gen_libs_generated_jar.xml.expected
@@ -4,6 +4,8 @@
       <root url="jar://$PROJECT_DIR$/buck-out/gen/libs/generated.jar!/" />
     </CLASSES>
     <JAVADOC />
-    <SOURCES />
+    <SOURCES>
+      <root url="jar://$PROJECT_DIR$/buck-out/gen/libs/generated-sources.jar!/" />
+    </SOURCES>
   </library>
 </component>

--- a/test/com/facebook/buck/java/intellij/testdata/project1/libs/BUCK
+++ b/test/com/facebook/buck/java/intellij/testdata/project1/libs/BUCK
@@ -28,9 +28,15 @@ genrule(
   out = 'generated.jar',
 )
 
+genrule(
+  name = 'generated_source_jar',
+  cmd = 'echo foo > $OUT',
+  out = 'generated-sources.jar',
+)
 prebuilt_jar(
   name = 'generated',
   binary_jar = ':generated_jar',
+  source_jar = ':generated_source_jar',
   visibility = [
     'PUBLIC',
   ],


### PR DESCRIPTION
Summary:
  The source jar path needs to be resolved before converting to a string,
  and used to generate IDE configuration files similar to binary jar.

Test:
  `buck test`