### PR TITLE
HH[Python Test] Fix tests that use FakeProcessExecutor.

### DIFF
--- a/test/com/facebook/buck/jvm/java/JavaSymbolFinderIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/java/JavaSymbolFinderIntegrationTest.java
@@ -62,6 +62,7 @@ public class JavaSymbolFinderIntegrationTest {
     workspace.setUp();
 
     ProjectFilesystem projectFilesystem = new ProjectFilesystem(temporaryFolder.getRootPath());
+    ImmutableMap<String, String> environment = ImmutableMap.copyOf(System.getenv());
     Config rawConfig = Config.createDefaultConfig(
         projectFilesystem.getRootPath(),
         ImmutableMap.<String, ImmutableMap<String, String>>of());
@@ -70,7 +71,7 @@ public class JavaSymbolFinderIntegrationTest {
         projectFilesystem,
         Architecture.detect(),
         Platform.detect(),
-        ImmutableMap.copyOf(System.getenv()));
+        environment);
 
     ParserConfig parserConfig = new ParserConfig(config);
     PythonBuckConfig pythonBuckConfig = new PythonBuckConfig(
@@ -78,7 +79,7 @@ public class JavaSymbolFinderIntegrationTest {
         new ExecutableFinder());
     ImmutableSet<Description<?>> allDescriptions =
         DefaultKnownBuildRuleTypes
-        .getDefaultKnownBuildRuleTypes(projectFilesystem)
+        .getDefaultKnownBuildRuleTypes(projectFilesystem, environment)
         .getAllDescriptions();
     SrcRootsFinder srcRootsFinder = new SrcRootsFinder(projectFilesystem);
     ProjectBuildFileParserFactory projectBuildFileParserFactory =
@@ -100,7 +101,7 @@ public class JavaSymbolFinderIntegrationTest {
         config,
         buckEventBus,
         new TestConsole(),
-        ImmutableMap.copyOf(System.getenv()));
+        environment);
 
     SetMultimap<String, BuildTarget> foundTargets =
         finder.findTargetsForSymbols(ImmutableSet.of("com.example.a.A"));

--- a/test/com/facebook/buck/jvm/java/MissingSymbolsHandlerIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/java/MissingSymbolsHandlerIntegrationTest.java
@@ -74,7 +74,7 @@ public class MissingSymbolsHandlerIntegrationTest {
         environment);
     ImmutableSet<Description<?>> allDescriptions =
         DefaultKnownBuildRuleTypes
-        .getDefaultKnownBuildRuleTypes(projectFilesystem)
+        .getDefaultKnownBuildRuleTypes(projectFilesystem, environment)
         .getAllDescriptions();
     BuckEventBus buckEventBus = BuckEventBusFactory.newInstance();
 

--- a/test/com/facebook/buck/rules/KnownBuildRuleTypesTest.java
+++ b/test/com/facebook/buck/rules/KnownBuildRuleTypesTest.java
@@ -72,6 +72,8 @@ public class KnownBuildRuleTypesTest {
   @Rule public DebuggableTemporaryFolder temporaryFolder = new DebuggableTemporaryFolder();
 
   private static final String FAKE_XCODE_DEV_PATH = "/Fake/Path/To/Xcode.app/Contents/Developer";
+  private static final ImmutableMap<String, String> environment =
+      ImmutableMap.copyOf(System.getenv());
 
   private static BuildRuleParams buildRuleParams;
 
@@ -200,7 +202,8 @@ public class KnownBuildRuleTypesTest {
     BuckConfig buckConfig = FakeBuckConfig.builder().setSections(sections).build();
 
     KnownBuildRuleTypes buildRuleTypes =
-        DefaultKnownBuildRuleTypes.getDefaultKnownBuildRuleTypes(new FakeProjectFilesystem());
+        DefaultKnownBuildRuleTypes.getDefaultKnownBuildRuleTypes(
+            new FakeProjectFilesystem(), environment);
     DefaultJavaLibrary libraryRule = createJavaLibrary(buildRuleTypes);
 
     ProcessExecutor processExecutor = createExecutor(javac.toString(), "fakeVersion 0.1");
@@ -379,7 +382,9 @@ public class KnownBuildRuleTypesTest {
 
     addXcodeSelectProcess(processMap, FAKE_XCODE_DEV_PATH);
 
-    processMap.putAll(DefaultKnownBuildRuleTypes.getPythonProcessMap());
+    processMap.putAll(
+        DefaultKnownBuildRuleTypes.getPythonProcessMap(
+            DefaultKnownBuildRuleTypes.getPaths(environment)));
 
     return new FakeProcessExecutor(processMap);
   }


### PR DESCRIPTION
Summary:
We assume that python is installed under '/usr/bin/' in
DefaultKnownBuildRuleTypes.java, and tests fail when this is not true. We
now get $PATH from the user's environment variable.

Test:
`ant clean lint && ant && buck test`