### PR TITLE
Decouple JavaLibrary from AnnotationProcessingParams

### DIFF
--- a/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
+++ b/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
@@ -18,6 +18,7 @@ package com.facebook.buck.jvm.java;
 
 import static com.facebook.buck.rules.BuildableProperties.Kind.ANDROID;
 import static com.facebook.buck.rules.BuildableProperties.Kind.LIBRARY;
+import static com.google.common.base.Optional.fromNullable;
 
 import com.facebook.buck.android.AndroidPackageable;
 import com.facebook.buck.android.AndroidPackageableCollector;
@@ -430,8 +431,9 @@ public class DefaultJavaLibrary extends AbstractBuildRule
   }
 
   @Override
-  public AnnotationProcessingParams getAnnotationProcessingParams() {
-    return javacOptions.getAnnotationProcessingParams();
+  public Optional<Path> getGeneratedSourcePath() {
+    return fromNullable(
+        javacOptions.getAnnotationProcessingParams().getGeneratedSourceFolderName());
   }
 
   @Override

--- a/src/com/facebook/buck/jvm/java/JavaLibrary.java
+++ b/src/com/facebook/buck/jvm/java/JavaLibrary.java
@@ -92,7 +92,7 @@ public interface JavaLibrary extends BuildRule, HasClasspathEntries,
   @Override
   public ImmutableSortedSet<SourcePath> getSources();
 
-  public AnnotationProcessingParams getAnnotationProcessingParams();
+  public Optional<Path> getGeneratedSourcePath();
 
   public static class Data {
     private final ImmutableSortedMap<String, HashCode> classNamesToHashes;

--- a/src/com/facebook/buck/jvm/java/PrebuiltJar.java
+++ b/src/com/facebook/buck/jvm/java/PrebuiltJar.java
@@ -218,8 +218,8 @@ public class PrebuiltJar extends AbstractBuildRule
   }
 
   @Override
-  public AnnotationProcessingParams getAnnotationProcessingParams() {
-    return AnnotationProcessingParams.EMPTY;
+  public Optional<Path> getGeneratedSourcePath() {
+    return Optional.absent();
   }
 
   @Override

--- a/src/com/facebook/buck/jvm/java/intellij/Project.java
+++ b/src/com/facebook/buck/jvm/java/intellij/Project.java
@@ -483,8 +483,7 @@ public class Project {
     }
     if (javaLibrary != null) {
       Optional<Path> processingParams = javaLibrary.getGeneratedSourcePath();
-      if (processingParams.isPresent())
-      {
+      if (processingParams.isPresent()) {
         module.annotationGenPath = basePath.relativize(processingParams.get());
         module.annotationGenIsForTest = !hasSourceFoldersForSrcRule;
       }

--- a/src/com/facebook/buck/jvm/java/intellij/Project.java
+++ b/src/com/facebook/buck/jvm/java/intellij/Project.java
@@ -34,7 +34,6 @@ import com.facebook.buck.android.NdkLibrary;
 import com.facebook.buck.cxx.CxxLibrary;
 import com.facebook.buck.graph.AbstractBreadthFirstTraversal;
 import com.facebook.buck.io.ProjectFilesystem;
-import com.facebook.buck.jvm.java.AnnotationProcessingParams;
 import com.facebook.buck.jvm.java.JavaBinary;
 import com.facebook.buck.jvm.java.JavaLibrary;
 import com.facebook.buck.jvm.java.JavaPackageFinder;
@@ -483,11 +482,10 @@ public class Project {
       javaLibrary = (JavaLibrary) projectRule;
     }
     if (javaLibrary != null) {
-      AnnotationProcessingParams processingParams = javaLibrary.getAnnotationProcessingParams();
-
-      Path annotationGenSrc = processingParams.getGeneratedSourceFolderName();
-      if (annotationGenSrc != null) {
-        module.annotationGenPath = basePath.relativize(annotationGenSrc);
+      Optional<Path> processingParams = javaLibrary.getGeneratedSourcePath();
+      if (processingParams.isPresent())
+      {
+        module.annotationGenPath = basePath.relativize(processingParams.get());
         module.annotationGenIsForTest = !hasSourceFoldersForSrcRule;
       }
     }

--- a/test/com/facebook/buck/android/AndroidLibraryTest.java
+++ b/test/com/facebook/buck/android/AndroidLibraryTest.java
@@ -16,9 +16,8 @@
 
 package com.facebook.buck.android;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
-import com.facebook.buck.jvm.java.AnnotationProcessingParams;
 import com.facebook.buck.jvm.java.JavaLibraryBuilder;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargetFactory;
@@ -49,7 +48,6 @@ public class AndroidLibraryTest {
         .addProcessorBuildTarget(processorRule.getBuildTarget())
         .build(ruleResolver);
 
-    AnnotationProcessingParams processingParams = library.getAnnotationProcessingParams();
-    assertNotNull(processingParams.getGeneratedSourceFolderName());
+    assertTrue(library.getGeneratedSourcePath().isPresent());
   }
 }

--- a/test/com/facebook/buck/jvm/java/FakeJavaLibrary.java
+++ b/test/com/facebook/buck/jvm/java/FakeJavaLibrary.java
@@ -117,8 +117,8 @@ public class FakeJavaLibrary extends FakeBuildRule implements JavaLibrary, Andro
   }
 
   @Override
-  public AnnotationProcessingParams getAnnotationProcessingParams() {
-    return AnnotationProcessingParams.EMPTY;
+  public Optional<Path> getGeneratedSourcePath() {
+    return Optional.absent();
   }
 
   @Override

--- a/test/com/facebook/buck/jvm/java/PrebuiltJarTest.java
+++ b/test/com/facebook/buck/jvm/java/PrebuiltJarTest.java
@@ -76,6 +76,6 @@ public class PrebuiltJarTest {
 
   @Test
   public void testGetAnnotationProcessingDataIsEmpty() {
-    assertTrue(junitJarRule.getAnnotationProcessingParams().isEmpty());
+    assertTrue(!junitJarRule.getGeneratedSourcePath().isPresent());
   }
 }

--- a/test/com/facebook/buck/jvm/java/PrebuiltJarTest.java
+++ b/test/com/facebook/buck/jvm/java/PrebuiltJarTest.java
@@ -16,6 +16,7 @@
 
 package com.facebook.buck.jvm.java;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.facebook.buck.model.BuildTargetFactory;
@@ -76,6 +77,6 @@ public class PrebuiltJarTest {
 
   @Test
   public void testGetAnnotationProcessingDataIsEmpty() {
-    assertTrue(!junitJarRule.getGeneratedSourcePath().isPresent());
+    assertFalse(junitJarRule.getGeneratedSourcePath().isPresent());
   }
 }


### PR DESCRIPTION
Summary:
We only need to expose the generated source directory (which may not
exist). As AnnotationProcessingParams is java specific (rather than
jvmlang agnostic) we'd prefer JavaLibrary (soon to become JvmLibrary)
to not know about it.

Context: I'm another LMAX person. We really want to make some progress towards the work described in https://github.com/facebook/buck/pull/439

Tested with ant && ./bin/buck test (advice on whether this is enough gratefully received!)