### PR TITLE
Include PrebuiltJar in transitive deps to allow running inside inttelij

### DIFF
--- a/src/com/facebook/buck/jvm/java/intellij/ExportedDepsClosureResolver.java
+++ b/src/com/facebook/buck/jvm/java/intellij/ExportedDepsClosureResolver.java
@@ -18,6 +18,7 @@ package com.facebook.buck.jvm.java.intellij;
 
 import com.facebook.buck.android.AndroidLibraryDescription;
 import com.facebook.buck.jvm.java.JavaLibraryDescription;
+import com.facebook.buck.jvm.java.PrebuiltJarDescription;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.rules.TargetGraph;
 import com.facebook.buck.rules.TargetNode;
@@ -63,6 +64,9 @@ public class ExportedDepsClosureResolver {
       AndroidLibraryDescription.Arg arg =
           (AndroidLibraryDescription.Arg) targetNode.getConstructorArg();
       exportedDeps = arg.exportedDeps.get();
+    } else if (targetNode.getType().equals(PrebuiltJarDescription.TYPE)) {
+      PrebuiltJarDescription.Arg arg = (PrebuiltJarDescription.Arg) targetNode.getConstructorArg();
+      exportedDeps = arg.deps.get();
     }
 
     ImmutableSet<BuildTarget> exportedDepsClosure = FluentIterable.from(exportedDeps)


### PR DESCRIPTION
NOTE: this is just a sketch of the fix but has issues. There are no tests and the generated IJModule includes the transitive jars (IjLibraries) as compile time dependencies rather than runtime dependencies. I've tested that this allows running main() and junit tests from inside Ij
on a moderate size personal project (~70 buck targets, ~140 mvn dependencies, ~60k lines of .java excluding comments and 1k lines of .proto)

Summary: The classpath Ij generates when trying to run a module is incorrect because the IjModule doesn't include runtime dependencies of the libraries it depends on.

Prebuilt jars are often not fat (shaded) jars. The build targets listed in the 'deps' option of the 'prebuilt_jar' must be jars included on the runtime classpath. For example, imagine a java_app 'myapp' that depends on jetcd (https://github.com/justinsb/jetcd) a java / netty client for etcd. The jar might look something like:

```
    prebuilt_jar(
      name = 'jetcd',
      deps = [
        '//lib:jackson-core',
        '//lib:jackson-databind',
        '//lib:netty-all',
        '//lib:slf4j-api',
      ],
      binary_jar = ':jetcd_lib',
      visibility = ['PUBLIC'],
    )
```

Both `buck run` and `buck audit classpath` produce the correct result, including jackson, netty and slf4j on the classpath.

Bug: ExportedDepsClosureResolver#getExportedDepsClosure called by IjModuleGraph.from doesn't handle the PrebuildJar node type.
