### PR TITLE
Adding batch file for Windows users

### DIFF
--- a/bin/buck.bat
+++ b/bin/buck.bat
@@ -1,0 +1,2 @@
+@echo off
+python %~dp0..\programs\buck.py %*


### PR DESCRIPTION
This allows Windows users to simply call bin\buck and have it work
correctly.