### PR TITLE
AndroidLibrary/AndroidPrebuiltAar: code cleanup

### DIFF
--- a/src/com/facebook/buck/android/AndroidLibrary.java
+++ b/src/com/facebook/buck/android/AndroidLibrary.java
@@ -48,8 +48,6 @@ public class AndroidLibrary extends DefaultJavaLibrary implements AndroidPackage
   @AddToRuleKey
   private final Optional<SourcePath> manifestFile;
 
-  private final boolean isPrebuiltAar;
-
   @VisibleForTesting
   public AndroidLibrary(
       BuildRuleParams params,
@@ -66,7 +64,6 @@ public class AndroidLibrary extends DefaultJavaLibrary implements AndroidPackage
       Optional<Path> resourcesRoot,
       Optional<String> mavenCoords,
       Optional<SourcePath> manifestFile,
-      boolean isPrebuiltAar,
       ImmutableSortedSet<BuildTarget> tests) {
     super(
         params,
@@ -84,7 +81,6 @@ public class AndroidLibrary extends DefaultJavaLibrary implements AndroidPackage
         mavenCoords,
         tests);
     this.manifestFile = manifestFile;
-    this.isPrebuiltAar = isPrebuiltAar;
   }
 
   @Override
@@ -96,8 +92,4 @@ public class AndroidLibrary extends DefaultJavaLibrary implements AndroidPackage
     return manifestFile;
   }
 
-  /** @return whether this library was generated from an {@link AndroidPrebuiltAarDescription}. */
-  public boolean isPrebuiltAar() {
-    return isPrebuiltAar;
-  }
 }

--- a/src/com/facebook/buck/android/AndroidLibraryDescription.java
+++ b/src/com/facebook/buck/android/AndroidLibraryDescription.java
@@ -158,7 +158,6 @@ public class AndroidLibraryDescription
                   args.resourcesRoot,
                   args.mavenCoords,
                   args.manifest,
-                  /* isPrebuiltAar */ false,
                   args.tests.get()));
 
       resolver.addToIndex(

--- a/src/com/facebook/buck/android/AndroidPrebuiltAar.java
+++ b/src/com/facebook/buck/android/AndroidPrebuiltAar.java
@@ -70,7 +70,6 @@ public class AndroidPrebuiltAar
         /* mavenCoords */ Optional.<String>absent(),
         Optional.<SourcePath>of(
             new BuildTargetSourcePath(unzipAar.getBuildTarget(), unzipAar.getAndroidManifest())),
-        /* isPrebuiltAar */ true,
         /* tests */ ImmutableSortedSet.<BuildTarget>of());
     this.unzipAar = unzipAar;
     this.prebuiltJar = prebuiltJar;

--- a/test/com/facebook/buck/java/DefaultJavaLibraryTest.java
+++ b/test/com/facebook/buck/java/DefaultJavaLibraryTest.java
@@ -1599,7 +1599,6 @@ public class DefaultJavaLibraryTest {
           /* resourcesRoot */ Optional.<Path>absent(),
           /* mavenCoords */ Optional.<String>absent(),
           /* manifestFile */ Optional.<SourcePath>absent(),
-          /* isPrebuiltAar */ false,
           /* tests */ ImmutableSortedSet.<BuildTarget>of());
     }
 


### PR DESCRIPTION
Summary:
The only caller of the isPrebuiltAar() function in the AndroidLibrary
class was removed in 4cf0eb7 ("Simplify how we deal with resources
inside an `AndroidPrebuiltAar`.").  Remove the unnecessary function.

Test Plan: buck test