### PR TITLE
Add config option for multi install mode

### DIFF
--- a/docs/concept/buckconfig.soy
+++ b/docs/concept/buckconfig.soy
@@ -75,12 +75,16 @@ The following sections are recognized by Buck:
 
 {call .section}{param title: 'adb' /}{/call}
 
-This section controls adb restart behavior on errors.
+This section configures adb behavior.
 
 {literal}<pre class="prettyprint lang-ini">
 [adb]
   # This specifies a whether to restart adb on failure or not.
   adb_restart_on_failure = true
+
+  # This specifies whether multi-install mode is enabled or
+  # disabled by default.
+  multi_install_mode = false
 </pre>{/literal}
 
 

--- a/src/com/facebook/buck/cli/AdbCommandLineOptions.java
+++ b/src/com/facebook/buck/cli/AdbCommandLineOptions.java
@@ -42,7 +42,10 @@ public class AdbCommandLineOptions {
   )
   private boolean multiInstallMode;
 
-  public AdbOptions getAdbOptions() {
+  public AdbOptions getAdbOptions(BuckConfig buckConfig) {
+    if (buckConfig.getMultiInstallMode()) {
+      multiInstallMode = true;
+    }
     return new AdbOptions(
         adbThreadCount,
         multiInstallMode);

--- a/src/com/facebook/buck/cli/BuckConfig.java
+++ b/src/com/facebook/buck/cli/BuckConfig.java
@@ -434,6 +434,10 @@ public class BuckConfig {
     return Boolean.parseBoolean(getValue("adb", "adb_restart_on_failure").or("true"));
   }
 
+  public boolean getMultiInstallMode() {
+    return getBooleanValue("adb", "multi_install_mode", false);
+  }
+
   public boolean getFlushEventsBeforeExit() {
     return getBooleanValue("daemon", "flush_events_before_exit", false);
   }

--- a/src/com/facebook/buck/cli/InstallCommand.java
+++ b/src/com/facebook/buck/cli/InstallCommand.java
@@ -138,8 +138,8 @@ public class InstallCommand extends BuildCommand {
   @Nullable
   private String activity = null;
 
-  public AdbOptions adbOptions() {
-    return adbOptions.getAdbOptions();
+  public AdbOptions adbOptions(BuckConfig buckConfig) {
+    return adbOptions.getAdbOptions(buckConfig);
   }
 
   public TargetDeviceOptions targetDeviceOptions() {
@@ -190,7 +190,7 @@ public class InstallCommand extends BuildCommand {
     if (buildRule instanceof InstallableApk) {
       ExecutionContext.Builder builder = ExecutionContext.builder()
           .setExecutionContext(build.getExecutionContext())
-          .setAdbOptions(Optional.<AdbOptions>of(adbOptions()))
+          .setAdbOptions(Optional.<AdbOptions>of(adbOptions(params.getBuckConfig())))
           .setTargetDeviceOptions(Optional.<TargetDeviceOptions>of(targetDeviceOptions()));
       return installApk(
           params,

--- a/src/com/facebook/buck/cli/TestCommand.java
+++ b/src/com/facebook/buck/cli/TestCommand.java
@@ -185,8 +185,8 @@ public class TestCommand extends BuildCommand {
     return targetDeviceOptions.getTargetDeviceOptional();
   }
 
-  public AdbOptions getAdbOptions() {
-    return adbOptions.getAdbOptions();
+  public AdbOptions getAdbOptions(BuckConfig buckConfig) {
+    return adbOptions.getAdbOptions(buckConfig);
   }
 
   public TargetDeviceOptions getTargetDeviceOptions() {
@@ -366,7 +366,7 @@ public class TestCommand extends BuildCommand {
           params.getEnvironment(),
           params.getObjectMapper(),
           params.getClock(),
-          Optional.of(getAdbOptions()),
+          Optional.of(getAdbOptions(params.getBuckConfig())),
           Optional.of(getTargetDeviceOptions()))) {
 
         // Build all of the test rules.

--- a/src/com/facebook/buck/cli/UninstallCommand.java
+++ b/src/com/facebook/buck/cli/UninstallCommand.java
@@ -88,8 +88,8 @@ public class UninstallCommand extends AbstractCommand {
     return uninstallOptions;
   }
 
-  public AdbOptions adbOptions() {
-    return adbOptions.getAdbOptions();
+  public AdbOptions adbOptions(BuckConfig buckConfig) {
+    return adbOptions.getAdbOptions(buckConfig);
   }
 
   public TargetDeviceOptions targetDeviceOptions() {
@@ -148,7 +148,7 @@ public class UninstallCommand extends AbstractCommand {
     // We need this in case adb isn't already running.
     try (ExecutionContext context = createExecutionContext(params)) {
       final AdbHelper adbHelper = new AdbHelper(
-          adbOptions(),
+          adbOptions(params.getBuckConfig()),
           targetDeviceOptions(),
           context,
           params.getConsole(),

--- a/src/com/facebook/buck/step/AdbOptions.java
+++ b/src/com/facebook/buck/step/AdbOptions.java
@@ -34,6 +34,10 @@ public class AdbOptions {
     this.multiInstallMode = multiInstallMode;
   }
 
+  public void setMultiInstallMode(boolean multiInstallMode) {
+    this.multiInstallMode = multiInstallMode;
+  }
+
   public int getAdbThreadCount() {
     return adbThreadCount;
   }


### PR DESCRIPTION
Summary:
While developing or testing apps, multiple devices are often used.  Add
an option to enable multi-install mode by default in the .buckconfig, so
the user doesn't have to type it every time when installing the app, or
running the instrumentation tests for it.

Test Plan: added tests