### PR TITLE
Use try-with-resources to prevent resource leaks

### DIFF
--- a/third-party/java/dx-from-kitkat/src/com/android/dex/Dex.java
+++ b/third-party/java/dx-from-kitkat/src/com/android/dex/Dex.java
@@ -101,13 +101,13 @@ public final class Dex {
      */
     public Dex(File file) throws IOException {
         if (FileUtils.hasArchiveSuffix(file.getName())) {
-            ZipFile zipFile = new ZipFile(file);
-            ZipEntry entry = zipFile.getEntry(DexFormat.DEX_IN_JAR_NAME);
-            if (entry != null) {
-                loadFrom(zipFile.getInputStream(entry));
-                zipFile.close();
-            } else {
-                throw new DexException("Expected " + DexFormat.DEX_IN_JAR_NAME + " in " + file);
+            try (ZipFile zipFile = new ZipFile(file)) {
+                ZipEntry entry = zipFile.getEntry(DexFormat.DEX_IN_JAR_NAME);
+                if (entry != null) {
+                    loadFrom(zipFile.getInputStream(entry));
+                } else {
+                    throw new DexException("Expected " + DexFormat.DEX_IN_JAR_NAME + " in " + file);
+                }
             }
         } else if (file.getName().endsWith(".dex")) {
             loadFrom(new FileInputStream(file));

--- a/third-party/java/dx-from-kitkat/src/com/android/dex/util/FileUtils.java
+++ b/third-party/java/dx-from-kitkat/src/com/android/dex/util/FileUtils.java
@@ -67,8 +67,7 @@ public final class FileUtils {
 
         byte[] result = new byte[length];
 
-        try {
-            FileInputStream in = new FileInputStream(file);
+        try (FileInputStream in = new FileInputStream(file)) {
             int at = 0;
             while (length > 0) {
                 int amt = in.read(result, at, length);
@@ -78,7 +77,6 @@ public final class FileUtils {
                 at += amt;
                 length -= amt;
             }
-            in.close();
         } catch (IOException ex) {
             throw new RuntimeException(file + ": trouble reading", ex);
         }

--- a/third-party/java/dx-from-kitkat/src/com/android/dx/command/dexer/Main.java
+++ b/third-party/java/dx-from-kitkat/src/com/android/dx/command/dexer/Main.java
@@ -832,6 +832,7 @@ public class Main {
             OutputStream out = openOutput(fileName);
 
             try {
+                @SuppressWarnings("resource")
                 JarOutputStream jarOut = new JarOutputStream(out, manifest);
                 for (Map.Entry<String, byte[]> e :
                          outputResources.entrySet()) {

--- a/third-party/java/dx-from-kitkat/src/com/android/dx/command/dump/BaseDumper.java
+++ b/third-party/java/dx-from-kitkat/src/com/android/dx/command/dump/BaseDumper.java
@@ -277,16 +277,16 @@ public abstract class BaseDumper
         try {
             if (w1 == 0) {
                 int len2 = s2.length();
-                StringWriter sw = new StringWriter(len2 * 2);
-                IndentingWriter iw = new IndentingWriter(sw, w2, separator);
+                try (StringWriter sw = new StringWriter(len2 * 2);
+                        IndentingWriter iw = new IndentingWriter(sw, w2, separator)) {
+                    iw.write(s2);
+                    if ((len2 == 0) || (s2.charAt(len2 - 1) != '\n')) {
+                        iw.write('\n');
+	                }
+                    iw.flush();
 
-                iw.write(s2);
-                if ((len2 == 0) || (s2.charAt(len2 - 1) != '\n')) {
-                    iw.write('\n');
+                    return sw.toString();
                 }
-                iw.flush();
-
-                return sw.toString();
             } else {
                 return TwoColumnOutput.toString(s1, w1, separator, s2, w2);
             }

--- a/third-party/java/dx-from-kitkat/src/com/android/dx/dex/code/DalvInsnList.java
+++ b/third-party/java/dx-from-kitkat/src/com/android/dx/dex/code/DalvInsnList.java
@@ -222,6 +222,7 @@ public final class DalvInsnList extends FixedSizeList {
      * lines for zero-size instructions and explicit constant pool indices
      */
     public void debugPrint(Writer out, String prefix, boolean verbose) {
+        @SuppressWarnings("resource")
         IndentingWriter iw = new IndentingWriter(out, 0, prefix);
         int sz = size();
 


### PR DESCRIPTION
Summary:
In several places resources are opened but potentially not closed
if an exception occurs. In these places, use try-with-resource so
that the resource is properly closed on exception.

Test plan:

* `buck test`