### PR TITLE
Make python extension that depend on cxx_libraries work.

### DIFF
--- a/src/com/facebook/buck/cxx/DarwinLinker.java
+++ b/src/com/facebook/buck/cxx/DarwinLinker.java
@@ -76,6 +76,11 @@ public class DarwinLinker implements Linker {
   }
 
   @Override
+  public String libOrigin() {
+    return "@loader_path";
+  }
+
+  @Override
   public String searchPathEnvVar() {
     return "DYLD_LIBRARY_PATH";
   }

--- a/src/com/facebook/buck/cxx/GnuLinker.java
+++ b/src/com/facebook/buck/cxx/GnuLinker.java
@@ -74,6 +74,11 @@ public class GnuLinker implements Linker {
   }
 
   @Override
+  public String libOrigin() {
+    return "$ORIGIN";
+  }
+
+  @Override
   public String searchPathEnvVar() {
     return "LD_LIBRARY_PATH";
   }

--- a/src/com/facebook/buck/cxx/Linker.java
+++ b/src/com/facebook/buck/cxx/Linker.java
@@ -49,6 +49,12 @@ public interface Linker extends Tool {
   String origin();
 
   /**
+   * @return the placeholder used by the dynamic loader for the directory containing the top-level
+   *     library (useful for e.g. plugins).
+   */
+  String libOrigin();
+
+  /**
    * @return the name of the environment variable for the shared library runtime search path.
    */
   String searchPathEnvVar();

--- a/src/com/facebook/buck/cxx/UnknownLinker.java
+++ b/src/com/facebook/buck/cxx/UnknownLinker.java
@@ -81,6 +81,11 @@ public class UnknownLinker implements Linker {
   }
 
   @Override
+  public String libOrigin() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public RuleKeyBuilder appendToRuleKey(RuleKeyBuilder builder) {
     return builder
         .setReflectively("tool", tool)

--- a/src/com/facebook/buck/cxx/WindowsLinker.java
+++ b/src/com/facebook/buck/cxx/WindowsLinker.java
@@ -73,6 +73,11 @@ public class WindowsLinker implements Linker {
   }
 
   @Override
+  public String libOrigin() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public String searchPathEnvVar() {
     return "PATH";
   }

--- a/src/com/facebook/buck/python/pex.py
+++ b/src/com/facebook/buck/python/pex.py
@@ -131,7 +131,10 @@ def main():
             except Exception as e:
                 raise Exception("Failed to add {}: {}".format(req, e))
 
-        # TODO(mikekap): Do something about manifest['nativeLibraries'].
+        # Add resources listed in the manifest.
+        for dst, src in manifest['nativeLibraries'].iteritems():
+            # NOTE(agallagher): see rationale above.
+            pex_builder.add_resource(dereference_symlinks(src), dst)
 
         # Generate the PEX file.
         pex_builder.build(output)


### PR DESCRIPTION
We do this by adding a "-rpath @loader_path/" to the link flags of a cxx_python_extension.