### PR TITLE
Support specifying multiple Maven repositories in a .buckconfig

### DIFF
--- a/src/com/facebook/buck/android/AndroidDirectoryResolver.java
+++ b/src/com/facebook/buck/android/AndroidDirectoryResolver.java
@@ -47,4 +47,11 @@ public interface AndroidDirectoryResolver {
    * @return The NDK version in use from the directory returned by {@link #findAndroidNdkDir()}.
    */
   Optional<String> getNdkVersion();
+
+  /**
+   * @return {@code Optional.absent()} if the Android SDK is not found or if it does not contain a
+   * maven repository, Otherwise an {@code Optional<Path>} pointing to the Android maven
+   * repository in the Android SDK.
+   */
+  Optional<Path> findMavenRepository();
 }

--- a/src/com/facebook/buck/android/DefaultAndroidDirectoryResolver.java
+++ b/src/com/facebook/buck/android/DefaultAndroidDirectoryResolver.java
@@ -97,6 +97,19 @@ public class DefaultAndroidDirectoryResolver implements AndroidDirectoryResolver
     return findNdkVersionFromPath(ndkPath.get());
   }
 
+  @Override
+  public Optional<Path> findMavenRepository() {
+    Optional<Path> androidSdkDir = findAndroidSdkDirSafe();
+    if (androidSdkDir.isPresent()) {
+      Path mavenRepository = androidSdkDir.get().resolve("extras/google/m2repository");
+      if (mavenRepository.toFile().isDirectory()) {
+        return Optional.of(mavenRepository);
+      }
+    }
+    return Optional.absent();
+  }
+
+
   private Optional<String> findNdkVersionFromPath(Path ndkPath) {
     Path releaseVersion =  ndkPath.resolve("RELEASE.TXT");
     Optional<String> contents = projectFilesystem.readFirstLineFromFile(releaseVersion);

--- a/src/com/facebook/buck/cli/BuckConfig.java
+++ b/src/com/facebook/buck/cli/BuckConfig.java
@@ -711,6 +711,10 @@ public class BuckConfig {
     return sampleRate;
  }
 
+  public ImmutableMap<String, String> getMavenRepositories() {
+    return getEntriesForSection("maven_repositories");
+  }
+
   public Optional<String> getValue(String sectionName, String propertyName) {
     return config.getValue(sectionName, propertyName);
   }

--- a/src/com/facebook/buck/cli/CommandRunnerParams.java
+++ b/src/com/facebook/buck/cli/CommandRunnerParams.java
@@ -16,6 +16,7 @@
 
 package com.facebook.buck.cli;
 
+import com.facebook.buck.android.AndroidDirectoryResolver;
 import com.facebook.buck.android.AndroidPlatformTarget;
 import com.facebook.buck.event.BuckEventBus;
 import com.facebook.buck.httpserver.WebServer;
@@ -44,6 +45,7 @@ class CommandRunnerParams {
   private final Parser parser;
   private final BuckEventBus eventBus;
   private final Platform platform;
+  private final AndroidDirectoryResolver androidDirectoryResolver;
   private final Supplier<AndroidPlatformTarget> androidPlatformTargetSupplier;
   private final Repository repository;
   private final JavaPackageFinder javaPackageFinder;
@@ -52,11 +54,12 @@ class CommandRunnerParams {
   private final Optional<ProcessManager> processManager;
   private final Optional<WebServer> webServer;
   private final BuckConfig buckConfig;
-  private final FileHashCache fileHashCache;
+  private final FileHashCache fileHashCache;;
 
   public CommandRunnerParams(
       Console console,
       Repository repository,
+      AndroidDirectoryResolver androidDirectoryResolver,
       Supplier<AndroidPlatformTarget> androidPlatformTargetSupplier,
       ArtifactCacheFactory artifactCacheFactory,
       BuckEventBus eventBus,
@@ -77,6 +80,7 @@ class CommandRunnerParams {
     this.parser = parser;
     this.platform = platform;
     this.androidPlatformTargetSupplier = androidPlatformTargetSupplier;
+    this.androidDirectoryResolver = androidDirectoryResolver;
     this.environment = environment;
     this.javaPackageFinder = javaPackageFinder;
     this.objectMapper = objectMapper;
@@ -105,6 +109,10 @@ class CommandRunnerParams {
 
   public BuckEventBus getBuckEventBus() {
     return eventBus;
+  }
+
+  public AndroidDirectoryResolver getAndroidDirectoryResolver() {
+    return androidDirectoryResolver;
   }
 
   public Supplier<AndroidPlatformTarget> getAndroidPlatformTargetSupplier() {

--- a/src/com/facebook/buck/cli/FetchCommand.java
+++ b/src/com/facebook/buck/cli/FetchCommand.java
@@ -38,6 +38,7 @@ import com.facebook.buck.step.AdbOptions;
 import com.facebook.buck.step.TargetDevice;
 import com.facebook.buck.step.TargetDeviceOptions;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import java.io.IOException;
@@ -138,8 +139,8 @@ public class FetchCommand extends BuildCommand {
   }
 
   private FetchTargetNodeToBuildRuleTransformer createFetchTransformer(CommandRunnerParams params) {
-    Optional<String> defaultMavenRepo = params.getBuckConfig().getValue("download", "maven_repo");
-    Downloader downloader = new HttpDownloader(Optional.<Proxy>absent(), defaultMavenRepo);
+    ImmutableMap<String, String> mavenRepositories = params.getBuckConfig().getMavenRepositories();
+    Downloader downloader = new HttpDownloader(Optional.<Proxy>absent(), mavenRepositories);
     Description<?> description = new RemoteFileDescription(downloader);
     return new FetchTargetNodeToBuildRuleTransformer(
         ImmutableSet.<Description<?>>of(description)

--- a/src/com/facebook/buck/cli/FetchCommand.java
+++ b/src/com/facebook/buck/cli/FetchCommand.java
@@ -140,7 +140,9 @@ public class FetchCommand extends BuildCommand {
 
   private FetchTargetNodeToBuildRuleTransformer createFetchTransformer(CommandRunnerParams params) {
     ImmutableMap<String, String> mavenRepositories = params.getBuckConfig().getMavenRepositories();
-    Downloader downloader = new HttpDownloader(Optional.<Proxy>absent(), mavenRepositories);
+    Downloader downloader = new HttpDownloader(Optional.<Proxy>absent(),
+        params.getAndroidDirectoryResolver().findMavenRepository(),
+        mavenRepositories);
     Description<?> description = new RemoteFileDescription(downloader);
     return new FetchTargetNodeToBuildRuleTransformer(
         ImmutableSet.<Description<?>>of(description)

--- a/src/com/facebook/buck/cli/Main.java
+++ b/src/com/facebook/buck/cli/Main.java
@@ -725,6 +725,7 @@ public final class Main {
           new CommandRunnerParams(
               console,
               rootRepository,
+              androidDirectoryResolver,
               androidPlatformTargetSupplier,
               artifactCacheFactory,
               buildEventBus,

--- a/src/com/facebook/buck/file/HttpDownloader.java
+++ b/src/com/facebook/buck/file/HttpDownloader.java
@@ -19,6 +19,7 @@ package com.facebook.buck.file;
 import com.facebook.buck.event.BuckEventBus;
 import com.facebook.buck.util.HumanReadableException;
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 
 import java.io.BufferedInputStream;
@@ -31,6 +32,7 @@ import java.net.Proxy;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -38,11 +40,17 @@ import java.util.concurrent.TimeUnit;
  */
 public class HttpDownloader implements Downloader {
   public static final int PROGRESS_REPORT_EVERY_N_BYTES = 1000;
+  public static final String ANDROID_PREFIX = "android";
+
   private final Optional<Proxy> proxy;
+  private final Optional<Path> androidMavenRepository;
   private final ImmutableMap<String, String> mavenRepos;
 
-  public HttpDownloader(Optional<Proxy> proxy, ImmutableMap<String, String> mavenRepos) {
+  public HttpDownloader(Optional<Proxy> proxy,
+      Optional<Path> androidMavenRepository,
+      ImmutableMap<String, String> mavenRepos) {
     this.proxy = proxy;
+    this.androidMavenRepository = androidMavenRepository;
     this.mavenRepos = mavenRepos;
   }
 
@@ -50,32 +58,45 @@ public class HttpDownloader implements Downloader {
   public void fetch(BuckEventBus eventBus, URI uri, Path output) throws IOException {
     if (mavenRepos.containsKey(uri.getScheme())) {
       uri = MavenUrlDecoder.toHttpUrl(mavenRepos, uri);
+    } else if (ANDROID_PREFIX.equals(uri.getScheme())) {
+      Preconditions.checkState(androidMavenRepository.isPresent(),
+          "No Android Maven repository is present.  Ensure your Android SDK is configured and " +
+              "you've installed the 'Extras' required");
+      uri = MavenUrlDecoder.toHttpUrl(ImmutableMap.of(
+          ANDROID_PREFIX,
+          String.format("file://%s", androidMavenRepository.get().toAbsolutePath().toString())
+      ), uri);
     }
+
 
     DownloadEvent.Started started = DownloadEvent.started(uri);
     eventBus.post(started);
 
     try {
-      HttpURLConnection connection = createConnection(uri);
-      if (HttpURLConnection.HTTP_OK != connection.getResponseCode()) {
-        throw new HumanReadableException(
-            "Unable to download %s: %s", uri, connection.getResponseMessage());
-      }
-      long contentLength = connection.getContentLengthLong();
-      try (InputStream is = new BufferedInputStream(connection.getInputStream());
-           OutputStream os = new BufferedOutputStream(Files.newOutputStream(output))) {
-        long read = 0;
+      if ("file".equals(uri.getScheme())) {
+        Files.copy(Paths.get(uri.getRawPath()), output);
+      } else {
+        HttpURLConnection connection = createConnection(uri);
+        if (HttpURLConnection.HTTP_OK != connection.getResponseCode()) {
+          throw new HumanReadableException(
+              "Unable to download %s: %s", uri, connection.getResponseMessage());
+        }
+        long contentLength = connection.getContentLengthLong();
+        try (InputStream is = new BufferedInputStream(connection.getInputStream());
+             OutputStream os = new BufferedOutputStream(Files.newOutputStream(output))) {
+          long read = 0;
 
-        while (true) {
-          int r = is.read();
-          read++;
-          if (r == -1) {
-            break;
+          while (true) {
+            int r = is.read();
+            read++;
+            if (r == -1) {
+              break;
+            }
+            if (read % PROGRESS_REPORT_EVERY_N_BYTES == 0) {
+              eventBus.post(new DownloadProgressEvent(uri, contentLength, read));
+            }
+            os.write(r);
           }
-          if (read % PROGRESS_REPORT_EVERY_N_BYTES == 0) {
-            eventBus.post(new DownloadProgressEvent(uri, contentLength, read));
-          }
-          os.write(r);
         }
       }
     } finally {

--- a/src/com/facebook/buck/file/HttpDownloader.java
+++ b/src/com/facebook/buck/file/HttpDownloader.java
@@ -19,6 +19,7 @@ package com.facebook.buck.file;
 import com.facebook.buck.event.BuckEventBus;
 import com.facebook.buck.util.HumanReadableException;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -38,17 +39,17 @@ import java.util.concurrent.TimeUnit;
 public class HttpDownloader implements Downloader {
   public static final int PROGRESS_REPORT_EVERY_N_BYTES = 1000;
   private final Optional<Proxy> proxy;
-  private final Optional<String> mavenRepo;
+  private final ImmutableMap<String, String> mavenRepos;
 
-  public HttpDownloader(Optional<Proxy> proxy, Optional<String> mavenRepo) {
+  public HttpDownloader(Optional<Proxy> proxy, ImmutableMap<String, String> mavenRepos) {
     this.proxy = proxy;
-    this.mavenRepo = mavenRepo;
+    this.mavenRepos = mavenRepos;
   }
 
   @Override
   public void fetch(BuckEventBus eventBus, URI uri, Path output) throws IOException {
-    if ("mvn".equals(uri.getScheme())) {
-      uri = MavenUrlDecoder.toHttpUrl(mavenRepo, uri);
+    if (mavenRepos.containsKey(uri.getScheme())) {
+      uri = MavenUrlDecoder.toHttpUrl(mavenRepos, uri);
     }
 
     DownloadEvent.Started started = DownloadEvent.started(uri);

--- a/src/com/facebook/buck/file/MavenUrlDecoder.java
+++ b/src/com/facebook/buck/file/MavenUrlDecoder.java
@@ -19,7 +19,6 @@ package com.facebook.buck.file;
 import com.facebook.buck.util.HumanReadableException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
@@ -93,11 +92,13 @@ public class MavenUrlDecoder {
           version,
           fileExtensionFor(type));
       URI generated = new URI(plainUri);
-      if ("https".equals(generated.getScheme()) || "http".equals(generated.getScheme())) {
+      if ("https".equals(generated.getScheme()) ||
+          "http".equals(generated.getScheme()) ||
+          "file".equals(generated.getScheme())) {
         return generated;
       }
       throw new HumanReadableException(
-          "Can only download maven artifacts over HTTP or HTTPS: %s", generated);
+          "Can only download maven artifacts over HTTP or HTTPS or a file: %s", generated);
     } catch (URISyntaxException e) {
       throw new HumanReadableException("Unable to parse URL: " + uri);
     }

--- a/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
+++ b/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
@@ -377,11 +377,11 @@ public class KnownBuildRuleTypes {
     Optional<Long> testRuleTimeoutMs = config.getLong("test", "rule_timeout");
 
     // Default maven repo, if set
-    Optional<String> defaultMavenRepo = config.getValue("download", "maven_repo");
+    ImmutableMap<String, String> mavenRepositories = config.getMavenRepositories();
     boolean downloadAtRuntimeOk = config.getBooleanValue("download", "in_build", false);
     Downloader downloader;
     if (downloadAtRuntimeOk) {
-      downloader = new HttpDownloader(Optional.<Proxy>absent(), defaultMavenRepo);
+      downloader = new HttpDownloader(Optional.<Proxy>absent(), mavenRepositories);
     } else {
       downloader = new ExplodingDownloader();
     }

--- a/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
+++ b/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
@@ -381,7 +381,9 @@ public class KnownBuildRuleTypes {
     boolean downloadAtRuntimeOk = config.getBooleanValue("download", "in_build", false);
     Downloader downloader;
     if (downloadAtRuntimeOk) {
-      downloader = new HttpDownloader(Optional.<Proxy>absent(), mavenRepositories);
+      downloader = new HttpDownloader(Optional.<Proxy>absent(),
+          androidDirectoryResolver.findMavenRepository(),
+          mavenRepositories);
     } else {
       downloader = new ExplodingDownloader();
     }

--- a/test/com/facebook/buck/android/AndroidPlatformTargetTest.java
+++ b/test/com/facebook/buck/android/AndroidPlatformTargetTest.java
@@ -55,7 +55,8 @@ public class AndroidPlatformTargetTest {
         new FakeAndroidDirectoryResolver(
             Optional.of(androidSdkDir),
             /* androidNdkDir */ Optional.<Path>absent(),
-            /* ndkVersion */ Optional.<String>absent());
+            /* ndkVersion */ Optional.<String>absent(),
+            /* androidManifest */ Optional.<Path>absent());
 
     AndroidPlatformTarget androidPlatformTarget = AndroidPlatformTarget
         .createFromDefaultDirectoryStructure(
@@ -103,7 +104,8 @@ public class AndroidPlatformTargetTest {
         new FakeAndroidDirectoryResolver(
             Optional.of(androidSdkDir.toPath()),
             /* androidNdkDir */ Optional.<Path>absent(),
-            /* ndkVersion */ Optional.<String>absent());
+            /* ndkVersion */ Optional.<String>absent(),
+            /* androidManifest */ Optional.<Path>absent());
     File buildToolsDir = new File(androidSdkDir, "build-tools");
     buildToolsDir.mkdir();
     File buildToolsDirFromOldUpgradePath = new File(buildToolsDir, "17.0.0");
@@ -152,7 +154,8 @@ public class AndroidPlatformTargetTest {
         new FakeAndroidDirectoryResolver(
             Optional.of(androidSdkDir.toPath()),
             /* androidNdkDir */ Optional.<Path>absent(),
-            /* ndkVersion */ Optional.<String>absent());
+            /* ndkVersion */ Optional.<String>absent(),
+            /* androidManifest */ Optional.<Path>absent());
     File buildToolsDir = new File(androidSdkDir, "build-tools");
     buildToolsDir.mkdir();
     File buildToolsDirFromFreshDownload = new File(buildToolsDir, "android-4.2.2");
@@ -200,7 +203,8 @@ public class AndroidPlatformTargetTest {
         new FakeAndroidDirectoryResolver(
             Optional.of(androidSdkDir.toPath()),
             /* androidNdkDir */ Optional.<Path>absent(),
-            /* ndkVersion */ Optional.<String>absent());
+            /* ndkVersion */ Optional.<String>absent(),
+            /* androidManifest */ Optional.<Path>absent());
     File buildToolsDir = new File(androidSdkDir, "build-tools");
     buildToolsDir.mkdir();
     File addOnsLibsDir = new File(androidSdkDir, "add-ons/addon-google_apis-google-17/libs");
@@ -236,7 +240,8 @@ public class AndroidPlatformTargetTest {
         new FakeAndroidDirectoryResolver(
             Optional.of(androidSdkDir.toPath()),
             /* androidNdkDir */ Optional.<Path>absent(),
-            /* ndkVersion */ Optional.<String>absent());
+            /* ndkVersion */ Optional.<String>absent(),
+            /* androidManifest */ Optional.<Path>absent());
     File buildToolsDir = new File(androidSdkDir, "build-tools");
     buildToolsDir.mkdir();
 
@@ -282,7 +287,8 @@ public class AndroidPlatformTargetTest {
         new FakeAndroidDirectoryResolver(
             Optional.of(androidSdkDir.toPath()),
             /* androidNdkDir */ Optional.<Path>absent(),
-            /* ndkVersion */ Optional.<String>absent());
+            /* ndkVersion */ Optional.<String>absent(),
+            /* androidManifest */ Optional.<Path>absent());
     File buildToolsDir = new File(androidSdkDir, "build-tools");
     buildToolsDir.mkdir();
     new File(buildToolsDir, "android-4.2.2").mkdir();
@@ -320,7 +326,8 @@ public class AndroidPlatformTargetTest {
         new FakeAndroidDirectoryResolver(
             Optional.of(androidSdkDir.toPath()),
             /* androidNdkDir */ Optional.<Path>absent(),
-            /* ndkVersion */ Optional.<String>absent());
+            /* ndkVersion */ Optional.<String>absent(),
+            /* androidManifest */ Optional.<Path>absent());
     File optionalLibsDir = new File(androidSdkDir, "platforms/android-23/optional");
     optionalLibsDir.mkdirs();
     Files.touch(new File(optionalLibsDir, "httpclient.jar"));
@@ -363,7 +370,8 @@ public class AndroidPlatformTargetTest {
         new FakeAndroidDirectoryResolver(
             Optional.of(androidSdkDir.toPath()),
             /* androidNdkDir */ Optional.<Path>absent(),
-            /* ndkVersion */ Optional.<String>absent());
+            /* ndkVersion */ Optional.<String>absent(),
+            /* androidManifest */ Optional.<Path>absent());
     try {
       AndroidPlatformTarget.getTargetForId(
           platformId,
@@ -390,7 +398,8 @@ public class AndroidPlatformTargetTest {
         new FakeAndroidDirectoryResolver(
             Optional.of(androidSdkDir.toPath()),
             /* androidNdkDir */ Optional.<Path>absent(),
-            /* ndkVersion */ Optional.<String>absent());
+            /* ndkVersion */ Optional.<String>absent(),
+            /* androidManifest */ Optional.<Path>absent());
     File buildToolsDir = new File(androidSdkDir, "build-tools");
     buildToolsDir.mkdir();
     new File(buildToolsDir, "android-4.2.2").mkdir();
@@ -437,7 +446,8 @@ public class AndroidPlatformTargetTest {
         new FakeAndroidDirectoryResolver(
             Optional.of(androidSdkDir.toPath()),
             /* androidNdkDir */ Optional.<Path>absent(),
-            /* ndkVersion */ Optional.<String>absent());
+            /* ndkVersion */ Optional.<String>absent(),
+            /* androidManifest */ Optional.<Path>absent());
     File buildToolsDir = new File(androidSdkDir, "build-tools");
     buildToolsDir.mkdir();
     File buildToolsDirFromOldUpgradePath = new File(buildToolsDir, "17.0.0");

--- a/test/com/facebook/buck/android/FakeAndroidDirectoryResolver.java
+++ b/test/com/facebook/buck/android/FakeAndroidDirectoryResolver.java
@@ -25,21 +25,25 @@ public class FakeAndroidDirectoryResolver implements AndroidDirectoryResolver {
   private final Optional<Path> androidSdkDir;
   private final Optional<Path> androidNdkDir;
   private final Optional<String> ndkVersion;
+  private final Optional<Path> androidMavenRepository;
 
   public FakeAndroidDirectoryResolver() {
     this(
         /* androidSdkDir */ Optional.<Path>absent(),
         /* androidNdkDir */ Optional.<Path>absent(),
-        /* ndkVersion */ Optional.<String>absent());
+        /* ndkVersion */ Optional.<String>absent(),
+        /* androidMavenRepository */ Optional.<Path>absent());
   }
 
   public FakeAndroidDirectoryResolver(
       Optional<Path> androidSdkDir,
       Optional<Path> androidNdkDir,
-      Optional<String> ndkVersion) {
+      Optional<String> ndkVersion,
+      Optional<Path> androidMavenRepository) {
     this.androidSdkDir = Preconditions.checkNotNull(androidSdkDir);
     this.androidNdkDir = Preconditions.checkNotNull(androidNdkDir);
     this.ndkVersion = Preconditions.checkNotNull(ndkVersion);
+    this.androidMavenRepository = Preconditions.checkNotNull(androidMavenRepository);
   }
 
   @Override
@@ -64,6 +68,11 @@ public class FakeAndroidDirectoryResolver implements AndroidDirectoryResolver {
   }
 
   @Override
+  public Optional<Path> findMavenRepository() {
+    return androidMavenRepository;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -77,12 +86,13 @@ public class FakeAndroidDirectoryResolver implements AndroidDirectoryResolver {
     return
         Objects.equals(androidNdkDir, that.androidNdkDir) &&
         Objects.equals(androidSdkDir, that.androidSdkDir) &&
-        Objects.equals(ndkVersion, that.ndkVersion);
+        Objects.equals(ndkVersion, that.ndkVersion) &&
+        Objects.equals(androidMavenRepository, that.androidMavenRepository);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(androidNdkDir, androidSdkDir, ndkVersion);
+    return Objects.hash(androidNdkDir, androidSdkDir, ndkVersion, androidMavenRepository);
   }
 
 }

--- a/test/com/facebook/buck/cli/CleanCommandTest.java
+++ b/test/com/facebook/buck/cli/CleanCommandTest.java
@@ -21,6 +21,7 @@ import static org.easymock.EasyMock.newCapture;
 import static org.junit.Assert.assertEquals;
 
 import com.facebook.buck.android.AndroidPlatformTarget;
+import com.facebook.buck.android.FakeAndroidDirectoryResolver;
 import com.facebook.buck.event.BuckEventBusFactory;
 import com.facebook.buck.httpserver.WebServer;
 import com.facebook.buck.io.ProjectFilesystem;
@@ -119,6 +120,7 @@ public class CleanCommandTest extends EasyMockSupport {
     return new CommandRunnerParams(
         new TestConsole(),
         repository,
+        new FakeAndroidDirectoryResolver(),
         androidPlatformTargetSupplier,
         new InstanceArtifactCacheFactory(createMock(ArtifactCache.class)),
         BuckEventBusFactory.newInstance(),

--- a/test/com/facebook/buck/cli/CommandRunnerParamsForTesting.java
+++ b/test/com/facebook/buck/cli/CommandRunnerParamsForTesting.java
@@ -68,6 +68,7 @@ public class CommandRunnerParamsForTesting {
     return new CommandRunnerParams(
         console,
         repository,
+        androidDirectoryResolver,
         Main.createAndroidPlatformTargetSupplier(
             androidDirectoryResolver,
             new AndroidBuckConfig(new FakeBuckConfig(), platform),

--- a/test/com/facebook/buck/cli/DaemonIntegrationTest.java
+++ b/test/com/facebook/buck/cli/DaemonIntegrationTest.java
@@ -581,7 +581,8 @@ public class DaemonIntegrationTest {
                 new FakeAndroidDirectoryResolver(
                     Optional.<Path>absent(),
                     Optional.<Path>absent(),
-                    Optional.of("something")))
+                    Optional.of("something"),
+                    Optional.<Path>absent()))
             .setFilesystem(filesystem)
             .build(),
         new FakeClock(0),
@@ -596,7 +597,8 @@ public class DaemonIntegrationTest {
                     new FakeAndroidDirectoryResolver(
                         Optional.<Path>absent(),
                         Optional.<Path>absent(),
-                        Optional.of("different")))
+                        Optional.of("different"),
+                        Optional.<Path>absent()))
                 .setFilesystem(filesystem)
                 .build(),
             new FakeClock(0),

--- a/test/com/facebook/buck/file/HttpDownloaderIntegrationTest.java
+++ b/test/com/facebook/buck/file/HttpDownloaderIntegrationTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import com.facebook.buck.event.BuckEventBusFactory;
 import com.facebook.buck.testutil.integration.HttpdForTests;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 
 import org.eclipse.jetty.server.handler.MovedContextHandler;
@@ -62,7 +63,7 @@ public class HttpDownloaderIntegrationTest {
 
   @Before
   public void createDownloader() throws IOException {
-    downloader = new HttpDownloader(Optional.<Proxy>absent(), Optional.<String>absent());
+    downloader = new HttpDownloader(Optional.<Proxy>absent(), ImmutableMap.<String, String>of());
     outputDir = tmp.newFolder().toPath();
   }
 

--- a/test/com/facebook/buck/file/HttpDownloaderIntegrationTest.java
+++ b/test/com/facebook/buck/file/HttpDownloaderIntegrationTest.java
@@ -63,7 +63,9 @@ public class HttpDownloaderIntegrationTest {
 
   @Before
   public void createDownloader() throws IOException {
-    downloader = new HttpDownloader(Optional.<Proxy>absent(), ImmutableMap.<String, String>of());
+    downloader = new HttpDownloader(Optional.<Proxy>absent(),
+        Optional.<Path>absent(),
+        ImmutableMap.<String, String>of());
     outputDir = tmp.newFolder().toPath();
   }
 

--- a/test/com/facebook/buck/file/HttpDownloaderTest.java
+++ b/test/com/facebook/buck/file/HttpDownloaderTest.java
@@ -24,6 +24,7 @@ import com.facebook.buck.event.BuckEventBus;
 import com.facebook.buck.event.BuckEventBusFactory;
 import com.facebook.buck.util.HumanReadableException;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 
 import org.easymock.EasyMock;
 import org.junit.Test;
@@ -50,7 +51,7 @@ public class HttpDownloaderTest {
     EasyMock.replay(connection);
 
     Downloader downloader =
-        new HttpDownloader(Optional.<Proxy>absent(), Optional.<String>absent()) {
+        new HttpDownloader(Optional.<Proxy>absent(), ImmutableMap.<String, String>of()) {
           @Override
           protected HttpURLConnection createConnection(URI uri) throws IOException {
             return connection;
@@ -69,7 +70,8 @@ public class HttpDownloaderTest {
   @Test(expected = HumanReadableException.class)
   @SuppressWarnings("PMD.EmptyCatchBlock")
   public void shouldThrowIfUrlIsNotHttpOrMaven() throws URISyntaxException, IOException {
-    Downloader downloader = new HttpDownloader(Optional.<Proxy>absent(), Optional.<String>absent());
+    Downloader downloader = new HttpDownloader(Optional.<Proxy>absent(),
+        ImmutableMap.<String, String>of());
 
     downloader.fetch(eventBus, new URI("example:foo/bar/baz"), neverUsed);
   }

--- a/test/com/facebook/buck/file/HttpDownloaderTest.java
+++ b/test/com/facebook/buck/file/HttpDownloaderTest.java
@@ -51,7 +51,9 @@ public class HttpDownloaderTest {
     EasyMock.replay(connection);
 
     Downloader downloader =
-        new HttpDownloader(Optional.<Proxy>absent(), ImmutableMap.<String, String>of()) {
+        new HttpDownloader(Optional.<Proxy>absent(),
+            Optional.<Path>absent(),
+            ImmutableMap.<String, String>of()) {
           @Override
           protected HttpURLConnection createConnection(URI uri) throws IOException {
             return connection;
@@ -71,8 +73,18 @@ public class HttpDownloaderTest {
   @SuppressWarnings("PMD.EmptyCatchBlock")
   public void shouldThrowIfUrlIsNotHttpOrMaven() throws URISyntaxException, IOException {
     Downloader downloader = new HttpDownloader(Optional.<Proxy>absent(),
+        Optional.<Path>absent(),
         ImmutableMap.<String, String>of());
 
     downloader.fetch(eventBus, new URI("example:foo/bar/baz"), neverUsed);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void shouldThrowIfAndroidAndNotConfigured() throws URISyntaxException, IOException {
+    Downloader downloader = new HttpDownloader(Optional.<Proxy>absent(),
+        Optional.<Path>absent(),
+        ImmutableMap.<String, String>of());
+
+    downloader.fetch(eventBus, new URI("android:foo/bar/baz"), neverUsed);
   }
 }


### PR DESCRIPTION
Some android repositories support more than one one Maven repository at a time.  This allows us to declare them all in one place.