### PR TITLE
Use absolute paths when dealing with apks and test output

### DIFF
--- a/src/com/facebook/buck/android/AdbHelper.java
+++ b/src/com/facebook/buck/android/AdbHelper.java
@@ -534,7 +534,8 @@ public class AdbHelper {
       getBuckEventBus().post(started);
     }
 
-    final File apk = installableApk.getApkPath().toFile();
+    final File apk = installableApk.getProjectFilesystem().resolve(
+        installableApk.getApkPath()).toFile();
     boolean success = adbCall(
         new AdbHelper.AdbCallable() {
           @Override
@@ -724,7 +725,8 @@ public class AdbHelper {
       @Nullable String activity) throws IOException, InterruptedException {
 
     // Might need the package name and activities from the AndroidManifest.
-    Path pathToManifest = installableApk.getManifestPath();
+    Path pathToManifest = installableApk.getProjectFilesystem().resolve(
+        installableApk.getManifestPath());
     AndroidManifestReader reader = DefaultAndroidManifestReader.forPath(
         pathToManifest, installableApk.getProjectFilesystem());
 
@@ -917,7 +919,8 @@ public class AdbHelper {
   }
 
   public static String tryToExtractPackageNameFromManifest(InstallableApk androidBinaryRule) {
-    Path pathToManifest = androidBinaryRule.getManifestPath();
+    Path pathToManifest = androidBinaryRule.getProjectFilesystem().resolve(
+        androidBinaryRule.getManifestPath());
 
     // Note that the file may not exist if AndroidManifest.xml is a generated file
     // and the rule has not been built yet.
@@ -938,7 +941,8 @@ public class AdbHelper {
 
   public static String tryToExtractInstrumentationTestRunnerFromManifest(
       InstallableApk androidBinaryRule) {
-    Path pathToManifest = androidBinaryRule.getManifestPath();
+    Path pathToManifest = androidBinaryRule.getProjectFilesystem().resolve(
+        androidBinaryRule.getManifestPath());
 
     if (!Files.isRegularFile(pathToManifest)) {
       throw new HumanReadableException(

--- a/src/com/facebook/buck/android/AndroidInstrumentationTest.java
+++ b/src/com/facebook/buck/android/AndroidInstrumentationTest.java
@@ -117,7 +117,7 @@ public class AndroidInstrumentationTest extends AbstractBuildRule
     }
     steps.add(new InstrumentationStep(
             apk,
-            pathToTestOutput,
+            getProjectFilesystem().resolve(pathToTestOutput),
             testRuleTimeoutMs));
 
     return steps.build();
@@ -135,7 +135,7 @@ public class AndroidInstrumentationTest extends AbstractBuildRule
     // It might happen that a new device is attached when re-running the tests,
     // in which case we want to re-run the tests with the new device included.
     for (IDevice device : devices) {
-      Path testResultPath = getProjectFilesystem().getPathForRelativePath(
+      Path testResultPath = getProjectFilesystem().resolve(
           getPathToTestOutputDirectory().resolve(
               BuckXmlTestRunListener.TEST_RESULT_FILE_PREFIX +
                   device.getSerialNumber() +
@@ -190,7 +190,7 @@ public class AndroidInstrumentationTest extends AbstractBuildRule
         }
 
         for (IDevice device : devices) {
-          Path testResultPath = getProjectFilesystem().getPathForRelativePath(
+          Path testResultPath = getProjectFilesystem().resolve(
               getPathToTestOutputDirectory().resolve(
                   BuckXmlTestRunListener.TEST_RESULT_FILE_PREFIX +
                       device.getSerialNumber() +


### PR DESCRIPTION
Summary:
Using relative paths when dealing with installing apks or exopackages or
in test outputs causes problems when buck is not run from the right
location, such as in integration tests.  Fix this by using absolute
paths where appropriate.

Test Plan: buck test