### PR TITLE
Don't show warnings for superfluous R.txt entries in prebuilt aars

### DIFF
--- a/src/com/facebook/buck/android/AaptPackageResources.java
+++ b/src/com/facebook/buck/android/AaptPackageResources.java
@@ -99,7 +99,6 @@ public class AaptPackageResources extends AbstractBuildRule
   private final boolean rDotJavaNeedsDexing;
   @AddToRuleKey
   private final boolean shouldBuildStringSourceMap;
-  private final boolean shouldWarnIfMissingResource;
   @AddToRuleKey
   private final boolean skipCrunchPngs;
   private final BuildOutputInitializer<BuildOutput> buildOutputInitializer;
@@ -115,7 +114,6 @@ public class AaptPackageResources extends AbstractBuildRule
       JavacOptions javacOptions,
       boolean rDotJavaNeedsDexing,
       boolean shouldBuildStringSourceMap,
-      boolean shouldWarnIfMissingResources,
       boolean skipCrunchPngs) {
     super(params, resolver);
     this.manifest = manifest;
@@ -126,7 +124,6 @@ public class AaptPackageResources extends AbstractBuildRule
     this.javacOptions = javacOptions;
     this.rDotJavaNeedsDexing = rDotJavaNeedsDexing;
     this.shouldBuildStringSourceMap = shouldBuildStringSourceMap;
-    this.shouldWarnIfMissingResource = shouldWarnIfMissingResources;
     this.skipCrunchPngs = skipCrunchPngs;
     this.buildOutputInitializer = new BuildOutputInitializer<>(params.getBuildTarget(), this);
   }
@@ -364,7 +361,6 @@ public class AaptPackageResources extends AbstractBuildRule
         getProjectFilesystem(),
         resourceDeps,
         getPathToRDotTxtFile(),
-        shouldWarnIfMissingResource,
         rDotJavaSrc);
     steps.add(mergeStep);
 

--- a/src/com/facebook/buck/android/AndroidBinaryGraphEnhancer.java
+++ b/src/com/facebook/buck/android/AndroidBinaryGraphEnhancer.java
@@ -230,7 +230,6 @@ public class AndroidBinaryGraphEnhancer {
         javacOptions,
         shouldPreDex,
         shouldBuildStringSourceMap,
-        locales.isEmpty(),
         skipCrunchPngs);
     ruleResolver.addToIndex(aaptPackageResources);
     enhancedDeps.add(aaptPackageResources);

--- a/test/com/facebook/buck/android/AaptPackageResourcesTest.java
+++ b/test/com/facebook/buck/android/AaptPackageResourcesTest.java
@@ -81,7 +81,6 @@ public class AaptPackageResourcesTest {
         DEFAULT_JAVAC_OPTIONS,
         /* rDotJavaNeedsDexing */ false,
         /* shouldBuildStringSourceMap */ false,
-        /* shouldWarnIfMissingResources */ false,
         /* skipCrunchPngs */ false);
 
     // Build up the parameters needed to invoke createAllAssetsDirectory().
@@ -146,7 +145,6 @@ public class AaptPackageResourcesTest {
         DEFAULT_JAVAC_OPTIONS,
         /* rDotJavaNeedsDexing */ false,
         /* shouldBuildStringSourceMap */ false,
-        /* shouldWarnIfMissingResources */ false,
         /* skipCrunchPngs */ false);
 
     // Build up the parameters needed to invoke createAllAssetsDirectory().
@@ -228,7 +226,6 @@ public class AaptPackageResourcesTest {
         DEFAULT_JAVAC_OPTIONS,
         /* rDotJavaNeedsDexing */ false,
         /* shouldBuildStringSourceMap */ false,
-        /* shouldWarnIfMissingResources */ false,
         /* skipCrunchPngs */ false);
 
     AndroidResource resourceOne = (AndroidResource) ruleResolver.getRule(
@@ -343,7 +340,6 @@ public class AaptPackageResourcesTest {
             DEFAULT_JAVAC_OPTIONS,
             /* rDotJavaNeedsDexing */ false,
             /* shouldBuildStringSourceMap */ false,
-            /* shouldWarnIfMissingResources */ false,
             /* skipCrunchPngs */ false);
 
     FakeOnDiskBuildInfo onDiskBuildInfo =

--- a/test/com/facebook/buck/android/AndroidBinaryGraphEnhancerTest.java
+++ b/test/com/facebook/buck/android/AndroidBinaryGraphEnhancerTest.java
@@ -157,7 +157,6 @@ public class AndroidBinaryGraphEnhancerTest {
         ANDROID_JAVAC_OPTIONS,
         false,
         false,
-        /* warnMissingResource */ false,
         /* skipCrunchPngs */ false);
     ruleResolver.addToIndex(aaptPackageResources);
 

--- a/test/com/facebook/buck/android/AndroidPrebuiltAarIntegrationTest.java
+++ b/test/com/facebook/buck/android/AndroidPrebuiltAarIntegrationTest.java
@@ -17,10 +17,12 @@
 package com.facebook.buck.android;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 import com.facebook.buck.testutil.integration.DebuggableTemporaryFolder;
 import com.facebook.buck.testutil.integration.ProjectWorkspace;
+import com.facebook.buck.testutil.integration.ProjectWorkspace.ProcessResult;
 import com.facebook.buck.testutil.integration.TestDataHelper;
 import com.facebook.buck.testutil.integration.ZipInspector;
 
@@ -84,5 +86,17 @@ public class AndroidPrebuiltAarIntegrationTest {
         "R.txt contains transitive dependencies",
         rDotTxt,
         containsString(appCompatResource));
+  }
+
+  @Test
+  public void testExtraDepsDontResultInWarning() throws IOException {
+    ProcessResult result =
+        workspace.runBuckBuild("//:app-extra-res-entry").assertSuccess();
+
+    String buildOutput = result.getStderr();
+    assertThat(
+        "No warnings are shown",
+        buildOutput,
+        not(containsString("Cannot find resource")));
   }
 }

