### PR TITLE
Docs: Add missing space

### DIFF
--- a/docs/about/performance_tuning.soy
+++ b/docs/about/performance_tuning.soy
@@ -53,7 +53,7 @@ information on the trace viewer and the file format.
 After Buck is done with each build, it will produce a Chrome Trace file that can
 be loaded up in <code>chrome://tracing</code> in the directory
 {sp}<code>buck-out/log/traces/</code>.  Buck will save a file in the format
-<code>build.[timestamp].trace</code>, and then create a symlink from the most
+{sp}<code>build.[timestamp].trace</code>, and then create a symlink from the most
 recent trace to <code>build.trace</code>.
 
 <p>

--- a/docs/contributing/immutables.soy
+++ b/docs/contributing/immutables.soy
@@ -35,7 +35,7 @@ as well as <a href="http://cantina.co/immutable-objects-and-the-builder-pattern/
 put together instances of a value type piece by piece.
 
 <p>To use immutable value types in a Buck <code>java_library</code>, use the
-<code>java_immutables_library</code> function in your <code>BUCK</code> file.  For example:</code>
+{sp}<code>java_immutables_library</code> function in your <code>BUCK</code> file.  For example:
 
 {literal}<pre class="prettyprint lang-py">
 java_immutables_library(

--- a/docs/extending/rules.soy
+++ b/docs/extending/rules.soy
@@ -76,7 +76,7 @@ Optional&lt;String> name;</code>)
 <h3>Constructing new BuildRule instances</h3>
 
 When Buck needs to construct a <code>BuildRule</code> it will call
-<code>Description.createBuildRule()</code>, passing in a populated
+{sp}<code>Description.createBuildRule()</code>, passing in a populated
 constructor arg. Collection types on that arg will have been
 instantiated with an empty collection, even if they are declared as
 being optional.
@@ -93,10 +93,10 @@ and we suggest you do so too.
 <p>
 
 The created <code>BuildRule</code> will be registered with the
-<code>BuildRuleResolver</code> automatically. There are, however,
+{sp}<code>BuildRuleResolver</code> automatically. There are, however,
 plenty of cases where a <code>BuildRule</code> will want to depend on
 existing functionality that's already expressed as a
-<code>BuildRule</code>. In this case, it's fine to create that
+{sp}<code>BuildRule</code>. In this case, it's fine to create that
 intermediate rule in the <code>createBuildRule()</code> method, add it
 to the resolver, and then add that newly created rule as a dependency
 of the one ultimately returned from the method. The only caveat: each
@@ -106,7 +106,7 @@ name by which it's referred to in the action graph.
 <p>
 
 You are strongly encouraged to delay doing any work in your
-<code>BuildRule</code> until the <code>getBuildSteps()</code>
+{sp}<code>BuildRule</code> until the <code>getBuildSteps()</code>{sp}
 method. In particular, don't do any work other than assigning fields
 in the constructor! The exception to this is working out the path to
 the output of your rule.
@@ -114,8 +114,8 @@ the output of your rule.
 <p>
 
 You can think of a <code>Description</code> as a factory of
-<code>BuildRule</code> instances. Similarly, you can think of a
-<code>BuildRule</code> as a factory of <a
+{sp}<code>BuildRule</code> instances. Similarly, you can think of a
+{sp}<code>BuildRule</code> as a factory of <a
 href="https://buckbuild.com/javadoc/com/facebook/buck/step/Step.html"><code>Step</code>s</a>
 {sp}that must be executed in order to create a specific output. Unlike
 rules, steps are executed sequentially in the order in which they are
@@ -129,7 +129,7 @@ uniqueness with <a
 href="https://buckbuild.com/javadoc/com/facebook/buck/rules/AddToRuleKey.html"><code>@AddToRuleKey</code></a>. This
 is used by Buck to calculate the rule key, which, if the value changes
 between builds, will cause Buck to re-execute your
-<code>BuildRule</code>.
+{sp}<code>BuildRule</code>.
 
 <p>
 

--- a/docs/function/string_parameter_macros.soy
+++ b/docs/function/string_parameter_macros.soy
@@ -34,7 +34,7 @@ any time to prevent expansion (e.g. <code>\$(dirname ...)</code>).
 
 {param examples}
 
