### PR TITLE
Don't define the dependency on real_commad twice

### DIFF
--- a/test/com/facebook/buck/cli/testdata/run-command/cmd/BUCK.fixture
+++ b/test/com/facebook/buck/cli/testdata/run-command/cmd/BUCK.fixture
@@ -11,8 +11,5 @@ genrule(
 sh_binary(
   name = 'command',
   main = ':real_command',
-  deps = [
-    ':real_command',
-  ],
 )
 


### PR DESCRIPTION
It's already defined through:

  main = ':real_command'

So, no need to add a dependency on it.

Test Plan: CI.