### PR TITLE
MiniAapt: show friendlier message when node using id is invalid

### DIFF
--- a/src/com/facebook/buck/android/aapt/MiniAapt.java
+++ b/src/com/facebook/buck/android/aapt/MiniAapt.java
@@ -404,9 +404,10 @@ public class MiniAapt implements Step {
           (NodeList) ANDROID_ID_USAGE.evaluate(dom, XPathConstants.NODESET);
       for (int i = 0; i < nodesUsingIds.getLength(); i++) {
         String resourceName = nodesUsingIds.item(i).getNodeValue();
-        Preconditions.checkState(resourceName.charAt(0) == '@');
         int slashPosition = resourceName.indexOf('/');
-        Preconditions.checkState(slashPosition != -1);
+        if (resourceName.charAt(0) != '@' || slashPosition == -1) {
+          throw new ResourceParseException("Invalid definition of a resource: '%s'", resourceName);
+        }
 
         String rawRType = resourceName.substring(1, slashPosition);
         String name = resourceName.substring(slashPosition + 1);

--- a/test/com/facebook/buck/android/aapt/MiniAaptTest.java
+++ b/test/com/facebook/buck/android/aapt/MiniAaptTest.java
@@ -280,6 +280,27 @@ public class MiniAaptTest {
   }
 
   @Test
+  public void testInvalidNodeId() throws
+      IOException, XPathExpressionException, ResourceParseException {
+    thrown.expect(ResourceParseException.class);
+    thrown.expectMessage("Invalid definition of a resource: '@button2'");
+
+    ImmutableList<String> lines = ImmutableList.<String>builder().add(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "<LinearLayout>",
+        "<Button android:id=\"@+id/button1\" ",
+        "android:layout_toLeftOf=\"@button2\" />",
+        "</LinearLayout>")
+        .build();
+
+    Path resource = Paths.get("resource.xml");
+    filesystem.writeLinesToPath(lines, resource);
+
+    MiniAapt aapt = new MiniAapt(Paths.get("res"), Paths.get("R.txt"), ImmutableSet.<Path>of());
+    aapt.processXmlFile(filesystem, resource, ImmutableSet.<RDotTxtEntry>builder());
+  }
+
+  @Test
   public void testProcessFileNamesInDirectory() throws IOException, ResourceParseException {
     filesystem.touch(Paths.get("res/drawable/icon.png"));
     filesystem.touch(Paths.get("res/drawable/another_icon.png.orig"));


### PR DESCRIPTION
Summary:
MiniAapt checks the name of a resource using Preconditions.  That
results in an unfriendly error message, which doesn't help the user.
Throw a ResourceParseException instead, which gives a hint to the user
where to look.

Test plan: added test