### PR TITLE
Allow using go rules when the Go root is outside the "normal" location.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ before_install:
   - ./scripts/travisci_install_android_ndk.sh
   - export ANDROID_HOME=${HOME}/android-sdk-linux
   - ./scripts/travisci_install_android_sdk.sh
+  # Install go 1.5
+  - eval "$(gimme 1.5)"
 
 cache:
   directories:

--- a/docs/concept/buckconfig.soy
+++ b/docs/concept/buckconfig.soy
@@ -456,8 +456,18 @@ This section defines the go <code>compiler</code> and <code>linker</code> used b
 </p>
 
 <p>
-  You can specify the path find the <code>go</code> tool.  This in turn will
-  allow Buck to discover the compiler/linker by default.
+  If you have a non-standard go install, you will need to set the go root. The root should
+  contain <code>pkg</code> and <code>bin</code> directories.
+</p>
+{literal}<pre class="prettyprint lang-ini">
+[go]
+  root = /opt/golang/libexec
+</pre>{/literal}
+
+<p>
+  You can specify the path to find the <code>go</code> tool.  This in turn will
+  allow Buck to discover the compiler/linker by default. This defaults to
+  {sp}<code>${go.root}/bin/go</code>.
 </p>
 {literal}<pre class="prettyprint lang-ini">
 [go]

--- a/scripts/travisci_run.sh
+++ b/scripts/travisci_run.sh
@@ -14,8 +14,7 @@ export TERM=dumb
 # Until we get https://github.com/facebook/buck/pull/479, we cannot run the
 # Go tests in Travis
 ./bin/buck test \
-  --num-threads=3 \
-  --test-selectors '!GoBinaryIntegrationTest|GoTestIntegrationTest'
+  --num-threads=3
 
 # Run all the other checks with ant.
 ant travis

