### PR TITLE
Fix buck build buck

### DIFF
--- a/src/com/facebook/buck/java/BUCK
+++ b/src/com/facebook/buck/java/BUCK
@@ -93,6 +93,7 @@ java_immutables_library(
     '//src/com/facebook/buck/event:event',
     '//src/com/facebook/buck/io:io',
     '//src/com/facebook/buck/java/abi:protocol',
+    '//src/com/facebook/buck/java/tracing:api',
     '//src/com/facebook/buck/java/tracing:tracing',
     '//src/com/facebook/buck/log:api',
     '//src/com/facebook/buck/model:model',

--- a/src/com/facebook/buck/java/tracing/BUCK
+++ b/src/com/facebook/buck/java/tracing/BUCK
@@ -66,6 +66,7 @@ java_library(
   ],
   visibility = [
     '//src/com/facebook/buck/cli/bootstrapper:bootstrapper_lib',
+    '//src/com/facebook/buck/java:support',
     '//test/com/facebook/buck/java/tracing:tracing',
   ],
 )


### PR DESCRIPTION
Summary:
buck build buck was broken by b50c6d26b8 ("Load
TranslatingJavacPhaseTracer from resources"), with the following error
message:
/home/tommy/work/buck/src/com/facebook/buck/java/Jsr199Javac.java:171: error: cannot access com.facebook.buck.java.tracing.JavacPhaseTracer
      TranslatingJavacPhaseTracer.setupTracing(
                                 ^
  class file for com.facebook.buck.java.tracing.JavacPhaseTracer not found
Errors: 1. Warnings: 1.

This is because of a missing dependency.  Add the dependency to fix the
build.

Test plan:
Check that buck build buck compiles buck successfully.