--- a/test/com/facebook/buck/android/MergeAndroidResourcesStepTest.java
+++ b/test/com/facebook/buck/android/MergeAndroidResourcesStepTest.java
@@ -67,14 +67,10 @@ public class MergeAndroidResourcesStepTest {
             "int attr c1 0x7f010001",
             "int[] styleable c1 { 0x7f010001 }")));
 
-    ExecutionContext executionContext = TestExecutionContext.newInstance();
-
     SortedSetMultimap<String, RDotTxtEntry> packageNameToResources =
         MergeAndroidResourcesStep.sortSymbols(
             entriesBuilder.buildFilePathToPackageNameSet(),
             Optional.<ImmutableMap<RDotTxtEntry, String>>absent(),
-            /* warnMissingResource */ false,
-            executionContext,
             entriesBuilder.getProjectFilesystem());
 
     assertEquals(1, packageNameToResources.keySet().size());
@@ -131,7 +127,6 @@ public class MergeAndroidResourcesStepTest {
         filesystem,
         ImmutableList.of(resource),
         Optional.of(uberRDotTxt),
-        /* warnMissingResource */ false,
         Paths.get("output"));
 
     ExecutionContext executionContext = TestExecutionContext.newInstance();

--- a/test/com/facebook/buck/android/testdata/android_prebuilt_aar/BUCK.fixture
+++ b/test/com/facebook/buck/android/testdata/android_prebuilt_aar/BUCK.fixture
@@ -17,6 +17,15 @@ genrule(
   ],
 )
 
+genrule(
+  name = 'gen_aar-with-extra-res-entry',
+  cmd = '$(exe :aar_generator) --extra-res-entry $TMP $OUT',
+  out = 'extra.aar',
+  visibility = [
+    'PUBLIC',
+  ],
+)
+
 python_binary(
   name = 'aar_generator',
   main = 'gen_aar.py',
@@ -47,6 +56,15 @@ android_binary(
   package_type = 'DEBUG',
   deps = [
     ':lib',
+  ],
+)
+
+android_binary(
+  name = 'app-extra-res-entry',
+  manifest = 'AndroidManifest.xml',
+  keystore = ':debug',
+  deps = [
+    '//android_prebuilt_aar-dep:aar-extra-res-entry',
   ],
 )
 

--- a/test/com/facebook/buck/android/testdata/android_prebuilt_aar/android_prebuilt_aar-dep/BUCK.fixture
+++ b/test/com/facebook/buck/android/testdata/android_prebuilt_aar/android_prebuilt_aar-dep/BUCK.fixture
@@ -11,6 +11,12 @@ android_prebuilt_aar(
   aar = '//:gen_aar-with-jsr',
 )
 
+android_prebuilt_aar(
+  name = 'aar-extra-res-entry',
+  aar = '//:gen_aar-with-extra-res-entry',
+  visibility = [ 'PUBLIC' ],
+)
+
 android_library(
   name = 'lib',
   srcs = [ 'ExampleActivity.java' ],

--- a/test/com/facebook/buck/android/testdata/android_prebuilt_aar/gen_aar.py
+++ b/test/com/facebook/buck/android/testdata/android_prebuilt_aar/gen_aar.py
@@ -24,6 +24,7 @@ from optparse import OptionParser
 if __name__ == "__main__":
     parser = OptionParser()
     parser.add_option("--lib", action="store", dest="lib", default="")
+    parser.add_option("--extra-res-entry", action="store_true", dest="extra_res", default=False)
     (options, args) = parser.parse_args()
     tmp = args[0]
     output = args[1]
@@ -46,6 +47,8 @@ if __name__ == "__main__":
     # Write out R.txt
     with open(os.path.join(tmp, "R.txt"), "w") as f:
         f.write("int string app_name 0x7f030000")
+        if options.extra_res:
+            f.write("\nint string extra_res 0x7f030001")
 
     # Include some .class files in classes.jar because the .aar spec requires it
     with open(os.path.join(tmp, "Utils.java"), "w") as f:


### PR DESCRIPTION
Summary:
Some R.txt files in prebuilt aars contain entries which are not defined
in the res directory, e.g. the R.txt in the google-play-services-base aar
contains the entries for all other play-services aars, but doesn't
define all of them in the res directory.

Because buck recently switched to using the resource entries from the
R.txt from a prebuilt aar, instead of generating them from the res
directory, this causes warnings such as: "Cannot find resource
'RDotTxtEntry{idType=int, type=attr, name=adSize, idValue=0x7f010000}'
in the uber R.txt.".

The user cannot do anything about these warnings, short of editing the
prebuilt aar, and they could be distracting from actual issues in the
project.  Disable the warnings if the resources come from a prebuilt aar
to fix this.

Test Plan:
add test
build project which includes the google-play-services-base