### PR TITLE
show the name of the relevant jar when we find a duplicate file entry

### DIFF
--- a/src/com/facebook/buck/java/JarDirectoryStepHelper.java
+++ b/src/com/facebook/buck/java/JarDirectoryStepHelper.java
@@ -85,7 +85,8 @@ public class JarDirectoryStepHelper {
               "Trying to put file %s into itself",
               file);
           // Assume the file is a ZIP/JAR file.
-          copyZipEntriesToJar(file,
+          copyZipEntriesToJar(
+              file,
               outputFile,
               manifest,
               alreadyAddedEntries,
@@ -189,7 +190,7 @@ public class JarDirectoryStepHelper {
         if (!isDuplicateAllowed(entryName) && !alreadyAddedEntries.add(entryName)) {
           // Duplicate entries. Skip.
           eventBus.post(ConsoleEvent.create(
-              determineSeverity(entry), "Duplicate found when adding file to jar: %s", entryName));
+              determineSeverity(entry), "Duplicate found when adding file: %s to jar: %s", entryName, file.toString()));
           continue;
         }
 


### PR DESCRIPTION
We have found it useful to know which jar we're constructing when we hit a duplicate entry.