### PR TITLE
[Test] Skip JNI test for MacOS.

### DIFF
--- a/test/com/facebook/buck/jvm/java/JavaTestIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/java/JavaTestIntegrationTest.java
@@ -189,7 +189,7 @@ public class JavaTestIntegrationTest {
 
   @Test
   public void testWithJni() throws IOException {
-    assumeTrue(Platform.detect() != Platform.WINDOWS);
+    assumeTrue(Platform.detect() == Platform.LINUX);
     ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(
         this,
         "test_with_jni",


### PR DESCRIPTION
Summary:
The assumption for the JNI folder at java home only works reliably for
linux systems. For example, for MacOS, some of the headers are under
`$JAVA_HOME/include/darwin/` instead of `$JAVA_HOME/include/linux`. This
change set change the test to only run for Linux to make the MacOS test
pass. We need to find a reliable way to find the headers on different OSes.

Test:
`ant clean lint && ant && buck test`