### PR TITLE
Select only *enabled* activity aliases when looking for a default act…

### DIFF
--- a/src/com/facebook/buck/android/DefaultAndroidManifestReader.java
+++ b/src/com/facebook/buck/android/DefaultAndroidManifestReader.java
@@ -47,7 +47,8 @@ public class DefaultAndroidManifestReader implements AndroidManifestReader {
    * to show up in the launcher.
    */
   private static final String XPATH_LAUNCHER_ACTIVITIES =
-      "/manifest/application/*[self::activity or self::activity-alias[not(@android:enabled) or @android:enabled='true']]" +
+      "/manifest/application/*[self::activity or" +
+      "  self::activity-alias[not(@android:enabled) or @android:enabled='true']]" +
       "  [intent-filter[action/@android:name='android.intent.action.MAIN' and " +
       "                 category/@android:name='android.intent.category.LAUNCHER']]" +
       "  /@android:name";

--- a/src/com/facebook/buck/android/DefaultAndroidManifestReader.java
+++ b/src/com/facebook/buck/android/DefaultAndroidManifestReader.java
@@ -47,7 +47,7 @@ public class DefaultAndroidManifestReader implements AndroidManifestReader {
    * to show up in the launcher.
    */
   private static final String XPATH_LAUNCHER_ACTIVITIES =
-      "/manifest/application/*[self::activity or self::activity-alias]" +
+      "/manifest/application/*[self::activity or self::activity-alias[not(@android:enabled) or @android:enabled='true']]" +
       "  [intent-filter[action/@android:name='android.intent.action.MAIN' and " +
       "                 category/@android:name='android.intent.category.LAUNCHER']]" +
       "  /@android:name";


### PR DESCRIPTION
…ivity to launch (avoid 'Default activity is ambiguous' error).

This is useful for apps that create multiple <activity-alias> elements, but only enable one of them. This is populate with apps that want to offer the user a choice of different icons for their app.

Thanks,

Theo