### PR TITLE
Use POSIX standard way to get the executable path.

### DIFF
--- a/bin/buck
+++ b/bin/buck
@@ -9,5 +9,5 @@ while [ -h "$BUCK_PATH" ]; do
 done
 BUCK_DIR=$(dirname "$BUCK_PATH")
 
-PYTHON=`type -p python2 python | head -1`
+PYTHON=$(command -v python2 python | head -1)
 exec $PYTHON "$BUCK_DIR"/../programs/buck.py "$@"


### PR DESCRIPTION
command -v is part of the POSIX standard and should be used instead of type.
While type is also part of the standard "type -p" is not.
http://pubs.opengroup.org/onlinepubs/9699919799/utilities/type.html
http://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html#tag_20_22_04

While at it, use $() instead of `` for consistency.