### PR TITLE
[Publisher/PMD] Refactor publisher to workaround a PMD issue.

### DIFF
--- a/test/com/facebook/buck/maven/PublisherIntegrationTest.java
+++ b/test/com/facebook/buck/maven/PublisherIntegrationTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
 import com.facebook.buck.testutil.integration.TestDataHelper;
+import com.google.common.collect.ImmutableList;
 
 import org.junit.After;
 import org.junit.Before;
@@ -69,7 +70,7 @@ public class PublisherIntegrationTest {
     File jar = artifactDir.resolve(String.format(fileNameTemplate, extension)).toFile();
     File pom = artifactDir.resolve(String.format(fileNameTemplate, "pom")).toFile();
 
-    publisher.publish(groupId, artifactName, version, jar, pom);
+    publisher.publish(groupId, artifactName, version, ImmutableList.of(jar, pom));
 
     List<String> putRequestsInvoked = publisher.getPutRequestsHandler().getPutRequestsPaths();
     assertFalse(putRequestsInvoked.isEmpty());


### PR DESCRIPTION
Summary:
The version of PMD that we use dose not handle varargs properly, and hit
errors while processing them. We update the varargs to Lists. This also
avoids arrays and array-list conversions. There is no functional changes
in the change set.

Test:
ant clean lint && ant && buck test