### PR TITLE
Avoid running ant when buck is already built

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -162,7 +162,7 @@
 
   <!-- Default target so that a command line build can
        do more than one thing. -->
-  <target name="default" depends="compile, dx, client, javac-tracing, report-generator-jar" />
+  <target name="default" depends="start-build, compile, dx, client, javac-tracing, report-generator-jar, build-successful" />
 
   <target name="checkversion">
     <!-- The nio Files class was only introduced in Java 7. -->
@@ -992,4 +992,16 @@
 
   <target name="pre-checkin" depends="clean, default, compile-tests, lint"/>
   <target name="all" depends="jar, test, javadoc, client" />
+
+  <target name="start-build"
+          description="Remove build successful marker before building">
+    <delete file="${build.dir}/successful-build" />
+  </target>
+
+  <target name="build-successful"
+          depends="compile"
+          description="Mark the build as successful">
+    <touch file="${build.dir}/successful-build" />
+  </target>
+
 </project>

--- a/programs/buck_repo.py
+++ b/programs/buck_repo.py
@@ -260,7 +260,6 @@ class BuckRepo(BuckTool):
                 ant = self._check_for_ant()
                 self._run_ant_clean(ant)
                 self._run_ant(ant)
-                open(self._build_success_file, 'w').close()
                 print("All done, continuing with build.", file=sys.stderr)
 
     def _has_resource(self, resource):


### PR DESCRIPTION
Summary:
When building buck using ant, no "successful-build" file is created in
the build directory.  Because buck checks this file to determine whether
to invoke ant or not to build buck from source when it is executed, ant
is unnecessarily invoked again when buck is run, when buck was build
directly using ant.

Instead of writing the file after the python wrapper executes ant, write
the file when ant compiles buck successfully.

Test Plan:
Build buck using ant, and then build a project using buck