### PR TITLE
Fix AndroidBinaryIntegrationTest with python3 as default

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -177,7 +177,7 @@
   <target name="python-get-prefix">
     <exec executable="python" failonerror="true" outputproperty="python.prefix" logError="true">
       <arg value="-c" />
-      <arg value="import distutils.sysconfig; print distutils.sysconfig.PREFIX" />
+      <arg value="import distutils.sysconfig; print(distutils.sysconfig.PREFIX)" />
     </exec>
   </target>
 

--- a/test/com/facebook/buck/android/testdata/android_project/java/com/preprocess/convert.py
+++ b/test/com/facebook/buck/android/testdata/android_project/java/com/preprocess/convert.py
@@ -23,8 +23,8 @@ def main(argv):
                 for zinfo in inzip.infolist():
                     raw_content = inzip.read(zinfo.filename)
                     transformed = raw_content.replace(
-                        "__FIND_ME_HERE__content=1__GOODBYE__",
-                        "__FIND_ME_HERE__content=2__GOODBYE__")
+                        b"__FIND_ME_HERE__content=1__GOODBYE__",
+                        b"__FIND_ME_HERE__content=2__GOODBYE__")
                     outzip.writestr(zinfo, transformed)
                 outzip.close()
                 inzip.close()


### PR DESCRIPTION
Summary:
On systems on which python refers to python3, the
AndroidBinaryIntegrationTest fails in the testPreprocessorForcesReDex
test, because of a python script that is not compatible with python3.
PEP 0394 suggests that python2 should always refer to a valid python2
interpreter.  Adjust the shebang line to make the script use python2,
which fixes the test.

Test plan: buck test