### PR TITLE
[JNI Test] Add the include folder for MacOS.

### DIFF
--- a/test/com/facebook/buck/jvm/java/testdata/test_with_jni/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/java/testdata/test_with_jni/BUCK.fixture
@@ -6,8 +6,8 @@ if 'JAVA_HOME' in os.environ:
   cppflags = [
     '-DUSE_JNI_H',
     '-I' + os.environ['JAVA_HOME'] + '/include',
-    '-I' + os.environ['JAVA_HOME'] + '/include/darwin',
     '-I' + os.environ['JAVA_HOME'] + '/include/linux',
+    '-I' + os.environ['JAVA_HOME'] + '/include/darwin', # For MacOS.
   ]
 else:
   cppflags = []


### PR DESCRIPTION
Summary:
For MacOS, the default header folder location is different from Linux's.
The change set solves the problem for `buck test`. Additional changes are
needed to get `ant test` and test in Intellij to work. Please refer to the
discussion at: https://github.com/facebook/buck/pull/480, for more details.

Test:
`ant clean lint && ant && buck test`