### PR TITLE
Send missing symbols to stderr

### DIFF
--- a/src/com/facebook/buck/cli/MissingSymbolsHandler.java
+++ b/src/com/facebook/buck/cli/MissingSymbolsHandler.java
@@ -221,6 +221,6 @@ public class MissingSymbolsHandler {
   }
 
   private void print(String line) {
-    console.getStdOut().println(console.getAnsi().asWarningText(line));
+    console.getStdErr().println(console.getAnsi().asWarningText(line));
   }
 }

--- a/test/com/facebook/buck/java/MissingSymbolsHandlerIntegrationTest.java
+++ b/test/com/facebook/buck/java/MissingSymbolsHandlerIntegrationTest.java
@@ -117,7 +117,7 @@ public class MissingSymbolsHandlerIntegrationTest {
 
     assertThat(
         "Output should describe the missing dependency.",
-        processResult.getStdout(),
+        processResult.getStderr(),
         containsString(expectedDependencyOutput));
   }
 
@@ -140,7 +140,7 @@ public class MissingSymbolsHandlerIntegrationTest {
 
     assertThat(
         "Output should describe the missing dependency.",
-        processResult.getStdout(),
+        processResult.getStderr(),
         containsString(expectedDependencyOutput));
   }
 }


### PR DESCRIPTION
It makes sense to send this to stderr instead of stdout since it's an error condition.  This makes parsing this output easier.