-The following example uses a string parameter macros in a <code>genrule()</code>
+The following example uses a string parameter macros in a <code>genrule()</code>{sp}
 to copy the output of another rule:
 {literal}<pre class="prettyprint lang-py">
 genrule(

--- a/docs/rule/android_instrumentation_apk.soy
+++ b/docs/rule/android_instrumentation_apk.soy
@@ -57,7 +57,7 @@ when running the test.
 {/param} // close args
 
 {param examples}
-Here is an example of an <code>android_instrumentation_apk()</code>
+Here is an example of an <code>android_instrumentation_apk()</code>{sp}
 rule that tests a <code>android_binary()</code>, and depends on a test
 package.
 

--- a/docs/rule/java_binary.soy
+++ b/docs/rule/java_binary.soy
@@ -47,7 +47,7 @@ compiled .class files and resources of the <code>java_library()</code>
   {sp}<code>Main-Class</code> attribute of the <code>META-INF/MANIFEST.MF</code>
   {sp}file in the generated JAR file. Also, when this rule is used as
   an executable in a <a href="genrule.html"><code>genrule()</code></a>,
-  {sp}<code>main_class</code> will indicate the class whose <code>main()</code>
+  {sp}<code>main_class</code> will indicate the class whose <code>main()</code>{sp}
   method will be invoked to process the command-line arguments. This
   is consistent with the expected usage of <code>java -jar
   <em>&lt;name.jar></em> <em>&lt;args></em></code>.

--- a/docs/rule/java_library.soy
+++ b/docs/rule/java_library.soy
@@ -111,7 +111,7 @@ of the compiled class files and resources.
   {param default: '<global value>' /}
   {param desc}
   Equivalent to setting both <code>source</code> and <code>target
-  </code> to the given value. Setting this and <code>source</code>
+  </code> to the given value. Setting this and <code>source</code>{sp}
   or <code>target</code> (or both!) is an error.
   {/param} 
 {/call}

--- a/docs/rule/java_test.soy
+++ b/docs/rule/java_test.soy
@@ -14,7 +14,7 @@
 {param status: 'FROZEN' /}
 {param overview}
 A <code>java_test()</code> rule is used to define a set of
-<code>.java</code> files that contain tests to run via JUnit.
+{sp}<code>.java</code> files that contain tests to run via JUnit.
 {/param}
 
 {param args}

--- a/docs/rule/python_test.soy
+++ b/docs/rule/python_test.soy
@@ -14,7 +14,7 @@
 {call buck.rule}
 {param status: 'UNFROZEN' /}
 {param overview}
-A <code>python_test()</code> rule is used to define a set of <code>.py</code>
+A <code>python_test()</code> rule is used to define a set of <code>.py</code>{sp}
 files that contain tests to run via the <a href="https://docs.python.org/2/library/unittest.html">Python unit testing framework</a>.
 {/param}
 

--- a/docs/rule/remote_file.soy
+++ b/docs/rule/remote_file.soy
@@ -17,7 +17,7 @@
 A <code>remote_file()</code> rule is used to download files from the Internet to be used as
 dependencies for other rules. These rules are downloaded by running {call buck.cmd_fetch /}, or can
 be downloaded as part of {call buck.cmd_build /}. See the note there about the
-<code>.buckconfig</code> setting to configure that.
+{sp}<code>.buckconfig</code> setting to configure that.
 {/param}
 
 {param args}

--- a/docs/rule/zip_file.soy
+++ b/docs/rule/zip_file.soy
@@ -41,7 +41,7 @@
   {param name: 'srcs' /}
   {param desc}
   The set of files to include in the zip. If any of these are source
-  zips (indicated by a file name ending in <code>-sources.jar</code>
+  zips (indicated by a file name ending in <code>-sources.jar</code>{sp}
   or <code>.src.zip</code>) the contents of the source zip will be
   added to the generated zip, rather than the source zip itself. This
   provides a mechanism to roll up multiple source zips into a single
@@ -94,7 +94,7 @@ zip_file(
 If you were to examine the generated zip, the contents would look
 something like (assuming the output of
 "<code>//some/other:target</code>" was a file who's path ended with
-<code>hello.txt</code>, the "<code>dir</code>" glob found two files,
+{sp}<code>hello.txt</code>, the "<code>dir</code>" glob found two files,
 and "<code>amazing-library-1.0-sources.zip</code>" contained two Java
 source files):
 


### PR DESCRIPTION
Summary:
Soy templates don't add spaces on new lines when the previous line ends
with a html tag, or when the new line starts with one.  Some places in
the docs don't have a {sp} tag to force spaces on these lines.  Add
these tags where appropriate to improve the visualization of the docs.

In addition remove a stray </code> tag in the immutables documentation.

Test Plan: docs/soyweb-local.sh