--- a/src/com/facebook/buck/go/BUCK
+++ b/src/com/facebook/buck/go/BUCK
@@ -16,6 +16,7 @@ java_library(
     'GoTestMain.java',
     'GoTestMainStep.java',
     'GoTestStep.java',
+    'GoTool.java',
   ],
   deps = [
     '//src/com/facebook/buck/cli:config',

--- a/src/com/facebook/buck/go/GoBinary.java
+++ b/src/com/facebook/buck/go/GoBinary.java
@@ -38,7 +38,7 @@ import java.nio.file.Path;
 public class GoBinary extends AbstractBuildRule implements BinaryBuildRule {
 
   @AddToRuleKey
-  private final Tool linker;
+  private final GoTool linker;
   @AddToRuleKey
   private final ImmutableList<String> linkerFlags;
   @AddToRuleKey
@@ -55,7 +55,7 @@ public class GoBinary extends AbstractBuildRule implements BinaryBuildRule {
       Linker cxxLinker,
       GoSymlinkTree linkTree,
       GoLinkable mainObject,
-      Tool linker,
+      GoTool linker,
       ImmutableList<String> linkerFlags) {
     super(params, resolver);
     this.cxxLinker = cxxLinker;
@@ -86,6 +86,7 @@ public class GoBinary extends AbstractBuildRule implements BinaryBuildRule {
         new MkdirStep(getProjectFilesystem(), output.getParent()),
         new GoLinkStep(
             getProjectFilesystem().getRootPath(),
+            linker.getGoRoot(),
             cxxLinker.getCommandPrefix(getResolver()),
             linker.getCommandPrefix(getResolver()),
             linkerFlags,

--- a/src/com/facebook/buck/go/GoCompileStep.java
+++ b/src/com/facebook/buck/go/GoCompileStep.java
@@ -21,11 +21,13 @@ import com.facebook.buck.step.ExecutionContext;
 import com.google.common.base.Function;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import java.nio.file.Path;
 
 public class GoCompileStep extends ShellStep {
 
+  private final Path goRoot;
   private final ImmutableList<String> compilerCommandPrefix;
   private final Path packageName;
   private final ImmutableList<String> flags;
@@ -35,6 +37,7 @@ public class GoCompileStep extends ShellStep {
 
   public GoCompileStep(
       Path workingDirectory,
+      Path goRoot,
       ImmutableList<String> compilerCommandPrefix,
       ImmutableList<String> flags,
       Path packageName,
@@ -42,6 +45,7 @@ public class GoCompileStep extends ShellStep {
       ImmutableList<Path> includeDirectories,
       Path output) {
     super(workingDirectory);
+    this.goRoot = goRoot;
     this.compilerCommandPrefix = compilerCommandPrefix;
     this.flags = flags;
     this.packageName = packageName;
@@ -74,6 +78,11 @@ public class GoCompileStep extends ShellStep {
             }));
 
     return commandBuilder.build();
+  }
+
+  @Override
+  public ImmutableMap<String, String> getEnvironmentVariables(ExecutionContext context) {
+    return ImmutableMap.of("GOROOT", goRoot.toString());
   }
 
   @Override

--- a/src/com/facebook/buck/go/GoLibrary.java
+++ b/src/com/facebook/buck/go/GoLibrary.java
@@ -21,7 +21,6 @@ import com.facebook.buck.model.HasTests;
 import com.facebook.buck.rules.AddToRuleKey;
 import com.facebook.buck.rules.BuildContext;
 import com.facebook.buck.rules.BuildableContext;
-import com.facebook.buck.rules.Tool;
 import com.facebook.buck.model.BuildTargets;
 import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildableProperties;
@@ -37,7 +36,7 @@ import java.nio.file.Path;
 
 public class GoLibrary extends GoLinkable implements HasTests {
   @AddToRuleKey
-  private final Tool compiler;
+  private final GoTool compiler;
   @AddToRuleKey(stringify = true)
   private final Path packageName;
   @AddToRuleKey
@@ -58,7 +57,7 @@ public class GoLibrary extends GoLinkable implements HasTests {
       Path packageName,
       ImmutableSet<SourcePath> srcs,
       ImmutableList<String> compilerFlags,
-      Tool compiler,
+      GoTool compiler,
       ImmutableSortedSet<BuildTarget> tests) {
     super(params, resolver);
     this.srcs = srcs;
@@ -85,6 +84,7 @@ public class GoLibrary extends GoLinkable implements HasTests {
         new MkdirStep(getProjectFilesystem(), output.getParent()),
         new GoCompileStep(
             getProjectFilesystem().getRootPath(),
+            compiler.getGoRoot(),
             compiler.getCommandPrefix(getResolver()),
             flags,
             packageName,

--- a/src/com/facebook/buck/go/GoLinkStep.java
+++ b/src/com/facebook/buck/go/GoLinkStep.java
@@ -22,10 +22,12 @@ import com.facebook.buck.util.Escaper;
 import com.google.common.base.Joiner;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import java.nio.file.Path;
 
 public class GoLinkStep extends ShellStep {
+
   enum LinkMode {
     EXECUTABLE("exe");
     // Other gc modes: http://blog.ralch.com/tutorial/golang-sharing-libraries/
@@ -40,6 +42,7 @@ public class GoLinkStep extends ShellStep {
     }
   }
 
+  private final Path goRoot;
   private final ImmutableList<String> cxxLinkCommandPrefix;
   private final ImmutableList<String> linkCommandPrefix;
   private final ImmutableList<String> flags;
@@ -50,6 +53,7 @@ public class GoLinkStep extends ShellStep {
 
   public GoLinkStep(
       Path workingDirectory,
+      Path goRoot,
       ImmutableList<String> cxxLinkCommandPrefix,
       ImmutableList<String> linkCommandPrefix,
       ImmutableList<String> flags,
@@ -58,6 +62,7 @@ public class GoLinkStep extends ShellStep {
       LinkMode linkMode,
       Path output) {
     super(workingDirectory);
+    this.goRoot = goRoot;
     this.cxxLinkCommandPrefix = cxxLinkCommandPrefix;
     this.linkCommandPrefix = linkCommandPrefix;
     this.flags = flags;
@@ -91,6 +96,11 @@ public class GoLinkStep extends ShellStep {
     command.add(mainArchive.toString());
 
     return command.build();
+  }
+
+  @Override
+  public ImmutableMap<String, String> getEnvironmentVariables(ExecutionContext context) {
+    return ImmutableMap.of("GOROOT", goRoot.toString());
   }
 
   @Override

--- a/src/com/facebook/buck/go/GoTool.java
+++ b/src/com/facebook/buck/go/GoTool.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.go;
+
+import com.facebook.buck.rules.BuildRule;
+import com.facebook.buck.rules.RuleKeyBuilder;
+import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.buck.rules.Tool;
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
+
+import java.nio.file.Path;
+
+public class GoTool implements Tool {
+  private final Path goRoot;
+  private final Tool underlyingCommand;
+
+  public GoTool(Path goRoot, Tool underlyingCommand) {
+    this.goRoot = goRoot;
+    this.underlyingCommand = underlyingCommand;
+  }
+
+  Path getGoRoot() {
+    return goRoot;
+  }
+
+  @Override
+  public ImmutableCollection<BuildRule> getDeps(SourcePathResolver resolver) {
+    return underlyingCommand.getDeps(resolver);
+  }
+
+  @Override
+  public ImmutableCollection<SourcePath> getInputs() {
+    return underlyingCommand.getInputs();
+  }
+
+  @Override
+  public ImmutableList<String> getCommandPrefix(SourcePathResolver resolver) {
+    return underlyingCommand.getCommandPrefix(resolver);
+  }
+
+  @Override
+  public RuleKeyBuilder appendToRuleKey(RuleKeyBuilder builder) {
+    return underlyingCommand.appendToRuleKey(builder).setReflectively("goRoot", goRoot);
+  }
+}


### PR DESCRIPTION
"normal" in this case means /usr/local/

Introduce the concept of a GoTool - just a Tool that needs GOROOT set. The go compiler/linker are these kinds of tools.

This should let travis tests work for go.
