### PR TITLE
Fix NullPointerException when traversing the filesystem.

### DIFF
--- a/src/com/facebook/buck/cli/TestRunning.java
+++ b/src/com/facebook/buck/cli/TestRunning.java
@@ -789,41 +789,50 @@ public class TestRunning {
     Set<String> srcFolders = Sets.newHashSet();
     loopThroughSourcePath:
     for (Path javaSrcPath : javaSrcs) {
-      if (!MorePaths.isGeneratedFile(javaSrcPath)) {
-        // If the source path is already under a known source folder, then we can skip this
-        // source path.
-        for (String srcFolder : srcFolders) {
-          if (javaSrcPath.startsWith(srcFolder)) {
-            continue loopThroughSourcePath;
-          }
-        }
+      if (MorePaths.isGeneratedFile(javaSrcPath)) {
+        continue;
+      }
 
-        // If the source path is under one of the source roots, then we can just add the source
-        // root.
-        ImmutableSortedSet<String> pathsFromRoot = defaultJavaPackageFinder.getPathsFromRoot();
-        for (String root : pathsFromRoot) {
-          if (javaSrcPath.startsWith(root)) {
-            srcFolders.add(root);
-            continue loopThroughSourcePath;
-          }
-        }
-
-        // Traverse the file system from the parent directory of the java file until we hit the
-        // parent of the src root directory.
-        ImmutableSet<String> pathElements = defaultJavaPackageFinder.getPathElements();
-        Path directory = filesystem.getPathForRelativePath(javaSrcPath.getParent());
-        while (directory != null && !pathElements.contains(directory.getFileName().toString())) {
-          directory = directory.getParent();
-        }
-
-        if (directory != null) {
-          String directoryPath = directory.toString();
-          if (!directoryPath.endsWith("/")) {
-            directoryPath += "/";
-          }
-          srcFolders.add(directoryPath);
+      // If the source path is already under a known source folder, then we can skip this
+      // source path.
+      for (String srcFolder : srcFolders) {
+        if (javaSrcPath.startsWith(srcFolder)) {
+          continue loopThroughSourcePath;
         }
       }
+
+      // If the source path is under one of the source roots, then we can just add the source
+      // root.
+      ImmutableSortedSet<String> pathsFromRoot = defaultJavaPackageFinder.getPathsFromRoot();
+      for (String root : pathsFromRoot) {
+        if (javaSrcPath.startsWith(root)) {
+          srcFolders.add(root);
+          continue loopThroughSourcePath;
+        }
+      }
+
+      // Traverse the file system from the parent directory of the java file until we hit the
+      // parent of the src root directory.
+      ImmutableSet<String> pathElements = defaultJavaPackageFinder.getPathElements();
+      Path directory = filesystem.getPathForRelativePath(javaSrcPath.getParent());
+      if (pathElements.isEmpty()) {
+        continue;
+      }
+
+      while (directory != null && directory.getFileName() != null &&
+          !pathElements.contains(directory.getFileName().toString())) {
+        directory = directory.getParent();
+      }
+
+      if (directory == null || directory.getFileName() == null) {
+        continue;
+      }
+
+      String directoryPath = directory.toString();
+      if (!directoryPath.endsWith("/")) {
+        directoryPath += "/";
+      }
+      srcFolders.add(directoryPath);
     }
 
     return ImmutableSet.copyOf(srcFolders);

--- a/test/com/facebook/buck/cli/TestRunningTest.java
+++ b/test/com/facebook/buck/cli/TestRunningTest.java
@@ -165,6 +165,28 @@ public class TestRunningTest {
     verify(defaultJavaPackageFinder);
   }
 
+  @Test
+  public void testNonGeneratedSourceFileWithoutPathElements() {
+    Path pathToNonGenFile = Paths.get("package/src/SourceFile1.java");
+    assertFalse(MorePaths.isGeneratedFile(pathToNonGenFile));
+
+    ImmutableSortedSet<Path> javaSrcs = ImmutableSortedSet.of(pathToNonGenFile);
+    JavaLibrary javaLibrary = new FakeJavaLibrary(
+        BuildTarget.builder("//foo", "bar").build(),
+        new SourcePathResolver(new BuildRuleResolver())).setJavaSrcs(javaSrcs);
+
+    DefaultJavaPackageFinder defaultJavaPackageFinder =
+        createMock(DefaultJavaPackageFinder.class);
+    expect(defaultJavaPackageFinder.getPathsFromRoot()).andReturn(pathsFromRoot);
+    expect(defaultJavaPackageFinder.getPathElements()).andReturn(ImmutableSet.<String>of("/"));
+
+    replay(defaultJavaPackageFinder);
+
+    TestRunning.getPathToSourceFolders(
+        javaLibrary, Optional.of(defaultJavaPackageFinder), new FakeProjectFilesystem());
+
+    verify(defaultJavaPackageFinder);
+  }
   /**
    * If the source paths specified are from the new unified source tmp then we should return
    * the correct source tmp corresponding to the unified source path.


### PR DESCRIPTION
Summary:
When we traverse the file system to the root, directory.getFileName()
returns null and we do not want to get toString() on it.

Test:
`buck test`