### PR TITLE
Fix bug in build-with-buck with library targets

### DIFF
--- a/src/com/facebook/buck/apple/BUCK
+++ b/src/com/facebook/buck/apple/BUCK
@@ -9,6 +9,7 @@ java_immutables_library(
   ],
   resources = [
     'build-with-buck.st',
+    'fix-uuid.st',
     'halide-compiler.st',
     'rn-package.st',
     'fix_uuid.py',

--- a/src/com/facebook/buck/apple/build-with-buck.st
+++ b/src/com/facebook/buck/apple/build-with-buck.st
@@ -1,13 +1,3 @@
 set -e
 cd <repo_root>
 <path_to_buck> build <build_flags> <escaped_build_target>
-rm -r <resolved_bundle_destination> 2> /dev/null || true
-rm -r <resolved_dsym_destination> 2> /dev/null || true
-mkdir -p <resolved_bundle_destination_parent>
-cp -r <resolved_bundle_source> <resolved_bundle_destination>
-cp -r <resolved_dsym_source> <resolved_dsym_destination>
-export LANG=C
-export LC_ALL=C
-sed -i '' 's|<comp_dir>|<source_dir>|g' <resolved_dsym_destination>/Contents/Resources/DWARF/<binary_name>
-
-python <path_to_fix_uuid_script> --verbose <resolved_bundle_destination> <resolved_dsym_destination> <binary_name>

--- a/src/com/facebook/buck/apple/fix-uuid.st
+++ b/src/com/facebook/buck/apple/fix-uuid.st
@@ -1,0 +1,10 @@
+rm -r <resolved_bundle_destination> 2> /dev/null || true
+rm -r <resolved_dsym_destination> 2> /dev/null || true
+mkdir -p <resolved_bundle_destination_parent>
+cp -r <resolved_bundle_source> <resolved_bundle_destination>
+cp -r <resolved_dsym_source> <resolved_dsym_destination>
+export LANG=C
+export LC_ALL=C
+sed -i '' 's|<comp_dir>|<source_dir>|g' <resolved_dsym_destination>/Contents/Resources/DWARF/<binary_name>
+
+python <path_to_fix_uuid_script> --verbose <resolved_bundle_destination> <resolved_dsym_destination> <binary_name>

--- a/test/com/facebook/buck/apple/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/apple/ProjectGeneratorTest.java
@@ -3215,7 +3215,77 @@ public class ProjectGeneratorTest {
   }
 
   @Test
-  public void aggregateTargetForBuildWithBuck() throws IOException {
+  public void aggregateTargetForBundleForBuildWithBuck() throws IOException {
+    Optional<Path> buck = new ExecutableFinder().getOptionalExecutable(
+        Paths.get("buck"),
+        ImmutableMap.<String, String>of());
+    assumeThat(buck.isPresent(), is(true));
+    BuildTarget binaryTarget = BuildTarget.builder(rootPath, "//foo", "binary").build();
+    BuildTarget bundleTarget = BuildTarget.builder(rootPath, "//foo", "bundle").build();
+    TargetNode<?> bundleNode = AppleBundleBuilder
+        .createBuilder(bundleTarget)
+        .setBinary(binaryTarget)
+        .build();
+
+    ImmutableSet<TargetNode<?>> nodes = ImmutableSet.<TargetNode<?>>of(bundleNode);
+    ProjectGenerator projectGenerator = new ProjectGenerator(
+        TargetGraphFactory.newInstance(nodes),
+        FluentIterable.from(nodes).transform(HasBuildTarget.TO_TARGET).toSet(),
+        projectFilesystem,
+        OUTPUT_DIRECTORY,
+        PROJECT_NAME,
+        "BUCK",
+        ImmutableSet.<ProjectGenerator.Option>of(),
+        Optional.of(bundleTarget),
+        ImmutableList.of("--flag", "value with spaces"),
+        new AlwaysFoundExecutableFinder(),
+        ImmutableMap.<String, String>of(),
+        PLATFORMS,
+        DEFAULT_PLATFORM,
+        Functions.<Path>constant(null),
+        getFakeBuckEventBus(),
+        false);
+    projectGenerator.createXcodeProjects();
+
+    PBXTarget buildWithBuckTarget = null;
+    for (PBXTarget target : projectGenerator.getGeneratedProject().getTargets()) {
+      if (target.getProductName() != null &&
+          target.getProductName().endsWith("-Buck")) {
+        buildWithBuckTarget = target;
+      }
+    }
+    assertThat(buildWithBuckTarget, is(notNullValue()));
+
+    assertHasConfigurations(buildWithBuckTarget, "Debug");
+    assertKeepsConfigurationsInMainGroup(
+        projectGenerator.getGeneratedProject(),
+        buildWithBuckTarget);
+
+    assertEquals(
+        "Should have exact number of build phases",
+        2,
+        buildWithBuckTarget.getBuildPhases().size());
+    PBXBuildPhase buildPhase = Iterables.get(buildWithBuckTarget.getBuildPhases(), 0);
+    assertThat(buildPhase, instanceOf(PBXShellScriptBuildPhase.class));
+    PBXShellScriptBuildPhase shellScriptBuildPhase = (PBXShellScriptBuildPhase) buildPhase;
+    assertThat(
+        shellScriptBuildPhase.getShellScript(),
+        containsString(
+            "buck build --report-absolute-paths --flag 'value with spaces' " +
+                binaryTarget.getFullyQualifiedName()));
+
+    PBXBuildPhase fixUUIDPhase = Iterables.getLast(buildWithBuckTarget.getBuildPhases());
+    assertThat(fixUUIDPhase, instanceOf(PBXShellScriptBuildPhase.class));
+    PBXShellScriptBuildPhase fixUUIDShellScriptBuildPhase = (PBXShellScriptBuildPhase) buildPhase;
+    String fixUUIDScriptPath = ProjectGenerator.getFixUUIDScriptPath();
+    assertThat(
+        fixUUIDShellScriptBuildPhase.getShellScript(),
+        containsString(
+            "python " + fixUUIDScriptPath + " --verbose"));
+  }
+
+  @Test
+  public void aggregateTargetForBinaryForBuildWithBuck() throws IOException {
     Optional<Path> buck = new ExecutableFinder().getOptionalExecutable(
         Paths.get("buck"),
         ImmutableMap.<String, String>of());
@@ -3281,6 +3351,75 @@ public class ProjectGeneratorTest {
         containsString(
             "buck build --report-absolute-paths --flag 'value with spaces' " +
                 binaryTarget.getFullyQualifiedName()));
+  }
+
+  @Test
+  public void aggregateTargetForLibraryForBuildWithBuck() throws IOException {
+    Optional<Path> buck = new ExecutableFinder().getOptionalExecutable(
+        Paths.get("buck"),
+        ImmutableMap.<String, String>of());
+    assumeThat(buck.isPresent(), is(true));
+    BuildTarget libraryTarget = BuildTarget.builder(rootPath, "//foo", "library").build();
+    TargetNode<?> binaryNode = AppleLibraryBuilder
+        .createBuilder(libraryTarget)
+        .setConfigs(
+            Optional.of(
+                ImmutableSortedMap.of(
+                    "Debug",
+                    ImmutableMap.<String, String>of())))
+        .setSrcs(
+            Optional.of(
+                ImmutableSortedSet.of(
+                    SourceWithFlags.of(
+                        new TestSourcePath("foo.m"), ImmutableList.of("-foo")))))
+        .build();
+
+    ImmutableSet<TargetNode<?>> nodes = ImmutableSet.<TargetNode<?>>of(binaryNode);
+    ProjectGenerator projectGenerator = new ProjectGenerator(
+        TargetGraphFactory.newInstance(nodes),
+        FluentIterable.from(nodes).transform(HasBuildTarget.TO_TARGET).toSet(),
+        projectFilesystem,
+        OUTPUT_DIRECTORY,
+        PROJECT_NAME,
+        "BUCK",
+        ImmutableSet.<ProjectGenerator.Option>of(),
+        Optional.of(libraryTarget),
+        ImmutableList.of("--flag", "value with spaces"),
+        new AlwaysFoundExecutableFinder(),
+        ImmutableMap.<String, String>of(),
+        PLATFORMS,
+        DEFAULT_PLATFORM,
+        Functions.<Path>constant(null),
+        getFakeBuckEventBus(),
+        false);
+    projectGenerator.createXcodeProjects();
+
+    PBXTarget buildWithBuckTarget = null;
+    for (PBXTarget target : projectGenerator.getGeneratedProject().getTargets()) {
+      if (target.getProductName() != null &&
+          target.getProductName().endsWith("-Buck")) {
+        buildWithBuckTarget = target;
+      }
+    }
+    assertThat(buildWithBuckTarget, is(notNullValue()));
+
+    assertHasConfigurations(buildWithBuckTarget, "Debug");
+    assertKeepsConfigurationsInMainGroup(
+        projectGenerator.getGeneratedProject(),
+        buildWithBuckTarget);
+
+    assertEquals(
+        "Should have exact number of build phases",
+        1,
+        buildWithBuckTarget.getBuildPhases().size());
+    PBXBuildPhase buildPhase = Iterables.getOnlyElement(buildWithBuckTarget.getBuildPhases());
+    assertThat(buildPhase, instanceOf(PBXShellScriptBuildPhase.class));
+    PBXShellScriptBuildPhase shellScriptBuildPhase = (PBXShellScriptBuildPhase) buildPhase;
+    assertThat(
+        shellScriptBuildPhase.getShellScript(),
+        containsString(
+            "buck build --report-absolute-paths --flag 'value with spaces' " +
+                libraryTarget.getFullyQualifiedName()));
   }
 
   @Test

--- a/test/com/facebook/buck/apple/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/apple/ProjectGeneratorTest.java
@@ -35,7 +35,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeThat;
 
 import com.dd.plist.NSDictionary;
 import com.dd.plist.NSString;
@@ -65,10 +64,9 @@ import com.facebook.buck.cxx.CxxPlatformUtils;
 import com.facebook.buck.cxx.CxxSource;
 import com.facebook.buck.event.BuckEventBus;
 import com.facebook.buck.event.BuckEventBusFactory;
-import com.facebook.buck.halide.HalideLibraryDescription;
 import com.facebook.buck.halide.HalideLibraryBuilder;
+import com.facebook.buck.halide.HalideLibraryDescription;
 import com.facebook.buck.io.AlwaysFoundExecutableFinder;
-import com.facebook.buck.io.ExecutableFinder;
 import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.js.IosReactNativeLibraryBuilder;
 import com.facebook.buck.js.ReactNativeBuckConfig;
@@ -3215,19 +3213,26 @@ public class ProjectGeneratorTest {
   }
 
   @Test
-  public void aggregateTargetForBundleForBuildWithBuck() throws IOException {
-    Optional<Path> buck = new ExecutableFinder().getOptionalExecutable(
-        Paths.get("buck"),
-        ImmutableMap.<String, String>of());
-    assumeThat(buck.isPresent(), is(true));
+  public void testAggregateTargetForBundleForBuildWithBuck() throws IOException {
     BuildTarget binaryTarget = BuildTarget.builder(rootPath, "//foo", "binary").build();
+    TargetNode<?> binaryNode = AppleBinaryBuilder
+        .createBuilder(binaryTarget)
+        .setConfigs(
+            Optional.of(
+                ImmutableSortedMap.of(
+                    "Debug",
+                    ImmutableMap.<String, String>of())))
+        .build();
+
     BuildTarget bundleTarget = BuildTarget.builder(rootPath, "//foo", "bundle").build();
     TargetNode<?> bundleNode = AppleBundleBuilder
         .createBuilder(bundleTarget)
+        .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.APP))
+        .setInfoPlist(new TestSourcePath("Info.plist"))
         .setBinary(binaryTarget)
         .build();
 
-    ImmutableSet<TargetNode<?>> nodes = ImmutableSet.<TargetNode<?>>of(bundleNode);
+    ImmutableSet<TargetNode<?>> nodes = ImmutableSet.<TargetNode<?>>of(bundleNode, binaryNode);
     ProjectGenerator projectGenerator = new ProjectGenerator(
         TargetGraphFactory.newInstance(nodes),
         FluentIterable.from(nodes).transform(HasBuildTarget.TO_TARGET).toSet(),
@@ -3272,11 +3277,11 @@ public class ProjectGeneratorTest {
         shellScriptBuildPhase.getShellScript(),
         containsString(
             "buck build --report-absolute-paths --flag 'value with spaces' " +
-                binaryTarget.getFullyQualifiedName()));
+                bundleTarget.getFullyQualifiedName()));
 
     PBXBuildPhase fixUUIDPhase = Iterables.getLast(buildWithBuckTarget.getBuildPhases());
     assertThat(fixUUIDPhase, instanceOf(PBXShellScriptBuildPhase.class));
-    PBXShellScriptBuildPhase fixUUIDShellScriptBuildPhase = (PBXShellScriptBuildPhase) buildPhase;
+    PBXShellScriptBuildPhase fixUUIDShellScriptBuildPhase = (PBXShellScriptBuildPhase) fixUUIDPhase;
     String fixUUIDScriptPath = ProjectGenerator.getFixUUIDScriptPath();
     assertThat(
         fixUUIDShellScriptBuildPhase.getShellScript(),
@@ -3285,11 +3290,7 @@ public class ProjectGeneratorTest {
   }
 
   @Test
-  public void aggregateTargetForBinaryForBuildWithBuck() throws IOException {
-    Optional<Path> buck = new ExecutableFinder().getOptionalExecutable(
-        Paths.get("buck"),
-        ImmutableMap.<String, String>of());
-    assumeThat(buck.isPresent(), is(true));
+  public void testAggregateTargetForBinaryForBuildWithBuck() throws IOException {
     BuildTarget binaryTarget = BuildTarget.builder(rootPath, "//foo", "binary").build();
     TargetNode<?> binaryNode = AppleBinaryBuilder
         .createBuilder(binaryTarget)
@@ -3354,11 +3355,7 @@ public class ProjectGeneratorTest {
   }
 
   @Test
-  public void aggregateTargetForLibraryForBuildWithBuck() throws IOException {
-    Optional<Path> buck = new ExecutableFinder().getOptionalExecutable(
-        Paths.get("buck"),
-        ImmutableMap.<String, String>of());
-    assumeThat(buck.isPresent(), is(true));
+  public void testAggregateTargetForLibraryForBuildWithBuck() throws IOException {
     BuildTarget libraryTarget = BuildTarget.builder(rootPath, "//foo", "library").build();
     TargetNode<?> binaryNode = AppleLibraryBuilder
         .createBuilder(libraryTarget)


### PR DESCRIPTION
Summary: Running `buck project //src:foo --build-with-buck` creates a project that cannot be built in Xcode if //src:foo is a library target. Previously we used one shell script that 1) built the project with Buck and 2) fixed UUIDs in the binary. Now we add the shell script to build in all cases, but only add the fix_uuid script if it is an apple_bundle.

Test plan: Unit tests updated. `ant java-test -Dtest.class=ProjectGeneratorTest`. Also, build an `apple_bundle`, `apple_binary` and `apple_library`, with `buck project <target> --build-with-buck --combined-project` and make sure all generated Xcode projects build correctly.