### PR TITLE
Docs: remove deps parameter for genrules

### DIFF
--- a/docs/__genrule_common.soy
+++ b/docs/__genrule_common.soy
@@ -103,16 +103,3 @@
   {/param}
 {/call}
 {/template}
-
-/***/
-{template .deps_arg}
-{call buck.arg}
-  {param name: 'deps' /}
-  {param default: '[]' /}
-  {param desc}
-  A list of rules that must be built before this rule. These may be
-  accessed within the <code>cmd</code> by treating the target as a
-  brace-wrapped variable: <code>$(location /&#x2F;like:this)</code>.
-  {/param}
-{/call}
-{/template}

--- a/docs/rule/apk_genrule.soy
+++ b/docs/rule/apk_genrule.soy
@@ -48,8 +48,6 @@ produce APKs, so commands like <code>buck install</code> or
 
 {call genrule_common.out_arg /}
 
-{call genrule_common.deps_arg /}
-
 {call buck.visibility_arg /}
 
 {/param} // close args

--- a/docs/rule/genrule.soy
+++ b/docs/rule/genrule.soy
@@ -37,8 +37,6 @@
 
 {call genrule_common.out_arg /}
 
-{call genrule_common.deps_arg /}
-
 {call buck.visibility_arg /}
 
 {/param} // args


### PR DESCRIPTION
Summary:
The deps parameter for genrules is not respected, and should therefore
not be documented, as it might confuse users otherwise.  The deps are
instead pulled out of the cmd, cmd_exe or bash parameters, if location,
exe or classpath macros are given.

Test Plan: ./docs/soyweb-local.sh