### PR TITLE
Fix maven resolver for certain packages.

### DIFF
--- a/src/com/facebook/buck/maven/Resolver.java
+++ b/src/com/facebook/buck/maven/Resolver.java
@@ -405,28 +405,6 @@ public class Resolver {
     for (String coord : mavenCoords) {
       DefaultArtifact artifact = new DefaultArtifact(coord);
       collectRequest.addDependency(new Dependency(artifact, JavaScopes.RUNTIME));
-
-      ArtifactDescriptorRequest descriptorRequest = new ArtifactDescriptorRequest();
-      descriptorRequest.setArtifact(artifact);
-      // Setting this appears to have exactly zero effect on the returned values. *sigh*
-//      descriptorRequest.setRequestContext(JavaScopes.RUNTIME);
-      descriptorRequest.setRepositories(repos);
-      ArtifactDescriptorResult descriptorResult = repoSys.readArtifactDescriptor(
-          session,
-          descriptorRequest);
-
-      for (Dependency dependency : descriptorResult.getDependencies()) {
-        if (isTestTime(dependency)) {
-          continue;
-        }
-        collectRequest.addDependency(dependency);
-      }
-      for (Dependency dependency : descriptorResult.getManagedDependencies()) {
-        if (isTestTime(dependency)) {
-          continue;
-        }
-        collectRequest.addManagedDependency(dependency);
-      }
     }
 
     DependencyFilter filter = DependencyFilterUtils.classpathFilter(JavaScopes.RUNTIME);


### PR DESCRIPTION
The values specified in ArtifactDescriptorResult aren't sane in most ways. That is, they need evaluation & variable substitution.

I'm not sure why this was here in the first place, so this patch may be wrong. That is, I think the CollectRequest correctly returns direct dependencies as part of the query. Perhaps I'm missing something, so please tell me if something breaks with this approach.

I'd love to test this for buck itself, but I couldn't find a (direct) dependency list for it. Is there one somewhere?

Testing done:
```shell
buck run src/com/facebook/buck/maven:resolver -- /tmp/buck_repo/ thirdparty/jvm /tmp/mvn/ http://repo1.maven.org/maven2 io.netty:netty-all:4.0.24.Final
```

Before:
```shell
Exception in thread "main" org.eclipse.aether.resolution.DependencyResolutionException: Could not find artifact
io.netty:netty-tcnative:jar:${os.detected.classifier}:1.1.30.Fork2 in http://repo1.maven.org/maven2 (http://repo1.maven.org/maven2)
	at org.eclipse.aether.internal.impl.DefaultRepositorySystem.resolveDependencies(DefaultRepositorySystem.java:384)
	at com.facebook.buck.maven.Resolver.getRunTimeTransitiveDeps(Resolver.java:435)
	at com.facebook.buck.maven.Resolver.resolve(Resolver.java:121)
	at com.facebook.buck.maven.Resolver.main(Resolver.java:482)
Caused by: org.eclipse.aether.resolution.ArtifactResolutionException: Could not find artifact io.netty:netty-tcnative:jar:${os.detected.classifier}:1.1.30.Fork2
in http://repo1.maven.org/maven2 (http://repo1.maven.org/maven2)
	at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:444)
	at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifacts(DefaultArtifactResolver.java:246)
	at org.eclipse.aether.internal.impl.DefaultRepositorySystem.resolveDependencies(DefaultRepositorySystem.java:367)
	... 3 more
Caused by: org.eclipse.aether.transfer.ArtifactNotFoundException: Could not find artifact io.netty:netty-tcnative:jar:${os.detected.classifier}:1.1.30.Fork2 in
http://repo1.maven.org/maven2 (http://repo1.maven.org/maven2)
	at org.eclipse.aether.connector.basic.ArtifactTransportListener.transferFailed(ArtifactTransportListener.java:39)
	at org.eclipse.aether.connector.basic.BasicRepositoryConnector$TaskRunner.run(BasicRepositoryConnector.java:355)
	at org.eclipse.aether.util.concurrency.RunnableErrorForwarder$1.run(RunnableErrorForwarder.java:67)
	at org.eclipse.aether.connector.basic.BasicRepositoryConnector$DirectExecutor.execute(BasicRepositoryConnector.java:581)
	at org.eclipse.aether.connector.basic.BasicRepositoryConnector.get(BasicRepositoryConnector.java:249)
	at org.eclipse.aether.internal.impl.DefaultArtifactResolver.performDownloads(DefaultArtifactResolver.java:520)
	at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:421)
	... 5 more

```

After: Works :)

This fixes #456 as well.