### PR TITLE
Rename TestSourcePath to FakeSourcePath

### DIFF
--- a/test/com/facebook/buck/android/AaptPackageResourcesTest.java
+++ b/test/com/facebook/buck/android/AaptPackageResourcesTest.java
@@ -17,15 +17,16 @@
 package com.facebook.buck.android;
 
 import static com.facebook.buck.jvm.java.JavaCompilationConstants.DEFAULT_JAVAC_OPTIONS;
+
 import com.facebook.buck.android.AndroidBinary.PackageType;
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
 import com.facebook.buck.rules.FakeOnDiskBuildInfo;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -61,7 +62,7 @@ public class AaptPackageResourcesTest {
         new AaptPackageResources(
             params,
             pathResolver,
-            /* manifest */ new TestSourcePath("facebook/base/AndroidManifest.xml"),
+            /* manifest */ new FakeSourcePath("facebook/base/AndroidManifest.xml"),
             resourcesProvider,
             ImmutableList.<HasAndroidResourceDeps>of(),
             ImmutableSet.<SourcePath>of(),

--- a/test/com/facebook/buck/android/AndroidBinaryDescriptionTest.java
+++ b/test/com/facebook/buck/android/AndroidBinaryDescriptionTest.java
@@ -25,8 +25,8 @@ import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 
@@ -55,12 +55,12 @@ public class AndroidBinaryDescriptionTest {
             new Keystore(
                 new FakeBuildRuleParamsBuilder("//:keystore").build(),
                 pathResolver,
-                new TestSourcePath("store"),
-                new TestSourcePath("properties")));
+                new FakeSourcePath("store"),
+                new FakeSourcePath("properties")));
     BuildTarget target = BuildTargetFactory.newInstance("//:rule");
     AndroidBinary androidBinary =
         (AndroidBinary) AndroidBinaryBuilder.createBuilder(target)
-            .setManifest(new TestSourcePath("manifest.xml"))
+            .setManifest(new FakeSourcePath("manifest.xml"))
             .setKeystore(keystore.getBuildTarget())
             .setNoDx(ImmutableSet.of(transitiveDep.getBuildTarget()))
             .setOriginalDeps(ImmutableSortedSet.of(dep.getBuildTarget()))

--- a/test/com/facebook/buck/android/AndroidBinaryGraphEnhancerTest.java
+++ b/test/com/facebook/buck/android/AndroidBinaryGraphEnhancerTest.java
@@ -45,13 +45,13 @@ import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildTargetSourcePath;
 import com.facebook.buck.rules.FakeBuildRule;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.PathSourcePath;
 import com.facebook.buck.rules.RuleKeyBuilderFactory;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.TargetGraph;
 import com.facebook.buck.rules.TestCellBuilder;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.coercer.BuildConfigFields;
 import com.facebook.buck.rules.keys.DefaultRuleKeyBuilderFactory;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
@@ -150,7 +150,7 @@ public class AndroidBinaryGraphEnhancerTest {
     AaptPackageResources aaptPackageResources = new AaptPackageResources(
         aaptPackageResourcesParams,
         new SourcePathResolver(ruleResolver),
-        /* manifest */ new TestSourcePath("java/src/com/facebook/base/AndroidManifest.xml"),
+        /* manifest */ new FakeSourcePath("java/src/com/facebook/base/AndroidManifest.xml"),
         createMock(FilteredResourcesProvider.class),
         ImmutableList.<HasAndroidResourceDeps>of(),
         ImmutableSet.<SourcePath>of(),
@@ -167,11 +167,11 @@ public class AndroidBinaryGraphEnhancerTest {
         ImmutableSet.of(javaDep2BuildTarget),
             /* resourcesToExclude */ ImmutableSet.<BuildTarget>of())
         .addClasspathEntry(
-            ((HasJavaClassHashes) javaDep1), new TestSourcePath("ignored"))
+            ((HasJavaClassHashes) javaDep1), new FakeSourcePath("ignored"))
         .addClasspathEntry(
-            ((HasJavaClassHashes) javaDep2), new TestSourcePath("ignored"))
+            ((HasJavaClassHashes) javaDep2), new FakeSourcePath("ignored"))
         .addClasspathEntry(
-            ((HasJavaClassHashes) javaLib), new TestSourcePath("ignored"))
+            ((HasJavaClassHashes) javaLib), new FakeSourcePath("ignored"))
         .build();
 
 
@@ -243,7 +243,7 @@ public class AndroidBinaryGraphEnhancerTest {
         FilterResourcesStep.ResourceFilter.EMPTY_FILTER,
         Optional.<String>absent(),
         /* locales */ ImmutableSet.<String>of(),
-        new TestSourcePath("AndroidManifest.xml"),
+        new FakeSourcePath("AndroidManifest.xml"),
         AndroidBinary.PackageType.DEBUG,
         /* cpuFilters */ ImmutableSet.<TargetCpuType>of(),
         /* shouldBuildStringSourceMap */ false,
@@ -363,7 +363,7 @@ public class AndroidBinaryGraphEnhancerTest {
         FilterResourcesStep.ResourceFilter.EMPTY_FILTER,
         Optional.<String>absent(),
         /* locales */ ImmutableSet.<String>of(),
-        new TestSourcePath("AndroidManifest.xml"),
+        new FakeSourcePath("AndroidManifest.xml"),
         AndroidBinary.PackageType.DEBUG,
         /* cpuFilters */ ImmutableSet.<TargetCpuType>of(),
         /* shouldBuildStringSourceMap */ false,
@@ -407,7 +407,7 @@ public class AndroidBinaryGraphEnhancerTest {
         FilterResourcesStep.ResourceFilter.EMPTY_FILTER,
         Optional.<String>absent(),
         /* locales */ ImmutableSet.<String>of(),
-        new TestSourcePath("AndroidManifest.xml"),
+        new FakeSourcePath("AndroidManifest.xml"),
         AndroidBinary.PackageType.DEBUG,
         /* cpuFilters */ ImmutableSet.<TargetCpuType>of(),
         /* shouldBuildStringSourceMap */ false,
@@ -461,7 +461,7 @@ public class AndroidBinaryGraphEnhancerTest {
                 null,
                 ImmutableSortedSet.<SourcePath>of(),
                 Optional.<SourcePath>absent(),
-                new TestSourcePath("manifest"),
+                new FakeSourcePath("manifest"),
                 false));
 
     // set it up.
@@ -478,7 +478,7 @@ public class AndroidBinaryGraphEnhancerTest {
         FilterResourcesStep.ResourceFilter.EMPTY_FILTER,
         Optional.<String>absent(),
         /* locales */ ImmutableSet.<String>of(),
-        new TestSourcePath("AndroidManifest.xml"),
+        new FakeSourcePath("AndroidManifest.xml"),
         AndroidBinary.PackageType.DEBUG,
         /* cpuFilters */ ImmutableSet.<TargetCpuType>of(),
         /* shouldBuildStringSourceMap */ false,

--- a/test/com/facebook/buck/android/AndroidBinaryTest.java
+++ b/test/com/facebook/buck/android/AndroidBinaryTest.java
@@ -35,9 +35,9 @@ import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildTargetSourcePath;
 import com.facebook.buck.rules.FakeBuildableContext;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.shell.GenruleBuilder;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
@@ -99,7 +99,7 @@ public class AndroidBinaryTest {
         .setBuildTargetsToExcludeFromDex(
             ImmutableSet.of(
                 BuildTargetFactory.newInstance("//java/src/com/facebook/base:libraryTwo")))
-        .setManifest(new TestSourcePath("java/src/com/facebook/base/AndroidManifest.xml"))
+        .setManifest(new FakeSourcePath("java/src/com/facebook/base/AndroidManifest.xml"))
         .setKeystore(keystoreRule.getBuildTarget())
         .build(ruleResolver);
 
@@ -172,8 +172,8 @@ public class AndroidBinaryTest {
       BuildRule androidResourceRule = ruleResolver.addToIndex(
           AndroidResourceRuleBuilder.newBuilder()
               .setResolver(new SourcePathResolver(ruleResolver))
-              .setAssets(new TestSourcePath(assetDirectory))
-              .setRes(resDirectory == null ? null : new TestSourcePath(resDirectory))
+              .setAssets(new FakeSourcePath(assetDirectory))
+              .setRes(resDirectory == null ? null : new FakeSourcePath(resDirectory))
               .setBuildTarget(resourceOnebuildTarget)
               .build());
 
@@ -200,14 +200,14 @@ public class AndroidBinaryTest {
 
     AndroidBinary ruleInRootDirectory = (AndroidBinary) AndroidBinaryBuilder.createBuilder(
         BuildTargetFactory.newInstance("//:fb4a"))
-        .setManifest(new TestSourcePath("AndroidManifest.xml"))
+        .setManifest(new FakeSourcePath("AndroidManifest.xml"))
         .setKeystore(keystore.getBuildTarget())
         .build(ruleResolver);
     assertEquals(Paths.get(GEN_DIR + "/fb4a.apk"), ruleInRootDirectory.getApkPath());
 
     AndroidBinary ruleInNonRootDirectory = (AndroidBinary) AndroidBinaryBuilder.createBuilder(
         BuildTargetFactory.newInstance("//java/com/example:fb4a"))
-        .setManifest(new TestSourcePath("AndroidManifest.xml"))
+        .setManifest(new FakeSourcePath("AndroidManifest.xml"))
         .setKeystore(keystore.getBuildTarget())
         .build(ruleResolver);
     assertEquals(
@@ -220,7 +220,7 @@ public class AndroidBinaryTest {
 
     AndroidBinary rule = (AndroidBinary) AndroidBinaryBuilder.createBuilder(
         BuildTargetFactory.newInstance("//:fbandroid_with_dash_debug_fbsign"))
-        .setManifest(new TestSourcePath("AndroidManifest.xml"))
+        .setManifest(new FakeSourcePath("AndroidManifest.xml"))
         .setKeystore(addKeystoreRule(ruleResolver).getBuildTarget())
         .build(ruleResolver);
 
@@ -253,7 +253,7 @@ public class AndroidBinaryTest {
     BuildRuleResolver ruleResolver = new BuildRuleResolver();
     AndroidBinary splitDexRule = (AndroidBinary) AndroidBinaryBuilder.createBuilder(
         BuildTargetFactory.newInstance("//:fbandroid_with_dash_debug_fbsign"))
-        .setManifest(new TestSourcePath("AndroidManifest.xml"))
+        .setManifest(new FakeSourcePath("AndroidManifest.xml"))
         .setKeystore(addKeystoreRule(ruleResolver).getBuildTarget())
         .setShouldSplitDex(true)
         .setLinearAllocHardLimit(0)
@@ -285,12 +285,12 @@ public class AndroidBinaryTest {
 
   @Test
   public void testDexingCommandWithIntraDexReorder() {
-    SourcePath reorderTool = new TestSourcePath("/tools#reorder_tool");
-    SourcePath reorderData = new TestSourcePath("/tools#reorder_data");
+    SourcePath reorderTool = new FakeSourcePath("/tools#reorder_tool");
+    SourcePath reorderData = new FakeSourcePath("/tools#reorder_data");
     BuildRuleResolver ruleResolver = new BuildRuleResolver();
     AndroidBinary splitDexRule = (AndroidBinary) AndroidBinaryBuilder.createBuilder(
         BuildTargetFactory.newInstance("//:fbandroid_with_dash_debug_fbsign"))
-        .setManifest(new TestSourcePath("AndroidManifest.xml"))
+        .setManifest(new FakeSourcePath("AndroidManifest.xml"))
         .setKeystore(addKeystoreRule(ruleResolver).getBuildTarget())
         .setShouldSplitDex(true)
         .setLinearAllocHardLimit(0)
@@ -331,7 +331,7 @@ public class AndroidBinaryTest {
     BuildRule keystoreRule = addKeystoreRule(resolver);
     AndroidBinaryBuilder builder = AndroidBinaryBuilder.createBuilder(
         BuildTargetFactory.newInstance("//:target"))
-        .setManifest(new TestSourcePath("AndroidManifest.xml"))
+        .setManifest(new FakeSourcePath("AndroidManifest.xml"))
         .setKeystore(keystoreRule.getBuildTarget())
         .setResourceFilter(new ResourceFilter(ImmutableList.of("mdpi")))
         .setResourceCompressionMode(ResourceCompressionMode.ENABLED_WITH_STRINGS_AS_ASSETS);
@@ -369,7 +369,7 @@ public class AndroidBinaryTest {
                 BuildTargetFactory.newInstance(
                     "//missing:dep")))
         .setKeystore(keystoreRule.getBuildTarget())
-        .setManifest(new TestSourcePath("AndroidManifest.xml"))
+        .setManifest(new FakeSourcePath("AndroidManifest.xml"))
         .build(resolver);
   }
 
@@ -398,7 +398,7 @@ public class AndroidBinaryTest {
 
     BuildRule rule = AndroidBinaryBuilder.createBuilder(BuildTargetFactory.newInstance("//:target"))
         .setKeystore(keystoreRule.getBuildTarget())
-        .setManifest(new TestSourcePath("AndroidManifest.xml"))
+        .setManifest(new FakeSourcePath("AndroidManifest.xml"))
         .setOriginalDeps(ImmutableSortedSet.of(immediateDep.getBuildTarget()))
         .build(resolver);
 
@@ -408,8 +408,8 @@ public class AndroidBinaryTest {
   private Keystore addKeystoreRule(BuildRuleResolver ruleResolver) {
     BuildTarget keystoreTarget = BuildTargetFactory.newInstance("//keystore:debug");
     return (Keystore) KeystoreBuilder.createBuilder(keystoreTarget)
-        .setStore(new TestSourcePath("keystore/debug.keystore"))
-        .setProperties(new TestSourcePath("keystore/debug.keystore.properties"))
+        .setStore(new FakeSourcePath("keystore/debug.keystore"))
+        .setProperties(new FakeSourcePath("keystore/debug.keystore.properties"))
         .build(ruleResolver);
   }
 }

--- a/test/com/facebook/buck/android/AndroidInstrumentationApkDescriptionTest.java
+++ b/test/com/facebook/buck/android/AndroidInstrumentationApkDescriptionTest.java
@@ -25,8 +25,8 @@ import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 
@@ -57,11 +57,11 @@ public class AndroidInstrumentationApkDescriptionTest {
             new Keystore(
                 new FakeBuildRuleParamsBuilder("//:keystore").build(),
                 pathResolver,
-                new TestSourcePath("store"),
-                new TestSourcePath("properties")));
+                new FakeSourcePath("store"),
+                new FakeSourcePath("properties")));
     AndroidBinary androidBinary =
         (AndroidBinary) AndroidBinaryBuilder.createBuilder(BuildTargetFactory.newInstance("//:apk"))
-            .setManifest(new TestSourcePath("manifest.xml"))
+            .setManifest(new FakeSourcePath("manifest.xml"))
             .setKeystore(keystore.getBuildTarget())
             .setNoDx(ImmutableSet.of(transitiveDep.getBuildTarget()))
             .setOriginalDeps(ImmutableSortedSet.of(dep.getBuildTarget()))
@@ -70,7 +70,7 @@ public class AndroidInstrumentationApkDescriptionTest {
     BuildTarget target = BuildTargetFactory.newInstance("//:rule");
     AndroidInstrumentationApk androidInstrumentationApk =
         (AndroidInstrumentationApk) AndroidInstrumentationApkBuilder.createBuilder(target)
-            .setManifest(new TestSourcePath("manifest.xml"))
+            .setManifest(new FakeSourcePath("manifest.xml"))
             .setApk(androidBinary.getBuildTarget())
             .build(ruleResolver);
     assertThat(androidInstrumentationApk.getDeps(), Matchers.hasItem(transitiveDep));

--- a/test/com/facebook/buck/android/AndroidInstrumentationApkTest.java
+++ b/test/com/facebook/buck/android/AndroidInstrumentationApkTest.java
@@ -29,9 +29,9 @@ import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.TargetGraph;
-import com.facebook.buck.rules.TestSourcePath;
 import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableMap;
@@ -92,8 +92,8 @@ public class AndroidInstrumentationApkTest {
 
     BuildRule keystore = KeystoreBuilder.createBuilder(
         BuildTargetFactory.newInstance("//keystores:debug"))
-        .setProperties(new TestSourcePath("keystores/debug.properties"))
-        .setStore(new TestSourcePath("keystores/debug.keystore"))
+        .setProperties(new FakeSourcePath("keystores/debug.properties"))
+        .setStore(new FakeSourcePath("keystores/debug.keystore"))
         .build(ruleResolver);
 
     // AndroidBinaryRule transitively depends on :lib1, :lib2, and :lib3.
@@ -103,7 +103,7 @@ public class AndroidInstrumentationApkTest {
         javaLibrary2.getBuildTarget(),
         javaLibrary3.getBuildTarget());
     androidBinaryBuilder
-        .setManifest(new TestSourcePath("apps/AndroidManifest.xml"))
+        .setManifest(new FakeSourcePath("apps/AndroidManifest.xml"))
         .setKeystore(keystore.getBuildTarget())
         .setOriginalDeps(originalDepsTargets);
     AndroidBinary androidBinary = (AndroidBinary) androidBinaryBuilder.build(ruleResolver);
@@ -115,7 +115,7 @@ public class AndroidInstrumentationApkTest {
     AndroidInstrumentationApkDescription.Arg arg = new AndroidInstrumentationApkDescription.Arg();
     arg.apk = androidBinary.getBuildTarget();
     arg.deps = Optional.of(apkOriginalDepsTargets);
-    arg.manifest = new TestSourcePath("apps/InstrumentationAndroidManifest.xml");
+    arg.manifest = new FakeSourcePath("apps/InstrumentationAndroidManifest.xml");
 
     BuildRuleParams params = new FakeBuildRuleParamsBuilder(
         BuildTargetFactory.newInstance("//apps:instrumentation"))

--- a/test/com/facebook/buck/android/AndroidLibraryGraphEnhancerTest.java
+++ b/test/com/facebook/buck/android/AndroidLibraryGraphEnhancerTest.java
@@ -33,8 +33,8 @@ import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildTargetSourcePath;
 import com.facebook.buck.rules.FakeBuildRule;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.google.common.base.Functions;
 import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
@@ -91,14 +91,14 @@ public class AndroidLibraryGraphEnhancerTest {
             .setResolver(pathResolver)
             .setBuildTarget(BuildTargetFactory.newInstance("//android_res/com/example:res1"))
             .setRDotJavaPackage("com.facebook")
-            .setRes(new TestSourcePath("android_res/com/example/res1"))
+            .setRes(new FakeSourcePath("android_res/com/example/res1"))
             .build());
     BuildRule resourceRule2 = ruleResolver.addToIndex(
         AndroidResourceRuleBuilder.newBuilder()
             .setResolver(pathResolver)
             .setBuildTarget(BuildTargetFactory.newInstance("//android_res/com/example:res2"))
             .setRDotJavaPackage("com.facebook")
-            .setRes(new TestSourcePath("android_res/com/example/res2"))
+            .setRes(new FakeSourcePath("android_res/com/example/res2"))
             .build());
 
     BuildRuleParams buildRuleParams = new FakeBuildRuleParamsBuilder(buildTarget)
@@ -141,14 +141,14 @@ public class AndroidLibraryGraphEnhancerTest {
             .setResolver(pathResolver)
             .setBuildTarget(BuildTargetFactory.newInstance("//android_res/com/example:res1"))
             .setRDotJavaPackage("com.facebook")
-            .setRes(new TestSourcePath("android_res/com/example/res1"))
+            .setRes(new FakeSourcePath("android_res/com/example/res1"))
             .build());
     BuildRule resourceRule2 = ruleResolver.addToIndex(
         AndroidResourceRuleBuilder.newBuilder()
             .setResolver(pathResolver)
             .setBuildTarget(BuildTargetFactory.newInstance("//android_res/com/example:res2"))
             .setRDotJavaPackage("com.facebook")
-            .setRes(new TestSourcePath("android_res/com/example/res2"))
+            .setRes(new FakeSourcePath("android_res/com/example/res2"))
             .build());
 
     BuildRuleParams buildRuleParams = new FakeBuildRuleParamsBuilder(buildTarget)

--- a/test/com/facebook/buck/android/AndroidManifestTest.java
+++ b/test/com/facebook/buck/android/AndroidManifestTest.java
@@ -25,8 +25,8 @@ import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
 import com.facebook.buck.rules.FakeBuildableContext;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.TargetGraph;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.util.BuckConstant;
 import com.google.common.base.Optional;
@@ -85,7 +85,7 @@ public class AndroidManifestTest {
         new FakeBuildRuleParamsBuilder("//java/com/example:manifest").build();
     AndroidManifestDescription description = new AndroidManifestDescription();
     AndroidManifestDescription.Arg arg = description.createUnpopulatedConstructorArg();
-    arg.skeleton = new TestSourcePath("java/com/example/AndroidManifestSkeleton.xml");
+    arg.skeleton = new FakeSourcePath("java/com/example/AndroidManifestSkeleton.xml");
     arg.deps = Optional.of(ImmutableSortedSet.<BuildTarget>of());
     return description
         .createBuildRule(TargetGraph.EMPTY, buildRuleParams, new BuildRuleResolver(), arg);

--- a/test/com/facebook/buck/android/AndroidNativeLibsPackageableGraphEnhancerTest.java
+++ b/test/com/facebook/buck/android/AndroidNativeLibsPackageableGraphEnhancerTest.java
@@ -29,11 +29,11 @@ import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.TargetGraph;
 import com.facebook.buck.rules.TargetNode;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.coercer.SourceWithFlags;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
 import com.facebook.buck.testutil.TargetGraphFactory;
@@ -120,7 +120,7 @@ public class AndroidNativeLibsPackageableGraphEnhancerTest {
     AbstractCxxSourceBuilder<CxxLibraryDescription.Arg> cxxLibraryBuilder = new CxxLibraryBuilder(
         BuildTargetFactory.newInstance("//:cxxlib"))
         .setSoname("somelib.so")
-        .setSrcs(ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("test/bar.cpp"))));
+        .setSrcs(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("test/bar.cpp"))));
     TargetNode<CxxLibraryDescription.Arg> cxxLibraryDescription = cxxLibraryBuilder.build();
     TargetGraph targetGraph = TargetGraphFactory.newInstance(cxxLibraryDescription);
     CxxLibrary cxxLibrary = (CxxLibrary) cxxLibraryBuilder.build(

--- a/test/com/facebook/buck/android/AndroidPackageableCollectorTest.java
+++ b/test/com/facebook/buck/android/AndroidPackageableCollectorTest.java
@@ -26,10 +26,10 @@ import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.PathSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
 import com.facebook.buck.util.BuckConstant;
 import com.google.common.collect.FluentIterable;
@@ -105,14 +105,14 @@ public class AndroidPackageableCollectorTest {
             new PathSourcePath(
                 projectFilesystem,
                 Paths.get("java/src/com/facebook/module/AndroidManifest.xml")))
-        .setAssets(new TestSourcePath("assets"))
+        .setAssets(new FakeSourcePath("assets"))
         .build();
     ruleResolver.addToIndex(manifestRule);
 
     BuildTarget keystoreTarget = BuildTargetFactory.newInstance("//keystore:debug");
     KeystoreBuilder.createBuilder(keystoreTarget)
-        .setStore(new TestSourcePath(projectFilesystem, "keystore/debug.keystore"))
-        .setProperties(new TestSourcePath(projectFilesystem, "keystore/debug.keystore.properties"))
+        .setStore(new FakeSourcePath(projectFilesystem, "keystore/debug.keystore"))
+        .setProperties(new FakeSourcePath(projectFilesystem, "keystore/debug.keystore.properties"))
         .build(ruleResolver);
 
     ImmutableSortedSet<BuildTarget> originalDepsTargets =
@@ -123,7 +123,7 @@ public class AndroidPackageableCollectorTest {
         .setOriginalDeps(originalDepsTargets)
         .setBuildTargetsToExcludeFromDex(
             ImmutableSet.of(BuildTargetFactory.newInstance("//third_party/guava:guava")))
-        .setManifest(new TestSourcePath("java/src/com/facebook/AndroidManifest.xml"))
+        .setManifest(new FakeSourcePath("java/src/com/facebook/AndroidManifest.xml"))
         .setKeystore(keystoreTarget)
         .build(ruleResolver);
 
@@ -155,7 +155,7 @@ public class AndroidPackageableCollectorTest {
     assertEquals(
         "Because assets directory was passed an AndroidResourceRule it should be added to the " +
             "transitive dependencies",
-        ImmutableSet.of(new TestSourcePath("assets")),
+        ImmutableSet.of(new FakeSourcePath("assets")),
         packageableCollection.getAssetsDirectories());
     assertEquals(
         "Because a native library was declared as a dependency, it should be added to the " +
@@ -174,7 +174,7 @@ public class AndroidPackageableCollectorTest {
                 ((NativeLibraryBuildRule) prebuiltNativeLibraryBuild).getLibraryPath())),
         packageableCollection.getNativeLibAssetsDirectories());
     assertEquals(
-        ImmutableSet.of(new TestSourcePath("debug.pro")),
+        ImmutableSet.of(new FakeSourcePath("debug.pro")),
         packageableCollection.getProguardConfigs());
   }
 
@@ -205,7 +205,7 @@ public class AndroidPackageableCollectorTest {
         AndroidResourceRuleBuilder.newBuilder()
             .setResolver(pathResolver)
             .setBuildTarget(BuildTargetFactory.newInstance("//:c"))
-            .setRes(new TestSourcePath("res_c"))
+            .setRes(new FakeSourcePath("res_c"))
             .setRDotJavaPackage("com.facebook")
             .build());
 
@@ -213,7 +213,7 @@ public class AndroidPackageableCollectorTest {
         AndroidResourceRuleBuilder.newBuilder()
             .setResolver(pathResolver)
             .setBuildTarget(BuildTargetFactory.newInstance("//:b"))
-            .setRes(new TestSourcePath("res_b"))
+            .setRes(new FakeSourcePath("res_b"))
             .setRDotJavaPackage("com.facebook")
             .setDeps(ImmutableSortedSet.of(c))
             .build());
@@ -222,7 +222,7 @@ public class AndroidPackageableCollectorTest {
         AndroidResourceRuleBuilder.newBuilder()
             .setResolver(pathResolver)
             .setBuildTarget(BuildTargetFactory.newInstance("//:d"))
-            .setRes(new TestSourcePath("res_d"))
+            .setRes(new FakeSourcePath("res_d"))
             .setRDotJavaPackage("com.facebook")
             .setDeps(ImmutableSortedSet.of(c))
             .build());
@@ -231,7 +231,7 @@ public class AndroidPackageableCollectorTest {
         AndroidResourceRuleBuilder.newBuilder()
             .setResolver(pathResolver)
             .setBuildTarget(BuildTargetFactory.newInstance("//:a"))
-            .setRes(new TestSourcePath("res_a"))
+            .setRes(new FakeSourcePath("res_a"))
             .setRDotJavaPackage("com.facebook")
             .setDeps(ImmutableSortedSet.of(b, c, d))
             .build());
@@ -255,15 +255,15 @@ public class AndroidPackageableCollectorTest {
     // right thing when it gets a non-AndroidResourceRule as well as an AndroidResourceRule.
     BuildTarget keystoreTarget = BuildTargetFactory.newInstance("//keystore:debug");
     KeystoreBuilder.createBuilder(keystoreTarget)
-        .setStore(new TestSourcePath("keystore/debug.keystore"))
-        .setProperties(new TestSourcePath("keystore/debug.keystore.properties"))
+        .setStore(new FakeSourcePath("keystore/debug.keystore"))
+        .setProperties(new FakeSourcePath("keystore/debug.keystore.properties"))
         .build(ruleResolver);
 
     ImmutableSortedSet<BuildTarget> declaredDepsTargets =
         ImmutableSortedSet.of(a.getBuildTarget(), c.getBuildTarget());
     AndroidBinary androidBinary = (AndroidBinary) AndroidBinaryBuilder
         .createBuilder(BuildTargetFactory.newInstance("//:e"))
-        .setManifest(new TestSourcePath("AndroidManfiest.xml"))
+        .setManifest(new FakeSourcePath("AndroidManfiest.xml"))
         .setKeystore(keystoreTarget)
         .setOriginalDeps(declaredDepsTargets)
         .build(ruleResolver);
@@ -295,8 +295,8 @@ public class AndroidPackageableCollectorTest {
 
     BuildTarget keystoreTarget = BuildTargetFactory.newInstance("//keystore:debug");
     KeystoreBuilder.createBuilder(keystoreTarget)
-        .setStore(new TestSourcePath("keystore/debug.keystore"))
-        .setProperties(new TestSourcePath("keystore/debug.keystore.properties"))
+        .setStore(new FakeSourcePath("keystore/debug.keystore"))
+        .setProperties(new FakeSourcePath("keystore/debug.keystore.properties"))
         .addDep(androidLibraryKeystore.getBuildTarget())
         .build(ruleResolver);
 
@@ -310,7 +310,7 @@ public class AndroidPackageableCollectorTest {
         ImmutableSortedSet.of(androidLibrary.getBuildTarget());
     AndroidBinary androidBinary = (AndroidBinary) AndroidBinaryBuilder.createBuilder(
         BuildTargetFactory.newInstance("//apps/sample:app"))
-        .setManifest(new TestSourcePath("apps/sample/AndroidManifest.xml"))
+        .setManifest(new FakeSourcePath("apps/sample/AndroidManifest.xml"))
         .setOriginalDeps(originalDepsTargets)
         .setKeystore(keystoreTarget)
         .build(ruleResolver);

--- a/test/com/facebook/buck/android/AndroidPrebuiltAarBuilder.java
+++ b/test/com/facebook/buck/android/AndroidPrebuiltAarBuilder.java
@@ -19,7 +19,7 @@ package com.facebook.buck.android;
 import com.facebook.buck.jvm.java.JavaCompilationConstants;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.rules.AbstractNodeBuilder;
-import com.facebook.buck.rules.TestSourcePath;
+import com.facebook.buck.rules.FakeSourcePath;
 
 import java.nio.file.Path;
 
@@ -35,7 +35,7 @@ public class AndroidPrebuiltAarBuilder
  }
 
  public AndroidPrebuiltAarBuilder setBinaryAar(Path binaryAar) {
-  arg.aar = new TestSourcePath(binaryAar.toString());
+  arg.aar = new FakeSourcePath(binaryAar.toString());
   return this;
  }
 }

--- a/test/com/facebook/buck/android/AndroidResourceDescriptionTest.java
+++ b/test/com/facebook/buck/android/AndroidResourceDescriptionTest.java
@@ -20,8 +20,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
 import com.facebook.buck.io.ProjectFilesystem;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
-import com.facebook.buck.rules.TestSourcePath;
 import com.google.common.base.Optional;
 
 import org.junit.Rule;
@@ -90,9 +90,9 @@ public class AndroidResourceDescriptionTest {
         inputs,
         containsInAnyOrder(
             // This clever cast saves us mucking around with generics.
-            (SourcePath) new TestSourcePath(filesystem, "res/image.png"),
-            new TestSourcePath(filesystem, "res/layout.xml"),
-            new TestSourcePath(filesystem, "res/_file"),
-            new TestSourcePath(filesystem, "res/dirs/values/strings.xml")));
+            (SourcePath) new FakeSourcePath(filesystem, "res/image.png"),
+            new FakeSourcePath(filesystem, "res/layout.xml"),
+            new FakeSourcePath(filesystem, "res/_file"),
+            new FakeSourcePath(filesystem, "res/dirs/values/strings.xml")));
   }
 }

--- a/test/com/facebook/buck/android/AndroidResourceTest.java
+++ b/test/com/facebook/buck/android/AndroidResourceTest.java
@@ -32,12 +32,12 @@ import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
 import com.facebook.buck.rules.FakeBuildableContext;
 import com.facebook.buck.rules.FakeOnDiskBuildInfo;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.PathSourcePath;
 import com.facebook.buck.rules.RuleKey;
 import com.facebook.buck.rules.Sha1HashCode;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.keys.DefaultRuleKeyBuilderFactory;
 import com.facebook.buck.rules.keys.InputBasedRuleKeyBuilderFactory;
 import com.facebook.buck.testutil.FakeFileHashCache;
@@ -79,17 +79,17 @@ public class AndroidResourceTest {
     AndroidResource androidResource1 = AndroidResourceRuleBuilder.newBuilder()
         .setResolver(pathResolver)
         .setBuildRuleParams(params)
-        .setRes(new TestSourcePath("java/src/com/facebook/base/res"))
+        .setRes(new FakeSourcePath("java/src/com/facebook/base/res"))
         .setResSrcs(
             ImmutableSortedSet.of(
-                new TestSourcePath(
+                new FakeSourcePath(
                     params.getProjectFilesystem(),
                     "java/src/com/facebook/base/res/drawable/A.xml")))
         .setRDotJavaPackage("com.facebook")
-        .setAssets(new TestSourcePath("java/src/com/facebook/base/assets"))
+        .setAssets(new FakeSourcePath("java/src/com/facebook/base/assets"))
         .setAssetsSrcs(
             ImmutableSortedSet.of(
-                new TestSourcePath(
+                new FakeSourcePath(
                     params.getProjectFilesystem(),
                     "java/src/com/facebook/base/assets/drawable/B.xml")))
         .setManifest(
@@ -101,17 +101,17 @@ public class AndroidResourceTest {
     AndroidResource androidResource2 = AndroidResourceRuleBuilder.newBuilder()
         .setResolver(pathResolver)
         .setBuildRuleParams(params)
-        .setRes(new TestSourcePath("java/src/com/facebook/base/res"))
+        .setRes(new FakeSourcePath("java/src/com/facebook/base/res"))
         .setResSrcs(
             ImmutableSortedSet.of(
-                new TestSourcePath(
+                new FakeSourcePath(
                     params.getProjectFilesystem(),
                     "java/src/com/facebook/base/res/drawable/C.xml")))
         .setRDotJavaPackage("com.facebook")
-        .setAssets(new TestSourcePath("java/src/com/facebook/base/assets"))
+        .setAssets(new FakeSourcePath("java/src/com/facebook/base/assets"))
         .setAssetsSrcs(
             ImmutableSortedSet.of(
-                new TestSourcePath(
+                new FakeSourcePath(
                     params.getProjectFilesystem(),
                     "java/src/com/facebook/base/assets/drawable/B.xml")))
         .setManifest(
@@ -148,7 +148,7 @@ public class AndroidResourceTest {
             .setResolver(pathResolver)
             .setBuildTarget(BuildTargetFactory.newInstance("//android_res/com/example:res1"))
             .setRDotJavaPackage("com.facebook")
-            .setRes(new TestSourcePath("android_res/com/example/res1"))
+            .setRes(new FakeSourcePath("android_res/com/example/res1"))
             .build());
     setAndroidResourceBuildOutput(resourceRule1, "a");
     BuildRule resourceRule2 = ruleResolver.addToIndex(
@@ -190,8 +190,8 @@ public class AndroidResourceTest {
         new FakeBuildRuleParamsBuilder("//foo:bar").build(),
         new SourcePathResolver(new BuildRuleResolver()),
         /* deps */ ImmutableSortedSet.<BuildRule>of(),
-        new TestSourcePath("foo/res"),
-        ImmutableSortedSet.of((SourcePath) new TestSourcePath("foo/res/values/strings.xml")),
+        new FakeSourcePath("foo/res"),
+        ImmutableSortedSet.of((SourcePath) new FakeSourcePath("foo/res/values/strings.xml")),
         Optional.<SourcePath>absent(),
         /* rDotJavaPackage */ "com.example.android",
         /* assets */ null,
@@ -209,8 +209,8 @@ public class AndroidResourceTest {
         new FakeBuildRuleParamsBuilder("//foo:bar").build(),
         new SourcePathResolver(new BuildRuleResolver()),
         /* deps */ ImmutableSortedSet.<BuildRule>of(),
-        new TestSourcePath("foo/res"),
-        ImmutableSortedSet.of((SourcePath) new TestSourcePath("foo/res/values/strings.xml")),
+        new FakeSourcePath("foo/res"),
+        ImmutableSortedSet.of((SourcePath) new FakeSourcePath("foo/res/values/strings.xml")),
         Optional.<SourcePath>absent(),
         /* rDotJavaPackage */ null,
         /* assets */ null,
@@ -238,7 +238,7 @@ public class AndroidResourceTest {
     AndroidResource dep =
         (AndroidResource) AndroidResourceBuilder
             .createBuilder(BuildTargetFactory.newInstance("//:dep"))
-            .setManifest(new TestSourcePath("manifest"))
+            .setManifest(new FakeSourcePath("manifest"))
             .setRes(Paths.get("res"))
             .build(resolver, filesystem);
     AndroidResource resource =

--- a/test/com/facebook/buck/android/AndroidTransitiveDependencyGraphTest.java
+++ b/test/com/facebook/buck/android/AndroidTransitiveDependencyGraphTest.java
@@ -21,8 +21,8 @@ import static org.junit.Assert.assertThat;
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
-import com.facebook.buck.rules.TestSourcePath;
 import com.google.common.collect.ImmutableSortedSet;
 
 import org.hamcrest.Matchers;
@@ -35,7 +35,7 @@ public class AndroidTransitiveDependencyGraphTest {
     BuildRuleResolver resolver = new BuildRuleResolver();
     BuildRule dep3 =
         AndroidLibraryBuilder.createBuilder(BuildTargetFactory.newInstance("//:dep3"))
-            .setManifestFile(new TestSourcePath("manifest3.xml"))
+            .setManifestFile(new FakeSourcePath("manifest3.xml"))
             .build(resolver);
     BuildRule dep2 =
         AndroidLibraryBuilder.createBuilder(BuildTargetFactory.newInstance("//:dep2"))
@@ -43,14 +43,14 @@ public class AndroidTransitiveDependencyGraphTest {
             .build(resolver);
     BuildRule dep1 =
         AndroidLibraryBuilder.createBuilder(BuildTargetFactory.newInstance("//:dep1"))
-            .setManifestFile(new TestSourcePath("manifest1.xml"))
+            .setManifestFile(new FakeSourcePath("manifest1.xml"))
             .addDep(dep2.getBuildTarget())
             .build(resolver);
     assertThat(
         new AndroidTransitiveDependencyGraph(ImmutableSortedSet.of(dep1)).findManifestFiles(),
         Matchers.<SourcePath>containsInAnyOrder(
-            new TestSourcePath("manifest1.xml"),
-            new TestSourcePath("manifest3.xml")));
+            new FakeSourcePath("manifest1.xml"),
+            new FakeSourcePath("manifest3.xml")));
   }
 
 }

--- a/test/com/facebook/buck/android/ApkGenruleTest.java
+++ b/test/com/facebook/buck/android/ApkGenruleTest.java
@@ -44,13 +44,13 @@ import com.facebook.buck.rules.ExopackageInfo;
 import com.facebook.buck.rules.FakeBuildRule;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
 import com.facebook.buck.rules.FakeBuildableContext;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.ImmutableBuildContext;
 import com.facebook.buck.rules.InstallableApk;
 import com.facebook.buck.rules.PathSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.TargetGraph;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.shell.ShellStep;
 import com.facebook.buck.step.ExecutionContext;
 import com.facebook.buck.step.Step;
@@ -95,12 +95,12 @@ public class ApkGenruleTest {
 
     BuildTarget keystoreTarget = BuildTargetFactory.newInstance("//keystore:debug");
     Keystore keystore = (Keystore) KeystoreBuilder.createBuilder(keystoreTarget)
-        .setStore(new TestSourcePath(filesystem, "keystore/debug.keystore"))
-        .setProperties(new TestSourcePath(filesystem, "keystore/debug.keystore.properties"))
+        .setStore(new FakeSourcePath(filesystem, "keystore/debug.keystore"))
+        .setProperties(new FakeSourcePath(filesystem, "keystore/debug.keystore.properties"))
         .build(ruleResolver, filesystem);
 
     AndroidBinaryBuilder.createBuilder(BuildTargetFactory.newInstance("//:fb4a"))
-        .setManifest(new TestSourcePath("AndroidManifest.xml"))
+        .setManifest(new FakeSourcePath("AndroidManifest.xml"))
         .setOriginalDeps(ImmutableSortedSet.of(androidLibRule.getBuildTarget()))
         .setKeystore(keystore.getBuildTarget())
         .build(ruleResolver, filesystem);

--- a/test/com/facebook/buck/android/AssembleDirectoriesTest.java
+++ b/test/com/facebook/buck/android/AssembleDirectoriesTest.java
@@ -25,9 +25,9 @@ import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildContext;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
 import com.facebook.buck.rules.FakeBuildableContext;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.step.ExecutionContext;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.TestExecutionContext;
@@ -67,7 +67,7 @@ public class AssembleDirectoriesTest {
         .setProjectFilesystem(filesystem)
         .build();
     ImmutableList<SourcePath> directories = ImmutableList.<SourcePath>of(
-        new TestSourcePath(filesystem, "folder_a"), new TestSourcePath(filesystem, "folder_b"));
+        new FakeSourcePath(filesystem, "folder_a"), new FakeSourcePath(filesystem, "folder_b"));
     AssembleDirectories assembleDirectories = new AssembleDirectories(
         buildRuleParams, new SourcePathResolver(new BuildRuleResolver()), directories);
     ImmutableList<Step> steps = assembleDirectories.getBuildSteps(

--- a/test/com/facebook/buck/android/CopyNativeLibrariesTest.java
+++ b/test/com/facebook/buck/android/CopyNativeLibrariesTest.java
@@ -26,9 +26,9 @@ import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildContext;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
 import com.facebook.buck.rules.FakeBuildableContext;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.step.ExecutionContext;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.TestExecutionContext;
@@ -109,7 +109,7 @@ public class CopyNativeLibrariesTest {
         new CopyNativeLibraries(
             new FakeBuildRuleParamsBuilder(target).build(),
             new SourcePathResolver(new BuildRuleResolver()),
-            ImmutableSet.<SourcePath>of(new TestSourcePath("lib1"), new TestSourcePath("lib2")),
+            ImmutableSet.<SourcePath>of(new FakeSourcePath("lib1"), new FakeSourcePath("lib2")),
             ImmutableSet.<StrippedObjectDescription>of(),
             ImmutableSet.<StrippedObjectDescription>of(),
             ImmutableSet.<TargetCpuType>of());

--- a/test/com/facebook/buck/android/DummyRDotJavaTest.java
+++ b/test/com/facebook/buck/android/DummyRDotJavaTest.java
@@ -27,9 +27,9 @@ import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
 import com.facebook.buck.rules.FakeBuildableContext;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.Sha1HashCode;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.TestExecutionContext;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
@@ -66,7 +66,7 @@ public class DummyRDotJavaTest {
             .setResolver(pathResolver)
             .setBuildTarget(BuildTargetFactory.newInstance("//android_res/com/example:res1"))
             .setRDotJavaPackage("com.facebook")
-            .setRes(new TestSourcePath("android_res/com/example/res1"))
+            .setRes(new FakeSourcePath("android_res/com/example/res1"))
             .build());
     setAndroidResourceBuildOutput(resourceRule1, RESOURCE_RULE1_KEY);
     BuildRule resourceRule2 = ruleResolver.addToIndex(
@@ -74,7 +74,7 @@ public class DummyRDotJavaTest {
             .setResolver(pathResolver)
             .setBuildTarget(BuildTargetFactory.newInstance("//android_res/com/example:res2"))
             .setRDotJavaPackage("com.facebook")
-            .setRes(new TestSourcePath("android_res/com/example/res2"))
+            .setRes(new FakeSourcePath("android_res/com/example/res2"))
             .build());
     setAndroidResourceBuildOutput(resourceRule2, RESOURCE_RULE2_KEY);
 
@@ -84,7 +84,7 @@ public class DummyRDotJavaTest {
         ImmutableSet.of(
             (HasAndroidResourceDeps) resourceRule1,
             (HasAndroidResourceDeps) resourceRule2),
-        new TestSourcePath("abi.jar"),
+        new FakeSourcePath("abi.jar"),
         ANDROID_JAVAC_OPTIONS,
         Optional.<String>absent());
 
@@ -133,7 +133,7 @@ public class DummyRDotJavaTest {
             .build(),
         new SourcePathResolver(new BuildRuleResolver()),
         ImmutableSet.<HasAndroidResourceDeps>of(),
-        new TestSourcePath("abi.jar"),
+        new FakeSourcePath("abi.jar"),
         ANDROID_JAVAC_OPTIONS,
         Optional.<String>absent());
     assertEquals(Paths.get("buck-out/bin/java/com/example/__library_rdotjava_bin__"),

--- a/test/com/facebook/buck/android/GenAidlTest.java
+++ b/test/com/facebook/buck/android/GenAidlTest.java
@@ -31,8 +31,8 @@ import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
 import com.facebook.buck.rules.FakeBuildableContext;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.shell.ShellStep;
 import com.facebook.buck.step.ExecutionContext;
 import com.facebook.buck.step.Step;
@@ -69,7 +69,7 @@ public class GenAidlTest {
     ProjectFilesystem stubFilesystem = FakeProjectFilesystem.createJavaOnlyFilesystem();
     Files.createDirectories(stubFilesystem.getRootPath().resolve("java/com/example/base"));
 
-    TestSourcePath pathToAidl = new TestSourcePath(
+    FakeSourcePath pathToAidl = new FakeSourcePath(
         stubFilesystem,
         "java/com/example/base/IWhateverService.aidl");
     String importPath = Paths.get("java/com/example/base").toString();

--- a/test/com/facebook/buck/android/MergeAndroidResourcesStepTest.java
+++ b/test/com/facebook/buck/android/MergeAndroidResourcesStepTest.java
@@ -23,8 +23,8 @@ import static org.junit.Assert.assertThat;
 import com.facebook.buck.android.aapt.RDotTxtEntry;
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.step.ExecutionContext;
 import com.facebook.buck.step.TestExecutionContext;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
@@ -122,7 +122,7 @@ public class MergeAndroidResourcesStepTest {
     HasAndroidResourceDeps resource = AndroidResourceRuleBuilder.newBuilder()
         .setResolver(new SourcePathResolver(new BuildRuleResolver()))
         .setBuildTarget(BuildTargetFactory.newInstance("//android_res/com/facebook/http:res"))
-        .setRes(new TestSourcePath("res"))
+        .setRes(new FakeSourcePath("res"))
         .setRDotJavaPackage("com.facebook")
         .build();
 
@@ -190,7 +190,7 @@ public class MergeAndroidResourcesStepTest {
     HasAndroidResourceDeps resource = AndroidResourceRuleBuilder.newBuilder()
         .setResolver(new SourcePathResolver(new BuildRuleResolver()))
         .setBuildTarget(BuildTargetFactory.newInstance("//android_res/com/facebook/http:res"))
-        .setRes(new TestSourcePath("res"))
+        .setRes(new FakeSourcePath("res"))
         .setRDotJavaPackage("com.facebook")
         .build();
 
@@ -243,14 +243,14 @@ public class MergeAndroidResourcesStepTest {
     HasAndroidResourceDeps res1 = AndroidResourceRuleBuilder.newBuilder()
         .setResolver(new SourcePathResolver(new BuildRuleResolver()))
         .setBuildTarget(BuildTargetFactory.newInstance("//:res1"))
-        .setRes(new TestSourcePath("res1"))
+        .setRes(new FakeSourcePath("res1"))
         .setRDotJavaPackage("res1")
         .build();
 
     HasAndroidResourceDeps res2 = AndroidResourceRuleBuilder.newBuilder()
         .setResolver(new SourcePathResolver(new BuildRuleResolver()))
         .setBuildTarget(BuildTargetFactory.newInstance("//:res2"))
-        .setRes(new TestSourcePath("res2"))
+        .setRes(new FakeSourcePath("res2"))
         .setRDotJavaPackage("res2")
         .build();
 

--- a/test/com/facebook/buck/android/NdkCxxPlatformTest.java
+++ b/test/com/facebook/buck/android/NdkCxxPlatformTest.java
@@ -32,12 +32,12 @@ import com.facebook.buck.model.Pair;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.RuleKey;
 import com.facebook.buck.rules.RuleKeyBuilderFactory;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.TargetGraph;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.args.SourcePathArg;
 import com.facebook.buck.rules.coercer.FrameworkPath;
 import com.facebook.buck.rules.keys.DefaultRuleKeyBuilderFactory;
@@ -110,7 +110,7 @@ public class NdkCxxPlatformTest {
                   source,
                   CxxSource.of(
                       CxxSource.Type.CXX,
-                      new TestSourcePath(source),
+                      new FakeSourcePath(source),
                       ImmutableList.<String>of()),
                   CxxSourceRuleFactory.PicType.PIC,
                   CxxPreprocessMode.COMBINED);
@@ -122,7 +122,7 @@ public class NdkCxxPlatformTest {
                   source,
                   CxxSource.of(
                       CxxSource.Type.CXX,
-                      new TestSourcePath(source),
+                      new FakeSourcePath(source),
                       ImmutableList.<String>of()),
                   CxxSourceRuleFactory.PicType.PIC);
           break;
@@ -133,7 +133,7 @@ public class NdkCxxPlatformTest {
                   source,
                   CxxSource.of(
                       CxxSource.Type.CXX_CPP_OUTPUT,
-                      new TestSourcePath(source),
+                      new FakeSourcePath(source),
                       ImmutableList.<String>of()),
                   CxxSourceRuleFactory.PicType.PIC);
           break;
@@ -172,7 +172,7 @@ public class NdkCxxPlatformTest {
           Paths.get("output"),
           SourcePathArg.from(
               pathResolver,
-              new TestSourcePath("input.o")),
+              new FakeSourcePath("input.o")),
           Linker.LinkableDepType.SHARED,
           ImmutableList.<BuildRule>of(),
           Optional.<SourcePath>absent(),

--- a/test/com/facebook/buck/android/RobolectricTestRuleTest.java
+++ b/test/com/facebook/buck/android/RobolectricTestRuleTest.java
@@ -28,10 +28,10 @@ import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildTargetSourcePath;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.PathSourcePath;
 import com.facebook.buck.rules.Sha1HashCode;
 import com.facebook.buck.rules.SourcePath;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.shell.GenruleBuilder;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
 import com.google.common.collect.ImmutableList;
@@ -100,7 +100,7 @@ public class RobolectricTestRuleTest {
       String path = "java/src/com/facebook/base/" + i + "/res";
       filesystem.mkdirs(Paths.get(path).resolve("values"));
       resDepsBuilder.add(
-          new ResourceRule(new TestSourcePath(path)));
+          new ResourceRule(new FakeSourcePath(path)));
     }
     ImmutableList<HasAndroidResourceDeps> resDeps = resDepsBuilder.build();
 

--- a/test/com/facebook/buck/android/SplitZipStepTest.java
+++ b/test/com/facebook/buck/android/SplitZipStepTest.java
@@ -22,8 +22,8 @@ import static org.junit.Assert.assertTrue;
 
 import com.facebook.buck.dalvik.ZipSplitter;
 import com.facebook.buck.io.ProjectFilesystem;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.step.ExecutionContext;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
@@ -122,7 +122,7 @@ public class SplitZipStepTest {
             /* useLinearAllocSplitDex */ true,
             /* linearAllocHardLimit */ 4 * 1024 * 1024,
             /* primaryDexPatterns */ ImmutableSet.of("List"),
-            Optional.<SourcePath>of(new TestSourcePath("the/manifest.txt")),
+            Optional.<SourcePath>of(new FakeSourcePath("the/manifest.txt")),
             /* primaryDexScenarioFile */ Optional.<SourcePath>absent(),
             /* isPrimaryDexScenarioOverflowAllowed */ false,
             /* secondaryDexHeadClassesFile */ Optional.<SourcePath>absent(),
@@ -214,7 +214,7 @@ public class SplitZipStepTest {
             /* useLinearAllocSplitDex */ true,
             /* linearAllocHardLimit */ 4 * 1024 * 1024,
             /* primaryDexPatterns */ ImmutableSet.of("/primary/", "x/"),
-            Optional.<SourcePath>of(new TestSourcePath("the/manifest.txt")),
+            Optional.<SourcePath>of(new FakeSourcePath("the/manifest.txt")),
             /* primaryDexScenarioFile */ Optional.<SourcePath>absent(),
             /* isPrimaryDexScenarioOverflowAllowed */ false,
             /* secondaryDexHeadClassesFile */ Optional.<SourcePath>absent(),

--- a/test/com/facebook/buck/android/aapt/MergeAndroidResourcesSourcesTest.java
+++ b/test/com/facebook/buck/android/aapt/MergeAndroidResourcesSourcesTest.java
@@ -24,9 +24,9 @@ import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildContext;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
 import com.facebook.buck.rules.FakeBuildableContext;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.step.ExecutionContext;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.TestExecutionContext;
@@ -105,8 +105,8 @@ public class MergeAndroidResourcesSourcesTest {
         .setProjectFilesystem(filesystem)
         .build();
     ImmutableList<SourcePath> directories = ImmutableList.<SourcePath>of(
-        new TestSourcePath("res_in_1"),
-        new TestSourcePath("res_in_2"));
+        new FakeSourcePath("res_in_1"),
+        new FakeSourcePath("res_in_2"));
     MergeAndroidResourceSources mergeAndroidResourceSourcesStep =
         new MergeAndroidResourceSources(
             buildRuleParams,

--- a/test/com/facebook/buck/android/aapt/MiniAaptTest.java
+++ b/test/com/facebook/buck/android/aapt/MiniAaptTest.java
@@ -28,8 +28,8 @@ import com.facebook.buck.android.aapt.RDotTxtEntry.RType;
 import com.facebook.buck.event.BuckEventBus;
 import com.facebook.buck.model.BuildId;
 import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
 import com.facebook.buck.timing.FakeClock;
 import com.google.common.collect.ImmutableList;
@@ -75,7 +75,7 @@ public class MiniAaptTest {
     MiniAapt aapt = new MiniAapt(
         new SourcePathResolver(new BuildRuleResolver()),
         filesystem,
-        new TestSourcePath(filesystem, "res"),
+        new FakeSourcePath(filesystem, "res"),
         Paths.get("R.txt"),
         ImmutableSet.<Path>of());
 
@@ -137,7 +137,7 @@ public class MiniAaptTest {
     MiniAapt aapt = new MiniAapt(
         new SourcePathResolver(new BuildRuleResolver()),
         filesystem,
-        new TestSourcePath(filesystem, "res"),
+        new FakeSourcePath(filesystem, "res"),
         Paths.get("R.txt"),
         ImmutableSet.<Path>of());
     aapt.processValuesFile(filesystem, Paths.get("values.xml"));
@@ -188,7 +188,7 @@ public class MiniAaptTest {
     MiniAapt aapt = new MiniAapt(
         new SourcePathResolver(new BuildRuleResolver()),
         filesystem,
-        new TestSourcePath(filesystem, "res"),
+        new FakeSourcePath(filesystem, "res"),
         Paths.get("R.txt"),
         ImmutableSet.<Path>of());
     aapt.processValuesFile(filesystem, Paths.get("values.xml"));
@@ -212,7 +212,7 @@ public class MiniAaptTest {
     MiniAapt aapt = new MiniAapt(
         new SourcePathResolver(new BuildRuleResolver()),
         filesystem,
-        new TestSourcePath(filesystem, "res"),
+        new FakeSourcePath(filesystem, "res"),
         Paths.get("R.txt"),
         ImmutableSet.<Path>of());
     aapt.processValuesFile(filesystem, Paths.get("values.xml"));
@@ -240,7 +240,7 @@ public class MiniAaptTest {
     MiniAapt aapt = new MiniAapt(
         new SourcePathResolver(new BuildRuleResolver()),
         filesystem,
-        new TestSourcePath(filesystem, "res"),
+        new FakeSourcePath(filesystem, "res"),
         Paths.get("R.txt"),
         ImmutableSet.<Path>of());
     aapt.processDrawables(filesystem, Paths.get("android_drawable.xml"));
@@ -273,7 +273,7 @@ public class MiniAaptTest {
     MiniAapt aapt = new MiniAapt(
         new SourcePathResolver(new BuildRuleResolver()),
         filesystem,
-        new TestSourcePath(filesystem, "res"),
+        new FakeSourcePath(filesystem, "res"),
         Paths.get("R.txt"),
         ImmutableSet.<Path>of());
     aapt.processDrawables(filesystem, Paths.get("custom_drawable.xml"));
@@ -301,7 +301,7 @@ public class MiniAaptTest {
     MiniAapt aapt = new MiniAapt(
         new SourcePathResolver(new BuildRuleResolver()),
         filesystem,
-        new TestSourcePath(filesystem, "res"),
+        new FakeSourcePath(filesystem, "res"),
         Paths.get("R.txt"),
         ImmutableSet.<Path>of());
     aapt.processValuesFile(filesystem, Paths.get("values.xml"));
@@ -321,7 +321,7 @@ public class MiniAaptTest {
     MiniAapt aapt = new MiniAapt(
         new SourcePathResolver(new BuildRuleResolver()),
         filesystem,
-        new TestSourcePath(filesystem, "res"),
+        new FakeSourcePath(filesystem, "res"),
         Paths.get("R.txt"),
         ImmutableSet.<Path>of());
     aapt.processValuesFile(filesystem, Paths.get("values.xml"));
@@ -344,7 +344,7 @@ public class MiniAaptTest {
     MiniAapt aapt = new MiniAapt(
         new SourcePathResolver(new BuildRuleResolver()),
         filesystem,
-        new TestSourcePath(filesystem, "res"),
+        new FakeSourcePath(filesystem, "res"),
         Paths.get("R.txt"),
         ImmutableSet.<Path>of());
     try {
@@ -372,7 +372,7 @@ public class MiniAaptTest {
     MiniAapt aapt = new MiniAapt(
         new SourcePathResolver(new BuildRuleResolver()),
         filesystem,
-        new TestSourcePath(filesystem, "res"),
+        new FakeSourcePath(filesystem, "res"),
         Paths.get("R.txt"),
         ImmutableSet.<Path>of());
     try {
@@ -400,7 +400,7 @@ public class MiniAaptTest {
     MiniAapt aapt = new MiniAapt(
         new SourcePathResolver(new BuildRuleResolver()),
         filesystem,
-        new TestSourcePath(filesystem, "res"),
+        new FakeSourcePath(filesystem, "res"),
         Paths.get("R.txt"),
         ImmutableSet.<Path>of());
     aapt.processValuesFile(filesystem, Paths.get("values.xml"));
@@ -422,7 +422,7 @@ public class MiniAaptTest {
     MiniAapt aapt = new MiniAapt(
         new SourcePathResolver(new BuildRuleResolver()),
         filesystem,
-        new TestSourcePath(filesystem, "res"),
+        new FakeSourcePath(filesystem, "res"),
         Paths.get("R.txt"),
         ImmutableSet.of(depRTxt));
     ImmutableSet.Builder<RDotTxtEntry> references = ImmutableSet.builder();
@@ -456,7 +456,7 @@ public class MiniAaptTest {
     MiniAapt aapt = new MiniAapt(
         new SourcePathResolver(new BuildRuleResolver()),
         filesystem,
-        new TestSourcePath(filesystem, "res"),
+        new FakeSourcePath(filesystem, "res"),
         Paths.get("R.txt"),
         ImmutableSet.<Path>of());
     aapt.processXmlFile(filesystem, resource, ImmutableSet.<RDotTxtEntry>builder());
@@ -479,7 +479,7 @@ public class MiniAaptTest {
     MiniAapt aapt = new MiniAapt(
         new SourcePathResolver(new BuildRuleResolver()),
         filesystem,
-        new TestSourcePath(filesystem, "res"),
+        new FakeSourcePath(filesystem, "res"),
         Paths.get("R.txt"),
         ImmutableSet.<Path>of());
     aapt.processFileNamesInDirectory(filesystem, Paths.get("res/drawable"));
@@ -515,7 +515,7 @@ public class MiniAaptTest {
     MiniAapt aapt = new MiniAapt(
         new SourcePathResolver(new BuildRuleResolver()),
         filesystem,
-        new TestSourcePath(filesystem, "res"),
+        new FakeSourcePath(filesystem, "res"),
         Paths.get("R.txt"),
         ImmutableSet.<Path>of());
 

--- a/test/com/facebook/buck/apple/AppleCxxPlatformsTest.java
+++ b/test/com/facebook/buck/apple/AppleCxxPlatformsTest.java
@@ -45,12 +45,12 @@ import com.facebook.buck.model.ImmutableFlavor;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.RuleKey;
 import com.facebook.buck.rules.RuleKeyBuilderFactory;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.TargetGraph;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.args.SourcePathArg;
 import com.facebook.buck.rules.coercer.FrameworkPath;
 import com.facebook.buck.rules.keys.DefaultRuleKeyBuilderFactory;
@@ -750,7 +750,7 @@ AppleSdkPaths appleSdkPaths =
                   source,
                   CxxSource.of(
                       CxxSource.Type.CXX,
-                      new TestSourcePath(source),
+                      new FakeSourcePath(source),
                       ImmutableList.<String>of()),
                   CxxSourceRuleFactory.PicType.PIC,
                   CxxPreprocessMode.COMBINED);
@@ -762,7 +762,7 @@ AppleSdkPaths appleSdkPaths =
                   source,
                   CxxSource.of(
                       CxxSource.Type.CXX,
-                      new TestSourcePath(source),
+                      new FakeSourcePath(source),
                       ImmutableList.<String>of()),
                   CxxSourceRuleFactory.PicType.PIC);
           break;
@@ -773,7 +773,7 @@ AppleSdkPaths appleSdkPaths =
                   source,
                   CxxSource.of(
                       CxxSource.Type.CXX_CPP_OUTPUT,
-                      new TestSourcePath(source),
+                      new FakeSourcePath(source),
                       ImmutableList.<String>of()),
                   CxxSourceRuleFactory.PicType.PIC);
           break;
@@ -813,7 +813,7 @@ AppleSdkPaths appleSdkPaths =
               Paths.get("output"),
               SourcePathArg.from(
                   pathResolver,
-                  new TestSourcePath("input.o")),
+                  new FakeSourcePath("input.o")),
               Linker.LinkableDepType.SHARED,
               ImmutableList.<BuildRule>of(),
               Optional.<SourcePath>absent(),

--- a/test/com/facebook/buck/apple/AppleDescriptionsTest.java
+++ b/test/com/facebook/buck/apple/AppleDescriptionsTest.java
@@ -19,9 +19,9 @@ package com.facebook.buck.apple;
 import static org.junit.Assert.assertEquals;
 
 import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.coercer.SourceList;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
@@ -41,46 +41,46 @@ public class AppleDescriptionsTest {
   public void parseAppleHeadersForUseFromOtherTargetsFromSet() {
     assertEquals(
         ImmutableMap.<String, SourcePath>of(
-            "prefix/some_file.h", new TestSourcePath("path/to/some_file.h"),
-            "prefix/another_file.h", new TestSourcePath("path/to/another_file.h"),
-            "prefix/a_file.h", new TestSourcePath("different/path/to/a_file.h"),
-            "prefix/file.h", new TestSourcePath("file.h")),
+            "prefix/some_file.h", new FakeSourcePath("path/to/some_file.h"),
+            "prefix/another_file.h", new FakeSourcePath("path/to/another_file.h"),
+            "prefix/a_file.h", new FakeSourcePath("different/path/to/a_file.h"),
+            "prefix/file.h", new FakeSourcePath("file.h")),
         AppleDescriptions.parseAppleHeadersForUseFromOtherTargets(
             new SourcePathResolver(new BuildRuleResolver()).deprecatedPathFunction(),
             Paths.get("prefix"),
             SourceList.ofUnnamedSources(
                 ImmutableSortedSet.<SourcePath>of(
-                    new TestSourcePath("path/to/some_file.h"),
-                    new TestSourcePath("path/to/another_file.h"),
-                    new TestSourcePath("different/path/to/a_file.h"),
-                    new TestSourcePath("file.h")))));
+                    new FakeSourcePath("path/to/some_file.h"),
+                    new FakeSourcePath("path/to/another_file.h"),
+                    new FakeSourcePath("different/path/to/a_file.h"),
+                    new FakeSourcePath("file.h")))));
   }
 
   @Test
   public void parseAppleHeadersForUseFromTheSameFromSet() {
     assertEquals(
         ImmutableMap.<String, SourcePath>of(
-            "some_file.h", new TestSourcePath("path/to/some_file.h"),
-            "another_file.h", new TestSourcePath("path/to/another_file.h"),
-            "a_file.h", new TestSourcePath("different/path/to/a_file.h"),
-            "file.h", new TestSourcePath("file.h")),
+            "some_file.h", new FakeSourcePath("path/to/some_file.h"),
+            "another_file.h", new FakeSourcePath("path/to/another_file.h"),
+            "a_file.h", new FakeSourcePath("different/path/to/a_file.h"),
+            "file.h", new FakeSourcePath("file.h")),
         AppleDescriptions.parseAppleHeadersForUseFromTheSameTarget(
             new SourcePathResolver(new BuildRuleResolver()).deprecatedPathFunction(),
             SourceList.ofUnnamedSources(
                 ImmutableSortedSet.<SourcePath>of(
-                    new TestSourcePath("path/to/some_file.h"),
-                    new TestSourcePath("path/to/another_file.h"),
-                    new TestSourcePath("different/path/to/a_file.h"),
-                    new TestSourcePath("file.h")))));
+                    new FakeSourcePath("path/to/some_file.h"),
+                    new FakeSourcePath("path/to/another_file.h"),
+                    new FakeSourcePath("different/path/to/a_file.h"),
+                    new FakeSourcePath("file.h")))));
   }
 
   @Test
   public void parseAppleHeadersForUseFromOtherTargetsFromMap() {
     ImmutableSortedMap<String, SourcePath> headerMap = ImmutableSortedMap.<String, SourcePath>of(
-        "virtual/path.h", new TestSourcePath("path/to/some_file.h"),
-        "another/path.h", new TestSourcePath("path/to/another_file.h"),
-        "another/file.h", new TestSourcePath("different/path/to/a_file.h"),
-        "file.h", new TestSourcePath("file.h"));
+        "virtual/path.h", new FakeSourcePath("path/to/some_file.h"),
+        "another/path.h", new FakeSourcePath("path/to/another_file.h"),
+        "another/file.h", new FakeSourcePath("different/path/to/a_file.h"),
+        "file.h", new FakeSourcePath("file.h"));
     assertEquals(
         headerMap,
         AppleDescriptions.parseAppleHeadersForUseFromOtherTargets(
@@ -92,10 +92,10 @@ public class AppleDescriptionsTest {
   @Test
   public void parseAppleHeadersForUseFromTheSameTargetFromMap() {
     ImmutableSortedMap<String, SourcePath> headerMap = ImmutableSortedMap.<String, SourcePath>of(
-        "virtual/path.h", new TestSourcePath("path/to/some_file.h"),
-        "another/path.h", new TestSourcePath("path/to/another_file.h"),
-        "another/file.h", new TestSourcePath("different/path/to/a_file.h"),
-        "file.h", new TestSourcePath("file.h"));
+        "virtual/path.h", new FakeSourcePath("path/to/some_file.h"),
+        "another/path.h", new FakeSourcePath("path/to/another_file.h"),
+        "another/file.h", new FakeSourcePath("different/path/to/a_file.h"),
+        "file.h", new FakeSourcePath("file.h"));
     assertEquals(
         ImmutableMap.of(),
         AppleDescriptions.parseAppleHeadersForUseFromTheSameTarget(
@@ -107,36 +107,36 @@ public class AppleDescriptionsTest {
   public void convertToFlatCxxHeadersWithPrefix() {
     assertEquals(
         ImmutableMap.<String, SourcePath>of(
-            "prefix/some_file.h", new TestSourcePath("path/to/some_file.h"),
-            "prefix/another_file.h", new TestSourcePath("path/to/another_file.h"),
-            "prefix/a_file.h", new TestSourcePath("different/path/to/a_file.h"),
-            "prefix/file.h", new TestSourcePath("file.h")),
+            "prefix/some_file.h", new FakeSourcePath("path/to/some_file.h"),
+            "prefix/another_file.h", new FakeSourcePath("path/to/another_file.h"),
+            "prefix/a_file.h", new FakeSourcePath("different/path/to/a_file.h"),
+            "prefix/file.h", new FakeSourcePath("file.h")),
         AppleDescriptions.convertToFlatCxxHeaders(
             Paths.get("prefix"),
             new SourcePathResolver(new BuildRuleResolver()).deprecatedPathFunction(),
             ImmutableSet.<SourcePath>of(
-                new TestSourcePath("path/to/some_file.h"),
-                new TestSourcePath("path/to/another_file.h"),
-                new TestSourcePath("different/path/to/a_file.h"),
-                new TestSourcePath("file.h"))));
+                new FakeSourcePath("path/to/some_file.h"),
+                new FakeSourcePath("path/to/another_file.h"),
+                new FakeSourcePath("different/path/to/a_file.h"),
+                new FakeSourcePath("file.h"))));
   }
 
   @Test
   public void convertToFlatCxxHeadersWithoutPrefix() {
     assertEquals(
         ImmutableMap.<String, SourcePath>of(
-            "some_file.h", new TestSourcePath("path/to/some_file.h"),
-            "another_file.h", new TestSourcePath("path/to/another_file.h"),
-            "a_file.h", new TestSourcePath("different/path/to/a_file.h"),
-            "file.h", new TestSourcePath("file.h")),
+            "some_file.h", new FakeSourcePath("path/to/some_file.h"),
+            "another_file.h", new FakeSourcePath("path/to/another_file.h"),
+            "a_file.h", new FakeSourcePath("different/path/to/a_file.h"),
+            "file.h", new FakeSourcePath("file.h")),
         AppleDescriptions.convertToFlatCxxHeaders(
             Paths.get(""),
             new SourcePathResolver(new BuildRuleResolver()).deprecatedPathFunction(),
             ImmutableSet.<SourcePath>of(
-                new TestSourcePath("path/to/some_file.h"),
-                new TestSourcePath("path/to/another_file.h"),
-                new TestSourcePath("different/path/to/a_file.h"),
-                new TestSourcePath("file.h"))));
+                new FakeSourcePath("path/to/some_file.h"),
+                new FakeSourcePath("path/to/another_file.h"),
+                new FakeSourcePath("different/path/to/a_file.h"),
+                new FakeSourcePath("file.h"))));
   }
 
   @Test

--- a/test/com/facebook/buck/apple/AppleResourcesTest.java
+++ b/test/com/facebook/buck/apple/AppleResourcesTest.java
@@ -23,10 +23,10 @@ import static org.junit.Assert.assertThat;
 
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargetFactory;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.TargetGraph;
 import com.facebook.buck.rules.TargetNode;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.testutil.TargetGraphFactory;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
@@ -56,13 +56,13 @@ public class AppleResourcesTest {
     BuildTarget resourceTarget = BuildTargetFactory.newInstance("//foo:resource");
 
     Set<SourcePath> variants = ImmutableSet.<SourcePath>of(
-        new TestSourcePath("path/aa.lproj/Localizable.strings"),
-        new TestSourcePath("path/bb.lproj/Localizable.strings"),
-        new TestSourcePath("path/cc.lproj/Localizable.strings"));
+        new FakeSourcePath("path/aa.lproj/Localizable.strings"),
+        new FakeSourcePath("path/bb.lproj/Localizable.strings"),
+        new FakeSourcePath("path/cc.lproj/Localizable.strings"));
 
     TargetNode<AppleResourceDescription.Arg> resourceNode =
         AppleResourceBuilder.createBuilder(resourceTarget)
-            .setFiles(ImmutableSet.<SourcePath>of(new TestSourcePath("foo.png")))
+            .setFiles(ImmutableSet.<SourcePath>of(new FakeSourcePath("foo.png")))
             .setDirs(ImmutableSet.<SourcePath>of())
             .setVariants(Optional.of(variants))
             .build();
@@ -89,7 +89,7 @@ public class AppleResourcesTest {
     BuildTarget fooResourceTarget = BuildTargetFactory.newInstance("//foo:resource");
     TargetNode<AppleResourceDescription.Arg> fooResourceNode =
         AppleResourceBuilder.createBuilder(fooResourceTarget)
-            .setFiles(ImmutableSet.<SourcePath>of(new TestSourcePath("foo.png")))
+            .setFiles(ImmutableSet.<SourcePath>of(new FakeSourcePath("foo.png")))
             .setDirs(ImmutableSet.<SourcePath>of())
             .build();
     BuildTarget fooLibTarget = BuildTargetFactory.newInstance("//foo:lib");
@@ -100,7 +100,7 @@ public class AppleResourcesTest {
     BuildTarget barResourceTarget = BuildTargetFactory.newInstance("//bar:resource");
     TargetNode<AppleResourceDescription.Arg> barResourceNode =
         AppleResourceBuilder.createBuilder(barResourceTarget)
-            .setFiles(ImmutableSet.<SourcePath>of(new TestSourcePath("bar.png")))
+            .setFiles(ImmutableSet.<SourcePath>of(new FakeSourcePath("bar.png")))
             .setDirs(ImmutableSet.<SourcePath>of())
             .build();
     TargetNode<AppleNativeTargetDescriptionArg> barLibNode = AppleLibraryBuilder

--- a/test/com/facebook/buck/apple/NewNativeTargetProjectMutatorTest.java
+++ b/test/com/facebook/buck/apple/NewNativeTargetProjectMutatorTest.java
@@ -53,11 +53,11 @@ import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.parser.NoSuchBuildTargetException;
 import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.PathSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.TargetNode;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.coercer.FrameworkPath;
 import com.facebook.buck.rules.coercer.SourceWithFlags;
 import com.facebook.buck.testutil.AllExistingProjectFilesystem;
@@ -131,9 +131,9 @@ public class NewNativeTargetProjectMutatorTest {
   public void testSourceGroups() throws NoSuchBuildTargetException {
     NewNativeTargetProjectMutator mutator = mutatorWithCommonDefaults();
 
-    SourcePath foo = new TestSourcePath("Group1/foo.m");
-    SourcePath bar = new TestSourcePath("Group1/bar.m");
-    SourcePath baz = new TestSourcePath("Group2/baz.m");
+    SourcePath foo = new FakeSourcePath("Group1/foo.m");
+    SourcePath bar = new FakeSourcePath("Group1/bar.m");
+    SourcePath baz = new FakeSourcePath("Group2/baz.m");
     mutator.setSourcesWithFlags(
         ImmutableSet.of(
             SourceWithFlags.of(foo),
@@ -163,9 +163,9 @@ public class NewNativeTargetProjectMutatorTest {
   public void testLibraryHeaderGroups() throws NoSuchBuildTargetException {
     NewNativeTargetProjectMutator mutator = mutatorWithCommonDefaults();
 
-    SourcePath foo = new TestSourcePath("HeaderGroup1/foo.h");
-    SourcePath bar = new TestSourcePath("HeaderGroup1/bar.h");
-    SourcePath baz = new TestSourcePath("HeaderGroup2/baz.h");
+    SourcePath foo = new FakeSourcePath("HeaderGroup1/foo.h");
+    SourcePath bar = new FakeSourcePath("HeaderGroup1/bar.h");
+    SourcePath baz = new FakeSourcePath("HeaderGroup2/baz.h");
     mutator.setPublicHeaders(ImmutableSet.of(bar, baz));
     mutator.setPrivateHeaders(ImmutableSet.of(foo));
     NewNativeTargetProjectMutator.Result result = mutator.buildTargetAndAddToProject(
@@ -193,7 +193,7 @@ public class NewNativeTargetProjectMutatorTest {
   @Test
   public void testPrefixHeaderInSourceGroup() throws NoSuchBuildTargetException {
     NewNativeTargetProjectMutator mutator = mutatorWithCommonDefaults();
-    SourcePath prefixHeader = new TestSourcePath("Group1/prefix.pch");
+    SourcePath prefixHeader = new FakeSourcePath("Group1/prefix.pch");
     mutator.setPrefixHeader(Optional.of(prefixHeader));
 
     NewNativeTargetProjectMutator.Result result = mutator.buildTargetAndAddToProject(
@@ -238,7 +238,7 @@ public class NewNativeTargetProjectMutatorTest {
 
     AppleResourceDescription appleResourceDescription = new AppleResourceDescription();
     AppleResourceDescription.Arg arg = createDescriptionArgWithDefaults(appleResourceDescription);
-    arg.files = ImmutableSet.<SourcePath>of(new TestSourcePath("foo.png"));
+    arg.files = ImmutableSet.<SourcePath>of(new FakeSourcePath("foo.png"));
 
     mutator.setRecursiveResources(ImmutableSet.of(arg));
     NewNativeTargetProjectMutator.Result result =
@@ -331,7 +331,7 @@ public class NewNativeTargetProjectMutatorTest {
 
     TargetNode<?> prebuildNode = XcodePrebuildScriptBuilder
         .createBuilder(BuildTargetFactory.newInstance("//foo:script"))
-        .setSrcs(ImmutableSortedSet.<SourcePath>of(new TestSourcePath("script/input.png")))
+        .setSrcs(ImmutableSortedSet.<SourcePath>of(new FakeSourcePath("script/input.png")))
         .setOutputs(ImmutableSortedSet.of("helloworld.txt"))
         .setCmd("echo \"hello world!\"")
         .build();

--- a/test/com/facebook/buck/apple/PathRelativizerTest.java
+++ b/test/com/facebook/buck/apple/PathRelativizerTest.java
@@ -20,8 +20,8 @@ import static org.junit.Assert.assertEquals;
 
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -52,7 +52,7 @@ public class PathRelativizerTest {
   public void testOutputPathToSourcePath() {
     assertEquals(
         Paths.get("../../source/path/foo.h"),
-        pathRelativizer.outputPathToSourcePath(new TestSourcePath("source/path/foo.h")));
+        pathRelativizer.outputPathToSourcePath(new FakeSourcePath("source/path/foo.h")));
   }
 
   @Test

--- a/test/com/facebook/buck/apple/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/apple/ProjectGeneratorTest.java
@@ -79,10 +79,10 @@ import com.facebook.buck.model.FlavorDomain;
 import com.facebook.buck.model.HasBuildTarget;
 import com.facebook.buck.model.ImmutableFlavor;
 import com.facebook.buck.rules.BuildTargetSourcePath;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.PathSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.TargetNode;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.coercer.FrameworkPath;
 import com.facebook.buck.rules.coercer.SourceWithFlags;
 import com.facebook.buck.shell.ExportFileBuilder;
@@ -188,14 +188,14 @@ public class ProjectGeneratorTest {
     TargetNode<?> libraryNode = AppleLibraryBuilder
         .createBuilder(libraryTarget)
         .setExportedHeaders(
-            ImmutableSortedSet.<SourcePath>of(new TestSourcePath("foo.h")))
+            ImmutableSortedSet.<SourcePath>of(new FakeSourcePath("foo.h")))
         .build();
 
     TargetNode<?> bundleNode = AppleBundleBuilder
         .createBuilder(bundleTarget)
         .setBinary(libraryTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.FRAMEWORK))
-        .setInfoPlist(new TestSourcePath(("Info.plist")))
+        .setInfoPlist(new FakeSourcePath(("Info.plist")))
         .build();
 
     ProjectGenerator projectGenerator = createProjectGeneratorForCombinedProject(
@@ -274,11 +274,11 @@ public class ProjectGeneratorTest {
         .setSrcs(Optional.of(ImmutableSortedSet.<SourceWithFlags>of()))
         .setHeaders(
             ImmutableSortedSet.<SourcePath>of(
-                new TestSourcePath("HeaderGroup1/foo.h"),
-                new TestSourcePath("HeaderGroup2/baz.h")))
+                new FakeSourcePath("HeaderGroup1/foo.h"),
+                new FakeSourcePath("HeaderGroup2/baz.h")))
         .setExportedHeaders(
             ImmutableSortedSet.<SourcePath>of(
-                new TestSourcePath("HeaderGroup1/bar.h")))
+                new FakeSourcePath("HeaderGroup1/bar.h")))
         .build();
 
     ProjectGenerator projectGenerator = createProjectGeneratorForCombinedProject(
@@ -361,12 +361,12 @@ public class ProjectGeneratorTest {
         .setSrcs(Optional.of(ImmutableSortedSet.<SourceWithFlags>of()))
         .setHeaders(
             ImmutableSortedMap.<String, SourcePath>of(
-                "any/name.h", new TestSourcePath("HeaderGroup1/foo.h"),
-                "different/name.h", new TestSourcePath("HeaderGroup2/baz.h"),
+                "any/name.h", new FakeSourcePath("HeaderGroup1/foo.h"),
+                "different/name.h", new FakeSourcePath("HeaderGroup2/baz.h"),
                 "one/more/name.h", new BuildTargetSourcePath(privateGeneratedTarget)))
         .setExportedHeaders(
             ImmutableSortedMap.<String, SourcePath>of(
-                "yet/another/name.h", new TestSourcePath("HeaderGroup1/bar.h"),
+                "yet/another/name.h", new FakeSourcePath("HeaderGroup1/bar.h"),
                 "and/one/more.h", new BuildTargetSourcePath(publicGeneratedTarget)))
         .build();
 
@@ -447,7 +447,7 @@ public class ProjectGeneratorTest {
         .setSrcs(Optional.of(ImmutableSortedSet.<SourceWithFlags>of()))
         .setHeaders(
             ImmutableSortedMap.<String, SourcePath>of(
-                "key.h", new TestSourcePath("value.h")))
+                "key.h", new FakeSourcePath("value.h")))
         .build();
 
     ProjectGenerator projectGenerator = createProjectGeneratorForCombinedProject(
@@ -470,7 +470,7 @@ public class ProjectGeneratorTest {
         .setSrcs(Optional.of(ImmutableSortedSet.<SourceWithFlags>of()))
         .setHeaders(
             ImmutableSortedMap.<String, SourcePath>of(
-                "new-key.h", new TestSourcePath("value.h")))
+                "new-key.h", new FakeSourcePath("value.h")))
         .build();
 
     projectGenerator = createProjectGeneratorForCombinedProject(
@@ -501,7 +501,7 @@ public class ProjectGeneratorTest {
         .setSrcs(Optional.of(ImmutableSortedSet.<SourceWithFlags>of()))
         .setHeaders(
             ImmutableSortedMap.<String, SourcePath>of(
-                "key.h", new TestSourcePath("value.h")))
+                "key.h", new FakeSourcePath("value.h")))
         .build();
 
     ProjectGenerator projectGenerator = createProjectGeneratorForCombinedProject(
@@ -524,7 +524,7 @@ public class ProjectGeneratorTest {
         .setSrcs(Optional.of(ImmutableSortedSet.<SourceWithFlags>of()))
         .setHeaders(
             ImmutableSortedMap.<String, SourcePath>of(
-                "key.h", new TestSourcePath("new-value.h")))
+                "key.h", new FakeSourcePath("new-value.h")))
         .build();
 
     projectGenerator = createProjectGeneratorForCombinedProject(
@@ -554,10 +554,10 @@ public class ProjectGeneratorTest {
             Optional.of(
                 ImmutableSortedSet.of(
                     SourceWithFlags.of(
-                        new TestSourcePath("foo.h"),
+                        new FakeSourcePath("foo.h"),
                         ImmutableList.of("public")),
                     SourceWithFlags.of(
-                        new TestSourcePath("bar.h")))))
+                        new FakeSourcePath("bar.h")))))
         .setTests(Optional.of(ImmutableSortedSet.of(testTarget)))
         .build();
 
@@ -568,7 +568,7 @@ public class ProjectGeneratorTest {
                 ImmutableSortedMap.of(
                     "Default",
                     ImmutableMap.<String, String>of())))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
         .setDeps(Optional.of(ImmutableSortedSet.of(libraryTarget)))
         .build();
@@ -612,17 +612,17 @@ public class ProjectGeneratorTest {
             Optional.of(
                 ImmutableSortedSet.of(
                     SourceWithFlags.of(
-                        new TestSourcePath("foo.h"),
+                        new FakeSourcePath("foo.h"),
                         ImmutableList.of("public")),
                     SourceWithFlags.of(
-                        new TestSourcePath("bar.h")))))
+                        new FakeSourcePath("bar.h")))))
         .build();
 
     TargetNode<?> bundleNode = AppleBundleBuilder
         .createBuilder(bundleTarget)
         .setBinary(libraryTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.FRAMEWORK))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setTests(Optional.of(ImmutableSortedSet.of(testTarget)))
         .build();
 
@@ -633,7 +633,7 @@ public class ProjectGeneratorTest {
                 ImmutableSortedMap.of(
                     "Default",
                     ImmutableMap.<String, String>of())))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
         .setDeps(Optional.of(ImmutableSortedSet.of(bundleTarget)))
         .build();
@@ -677,17 +677,17 @@ public class ProjectGeneratorTest {
             Optional.of(
                 ImmutableSortedSet.of(
                     SourceWithFlags.of(
-                        new TestSourcePath("foo.h"),
+                        new FakeSourcePath("foo.h"),
                         ImmutableList.of("public")),
                     SourceWithFlags.of(
-                        new TestSourcePath("bar.h")))))
+                        new FakeSourcePath("bar.h")))))
         .build();
 
     TargetNode<?> bundleNode = AppleBundleBuilder
         .createBuilder(bundleTarget)
         .setBinary(binaryTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.APP))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setTests(Optional.of(ImmutableSortedSet.of(testTarget)))
         .build();
 
@@ -699,7 +699,7 @@ public class ProjectGeneratorTest {
                     "Default",
                     ImmutableMap.<String, String>of())))
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setDeps(Optional.of(ImmutableSortedSet.of(bundleTarget)))
         .build();
 
@@ -771,14 +771,14 @@ public class ProjectGeneratorTest {
             Optional.of(
                 ImmutableSortedSet.of(
                     SourceWithFlags.of(
-                        new TestSourcePath("foo.m"), ImmutableList.of("-foo")),
-                    SourceWithFlags.of(new TestSourcePath("bar.m")))))
+                        new FakeSourcePath("foo.m"), ImmutableList.of("-foo")),
+                    SourceWithFlags.of(new FakeSourcePath("bar.m")))))
         .setExtraXcodeSources(
             Optional.of(
                 ImmutableList.<SourcePath>of(
-                    new TestSourcePath("libsomething.a"))))
+                    new FakeSourcePath("libsomething.a"))))
         .setHeaders(
-            ImmutableSortedSet.<SourcePath>of(new TestSourcePath("foo.h")))
+            ImmutableSortedSet.<SourcePath>of(new FakeSourcePath("foo.h")))
         .build();
 
     ProjectGenerator projectGenerator = createProjectGeneratorForCombinedProject(
@@ -815,8 +815,8 @@ public class ProjectGeneratorTest {
     TargetNode<?> compiler = new HalideLibraryBuilder(compilerTarget)
       .setSrcs(
         ImmutableSortedSet.of(
-          SourceWithFlags.of(new TestSourcePath("main.cpp")),
-          SourceWithFlags.of(new TestSourcePath("filter.cpp"))))
+          SourceWithFlags.of(new FakeSourcePath("main.cpp")),
+          SourceWithFlags.of(new FakeSourcePath("filter.cpp"))))
       .build();
 
     BuildTarget libTarget = BuildTarget.builder(rootPath, "//foo", "lib").build();
@@ -856,10 +856,10 @@ public class ProjectGeneratorTest {
         .setSrcs(
             ImmutableSortedSet.of(
                 SourceWithFlags.of(
-                    new TestSourcePath("foo.cpp"), ImmutableList.of("-foo")),
-                SourceWithFlags.of(new TestSourcePath("bar.cpp"))))
+                    new FakeSourcePath("foo.cpp"), ImmutableList.of("-foo")),
+                SourceWithFlags.of(new FakeSourcePath("bar.cpp"))))
         .setHeaders(
-            ImmutableSortedSet.<SourcePath>of(new TestSourcePath("foo.h")))
+            ImmutableSortedSet.<SourcePath>of(new FakeSourcePath("foo.h")))
         .build();
 
     ProjectGenerator projectGenerator = createProjectGeneratorForCombinedProject(
@@ -892,7 +892,7 @@ public class ProjectGeneratorTest {
                     "Debug",
                     ImmutableMap.<String, String>of())))
         .setHeaderPathPrefix(Optional.of("MyHeaderPathPrefix"))
-        .setPrefixHeader(Optional.<SourcePath>of(new TestSourcePath("Foo/Foo-Prefix.pch")))
+        .setPrefixHeader(Optional.<SourcePath>of(new FakeSourcePath("Foo/Foo-Prefix.pch")))
         .build();
 
     ProjectGenerator projectGenerator = createProjectGeneratorForCombinedProject(
@@ -1310,7 +1310,7 @@ public class ProjectGeneratorTest {
         .createBuilder(libraryTarget)
         .setConfigs(Optional.of(configs))
         .setSrcs(
-            Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("foo.m")))))
+            Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("foo.m")))))
         .setFrameworks(
             Optional.of(
                 ImmutableSortedSet.of(
@@ -1326,10 +1326,10 @@ public class ProjectGeneratorTest {
         .createBuilder(testTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
         .setConfigs(Optional.of(configs))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setSrcs(
             Optional.of(
-                ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("fooTest.m")))))
+                ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("fooTest.m")))))
         .setFrameworks(
             Optional.of(
                 ImmutableSortedSet.of(
@@ -1385,7 +1385,7 @@ public class ProjectGeneratorTest {
         .createBuilder(libraryTarget)
         .setConfigs(Optional.of(configs))
         .setSrcs(
-            Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("foo.m")))))
+            Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("foo.m")))))
         .setFrameworks(
             Optional.of(
                 ImmutableSortedSet.of(
@@ -1401,10 +1401,10 @@ public class ProjectGeneratorTest {
         .createBuilder(testTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
         .setConfigs(Optional.of(configs))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setSrcs(
             Optional.of(
-                ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("fooTest.m")))))
+                ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("fooTest.m")))))
         .setFrameworks(
             Optional.of(
                 ImmutableSortedSet.of(
@@ -1455,7 +1455,7 @@ public class ProjectGeneratorTest {
         .createBuilder(libraryDepTarget)
         .setConfigs(Optional.of(configs))
         .setSrcs(
-            Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("foo.m")))))
+            Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("foo.m")))))
         .setFrameworks(
             Optional.of(
                 ImmutableSortedSet.of(
@@ -1471,7 +1471,7 @@ public class ProjectGeneratorTest {
         .createBuilder(libraryTarget)
         .setConfigs(Optional.of(configs))
         .setSrcs(
-            Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("foo.m")))))
+            Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("foo.m")))))
         .setFrameworks(
             Optional.of(
                 ImmutableSortedSet.of(
@@ -1488,10 +1488,10 @@ public class ProjectGeneratorTest {
         .createBuilder(testTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
         .setConfigs(Optional.of(configs))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setSrcs(
             Optional.of(
-                ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("fooTest.m")))))
+                ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("fooTest.m")))))
         .setFrameworks(
             Optional.of(
                 ImmutableSortedSet.of(
@@ -1562,10 +1562,10 @@ public class ProjectGeneratorTest {
         .createBuilder(testTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
         .setConfigs(Optional.of(configs))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setSrcs(
             Optional.of(
-                ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("fooTest.m")))))
+                ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("fooTest.m")))))
         .setDeps(Optional.of(ImmutableSortedSet.of(libraryTarget)))
         .build();
 
@@ -1616,7 +1616,7 @@ public class ProjectGeneratorTest {
         .setConfigs(Optional.of(configs))
         .setExportedHeaders(
             ImmutableSortedSet.<SourcePath>of(
-                new TestSourcePath("HeaderGroup1/bar.h")))
+                new FakeSourcePath("HeaderGroup1/bar.h")))
         .setFrameworks(
             Optional.of(
                 ImmutableSortedSet.of(
@@ -1632,10 +1632,10 @@ public class ProjectGeneratorTest {
         .createBuilder(testTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
         .setConfigs(Optional.of(configs))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setSrcs(
             Optional.of(
-                ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("fooTest.m")))))
+                ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("fooTest.m")))))
         .setDeps(Optional.of(ImmutableSortedSet.of(libraryTarget)))
         .build();
 
@@ -1678,7 +1678,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> testNode = AppleTestBuilder
         .createBuilder(testTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .build();
 
     ProjectGenerator projectGenerator = createProjectGeneratorForCombinedProject(
@@ -1699,7 +1699,7 @@ public class ProjectGeneratorTest {
     BuildTarget depTarget = BuildTarget.builder(rootPath, "//dep", "dep").build();
     TargetNode<?> depNode = AppleLibraryBuilder
         .createBuilder(depTarget)
-        .setSrcs(Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("e.m")))))
+        .setSrcs(Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("e.m")))))
         .build();
 
     BuildTarget binaryTarget = BuildTarget.builder(rootPath, "//foo", "binary").build();
@@ -1714,14 +1714,14 @@ public class ProjectGeneratorTest {
             Optional.of(
                 ImmutableSortedSet.of(
                     SourceWithFlags.of(
-                        new TestSourcePath("foo.m"), ImmutableList.of("-foo")))))
+                        new FakeSourcePath("foo.m"), ImmutableList.of("-foo")))))
         .setExtraXcodeSources(
             Optional.of(
                 ImmutableList.<SourcePath>of(
-                    new TestSourcePath("libsomething.a"))))
+                    new FakeSourcePath("libsomething.a"))))
         .setHeaders(
             ImmutableSortedSet.<SourcePath>of(
-                new TestSourcePath("foo.h")))
+                new FakeSourcePath("foo.h")))
         .setFrameworks(
             Optional.of(
                 ImmutableSortedSet.of(
@@ -1778,7 +1778,7 @@ public class ProjectGeneratorTest {
     BuildTarget resourceTarget = BuildTarget.builder(rootPath, "//foo", "resource").build();
     TargetNode<?> resourceNode = AppleResourceBuilder
         .createBuilder(resourceTarget)
-        .setFiles(ImmutableSet.<SourcePath>of(new TestSourcePath("bar.png")))
+        .setFiles(ImmutableSet.<SourcePath>of(new FakeSourcePath("bar.png")))
         .setDirs(ImmutableSet.<SourcePath>of())
         .build();
 
@@ -1795,7 +1795,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> bundleNode = AppleBundleBuilder
         .createBuilder(bundleTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.BUNDLE))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(sharedLibraryTarget)
         .setDeps(Optional.of(ImmutableSortedSet.of(scriptTarget)))
         .build();
@@ -1843,7 +1843,7 @@ public class ProjectGeneratorTest {
     BuildTarget resourceTarget = BuildTarget.builder(rootPath, "//foo", "resource").build();
     TargetNode<?> resourceNode = AppleResourceBuilder
         .createBuilder(resourceTarget)
-        .setFiles(ImmutableSet.<SourcePath>of(new TestSourcePath("bar.png")))
+        .setFiles(ImmutableSet.<SourcePath>of(new FakeSourcePath("bar.png")))
         .setDirs(ImmutableSet.<SourcePath>of())
         .build();
 
@@ -1860,7 +1860,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> bundleNode = AppleBundleBuilder
         .createBuilder(bundleTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.BUNDLE))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(sharedLibraryTarget)
         .setDeps(Optional.of(ImmutableSortedSet.of(scriptTarget)))
         .build();
@@ -1927,7 +1927,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> bundleNode = AppleBundleBuilder
         .createBuilder(bundleTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.BUNDLE))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(sharedLibraryTarget)
         .setDeps(Optional.of(ImmutableSortedSet.of(rnLibraryTarget)))
         .build();
@@ -1987,7 +1987,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> bundleNode = AppleBundleBuilder
         .createBuilder(bundleTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.BUNDLE))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(sharedLibraryTarget)
         .setDeps(Optional.of(ImmutableSortedSet.of(rnLibraryTarget)))
         .build();
@@ -2031,7 +2031,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> node = AppleBundleBuilder
         .createBuilder(buildTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.FRAMEWORK))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(sharedLibraryTarget)
         .build();
 
@@ -2066,7 +2066,7 @@ public class ProjectGeneratorTest {
         .setVariants(
             Optional.<Set<SourcePath>>of(
                 ImmutableSet.<SourcePath>of(
-                    new TestSourcePath("Base.lproj/Bar.storyboard"))))
+                    new FakeSourcePath("Base.lproj/Bar.storyboard"))))
         .build();
     BuildTarget fooLibraryTarget = BuildTarget.builder(rootPath, "//foo", "lib").build();
     TargetNode<?> fooLibraryNode = AppleLibraryBuilder
@@ -2077,7 +2077,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> bundleNode = AppleBundleBuilder
         .createBuilder(bundleTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.BUNDLE))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(fooLibraryTarget)
         .setDeps(Optional.of(ImmutableSortedSet.of(resourceTarget)))
         .build();
@@ -2125,7 +2125,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> node = AppleBundleBuilder
         .createBuilder(buildTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.FRAMEWORK))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(sharedLibraryTarget)
         .setXcodeProductType(Optional.of("com.facebook.buck.niftyProductType"))
         .build();
@@ -2170,7 +2170,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> node = AppleBundleBuilder
         .createBuilder(buildTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.FRAMEWORK))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(sharedLibraryTarget)
         .build();
 
@@ -2191,7 +2191,7 @@ public class ProjectGeneratorTest {
     BuildTarget modelTarget = BuildTarget.builder(rootPath, "//foo", "model").build();
     TargetNode<?> modelNode = CoreDataModelBuilder
         .createBuilder(modelTarget)
-        .setPath(new TestSourcePath("foo.xcdatamodel").getRelativePath())
+        .setPath(new FakeSourcePath("foo.xcdatamodel").getRelativePath())
         .build();
 
     BuildTarget libraryTarget = BuildTarget.builder(rootPath, "//foo", "lib").build();
@@ -2233,7 +2233,7 @@ public class ProjectGeneratorTest {
         .createBuilder(watchAppTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.APP))
         .setXcodeProductType(Optional.<String>of("com.apple.product-type.application.watchapp2"))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(watchAppBinaryTarget)
         .build();
 
@@ -2247,7 +2247,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> hostAppNode = AppleBundleBuilder
         .createBuilder(hostAppTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.APP))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(hostAppBinaryTarget)
         .setDeps(Optional.of(ImmutableSortedSet.of(watchAppTarget)))
         .build();
@@ -2288,11 +2288,11 @@ public class ProjectGeneratorTest {
             Optional.of(
                 ImmutableSortedSet.of(
                     SourceWithFlags.of(
-                        new TestSourcePath("foo.m"), ImmutableList.of("-foo")),
-                    SourceWithFlags.of(new TestSourcePath("bar.m")))))
+                        new FakeSourcePath("foo.m"), ImmutableList.of("-foo")),
+                    SourceWithFlags.of(new FakeSourcePath("bar.m")))))
         .setHeaders(
             ImmutableSortedSet.<SourcePath>of(
-                new TestSourcePath("foo.h")))
+                new FakeSourcePath("foo.h")))
         .build();
 
     ProjectGenerator projectGenerator = createProjectGeneratorForCombinedProject(
@@ -2349,7 +2349,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> dependentSharedLibraryNode = AppleLibraryBuilder
         .createBuilder(dependentSharedLibraryTarget)
         .setSrcs(
-            Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("empty.m")))))
+            Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("empty.m")))))
         .setDeps(Optional.of(ImmutableSortedSet.of(dependentStaticLibraryTarget)))
         .build();
 
@@ -2366,7 +2366,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> bundleNode = AppleBundleBuilder
         .createBuilder(bundleTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.BUNDLE))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(libraryTarget)
         .build();
 
@@ -2403,7 +2403,7 @@ public class ProjectGeneratorTest {
         .build();
     TargetNode<?> dependentSharedLibraryNode = AppleLibraryBuilder
         .createBuilder(dependentSharedLibraryTarget)
-        .setSrcs(Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("e.m")))))
+        .setSrcs(Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("e.m")))))
         .setDeps(Optional.of(ImmutableSortedSet.of(dependentStaticLibraryTarget)))
         .build();
 
@@ -2412,7 +2412,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> dependentFrameworkNode = AppleBundleBuilder
         .createBuilder(dependentFrameworkTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.FRAMEWORK))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(dependentSharedLibraryTarget)
         .build();
 
@@ -2429,7 +2429,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> bundleNode = AppleBundleBuilder
         .createBuilder(bundleTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.BUNDLE))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(libraryTarget)
         .build();
 
@@ -2466,7 +2466,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> dependentStaticFrameworkNode = AppleBundleBuilder
         .createBuilder(dependentStaticFrameworkTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.FRAMEWORK))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(dependentStaticLibraryTarget)
         .build();
 
@@ -2484,7 +2484,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> dependentFrameworkNode = AppleBundleBuilder
         .createBuilder(dependentFrameworkTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.FRAMEWORK))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(dependentSharedLibraryTarget)
         .build();
 
@@ -2494,7 +2494,7 @@ public class ProjectGeneratorTest {
         .build();
     TargetNode<?> libraryNode = AppleLibraryBuilder
         .createBuilder(libraryTarget)
-        .setSrcs(Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("e.m")))))
+        .setSrcs(Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("e.m")))))
         .setDeps(Optional.of(ImmutableSortedSet.of(dependentFrameworkTarget)))
         .build();
 
@@ -2502,7 +2502,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> bundleNode = AppleBundleBuilder
         .createBuilder(bundleTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.BUNDLE))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(libraryTarget)
         .build();
 
@@ -2541,7 +2541,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> bundleNode = AppleBundleBuilder
         .createBuilder(bundleTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.BUNDLE))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(libraryTarget)
         .build();
 
@@ -2561,8 +2561,8 @@ public class ProjectGeneratorTest {
     BuildTarget resourceTarget = BuildTarget.builder(rootPath, "//foo", "res").build();
     TargetNode<?> resourceNode = AppleResourceBuilder
         .createBuilder(resourceTarget)
-        .setFiles(ImmutableSet.<SourcePath>of(new TestSourcePath("bar.png")))
-        .setDirs(ImmutableSet.<SourcePath>of(new TestSourcePath("foodir")))
+        .setFiles(ImmutableSet.<SourcePath>of(new FakeSourcePath("bar.png")))
+        .setDirs(ImmutableSet.<SourcePath>of(new FakeSourcePath("foodir")))
         .build();
 
     BuildTarget libraryTarget = BuildTarget.builder(rootPath, "//foo", "lib").build();
@@ -2581,7 +2581,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> bundleNode = AppleBundleBuilder
         .createBuilder(bundleTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.BUNDLE))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(bundleLibraryTarget)
         .build();
 
@@ -2621,7 +2621,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> bundleNode = AppleBundleBuilder
         .createBuilder(bundleTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.BUNDLE))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(bundleLibraryTarget)
         .build();
 
@@ -2855,7 +2855,7 @@ public class ProjectGeneratorTest {
   public void nonexistentResourceDirectoryShouldThrow() throws IOException {
     ImmutableSet<TargetNode<?>> nodes = setupSimpleLibraryWithResources(
         ImmutableSet.<SourcePath>of(),
-        ImmutableSet.<SourcePath>of(new TestSourcePath("nonexistent-directory")));
+        ImmutableSet.<SourcePath>of(new FakeSourcePath("nonexistent-directory")));
 
     thrown.expect(HumanReadableException.class);
     thrown.expectMessage(
@@ -2868,7 +2868,7 @@ public class ProjectGeneratorTest {
   @Test
   public void nonexistentResourceFileShouldThrow() throws IOException {
     ImmutableSet<TargetNode<?>> nodes = setupSimpleLibraryWithResources(
-        ImmutableSet.<SourcePath>of(new TestSourcePath("nonexistent-file.png")),
+        ImmutableSet.<SourcePath>of(new FakeSourcePath("nonexistent-file.png")),
         ImmutableSet.<SourcePath>of());
 
     thrown.expect(HumanReadableException.class);
@@ -2883,7 +2883,7 @@ public class ProjectGeneratorTest {
   public void usingFileAsResourceDirectoryShouldThrow() throws IOException {
     ImmutableSet<TargetNode<?>> nodes = setupSimpleLibraryWithResources(
         ImmutableSet.<SourcePath>of(),
-        ImmutableSet.<SourcePath>of(new TestSourcePath("bar.png")));
+        ImmutableSet.<SourcePath>of(new FakeSourcePath("bar.png")));
 
     thrown.expect(HumanReadableException.class);
     thrown.expectMessage(
@@ -2896,7 +2896,7 @@ public class ProjectGeneratorTest {
   @Test
   public void usingDirectoryAsResourceFileShouldThrow() throws IOException {
     ImmutableSet<TargetNode<?>> nodes = setupSimpleLibraryWithResources(
-        ImmutableSet.<SourcePath>of(new TestSourcePath("foodir")),
+        ImmutableSet.<SourcePath>of(new FakeSourcePath("foodir")),
         ImmutableSet.<SourcePath>of());
 
     thrown.expect(HumanReadableException.class);
@@ -2933,7 +2933,7 @@ public class ProjectGeneratorTest {
                 "//foo",
                 "libraryTestStatic").build())
             .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-            .setInfoPlist(new TestSourcePath("Info.plist"))
+            .setInfoPlist(new FakeSourcePath("Info.plist"))
             .build();
     TargetNode<AppleTestDescription.Arg> libraryTestNotStatic =
         AppleTestBuilder.createBuilder(
@@ -2942,7 +2942,7 @@ public class ProjectGeneratorTest {
                 "//foo",
                 "libraryTestNotStatic").build())
             .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-            .setInfoPlist(new TestSourcePath("Info.plist"))
+            .setInfoPlist(new FakeSourcePath("Info.plist"))
             .build();
 
     ProjectGenerator projectGenerator = createProjectGeneratorForCombinedProject(
@@ -2972,7 +2972,7 @@ public class ProjectGeneratorTest {
                 rootPath,
                 "//lib",
                 "deplibresource").build())
-            .setFiles(ImmutableSet.<SourcePath>of(new TestSourcePath("bar.png")))
+            .setFiles(ImmutableSet.<SourcePath>of(new FakeSourcePath("bar.png")))
             .setDirs(ImmutableSet.<SourcePath>of())
             .build();
     TargetNode<AppleNativeTargetDescriptionArg> testLibDepLib =
@@ -2987,13 +2987,13 @@ public class ProjectGeneratorTest {
                                 Optional.<String>absent())))))
             .setDeps(Optional.of(ImmutableSortedSet.of(testLibDepResource.getBuildTarget())))
             .setSrcs(
-                Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("e.m")))))
+                Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("e.m")))))
             .build();
     TargetNode<AppleNativeTargetDescriptionArg> dep1 =
         AppleLibraryBuilder.createBuilder(BuildTarget.builder(rootPath, "//foo", "dep1").build())
             .setDeps(Optional.of(ImmutableSortedSet.of(testLibDepLib.getBuildTarget())))
             .setSrcs(
-                Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("e.m")))))
+                Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("e.m")))))
             .setFrameworks(
                 Optional.of(
                     ImmutableSortedSet.of(
@@ -3006,12 +3006,12 @@ public class ProjectGeneratorTest {
     TargetNode<AppleNativeTargetDescriptionArg> dep2 =
         AppleLibraryBuilder.createBuilder(BuildTarget.builder(rootPath, "//foo", "dep2").build())
             .setSrcs(
-                Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("e.m")))))
+                Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("e.m")))))
             .build();
     TargetNode<AppleTestDescription.Arg> xctest1 =
         AppleTestBuilder.createBuilder(BuildTarget.builder(rootPath, "//foo", "xctest1").build())
             .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-            .setInfoPlist(new TestSourcePath("Info.plist"))
+            .setInfoPlist(new FakeSourcePath("Info.plist"))
             .setDeps(Optional.of(ImmutableSortedSet.of(dep1.getBuildTarget())))
             .setFrameworks(
                 Optional.of(
@@ -3025,7 +3025,7 @@ public class ProjectGeneratorTest {
     TargetNode<AppleTestDescription.Arg> xctest2 =
         AppleTestBuilder.createBuilder(BuildTarget.builder(rootPath, "//foo", "xctest2").build())
             .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-            .setInfoPlist(new TestSourcePath("Info.plist"))
+            .setInfoPlist(new FakeSourcePath("Info.plist"))
             .setDeps(Optional.of(ImmutableSortedSet.of(dep2.getBuildTarget())))
             .build();
 
@@ -3189,7 +3189,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> hostAppNode = AppleBundleBuilder
         .createBuilder(hostAppTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.APP))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(hostAppBinaryTarget)
         .build();
 
@@ -3201,7 +3201,7 @@ public class ProjectGeneratorTest {
                     "Debug",
                     ImmutableMap.<String, String>of())))
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setTestHostApp(Optional.of(hostAppTarget))
         .build();
 
@@ -3236,7 +3236,7 @@ public class ProjectGeneratorTest {
     TargetNode<?> bundleNode = AppleBundleBuilder
         .createBuilder(bundleTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.APP))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(binaryTarget)
         .build();
 
@@ -3311,7 +3311,7 @@ public class ProjectGeneratorTest {
             Optional.of(
                 ImmutableSortedSet.of(
                     SourceWithFlags.of(
-                        new TestSourcePath("foo.m"), ImmutableList.of("-foo")))))
+                        new FakeSourcePath("foo.m"), ImmutableList.of("-foo")))))
         .build();
 
     ImmutableSet<TargetNode<?>> nodes = ImmutableSet.<TargetNode<?>>of(binaryNode);
@@ -3376,7 +3376,7 @@ public class ProjectGeneratorTest {
             Optional.of(
                 ImmutableSortedSet.of(
                     SourceWithFlags.of(
-                        new TestSourcePath("foo.m"), ImmutableList.of("-foo")))))
+                        new FakeSourcePath("foo.m"), ImmutableList.of("-foo")))))
         .build();
 
     ImmutableSet<TargetNode<?>> nodes = ImmutableSet.<TargetNode<?>>of(binaryNode);
@@ -3450,10 +3450,10 @@ public class ProjectGeneratorTest {
         .setSrcs(
             Optional.of(
                 ImmutableSortedSet.of(
-                    SourceWithFlags.of(new TestSourcePath("foo1.m")),
-                    SourceWithFlags.of(new TestSourcePath("foo2.mm")),
-                    SourceWithFlags.of(new TestSourcePath("foo3.c")),
-                    SourceWithFlags.of(new TestSourcePath("foo4.cc"))
+                    SourceWithFlags.of(new FakeSourcePath("foo1.m")),
+                    SourceWithFlags.of(new FakeSourcePath("foo2.mm")),
+                    SourceWithFlags.of(new FakeSourcePath("foo3.c")),
+                    SourceWithFlags.of(new FakeSourcePath("foo4.cc"))
                     )))
         .build();
 
@@ -3492,7 +3492,7 @@ public class ProjectGeneratorTest {
         .createBuilder(buildTarget)
         .setSrcs(
             Optional.of(
-                ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("foo.mm")))))
+                ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("foo.mm")))))
         .build();
 
     ProjectGenerator projectGenerator = createProjectGeneratorForCombinedProject(
@@ -3539,7 +3539,7 @@ public class ProjectGeneratorTest {
                 ImmutableSortedMap.of(
                     "Default",
                     ImmutableMap.<String, String>of())))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setDeps(Optional.of(ImmutableSortedSet.of(libraryTarget)))
         .build();
     TargetNode<?> assetCatalogNode = AppleAssetCatalogBuilder
@@ -3698,7 +3698,7 @@ public class ProjectGeneratorTest {
         .createBuilder(libraryTarget)
         .setConfigs(Optional.of(configs))
         .setSrcs(
-            Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("foo.m")))))
+            Optional.of(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("foo.m")))))
         .build();
 
     BuildTarget testTarget = BuildTarget.builder(rootPath, "//foo", "xctest").build();
@@ -3706,10 +3706,10 @@ public class ProjectGeneratorTest {
         .createBuilder(testTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
         .setConfigs(Optional.of(configs))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setSrcs(
             Optional.of(
-                ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("fooTest.m")))))
+                ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("fooTest.m")))))
         .setDeps(Optional.of(ImmutableSortedSet.of(libraryTarget)))
         .build();
 

--- a/test/com/facebook/buck/apple/RuleUtilsTest.java
+++ b/test/com/facebook/buck/apple/RuleUtilsTest.java
@@ -18,9 +18,9 @@ package com.facebook.buck.apple;
 import static org.junit.Assert.assertEquals;
 
 import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.coercer.SourceWithFlags;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
@@ -36,13 +36,13 @@ public class RuleUtilsTest {
   @Test
   public void extractGroupedSources() {
     ImmutableList<SourceWithFlags> input = ImmutableList.of(
-        SourceWithFlags.of(new TestSourcePath("Group1/foo.m")),
+        SourceWithFlags.of(new FakeSourcePath("Group1/foo.m")),
         SourceWithFlags.of(
-            new TestSourcePath("Group1/bar.m"),
+            new FakeSourcePath("Group1/bar.m"),
             ImmutableList.of("-Wall")),
-        SourceWithFlags.of(new TestSourcePath("Group2/baz.m")),
+        SourceWithFlags.of(new FakeSourcePath("Group2/baz.m")),
         SourceWithFlags.of(
-            new TestSourcePath("Group2/blech.m"), ImmutableList.of("-fobjc-arc")));
+            new FakeSourcePath("Group2/blech.m"), ImmutableList.of("-fobjc-arc")));
 
     SourcePathResolver resolver = new SourcePathResolver(new BuildRuleResolver());
     ImmutableList<GroupedSource> sources = RuleUtils.createGroupsFromSourcePaths(
@@ -59,20 +59,20 @@ public class RuleUtilsTest {
                 ImmutableList.of(
                     GroupedSource.ofSourceWithFlags(
                         SourceWithFlags.of(
-                            new TestSourcePath("Group1/bar.m"),
+                            new FakeSourcePath("Group1/bar.m"),
                             ImmutableList.of("-Wall"))),
                     GroupedSource.ofSourceWithFlags(
-                        SourceWithFlags.of(new TestSourcePath("Group1/foo.m")))
+                        SourceWithFlags.of(new FakeSourcePath("Group1/foo.m")))
                 )),
             GroupedSource.ofSourceGroup(
                 "Group2",
                 Paths.get("Group2"),
                 ImmutableList.of(
                     GroupedSource.ofSourceWithFlags(
-                        SourceWithFlags.of(new TestSourcePath("Group2/baz.m"))),
+                        SourceWithFlags.of(new FakeSourcePath("Group2/baz.m"))),
                     GroupedSource.ofSourceWithFlags(
                         SourceWithFlags.of(
-                            new TestSourcePath("Group2/blech.m"),
+                            new FakeSourcePath("Group2/blech.m"),
                             ImmutableList.of("-fobjc-arc")))
                 ))),
         sources);
@@ -81,13 +81,13 @@ public class RuleUtilsTest {
   @Test
   public void creatingGroupsFromSourcePaths() {
     ImmutableList<SourcePath> input = ImmutableList.<SourcePath>of(
-        new TestSourcePath("File.h"),
-        new TestSourcePath("Lib/Foo/File2.h"),
-        new TestSourcePath("App/Foo/File.h"),
-        new TestSourcePath("Lib/Bar/File1.h"),
-        new TestSourcePath("App/File.h"),
-        new TestSourcePath("Lib/Foo/File1.h"),
-        new TestSourcePath("App/Foo/Bar/File.h"));
+        new FakeSourcePath("File.h"),
+        new FakeSourcePath("Lib/Foo/File2.h"),
+        new FakeSourcePath("App/Foo/File.h"),
+        new FakeSourcePath("Lib/Bar/File1.h"),
+        new FakeSourcePath("App/File.h"),
+        new FakeSourcePath("Lib/Foo/File1.h"),
+        new FakeSourcePath("App/Foo/Bar/File.h"));
 
     ImmutableList<GroupedSource> expected = ImmutableList.of(
         GroupedSource.ofSourceGroup(
@@ -103,11 +103,11 @@ public class RuleUtilsTest {
                             Paths.get("App/Foo/Bar"),
                             ImmutableList.of(
                                 GroupedSource.ofPrivateHeader(
-                                    new TestSourcePath("App/Foo/Bar/File.h")))),
+                                    new FakeSourcePath("App/Foo/Bar/File.h")))),
                         GroupedSource.ofPrivateHeader(
-                            new TestSourcePath("App/Foo/File.h")))),
+                            new FakeSourcePath("App/Foo/File.h")))),
                 GroupedSource.ofPrivateHeader(
-                    new TestSourcePath("App/File.h")))),
+                    new FakeSourcePath("App/File.h")))),
         GroupedSource.ofSourceGroup(
             "Lib",
             Paths.get("Lib"),
@@ -117,16 +117,16 @@ public class RuleUtilsTest {
                     Paths.get("Lib/Bar"),
                     ImmutableList.of(
                         GroupedSource.ofPrivateHeader(
-                            new TestSourcePath("Lib/Bar/File1.h")))),
+                            new FakeSourcePath("Lib/Bar/File1.h")))),
                 GroupedSource.ofSourceGroup(
                     "Foo",
                     Paths.get("Lib/Foo"),
                     ImmutableList.of(
                         GroupedSource.ofPrivateHeader(
-                            new TestSourcePath("Lib/Foo/File1.h")),
+                            new FakeSourcePath("Lib/Foo/File1.h")),
                         GroupedSource.ofPrivateHeader(
-                            new TestSourcePath("Lib/Foo/File2.h")))))),
-        GroupedSource.ofPrivateHeader(new TestSourcePath("File.h")));
+                            new FakeSourcePath("Lib/Foo/File2.h")))))),
+        GroupedSource.ofPrivateHeader(new FakeSourcePath("File.h")));
 
     SourcePathResolver resolver = new SourcePathResolver(new BuildRuleResolver());
     ImmutableList<GroupedSource> actual =
@@ -143,9 +143,9 @@ public class RuleUtilsTest {
   @Test
   public void creatingGroupsFromSourcePathsRemovesLongestCommonPrefix() {
     ImmutableList<SourcePath> input = ImmutableList.<SourcePath>of(
-        new TestSourcePath("Lib/Foo/File1.h"),
-        new TestSourcePath("Lib/Foo/File2.h"),
-        new TestSourcePath("Lib/Bar/File1.h"));
+        new FakeSourcePath("Lib/Foo/File1.h"),
+        new FakeSourcePath("Lib/Foo/File2.h"),
+        new FakeSourcePath("Lib/Bar/File1.h"));
 
     ImmutableList<GroupedSource> expected = ImmutableList.of(
         GroupedSource.ofSourceGroup(
@@ -153,15 +153,15 @@ public class RuleUtilsTest {
             Paths.get("Lib/Bar"),
             ImmutableList.of(
                 GroupedSource.ofPrivateHeader(
-                    new TestSourcePath("Lib/Bar/File1.h")))),
+                    new FakeSourcePath("Lib/Bar/File1.h")))),
         GroupedSource.ofSourceGroup(
             "Foo",
             Paths.get("Lib/Foo"),
             ImmutableList.of(
                 GroupedSource.ofPrivateHeader(
-                    new TestSourcePath("Lib/Foo/File1.h")),
+                    new FakeSourcePath("Lib/Foo/File1.h")),
                 GroupedSource.ofPrivateHeader(
-                    new TestSourcePath("Lib/Foo/File2.h")))));
+                    new FakeSourcePath("Lib/Foo/File2.h")))));
 
     SourcePathResolver resolver = new SourcePathResolver(new BuildRuleResolver());
     ImmutableList<GroupedSource> actual =
@@ -178,11 +178,11 @@ public class RuleUtilsTest {
   @Test
   public void creatingGroupsFromSingleSourcePath() {
     ImmutableList<SourcePath> input = ImmutableList.<SourcePath>of(
-        new TestSourcePath("Lib/Foo/File1.h"));
+        new FakeSourcePath("Lib/Foo/File1.h"));
 
     ImmutableList<GroupedSource> expected = ImmutableList.of(
         GroupedSource.ofPrivateHeader(
-            new TestSourcePath("Lib/Foo/File1.h")));
+            new FakeSourcePath("Lib/Foo/File1.h")));
 
     SourcePathResolver resolver = new SourcePathResolver(new BuildRuleResolver());
     ImmutableList<GroupedSource> actual =
@@ -226,25 +226,25 @@ public class RuleUtilsTest {
         ImmutableMultimap.<Path, GroupedSource>builder()
             .put(
                 Paths.get("root/Lib/Foo"),
-                GroupedSource.ofPrivateHeader(new TestSourcePath("Lib/Foo/File2.h")))
+                GroupedSource.ofPrivateHeader(new FakeSourcePath("Lib/Foo/File2.h")))
             .put(
                 Paths.get("root/App/Foo"),
-                GroupedSource.ofPrivateHeader(new TestSourcePath("App/Foo/File.h")))
+                GroupedSource.ofPrivateHeader(new FakeSourcePath("App/Foo/File.h")))
             .put(
                 Paths.get("root/App"),
-                GroupedSource.ofPrivateHeader(new TestSourcePath("App/File.h")))
+                GroupedSource.ofPrivateHeader(new FakeSourcePath("App/File.h")))
             .put(
                 Paths.get("root"),
-                GroupedSource.ofPrivateHeader(new TestSourcePath("File.h")))
+                GroupedSource.ofPrivateHeader(new FakeSourcePath("File.h")))
             .put(
                 Paths.get("root/Lib/Bar"),
-                GroupedSource.ofPrivateHeader(new TestSourcePath("Lib/Bar/File1.h")))
+                GroupedSource.ofPrivateHeader(new FakeSourcePath("Lib/Bar/File1.h")))
             .put(
                 Paths.get("root/Lib/Foo"),
-                GroupedSource.ofPrivateHeader(new TestSourcePath("Lib/Foo/File1.h")))
+                GroupedSource.ofPrivateHeader(new FakeSourcePath("Lib/Foo/File1.h")))
             .put(
                 Paths.get("root/App/Foo/Bar"),
-                GroupedSource.ofPrivateHeader(new TestSourcePath("App/Foo/Bar/File.h")))
+                GroupedSource.ofPrivateHeader(new FakeSourcePath("App/Foo/Bar/File.h")))
             .build();
 
     ImmutableList<GroupedSource> expected = ImmutableList.of(
@@ -261,11 +261,11 @@ public class RuleUtilsTest {
                             Paths.get("App/Foo/Bar"),
                             ImmutableList.of(
                                 GroupedSource.ofPrivateHeader(
-                                    new TestSourcePath("App/Foo/Bar/File.h")))),
+                                    new FakeSourcePath("App/Foo/Bar/File.h")))),
                         GroupedSource.ofPrivateHeader(
-                            new TestSourcePath("App/Foo/File.h")))),
+                            new FakeSourcePath("App/Foo/File.h")))),
                 GroupedSource.ofPrivateHeader(
-                    new TestSourcePath("App/File.h")))),
+                    new FakeSourcePath("App/File.h")))),
         GroupedSource.ofSourceGroup(
             "Lib",
             Paths.get("Lib"),
@@ -275,16 +275,16 @@ public class RuleUtilsTest {
                     Paths.get("Lib/Bar"),
                     ImmutableList.of(
                         GroupedSource.ofPrivateHeader(
-                            new TestSourcePath("Lib/Bar/File1.h")))),
+                            new FakeSourcePath("Lib/Bar/File1.h")))),
                 GroupedSource.ofSourceGroup(
                     "Foo",
                     Paths.get("Lib/Foo"),
                     ImmutableList.of(
                         GroupedSource.ofPrivateHeader(
-                            new TestSourcePath("Lib/Foo/File1.h")),
+                            new FakeSourcePath("Lib/Foo/File1.h")),
                         GroupedSource.ofPrivateHeader(
-                            new TestSourcePath("Lib/Foo/File2.h")))))),
-        GroupedSource.ofPrivateHeader(new TestSourcePath("File.h")));
+                            new FakeSourcePath("Lib/Foo/File2.h")))))),
+        GroupedSource.ofPrivateHeader(new FakeSourcePath("File.h")));
 
     ImmutableList<GroupedSource> actual = RuleUtils.createGroupsFromEntryMaps(
         subgroups,
@@ -308,13 +308,13 @@ public class RuleUtilsTest {
         ImmutableMultimap.<Path, GroupedSource>builder()
             .put(
                 Paths.get("root/Lib/Foo"),
-                GroupedSource.ofPrivateHeader(new TestSourcePath("Lib/Foo/File2.h")))
+                GroupedSource.ofPrivateHeader(new FakeSourcePath("Lib/Foo/File2.h")))
             .put(
                 Paths.get("root/Lib/Bar"),
-                GroupedSource.ofPrivateHeader(new TestSourcePath("Lib/Bar/File1.h")))
+                GroupedSource.ofPrivateHeader(new FakeSourcePath("Lib/Bar/File1.h")))
             .put(
                 Paths.get("root/Lib/Foo"),
-                GroupedSource.ofPrivateHeader(new TestSourcePath("Lib/Foo/File1.h")))
+                GroupedSource.ofPrivateHeader(new FakeSourcePath("Lib/Foo/File1.h")))
             .build();
 
     ImmutableList<GroupedSource> expected = ImmutableList.of(
@@ -327,15 +327,15 @@ public class RuleUtilsTest {
                     Paths.get("Lib/Bar"),
                     ImmutableList.of(
                         GroupedSource.ofPrivateHeader(
-                            new TestSourcePath("Lib/Bar/File1.h")))),
+                            new FakeSourcePath("Lib/Bar/File1.h")))),
                 GroupedSource.ofSourceGroup(
                     "Foo",
                     Paths.get("Lib/Foo"),
                     ImmutableList.of(
                         GroupedSource.ofPrivateHeader(
-                            new TestSourcePath("Lib/Foo/File1.h")),
+                            new FakeSourcePath("Lib/Foo/File1.h")),
                         GroupedSource.ofPrivateHeader(
-                            new TestSourcePath("Lib/Foo/File2.h")))))));
+                            new FakeSourcePath("Lib/Foo/File2.h")))))));
 
     ImmutableList<GroupedSource> actual = RuleUtils.createGroupsFromEntryMaps(
         subgroups,
@@ -352,11 +352,11 @@ public class RuleUtilsTest {
   public void creatingGroupsFromSingleFileEntryMaps() {
     ImmutableMultimap<Path, String> subgroups = ImmutableMultimap.of();
     ImmutableMultimap<Path, GroupedSource> entries = ImmutableMultimap.of(
-        Paths.get("root"), GroupedSource.ofPrivateHeader(new TestSourcePath("File1.h")));
+        Paths.get("root"), GroupedSource.ofPrivateHeader(new FakeSourcePath("File1.h")));
 
     ImmutableList<GroupedSource> expected = ImmutableList.of(
         GroupedSource.ofPrivateHeader(
-            new TestSourcePath("File1.h")));
+            new FakeSourcePath("File1.h")));
 
     ImmutableList<GroupedSource> actual = RuleUtils.createGroupsFromEntryMaps(
         subgroups,

--- a/test/com/facebook/buck/apple/WorkspaceAndProjectGeneratorTest.java
+++ b/test/com/facebook/buck/apple/WorkspaceAndProjectGeneratorTest.java
@@ -52,10 +52,10 @@ import com.facebook.buck.model.FlavorDomain;
 import com.facebook.buck.rules.ActionGraph;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildTargetSourcePath;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.TargetGraph;
 import com.facebook.buck.rules.TargetGraphToActionGraph;
 import com.facebook.buck.rules.TargetNode;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.coercer.SourceWithFlags;
 import com.facebook.buck.shell.GenruleBuilder;
 import com.facebook.buck.shell.GenruleDescription;
@@ -162,7 +162,7 @@ public class WorkspaceAndProjectGeneratorTest {
     TargetNode<?> fooBinNode = AppleBundleBuilder
         .createBuilder(fooBinTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.APP))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(fooBinBinaryTarget)
         .setTests(Optional.of(ImmutableSortedSet.of(fooBinTestTarget)))
         .build();
@@ -178,13 +178,13 @@ public class WorkspaceAndProjectGeneratorTest {
         .createBuilder(bazTestTarget)
         .setDeps(Optional.of(ImmutableSortedSet.of(bazLibTarget)))
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .build();
 
     TargetNode<?> fooTestNode = AppleTestBuilder
         .createBuilder(fooTestTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setDeps(Optional.of(ImmutableSortedSet.of(bazLibTarget)))
         .build();
 
@@ -192,7 +192,7 @@ public class WorkspaceAndProjectGeneratorTest {
         .createBuilder(fooBinTestTarget)
         .setDeps(Optional.of(ImmutableSortedSet.of(fooBinTarget)))
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .build();
 
     BuildTarget quxBinTarget = BuildTarget.builder(ROOT, "//qux", "bin").build();
@@ -625,25 +625,25 @@ public class WorkspaceAndProjectGeneratorTest {
     TargetNode<AppleTestDescription.Arg> combinableTest1 = AppleTestBuilder
         .createBuilder(BuildTarget.builder(ROOT, "//foo", "combinableTest1").build())
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setCanGroup(Optional.of(true))
         .build();
     TargetNode<AppleTestDescription.Arg> combinableTest2 = AppleTestBuilder
         .createBuilder(BuildTarget.builder(ROOT, "//bar", "combinableTest2").build())
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setCanGroup(Optional.of(true))
         .build();
     TargetNode<AppleTestDescription.Arg> testMarkedUncombinable = AppleTestBuilder
         .createBuilder(BuildTarget.builder(ROOT, "//foo", "testMarkedUncombinable").build())
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setCanGroup(Optional.of(false))
         .build();
     TargetNode<AppleTestDescription.Arg> anotherTest = AppleTestBuilder
         .createBuilder(BuildTarget.builder(ROOT, "//foo", "anotherTest").build())
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.OCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setCanGroup(Optional.of(true))
         .build();
     TargetNode<AppleNativeTargetDescriptionArg> library = AppleLibraryBuilder
@@ -776,13 +776,13 @@ public class WorkspaceAndProjectGeneratorTest {
     TargetNode<AppleTestDescription.Arg> combinableTest1 = AppleTestBuilder
         .createBuilder(BuildTarget.builder(ROOT, "//foo", "test1").build())
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setCanGroup(Optional.of(true))
         .build();
     TargetNode<AppleTestDescription.Arg> combinableTest2 = AppleTestBuilder
         .createBuilder(BuildTarget.builder(ROOT, "//bar", "test2").build())
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setCanGroup(Optional.of(true))
         .build();
 
@@ -824,13 +824,13 @@ public class WorkspaceAndProjectGeneratorTest {
     TargetNode<AppleTestDescription.Arg> combinableTest1 = AppleTestBuilder
         .createBuilder(BuildTarget.builder(ROOT, "//foo", "test1").build())
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setCanGroup(Optional.of(true))
         .build();
     TargetNode<AppleTestDescription.Arg> combinableTest2 = AppleTestBuilder
         .createBuilder(BuildTarget.builder(ROOT, "//bar", "test2").build())
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.OCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setCanGroup(Optional.of(true))
         .build();
 
@@ -876,13 +876,13 @@ public class WorkspaceAndProjectGeneratorTest {
     TargetNode<AppleTestDescription.Arg> combinableTest1 = AppleTestBuilder
         .createBuilder(BuildTarget.builder(ROOT, "//foo", "test1").build())
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setCanGroup(Optional.of(true))
         .build();
     TargetNode<AppleTestDescription.Arg> combinableTest2 = AppleTestBuilder
         .createBuilder(BuildTarget.builder(ROOT, "//bar", "test2").build())
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setConfigs(Optional.of(configs))
         .setCanGroup(Optional.of(true))
         .build();
@@ -925,13 +925,13 @@ public class WorkspaceAndProjectGeneratorTest {
     TargetNode<AppleTestDescription.Arg> combinableTest1 = AppleTestBuilder
         .createBuilder(BuildTarget.builder(ROOT, "//foo", "test1").build())
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setCanGroup(Optional.of(true))
         .build();
     TargetNode<AppleTestDescription.Arg> combinableTest2 = AppleTestBuilder
         .createBuilder(BuildTarget.builder(ROOT, "//bar", "test2").build())
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setLinkerFlags(Optional.of(ImmutableList.of("-flag")))
         .setExportedLinkerFlags(Optional.of(ImmutableList.of("-exported-flag")))
         .setCanGroup(Optional.of(true))
@@ -1014,7 +1014,7 @@ public class WorkspaceAndProjectGeneratorTest {
     TargetNode<?> fooBinNode = AppleBundleBuilder
         .createBuilder(fooBinTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.APP))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setBinary(fooBinBinaryTarget)
         .setTests(Optional.of(ImmutableSortedSet.of(fooBinTestTarget)))
         .build();
@@ -1030,13 +1030,13 @@ public class WorkspaceAndProjectGeneratorTest {
         .createBuilder(bazTestTarget)
         .setDeps(Optional.of(ImmutableSortedSet.of(bazLibTarget)))
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .build();
 
     TargetNode<?> fooTestNode = AppleTestBuilder
         .createBuilder(fooTestTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .setDeps(Optional.of(ImmutableSortedSet.of(bazLibTarget)))
         .build();
 
@@ -1044,7 +1044,7 @@ public class WorkspaceAndProjectGeneratorTest {
         .createBuilder(fooBinTestTarget)
         .setDeps(Optional.of(ImmutableSortedSet.of(fooBinTarget)))
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .build();
 
     BuildTarget quxBinTarget = BuildTarget.builder(ROOT, "//qux", "QuxBin").build();

--- a/test/com/facebook/buck/cli/AuditClasspathCommandTest.java
+++ b/test/com/facebook/buck/cli/AuditClasspathCommandTest.java
@@ -27,10 +27,10 @@ import com.facebook.buck.jvm.java.JavaTestBuilder;
 import com.facebook.buck.jvm.java.KeystoreBuilder;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargetFactory;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.TargetGraphToActionGraph;
 import com.facebook.buck.rules.TargetGraphTransformer;
 import com.facebook.buck.rules.TargetNode;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.testutil.TargetGraphFactory;
 import com.facebook.buck.testutil.TestConsole;
 import com.facebook.buck.util.cache.NullFileHashCache;
@@ -96,14 +96,14 @@ public class AuditClasspathCommandTest {
     BuildTarget keystoreTarget = BuildTargetFactory.newInstance("//:keystore");
     TargetNode<?> keystoreNode = KeystoreBuilder
         .createBuilder(keystoreTarget)
-        .setStore(new TestSourcePath("debug.keystore"))
-        .setProperties(new TestSourcePath("keystore.properties"))
+        .setStore(new FakeSourcePath("debug.keystore"))
+        .setProperties(new FakeSourcePath("keystore.properties"))
         .build();
 
     BuildTarget testAndroidTarget = BuildTargetFactory.newInstance("//:test-android-binary");
     TargetNode<?> testAndroidNode = AndroidBinaryBuilder
         .createBuilder(testAndroidTarget)
-        .setManifest(new TestSourcePath("AndroidManifest.xml"))
+        .setManifest(new FakeSourcePath("AndroidManifest.xml"))
         .setKeystore(keystoreTarget)
         .setOriginalDeps(ImmutableSortedSet.of(androidLibraryTarget, javaLibraryTarget))
         .build();

--- a/test/com/facebook/buck/cli/ProjectCommandXcodeTest.java
+++ b/test/com/facebook/buck/cli/ProjectCommandXcodeTest.java
@@ -29,10 +29,10 @@ import com.facebook.buck.apple.XcodeWorkspaceConfigBuilder;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.model.Either;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.TargetGraph;
 import com.facebook.buck.rules.TargetGraphAndTargets;
 import com.facebook.buck.rules.TargetNode;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.testutil.TargetGraphFactory;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
@@ -100,7 +100,7 @@ public class ProjectCommandXcodeTest {
         .createBuilder(fooTestTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
         .setDeps(Optional.of(ImmutableSortedSet.of(bazLibTarget)))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .build();
 
     BuildTarget fooLibTarget = BuildTargetFactory.newInstance("//foo:lib");
@@ -122,21 +122,21 @@ public class ProjectCommandXcodeTest {
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.APP))
         .setBinary(fooBinBinaryTarget)
         .setTests(Optional.of(ImmutableSortedSet.of(fooBinTestTarget)))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .build();
 
     bazTestNode = AppleTestBuilder
         .createBuilder(bazTestTarget)
         .setDeps(Optional.of(ImmutableSortedSet.of(bazLibTarget)))
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .build();
 
     fooBinTestNode = AppleTestBuilder
         .createBuilder(fooBinTestTarget)
         .setDeps(Optional.of(ImmutableSortedSet.of(fooBinTarget)))
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .build();
 
     BuildTarget quxBinTarget = BuildTargetFactory.newInstance("//qux:bin");
@@ -149,7 +149,7 @@ public class ProjectCommandXcodeTest {
     workspaceExtraTestNode = AppleTestBuilder
         .createBuilder(workspaceExtraTestTarget)
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
-        .setInfoPlist(new TestSourcePath("Info.plist"))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
         .build();
 
     BuildTarget workspaceTarget = BuildTargetFactory.newInstance("//foo:workspace");

--- a/test/com/facebook/buck/cli/TargetsCommandTest.java
+++ b/test/com/facebook/buck/cli/TargetsCommandTest.java
@@ -47,12 +47,12 @@ import com.facebook.buck.model.Either;
 import com.facebook.buck.parser.ParserConfig;
 import com.facebook.buck.rules.BuildRuleType;
 import com.facebook.buck.rules.Cell;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.PathSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.TargetGraph;
 import com.facebook.buck.rules.TargetNode;
 import com.facebook.buck.rules.TestCellBuilder;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.coercer.SourceWithFlags;
 import com.facebook.buck.shell.GenruleBuilder;
 import com.facebook.buck.testutil.FakeOutputStream;
@@ -408,7 +408,7 @@ public class TargetsCommandTest {
         .createBuilder(libraryTarget)
         .setSrcs(
             Optional.of(
-                ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("foo/foo.m")))))
+                ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("foo/foo.m")))))
         .build();
 
     ImmutableSet<TargetNode<?>> nodes = ImmutableSet.<TargetNode<?>>of(libraryNode);
@@ -447,7 +447,7 @@ public class TargetsCommandTest {
         .createBuilder(libraryTarget)
         .setSrcs(
             Optional.of(
-                ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("foo/foo.m")))))
+                ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("foo/foo.m")))))
         .build();
 
     BuildTarget testTarget = BuildTargetFactory.newInstance("//foo:xctest");
@@ -456,7 +456,7 @@ public class TargetsCommandTest {
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
         .setSrcs(
             Optional.of(
-                ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("foo/testfoo.m")))))
+                ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("foo/testfoo.m")))))
         .setDeps(Optional.of(ImmutableSortedSet.of(libraryTarget)))
         .build();
 
@@ -575,7 +575,7 @@ public class TargetsCommandTest {
         .createBuilder(libraryTarget)
         .setSrcs(
             Optional.of(
-                ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("foo/foo.m")))))
+                ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("foo/foo.m")))))
         .setTests(Optional.of(ImmutableSortedSet.of(libraryTestTarget1, libraryTestTarget2)))
         .build();
 
@@ -584,7 +584,7 @@ public class TargetsCommandTest {
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
         .setSrcs(
             Optional.of(
-                ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("foo/testfoo1.m")))))
+                ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("foo/testfoo1.m")))))
         .setDeps(Optional.of(ImmutableSortedSet.of(libraryTarget)))
         .build();
 
@@ -593,7 +593,7 @@ public class TargetsCommandTest {
         .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.XCTEST))
         .setSrcs(
             Optional.of(
-                ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("foo/testfoo2.m")))))
+                ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("foo/testfoo2.m")))))
         .setDeps(Optional.of(ImmutableSortedSet.of(testLibraryTarget)))
         .build();
 
@@ -601,7 +601,7 @@ public class TargetsCommandTest {
         .createBuilder(testLibraryTarget)
         .setSrcs(Optional.of(ImmutableSortedSet.of(
                     SourceWithFlags.of(
-                        new TestSourcePath("testlib/testlib.m")))))
+                        new FakeSourcePath("testlib/testlib.m")))))
         .setTests(Optional.of(ImmutableSortedSet.of(testLibraryTestTarget)))
         .build();
 
@@ -612,7 +612,7 @@ public class TargetsCommandTest {
             Optional.of(
                 ImmutableSortedSet.of(
                     SourceWithFlags.of(
-                        new TestSourcePath("testlib/testlib-test.m")))))
+                        new FakeSourcePath("testlib/testlib-test.m")))))
         .setDeps(Optional.of(ImmutableSortedSet.of(testLibraryTarget)))
         .build();
 

--- a/test/com/facebook/buck/cxx/ArchiveTest.java
+++ b/test/com/facebook/buck/cxx/ArchiveTest.java
@@ -23,12 +23,12 @@ import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.HashedFileTool;
 import com.facebook.buck.rules.RuleKey;
 import com.facebook.buck.rules.RuleKeyBuilderFactory;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.keys.DefaultRuleKeyBuilderFactory;
 import com.facebook.buck.testutil.FakeFileHashCache;
 import com.google.common.base.Strings;
@@ -47,9 +47,9 @@ public class ArchiveTest {
   private static final Path DEFAULT_OUTPUT = Paths.get("foo/libblah.a");
   private static final ImmutableList<SourcePath> DEFAULT_INPUTS =
       ImmutableList.<SourcePath>of(
-          new TestSourcePath("a.o"),
-          new TestSourcePath("b.o"),
-          new TestSourcePath("c.o"));
+          new FakeSourcePath("a.o"),
+          new FakeSourcePath("b.o"),
+          new FakeSourcePath("c.o"));
 
   @Test
   public void testThatInputChangesCauseRuleKeyChanges() {
@@ -103,7 +103,7 @@ public class ArchiveTest {
             pathResolver,
             DEFAULT_ARCHIVER,
             DEFAULT_OUTPUT,
-            ImmutableList.<SourcePath>of(new TestSourcePath("different"))));
+            ImmutableList.<SourcePath>of(new FakeSourcePath("different"))));
     assertNotEquals(defaultRuleKey, inputChange);
 
     // Verify that changing the type of archiver causes a rulekey change.

--- a/test/com/facebook/buck/cxx/ArchivesTest.java
+++ b/test/com/facebook/buck/cxx/ArchivesTest.java
@@ -26,10 +26,10 @@ import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildTargetSourcePath;
 import com.facebook.buck.rules.FakeBuildRule;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.HashedFileTool;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.shell.Genrule;
 import com.facebook.buck.shell.GenruleBuilder;
 import com.google.common.collect.ImmutableList;
@@ -46,9 +46,9 @@ public class ArchivesTest {
       new HashedFileTool(Paths.get("ar")));
   private static final Path DEFAULT_OUTPUT = Paths.get("libblah.a");
   private static final ImmutableList<SourcePath> DEFAULT_INPUTS = ImmutableList.<SourcePath>of(
-      new TestSourcePath("a.o"),
-      new TestSourcePath("b.o"),
-      new TestSourcePath("c.o"));
+      new FakeSourcePath("a.o"),
+      new FakeSourcePath("b.o"),
+      new FakeSourcePath("c.o"));
 
   @Test
   public void testThatBuildTargetSourcePathDepsAndPathsArePropagated() {
@@ -74,7 +74,7 @@ public class ArchivesTest {
         DEFAULT_ARCHIVER,
         DEFAULT_OUTPUT,
         ImmutableList.<SourcePath>of(
-            new TestSourcePath("simple.o"),
+            new FakeSourcePath("simple.o"),
             new BuildTargetSourcePath(genrule1.getBuildTarget()),
             new BuildTargetSourcePath(genrule2.getBuildTarget())));
 

--- a/test/com/facebook/buck/cxx/CxxBinaryDescriptionTest.java
+++ b/test/com/facebook/buck/cxx/CxxBinaryDescriptionTest.java
@@ -26,8 +26,8 @@ import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.model.HasBuildTarget;
-import com.facebook.buck.python.PythonPlatform;
 import com.facebook.buck.python.PythonPackageComponents;
+import com.facebook.buck.python.PythonPlatform;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildRuleResolver;
@@ -35,20 +35,20 @@ import com.facebook.buck.rules.BuildRules;
 import com.facebook.buck.rules.BuildTargetSourcePath;
 import com.facebook.buck.rules.FakeBuildRule;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.PathSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.TargetGraph;
 import com.facebook.buck.rules.TargetNode;
-import com.facebook.buck.rules.TestSourcePath;
+import com.facebook.buck.rules.args.Arg;
+import com.facebook.buck.rules.args.SourcePathArg;
 import com.facebook.buck.rules.coercer.FrameworkPath;
 import com.facebook.buck.rules.coercer.PatternMatchedCollection;
 import com.facebook.buck.rules.coercer.SourceWithFlags;
 import com.facebook.buck.shell.Genrule;
 import com.facebook.buck.shell.GenruleBuilder;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
-import com.facebook.buck.rules.args.Arg;
-import com.facebook.buck.rules.args.SourcePathArg;
 import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
@@ -206,13 +206,13 @@ public class CxxBinaryDescriptionTest {
         (CxxBinaryBuilder) new CxxBinaryBuilder(target)
               .setSrcs(
                   ImmutableSortedSet.of(
-                      SourceWithFlags.of(new TestSourcePath("test/bar.cpp")),
+                      SourceWithFlags.of(new FakeSourcePath("test/bar.cpp")),
                       SourceWithFlags.of(
                           new BuildTargetSourcePath(
                               genSource.getBuildTarget()))))
               .setHeaders(
                   ImmutableSortedSet.<SourcePath>of(
-                      new TestSourcePath("test/bar.h"),
+                      new FakeSourcePath("test/bar.h"),
                       new BuildTargetSourcePath(genHeader.getBuildTarget())))
               .setDeps(ImmutableSortedSet.of(dep.getBuildTarget()));
     CxxBinary binRule = (CxxBinary) cxxBinaryBuilder.build(resolver);

--- a/test/com/facebook/buck/cxx/CxxBoostTestTest.java
+++ b/test/com/facebook/buck/cxx/CxxBoostTestTest.java
@@ -25,9 +25,9 @@ import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.CommandTool;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.Label;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.step.ExecutionContext;
 import com.facebook.buck.step.TestExecutionContext;
 import com.facebook.buck.test.TestResultSummary;
@@ -78,7 +78,7 @@ public class CxxBoostTestTest {
             .build(),
         new SourcePathResolver(new BuildRuleResolver()),
         new CommandTool.Builder()
-            .addArg(new TestSourcePath(""))
+            .addArg(new FakeSourcePath(""))
             .build(),
         Suppliers.ofInstance(ImmutableMap.<String, String>of()),
         Suppliers.ofInstance(ImmutableList.<String>of()),

--- a/test/com/facebook/buck/cxx/CxxCompilationDatabaseTest.java
+++ b/test/com/facebook/buck/cxx/CxxCompilationDatabaseTest.java
@@ -30,10 +30,10 @@ import com.facebook.buck.rules.BuildableContext;
 import com.facebook.buck.rules.FakeBuildContext;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
 import com.facebook.buck.rules.FakeBuildableContext;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.HashedFileTool;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.fs.MkdirStep;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
@@ -117,7 +117,7 @@ public class CxxCompilationDatabaseTest {
                     Optional.<SourcePath>absent(),
                     ImmutableList.<CxxHeaders>of()),
               Paths.get("test.ii"),
-              new TestSourcePath("test.cpp"),
+              new FakeSourcePath("test.cpp"),
               CxxSource.Type.CXX,
               CxxPlatforms.DEFAULT_DEBUG_PATH_SANITIZER);
         rules.add(preprocessRule);
@@ -133,7 +133,7 @@ public class CxxCompilationDatabaseTest {
                 ImmutableList.<String>of(),
                 ImmutableList.<String>of(),
                 Paths.get("test.o"),
-                new TestSourcePath("test.ii"),
+                new FakeSourcePath("test.ii"),
                 CxxSource.Type.CXX_CPP_OUTPUT,
                 CxxPlatforms.DEFAULT_DEBUG_PATH_SANITIZER));
         break;
@@ -164,7 +164,7 @@ public class CxxCompilationDatabaseTest {
                 ImmutableList.<String>of(),
                 ImmutableList.<String>of(),
                 Paths.get("test.o"),
-                new TestSourcePath("test.cpp"),
+                new FakeSourcePath("test.cpp"),
                 CxxSource.Type.CXX,
                 CxxPlatforms.DEFAULT_DEBUG_PATH_SANITIZER,
                 strategy));

--- a/test/com/facebook/buck/cxx/CxxGtestTestTest.java
+++ b/test/com/facebook/buck/cxx/CxxGtestTestTest.java
@@ -25,9 +25,9 @@ import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.CommandTool;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.Label;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.step.ExecutionContext;
 import com.facebook.buck.step.TestExecutionContext;
 import com.facebook.buck.test.TestResultSummary;
@@ -83,7 +83,7 @@ public class CxxGtestTestTest {
         new FakeBuildRuleParamsBuilder(target).setProjectFilesystem(filesystem).build(),
         new SourcePathResolver(new BuildRuleResolver()),
         new CommandTool.Builder()
-            .addArg(new TestSourcePath(""))
+            .addArg(new FakeSourcePath(""))
             .build(),
         Suppliers.ofInstance(ImmutableMap.<String, String>of()),
         Suppliers.ofInstance(ImmutableList.<String>of()),

--- a/test/com/facebook/buck/cxx/CxxLibraryDescriptionTest.java
+++ b/test/com/facebook/buck/cxx/CxxLibraryDescriptionTest.java
@@ -40,11 +40,14 @@ import com.facebook.buck.rules.FakeBuildContext;
 import com.facebook.buck.rules.FakeBuildRule;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
 import com.facebook.buck.rules.FakeBuildableContext;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.PathSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.TargetGraph;
-import com.facebook.buck.rules.TestSourcePath;
+import com.facebook.buck.rules.args.Arg;
+import com.facebook.buck.rules.args.SourcePathArg;
+import com.facebook.buck.rules.args.StringArg;
 import com.facebook.buck.rules.coercer.FrameworkPath;
 import com.facebook.buck.rules.coercer.PatternMatchedCollection;
 import com.facebook.buck.rules.coercer.SourceWithFlags;
@@ -53,10 +56,7 @@ import com.facebook.buck.shell.ExportFileBuilder;
 import com.facebook.buck.shell.GenruleBuilder;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
 import com.facebook.buck.testutil.TargetGraphFactory;
-import com.facebook.buck.rules.args.Arg;
 import com.facebook.buck.util.BuckConstant;
-import com.facebook.buck.rules.args.SourcePathArg;
-import com.facebook.buck.rules.args.StringArg;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
@@ -259,18 +259,18 @@ public class CxxLibraryDescriptionTest {
     CxxLibraryBuilder cxxLibraryBuilder = (CxxLibraryBuilder) new CxxLibraryBuilder(target)
         .setExportedHeaders(
             ImmutableSortedSet.<SourcePath>of(
-                new TestSourcePath(headerName),
+                new FakeSourcePath(headerName),
                 new BuildTargetSourcePath(genHeaderTarget)))
         .setHeaders(
-            ImmutableSortedSet.<SourcePath>of(new TestSourcePath(privateHeaderName)))
+            ImmutableSortedSet.<SourcePath>of(new FakeSourcePath(privateHeaderName)))
         .setSrcs(
             ImmutableSortedSet.of(
-                SourceWithFlags.of(new TestSourcePath("test/bar.cpp")),
+                SourceWithFlags.of(new FakeSourcePath("test/bar.cpp")),
                 SourceWithFlags.of(new BuildTargetSourcePath(genSourceTarget))))
         .setFrameworks(
             ImmutableSortedSet.of(
-                FrameworkPath.ofSourcePath(new TestSourcePath("/some/framework/path/s.dylib")),
-                FrameworkPath.ofSourcePath(new TestSourcePath("/another/framework/path/a.dylib"))))
+                FrameworkPath.ofSourcePath(new FakeSourcePath("/some/framework/path/s.dylib")),
+                FrameworkPath.ofSourcePath(new FakeSourcePath("/another/framework/path/a.dylib"))))
         .setDeps(ImmutableSortedSet.of(dep.getBuildTarget()));
 
     TargetGraph targetGraph = TargetGraphFactory.newInstance(
@@ -300,13 +300,13 @@ public class CxxLibraryDescriptionTest {
                 CxxHeaders.builder()
                     .putNameToPathMap(
                         Paths.get(headerName),
-                        new TestSourcePath(headerName))
+                        new FakeSourcePath(headerName))
                     .putNameToPathMap(
                         Paths.get(genHeaderName),
                         new BuildTargetSourcePath(genHeaderTarget))
                     .putFullNameToPathMap(
                         headerRoot.resolve(headerName),
-                        new TestSourcePath(headerName))
+                        new FakeSourcePath(headerName))
                     .putFullNameToPathMap(
                         headerRoot.resolve(genHeaderName),
                         new BuildTargetSourcePath(genHeaderTarget))
@@ -348,10 +348,10 @@ public class CxxLibraryDescriptionTest {
                 CxxHeaders.builder()
                     .putNameToPathMap(
                         Paths.get(privateHeaderName),
-                        new TestSourcePath(privateHeaderName))
+                        new FakeSourcePath(privateHeaderName))
                     .putFullNameToPathMap(
                         privateHeaderRoot.resolve(privateHeaderName),
-                        new TestSourcePath(privateHeaderName))
+                        new FakeSourcePath(privateHeaderName))
                     .build())
             .addIncludeRoots(
                 getHeaderSymlinkTreeIncludePath(
@@ -486,7 +486,7 @@ public class CxxLibraryDescriptionTest {
             String.format("//:rule#shared,%s", CxxPlatformUtils.DEFAULT_PLATFORM.getFlavor()));
     AbstractCxxSourceBuilder<CxxLibraryDescription.Arg> ruleBuilder = new CxxLibraryBuilder(target)
         .setSoname(soname)
-        .setSrcs(ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("foo.cpp"))));
+        .setSrcs(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("foo.cpp"))));
     TargetGraph targetGraph = TargetGraphFactory.newInstance(ruleBuilder.build());
     CxxLink rule = (CxxLink) ruleBuilder
         .build(
@@ -523,7 +523,7 @@ public class CxxLibraryDescriptionTest {
     CxxLibrary normal = (CxxLibrary) normalBuilder
         .setSrcs(
             ImmutableSortedSet.<SourceWithFlags>of(
-                SourceWithFlags.of(new TestSourcePath("test.cpp"))))
+                SourceWithFlags.of(new FakeSourcePath("test.cpp"))))
         .build(
             resolver,
             filesystem,
@@ -545,14 +545,14 @@ public class CxxLibraryDescriptionTest {
     AbstractCxxSourceBuilder<CxxLibraryDescription.Arg> linkWholeBuilder =
         new CxxLibraryBuilder(target)
             .setLinkWhole(true)
-            .setSrcs(ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("foo.cpp"))));
+            .setSrcs(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("foo.cpp"))));
 
     TargetGraph linkWholeGraph = TargetGraphFactory.newInstance(linkWholeBuilder.build());
     resolver = new BuildRuleResolver();
     CxxLibrary linkWhole = (CxxLibrary) linkWholeBuilder
         .setSrcs(
             ImmutableSortedSet.<SourceWithFlags>of(
-                SourceWithFlags.of(new TestSourcePath("test.cpp"))))
+                SourceWithFlags.of(new FakeSourcePath("test.cpp"))))
         .build(
             resolver,
             filesystem,
@@ -730,12 +730,12 @@ public class CxxLibraryDescriptionTest {
                 genHeaderName, new BuildTargetSourcePath(genHeaderTarget)))
         .setSrcs(
             ImmutableSortedSet.of(
-                SourceWithFlags.of(new TestSourcePath(sourceName)),
+                SourceWithFlags.of(new FakeSourcePath(sourceName)),
                 SourceWithFlags.of(new BuildTargetSourcePath(genSourceTarget))))
         .setFrameworks(
             ImmutableSortedSet.of(
-                FrameworkPath.ofSourcePath(new TestSourcePath("/some/framework/path/s.dylib")),
-                FrameworkPath.ofSourcePath(new TestSourcePath("/another/framework/path/a.dylib"))))
+                FrameworkPath.ofSourcePath(new FakeSourcePath("/some/framework/path/s.dylib")),
+                FrameworkPath.ofSourcePath(new FakeSourcePath("/another/framework/path/a.dylib"))))
         .setDeps(ImmutableSortedSet.of(dep.getBuildTarget()));
 
     // Construct C/C++ library build rules.
@@ -1006,7 +1006,7 @@ public class CxxLibraryDescriptionTest {
     // methods.
     CxxLibraryBuilder cxxLibraryBuilder =
         (CxxLibraryBuilder) new CxxLibraryBuilder(target)
-            .setSrcs(ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath("test.c"))));
+            .setSrcs(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("test.c"))));
     TargetGraph targetGraph1 = TargetGraphFactory.newInstance(cxxLibraryBuilder.build());
     CxxLibrary cxxLibrary = (CxxLibrary) cxxLibraryBuilder
         .build(new BuildRuleResolver(), filesystem, targetGraph1);

--- a/test/com/facebook/buck/cxx/CxxLinkTest.java
+++ b/test/com/facebook/buck/cxx/CxxLinkTest.java
@@ -24,11 +24,11 @@ import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.HashedFileTool;
 import com.facebook.buck.rules.RuleKey;
 import com.facebook.buck.rules.RuleKeyBuilderFactory;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.args.Arg;
 import com.facebook.buck.rules.args.SanitizedArg;
 import com.facebook.buck.rules.args.SourcePathArg;
@@ -58,13 +58,13 @@ public class CxxLinkTest {
           new StringArg("libc.a"),
           new SourcePathArg(
               new SourcePathResolver(new BuildRuleResolver()),
-              new TestSourcePath("a.o")),
+              new FakeSourcePath("a.o")),
           new SourcePathArg(
               new SourcePathResolver(new BuildRuleResolver()),
-              new TestSourcePath("b.o")),
+              new FakeSourcePath("b.o")),
           new SourcePathArg(
               new SourcePathResolver(new BuildRuleResolver()),
-              new TestSourcePath("libc.a")),
+              new FakeSourcePath("libc.a")),
           new StringArg("-L"),
           new StringArg("/System/Libraries/libz.dynlib"),
           new StringArg("-llibz.dylib"));
@@ -128,7 +128,7 @@ public class CxxLinkTest {
             ImmutableList.<Arg>of(
                 new SourcePathArg(
                     new SourcePathResolver(new BuildRuleResolver()),
-                    new TestSourcePath("different")))));
+                    new FakeSourcePath("different")))));
     assertNotEquals(defaultRuleKey, flagsChange);
   }
 

--- a/test/com/facebook/buck/cxx/CxxLinkableEnhancerTest.java
+++ b/test/com/facebook/buck/cxx/CxxLinkableEnhancerTest.java
@@ -37,17 +37,17 @@ import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildTargetSourcePath;
 import com.facebook.buck.rules.FakeBuildRule;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.PathSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.TargetGraph;
-import com.facebook.buck.rules.TestSourcePath;
-import com.facebook.buck.rules.coercer.FrameworkPath;
-import com.facebook.buck.shell.Genrule;
-import com.facebook.buck.shell.GenruleBuilder;
 import com.facebook.buck.rules.args.Arg;
 import com.facebook.buck.rules.args.SourcePathArg;
 import com.facebook.buck.rules.args.StringArg;
+import com.facebook.buck.rules.coercer.FrameworkPath;
+import com.facebook.buck.shell.Genrule;
+import com.facebook.buck.shell.GenruleBuilder;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
@@ -71,9 +71,9 @@ public class CxxLinkableEnhancerTest {
   private static final ImmutableList<Arg> DEFAULT_INPUTS =
       SourcePathArg.from(
           new SourcePathResolver(new BuildRuleResolver()),
-          new TestSourcePath("a.o"),
-          new TestSourcePath("b.o"),
-          new TestSourcePath("c.o"));
+          new FakeSourcePath("a.o"),
+          new FakeSourcePath("b.o"),
+          new FakeSourcePath("c.o"));
   private static final ImmutableSortedSet<BuildRule> EMPTY_DEPS = ImmutableSortedSet.of();
   private static final CxxPlatform CXX_PLATFORM = DefaultCxxPlatforms.build(
       new CxxBuckConfig(FakeBuckConfig.builder().build()));
@@ -170,7 +170,7 @@ public class CxxLinkableEnhancerTest {
         DEFAULT_OUTPUT,
         SourcePathArg.from(
             new SourcePathResolver(resolver),
-            new TestSourcePath("simple.o"),
+            new FakeSourcePath("simple.o"),
             new BuildTargetSourcePath(genrule1.getBuildTarget()),
             new BuildTargetSourcePath(genrule2.getBuildTarget())),
         Linker.LinkableDepType.STATIC,
@@ -502,10 +502,10 @@ public class CxxLinkableEnhancerTest {
         DEFAULT_OUTPUT,
         SourcePathArg.from(
             new SourcePathResolver(resolver),
-            new TestSourcePath("simple.o")),
+            new FakeSourcePath("simple.o")),
         Linker.LinkableDepType.STATIC,
         EMPTY_DEPS,
-        Optional.<SourcePath>of(new TestSourcePath("path/to/MyBundleLoader")),
+        Optional.<SourcePath>of(new FakeSourcePath("path/to/MyBundleLoader")),
         ImmutableSet.<BuildTarget>of(),
         ImmutableSet.<FrameworkPath>of());
     assertThat(
@@ -533,7 +533,7 @@ public class CxxLinkableEnhancerTest {
         DEFAULT_OUTPUT,
         SourcePathArg.from(
             new SourcePathResolver(resolver),
-            new TestSourcePath("simple.o")),
+            new FakeSourcePath("simple.o")),
         Linker.LinkableDepType.STATIC,
         EMPTY_DEPS,
         Optional.<SourcePath>absent(),
@@ -554,7 +554,7 @@ public class CxxLinkableEnhancerTest {
         DEFAULT_OUTPUT,
         SourcePathArg.from(
             new SourcePathResolver(resolver),
-            new TestSourcePath("another.o")),
+            new FakeSourcePath("another.o")),
         Linker.LinkableDepType.STATIC,
         EMPTY_DEPS,
         Optional.<SourcePath>of(

--- a/test/com/facebook/buck/cxx/CxxPreprocessAndCompileTest.java
+++ b/test/com/facebook/buck/cxx/CxxPreprocessAndCompileTest.java
@@ -27,13 +27,13 @@ import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.CommandTool;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.HashedFileTool;
 import com.facebook.buck.rules.PathSourcePath;
 import com.facebook.buck.rules.RuleKey;
 import com.facebook.buck.rules.RuleKeyBuilderFactory;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.Tool;
 import com.facebook.buck.rules.keys.DefaultRuleKeyBuilderFactory;
 import com.facebook.buck.testutil.FakeFileHashCache;
@@ -68,12 +68,12 @@ public class CxxPreprocessAndCompileTest {
   private static final ImmutableList<String> DEFAULT_PREPROCESOR_RULE_FLAGS =
       ImmutableList.of("-DTEST");
   private static final Path DEFAULT_OUTPUT = Paths.get("test.o");
-  private static final SourcePath DEFAULT_INPUT = new TestSourcePath("test.cpp");
+  private static final SourcePath DEFAULT_INPUT = new FakeSourcePath("test.cpp");
   private static final CxxSource.Type DEFAULT_INPUT_TYPE = CxxSource.Type.CXX;
   private static final ImmutableList<CxxHeaders> DEFAULT_INCLUDES =
       ImmutableList.of(
           CxxHeaders.builder()
-              .putNameToPathMap(Paths.get("test.h"), new TestSourcePath("foo/test.h"))
+              .putNameToPathMap(Paths.get("test.h"), new FakeSourcePath("foo/test.h"))
               .build());
   private static final ImmutableSet<Path> DEFAULT_INCLUDE_ROOTS = ImmutableSet.of(
       Paths.get("foo/bar"),
@@ -202,7 +202,7 @@ public class CxxPreprocessAndCompileTest {
             DEFAULT_PLATFORM_FLAGS,
             DEFAULT_RULE_FLAGS,
             DEFAULT_OUTPUT,
-            new TestSourcePath("different"),
+            new FakeSourcePath("different"),
             DEFAULT_INPUT_TYPE,
             DEFAULT_SANITIZER));
     assertNotEquals(defaultRuleKey, inputChange);
@@ -459,7 +459,7 @@ public class CxxPreprocessAndCompileTest {
             platformFlags,
             ruleFlags,
             output,
-            new TestSourcePath(input.toString()),
+            new FakeSourcePath(input.toString()),
             DEFAULT_INPUT_TYPE,
             DEFAULT_SANITIZER);
 
@@ -507,10 +507,10 @@ public class CxxPreprocessAndCompileTest {
                 ImmutableSet.<Path>of(),
                 ImmutableSet.<Path>of(),
                 DEFAULT_FRAMEWORK_ROOTS,
-                Optional.<SourcePath>of(new TestSourcePath(prefixHeader.toString())),
+                Optional.<SourcePath>of(new FakeSourcePath(prefixHeader.toString())),
                 ImmutableList.of(CxxHeaders.builder().build())),
             output,
-            new TestSourcePath(input.toString()),
+            new FakeSourcePath(input.toString()),
             DEFAULT_INPUT_TYPE,
             DEFAULT_SANITIZER);
 

--- a/test/com/facebook/buck/cxx/CxxPreprocessablesTest.java
+++ b/test/com/facebook/buck/cxx/CxxPreprocessablesTest.java
@@ -29,10 +29,10 @@ import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildTargetSourcePath;
 import com.facebook.buck.rules.FakeBuildRule;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.TargetGraph;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.shell.Genrule;
 import com.facebook.buck.shell.GenruleBuilder;
 import com.google.common.base.Optional;
@@ -136,13 +136,13 @@ public class CxxPreprocessablesTest {
   public void resolveHeaderMap() {
     BuildTarget target = BuildTargetFactory.newInstance("//hello/world:test");
     ImmutableMap<String, SourcePath> headerMap = ImmutableMap.<String, SourcePath>of(
-        "foo/bar.h", new TestSourcePath("header1.h"),
-        "foo/hello.h", new TestSourcePath("header2.h"));
+        "foo/bar.h", new FakeSourcePath("header1.h"),
+        "foo/hello.h", new FakeSourcePath("header2.h"));
 
     // Verify that the resolveHeaderMap returns sane results.
     ImmutableMap<Path, SourcePath> expected = ImmutableMap.<Path, SourcePath>of(
-        target.getBasePath().resolve("foo/bar.h"), new TestSourcePath("header1.h"),
-        target.getBasePath().resolve("foo/hello.h"), new TestSourcePath("header2.h"));
+        target.getBasePath().resolve("foo/bar.h"), new FakeSourcePath("header1.h"),
+        target.getBasePath().resolve("foo/hello.h"), new FakeSourcePath("header2.h"));
     ImmutableMap<Path, SourcePath> actual = CxxPreprocessables.resolveHeaderMap(
         target.getBasePath(), headerMap);
     assertEquals(expected, actual);
@@ -222,7 +222,7 @@ public class CxxPreprocessablesTest {
     // another build rule.
     ImmutableMap<Path, SourcePath> links = ImmutableMap.<Path, SourcePath>of(
         Paths.get("link1"),
-        new TestSourcePath("hello"),
+        new FakeSourcePath("hello"),
         Paths.get("link2"),
         new BuildTargetSourcePath(genrule.getBuildTarget()));
 
@@ -286,10 +286,10 @@ public class CxxPreprocessablesTest {
             CxxHeaders.builder()
                 .putNameToPathMap(
                     Paths.get("prefix/file.h"),
-                    new TestSourcePath("bottom/file.h"))
+                    new FakeSourcePath("bottom/file.h"))
                 .putFullNameToPathMap(
                     Paths.get("buck-out/something/prefix/file.h"),
-                    new TestSourcePath("bottom/file.h"))
+                    new FakeSourcePath("bottom/file.h"))
                 .build())
         .build();
     BuildRule bottom = createFakeCxxPreprocessorDep("//:bottom", pathResolver, bottomInput);
@@ -299,10 +299,10 @@ public class CxxPreprocessablesTest {
             CxxHeaders.builder()
                 .putNameToPathMap(
                     Paths.get("prefix/file.h"),
-                    new TestSourcePath("top/file.h"))
+                    new FakeSourcePath("top/file.h"))
                 .putFullNameToPathMap(
                     Paths.get("buck-out/something-else/prefix/file.h"),
-                    new TestSourcePath("top/file.h"))
+                    new FakeSourcePath("top/file.h"))
                 .build())
         .build();
     BuildRule top = createFakeCxxPreprocessorDep("//:top", pathResolver, topInput, bottom);
@@ -335,10 +335,10 @@ public class CxxPreprocessablesTest {
             CxxHeaders.builder()
                 .putNameToPathMap(
                     Paths.get("prefix/file.h"),
-                    new TestSourcePath("common/file.h"))
+                    new FakeSourcePath("common/file.h"))
                 .putFullNameToPathMap(
                     Paths.get("buck-out/something/prefix/file.h"),
-                    new TestSourcePath("common/file.h"))
+                    new FakeSourcePath("common/file.h"))
                 .build())
         .build();
     BuildRule bottom = createFakeCxxPreprocessorDep("//:bottom", pathResolver, bottomInput);
@@ -348,10 +348,10 @@ public class CxxPreprocessablesTest {
             CxxHeaders.builder()
                 .putNameToPathMap(
                     Paths.get("prefix/file.h"),
-                    new TestSourcePath("common/file.h"))
+                    new FakeSourcePath("common/file.h"))
                 .putFullNameToPathMap(
                     Paths.get("buck-out/something-else/prefix/file.h"),
-                    new TestSourcePath("common/file.h"))
+                    new FakeSourcePath("common/file.h"))
                 .build())
         .build();
     BuildRule top = createFakeCxxPreprocessorDep("//:top", pathResolver, topInput, bottom);
@@ -361,13 +361,13 @@ public class CxxPreprocessablesTest {
             CxxHeaders.builder()
                 .putNameToPathMap(
                     Paths.get("prefix/file.h"),
-                    new TestSourcePath("common/file.h"))
+                    new FakeSourcePath("common/file.h"))
                 .putFullNameToPathMap(
                     Paths.get("buck-out/something/prefix/file.h"),
-                    new TestSourcePath("common/file.h"))
+                    new FakeSourcePath("common/file.h"))
                 .putFullNameToPathMap(
                     Paths.get("buck-out/something-else/prefix/file.h"),
-                    new TestSourcePath("common/file.h"))
+                    new FakeSourcePath("common/file.h"))
                 .build())
         .build();
 

--- a/test/com/facebook/buck/cxx/CxxPythonExtensionDescriptionTest.java
+++ b/test/com/facebook/buck/cxx/CxxPythonExtensionDescriptionTest.java
@@ -33,10 +33,10 @@ import com.facebook.buck.python.PythonVersion;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildTargetSourcePath;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.TargetNode;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.args.Arg;
 import com.facebook.buck.rules.coercer.SourceWithFlags;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
@@ -153,7 +153,7 @@ public class CxxPythonExtensionDescriptionTest {
             .setSrcs(
                 ImmutableSortedSet.of(
                     SourceWithFlags.of(
-                        new TestSourcePath("something.cpp"),
+                        new FakeSourcePath("something.cpp"),
                         ImmutableList.<String>of())))
             .build(resolver, filesystem, targetNodes);
     NativeLinkableInput depInput =

--- a/test/com/facebook/buck/cxx/CxxSourceRuleFactoryTest.java
+++ b/test/com/facebook/buck/cxx/CxxSourceRuleFactoryTest.java
@@ -33,10 +33,10 @@ import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildTargetSourcePath;
 import com.facebook.buck.rules.FakeBuildRule;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.PathSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.testutil.AllExistingProjectFilesystem;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
 import com.google.common.base.Joiner;
@@ -156,7 +156,7 @@ public class CxxSourceRuleFactoryTest {
     String name = "source.cpp";
     CxxSource cxxSource = CxxSource.of(
         CxxSource.Type.CXX,
-        new TestSourcePath(name),
+        new FakeSourcePath(name),
         ImmutableList.<String>of());
 
     // Verify that platform flags make it to the compile rule.
@@ -204,10 +204,10 @@ public class CxxSourceRuleFactoryTest {
 
     ImmutableList<String> asppflags = ImmutableList.of("-asppflag", "-asppflag");
 
-    SourcePath cpp = new TestSourcePath("cpp");
+    SourcePath cpp = new FakeSourcePath("cpp");
     ImmutableList<String> cppflags = ImmutableList.of("-cppflag", "-cppflag");
 
-    SourcePath cxxpp = new TestSourcePath("cxxpp");
+    SourcePath cxxpp = new FakeSourcePath("cxxpp");
     ImmutableList<String> cxxppflags = ImmutableList.of("-cxxppflag", "-cxxppflag");
 
     BuckConfig buckConfig = FakeBuckConfig.builder()
@@ -240,7 +240,7 @@ public class CxxSourceRuleFactoryTest {
         ImmutableList.of("-per-file-flag-for-c-file", "-and-another-one");
     CxxSource cSource = CxxSource.of(
         CxxSource.Type.C,
-        new TestSourcePath(cSourceName),
+        new FakeSourcePath(cSourceName),
         perFileFlagsForTestC);
     CxxPreprocessAndCompile cPreprocess =
         cxxSourceRuleFactory.requirePreprocessBuildRule(
@@ -267,7 +267,7 @@ public class CxxSourceRuleFactoryTest {
         ImmutableList.of("-per-file-flag-for-cpp-file");
     CxxSource cxxSource = CxxSource.of(
         CxxSource.Type.CXX,
-        new TestSourcePath(cxxSourceName),
+        new FakeSourcePath(cxxSourceName),
         perFileFlagsForTestCpp);
     CxxPreprocessAndCompile cxxPreprocess =
         cxxSourceRuleFactory.requirePreprocessBuildRule(
@@ -294,7 +294,7 @@ public class CxxSourceRuleFactoryTest {
         ImmutableList.of("-a-flag-for-s-file", "-another-one", "-one-more");
     CxxSource assemblerWithCppSource = CxxSource.of(
         CxxSource.Type.ASSEMBLER_WITH_CPP,
-        new TestSourcePath(assemblerWithCppSourceName),
+        new FakeSourcePath(assemblerWithCppSourceName),
         perFileFlagsForTestS);
     CxxPreprocessAndCompile assemblerWithCppPreprocess =
         cxxSourceRuleFactory.requirePreprocessBuildRule(
@@ -387,7 +387,7 @@ public class CxxSourceRuleFactoryTest {
     String name = "foo/bar.ii";
     CxxSource cxxSource = CxxSource.of(
         CxxSource.Type.CXX_CPP_OUTPUT,
-        new TestSourcePath(name),
+        new FakeSourcePath(name),
         ImmutableList.<String>of());
 
     // Verify building a non-PIC compile rule does *not* have the "-fPIC" flag and has the
@@ -423,7 +423,7 @@ public class CxxSourceRuleFactoryTest {
     name = "foo/bar.cpp";
     cxxSource = CxxSource.of(
         CxxSource.Type.CXX,
-        new TestSourcePath(name),
+        new FakeSourcePath(name),
         ImmutableList.<String>of());
 
     // Verify building a non-PIC compile rule does *not* have the "-fPIC" flag and has the
@@ -486,7 +486,7 @@ public class CxxSourceRuleFactoryTest {
     String name = "source.ii";
     CxxSource cxxSource = CxxSource.of(
         CxxSource.Type.CXX_CPP_OUTPUT,
-        new TestSourcePath(name),
+        new FakeSourcePath(name),
         ImmutableList.<String>of());
 
     // Verify that platform flags make it to the compile rule.
@@ -503,7 +503,7 @@ public class CxxSourceRuleFactoryTest {
     name = "source.cpp";
     cxxSource = CxxSource.of(
         CxxSource.Type.CXX,
-        new TestSourcePath(name),
+        new FakeSourcePath(name),
         ImmutableList.<String>of());
 
     // Verify that platform flags make it to the compile rule.
@@ -532,13 +532,13 @@ public class CxxSourceRuleFactoryTest {
 
     ImmutableList<String> explicitCompilerFlags = ImmutableList.of("-explicit-compilerflag");
 
-    SourcePath as = new TestSourcePath("as");
+    SourcePath as = new FakeSourcePath("as");
     ImmutableList<String> asflags = ImmutableList.of("-asflag", "-asflag");
 
-    SourcePath cc = new TestSourcePath("cc");
+    SourcePath cc = new FakeSourcePath("cc");
     ImmutableList<String> cflags = ImmutableList.of("-cflag", "-cflag");
 
-    SourcePath cxx = new TestSourcePath("cxx");
+    SourcePath cxx = new FakeSourcePath("cxx");
     ImmutableList<String> cxxflags = ImmutableList.of("-cxxflag", "-cxxflag");
 
     BuckConfig buckConfig = FakeBuckConfig.builder()
@@ -571,7 +571,7 @@ public class CxxSourceRuleFactoryTest {
     List<String> cSourcePerFileFlags = ImmutableList.of("-c-source-par-file-flag");
     CxxSource cSource = CxxSource.of(
         CxxSource.Type.C_CPP_OUTPUT,
-        new TestSourcePath(cSourceName),
+        new FakeSourcePath(cSourceName),
         cSourcePerFileFlags);
     CxxPreprocessAndCompile cCompile =
         cxxSourceRuleFactory.requireCompileBuildRule(
@@ -587,7 +587,7 @@ public class CxxSourceRuleFactoryTest {
     cSourceName = "test.c";
     cSource = CxxSource.of(
         CxxSource.Type.C,
-        new TestSourcePath(cSourceName),
+        new FakeSourcePath(cSourceName),
         cSourcePerFileFlags);
     CxxPreprocessAndCompile cPreprocessAndCompile =
         cxxSourceRuleFactory.requirePreprocessAndCompileBuildRule(
@@ -606,7 +606,7 @@ public class CxxSourceRuleFactoryTest {
     CxxSource cxxSource =
         CxxSource.of(
             CxxSource.Type.CXX_CPP_OUTPUT,
-            new TestSourcePath(cxxSourceName),
+            new FakeSourcePath(cxxSourceName),
             cxxSourcePerFileFlags);
     CxxPreprocessAndCompile cxxCompile =
         cxxSourceRuleFactory.requireCompileBuildRule(
@@ -623,7 +623,7 @@ public class CxxSourceRuleFactoryTest {
     cxxSource =
         CxxSource.of(
             CxxSource.Type.CXX,
-            new TestSourcePath(cxxSourceName),
+            new FakeSourcePath(cxxSourceName),
             cxxSourcePerFileFlags);
     CxxPreprocessAndCompile cxxPreprocessAndCompile =
         cxxSourceRuleFactory.requirePreprocessAndCompileBuildRule(
@@ -642,7 +642,7 @@ public class CxxSourceRuleFactoryTest {
         ImmutableList.of("-c-cpp-output-source-par-file-flag");
     CxxSource cCppOutputSource = CxxSource.of(
         CxxSource.Type.C_CPP_OUTPUT,
-        new TestSourcePath(cCppOutputSourceName),
+        new FakeSourcePath(cCppOutputSourceName),
         cCppOutputSourcePerFileFlags);
     CxxPreprocessAndCompile cCppOutputCompile =
         cxxSourceRuleFactory.requireCompileBuildRule(
@@ -658,7 +658,7 @@ public class CxxSourceRuleFactoryTest {
     cCppOutputSourceName = "test2.c";
     cCppOutputSource = CxxSource.of(
         CxxSource.Type.C,
-        new TestSourcePath(cCppOutputSourceName),
+        new FakeSourcePath(cCppOutputSourceName),
         cCppOutputSourcePerFileFlags);
     CxxPreprocessAndCompile cCppOutputPreprocessAndCompile =
         cxxSourceRuleFactory.requirePreprocessAndCompileBuildRule(
@@ -680,7 +680,7 @@ public class CxxSourceRuleFactoryTest {
     List<String> assemblerSourcePerFileFlags = ImmutableList.of("-assember-source-par-file-flag");
     CxxSource assemblerSource = CxxSource.of(
         CxxSource.Type.ASSEMBLER,
-        new TestSourcePath(assemblerSourceName),
+        new FakeSourcePath(assemblerSourceName),
         assemblerSourcePerFileFlags);
     CxxPreprocessAndCompile assemblerCompile =
         cxxSourceRuleFactory.requireCompileBuildRule(
@@ -694,7 +694,7 @@ public class CxxSourceRuleFactoryTest {
     assemblerSourceName = "test.S";
     assemblerSource = CxxSource.of(
         CxxSource.Type.ASSEMBLER_WITH_CPP,
-        new TestSourcePath(assemblerSourceName),
+        new FakeSourcePath(assemblerSourceName),
         assemblerSourcePerFileFlags);
     CxxPreprocessAndCompile assemblerPreprocessAndCompile =
         cxxSourceRuleFactory.requirePreprocessAndCompileBuildRule(
@@ -807,7 +807,7 @@ public class CxxSourceRuleFactoryTest {
     String objcSourceName = "test.mi";
     CxxSource objcSource = CxxSource.of(
         CxxSource.Type.OBJC_CPP_OUTPUT,
-        new TestSourcePath(objcSourceName),
+        new FakeSourcePath(objcSourceName),
         ImmutableList.<String>of());
     CxxPreprocessAndCompile objcCompile =
         cxxSourceRuleFactory.requireCompileBuildRule(
@@ -820,7 +820,7 @@ public class CxxSourceRuleFactoryTest {
     objcSourceName = "test.m";
     objcSource = CxxSource.of(
         CxxSource.Type.OBJC,
-        new TestSourcePath(objcSourceName),
+        new FakeSourcePath(objcSourceName),
         ImmutableList.<String>of());
     CxxPreprocessAndCompile objcPreprocessAndCompile =
         cxxSourceRuleFactory.requirePreprocessAndCompileBuildRule(
@@ -834,7 +834,7 @@ public class CxxSourceRuleFactoryTest {
     String objcxxSourceName = "test.mii";
     CxxSource objcxxSource = CxxSource.of(
         CxxSource.Type.OBJCXX_CPP_OUTPUT,
-        new TestSourcePath(objcxxSourceName),
+        new FakeSourcePath(objcxxSourceName),
         ImmutableList.<String>of());
     CxxPreprocessAndCompile objcxxCompile =
         cxxSourceRuleFactory.requireCompileBuildRule(
@@ -847,7 +847,7 @@ public class CxxSourceRuleFactoryTest {
     objcxxSourceName = "test.mm";
     objcxxSource = CxxSource.of(
         CxxSource.Type.OBJCXX,
-        new TestSourcePath(objcxxSourceName),
+        new FakeSourcePath(objcxxSourceName),
         ImmutableList.<String>of());
     CxxPreprocessAndCompile objcxxPreprocessAndCompile =
         cxxSourceRuleFactory.requirePreprocessAndCompileBuildRule(
@@ -870,7 +870,7 @@ public class CxxSourceRuleFactoryTest {
     CxxPlatform platform = DefaultCxxPlatforms.build(new CxxBuckConfig(buckConfig));
 
     String prefixHeaderName = "test.pch";
-    SourcePath prefixHeaderSourcePath = new TestSourcePath(prefixHeaderName);
+    SourcePath prefixHeaderSourcePath = new FakeSourcePath(prefixHeaderName);
 
     CxxSourceRuleFactory cxxSourceRuleFactory =
         new CxxSourceRuleFactory(
@@ -885,7 +885,7 @@ public class CxxSourceRuleFactoryTest {
     String objcSourceName = "test.m";
     CxxSource objcSource = CxxSource.of(
         CxxSource.Type.OBJC,
-        new TestSourcePath(objcSourceName),
+        new FakeSourcePath(objcSourceName),
         ImmutableList.<String>of());
     CxxPreprocessAndCompile objcPreprocessAndCompile =
         cxxSourceRuleFactory.requirePreprocessAndCompileBuildRule(
@@ -925,7 +925,7 @@ public class CxxSourceRuleFactoryTest {
     String objcSourceName = "test.m";
     CxxSource objcSource = CxxSource.of(
         CxxSource.Type.OBJC,
-        new TestSourcePath(objcSourceName),
+        new FakeSourcePath(objcSourceName),
         ImmutableList.<String>of());
     CxxPreprocessAndCompile objcCompile =
         cxxSourceRuleFactory.requirePreprocessAndCompileBuildRule(

--- a/test/com/facebook/buck/cxx/NativeLinkablesTest.java
+++ b/test/com/facebook/buck/cxx/NativeLinkablesTest.java
@@ -22,10 +22,10 @@ import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildRule;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.TargetGraph;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.args.StringArg;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
@@ -226,7 +226,7 @@ public class NativeLinkablesTest {
             ImmutableList.<NativeLinkable>of(),
             NativeLinkable.Linkage.ANY,
             NativeLinkableInput.builder().build(),
-            ImmutableMap.<String, SourcePath>of("libc.so", new TestSourcePath("libc.so")));
+            ImmutableMap.<String, SourcePath>of("libc.so", new FakeSourcePath("libc.so")));
     FakeNativeLinkable b =
         new FakeNativeLinkable(
             "//:b",
@@ -234,7 +234,7 @@ public class NativeLinkablesTest {
             ImmutableList.<NativeLinkable>of(),
             NativeLinkable.Linkage.STATIC,
             NativeLinkableInput.builder().build(),
-            ImmutableMap.<String, SourcePath>of("libb.so", new TestSourcePath("libb.so")));
+            ImmutableMap.<String, SourcePath>of("libb.so", new FakeSourcePath("libb.so")));
     FakeNativeLinkable a =
         new FakeNativeLinkable(
             "//:a",
@@ -242,7 +242,7 @@ public class NativeLinkablesTest {
             ImmutableList.<NativeLinkable>of(),
             NativeLinkable.Linkage.ANY,
             NativeLinkableInput.builder().build(),
-            ImmutableMap.<String, SourcePath>of("liba.so", new TestSourcePath("liba.so")));
+            ImmutableMap.<String, SourcePath>of("liba.so", new FakeSourcePath("liba.so")));
     ImmutableSortedMap<String, SourcePath> sharedLibs =
         NativeLinkables.getTransitiveSharedLibraries(
             TargetGraph.EMPTY,
@@ -253,8 +253,8 @@ public class NativeLinkablesTest {
         sharedLibs,
         Matchers.equalTo(
             ImmutableSortedMap.<String, SourcePath>of(
-                "liba.so", new TestSourcePath("liba.so"),
-                "libc.so", new TestSourcePath("libc.so"))));
+                "liba.so", new FakeSourcePath("liba.so"),
+                "libc.so", new FakeSourcePath("libc.so"))));
   }
 
   @Test

--- a/test/com/facebook/buck/halide/HalideLibraryDescriptionTest.java
+++ b/test/com/facebook/buck/halide/HalideLibraryDescriptionTest.java
@@ -31,21 +31,23 @@ import com.facebook.buck.cxx.Linker;
 import com.facebook.buck.cxx.NativeLinkableInput;
 import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.model.BuildTarget;
-import com.facebook.buck.model.BuildTargets;
 import com.facebook.buck.model.BuildTargetFactory;
+import com.facebook.buck.model.BuildTargets;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildTargetSourcePath;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.TargetGraph;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.args.Arg;
 import com.facebook.buck.rules.coercer.SourceWithFlags;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
 import com.facebook.buck.testutil.TargetGraphFactory;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableSortedSet;
+
 import org.junit.Test;
+
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -74,7 +76,7 @@ public class HalideLibraryDescriptionTest {
     compilerBuilder.setSrcs(
       ImmutableSortedSet.of(
         SourceWithFlags.of(
-          new TestSourcePath("main.cpp"))));
+          new FakeSourcePath("main.cpp"))));
     HalideLibraryBuilder libBuilder = new HalideLibraryBuilder(libTarget);
     TargetGraph targetGraph = TargetGraphFactory.newInstance(
       compilerBuilder.build(),

--- a/test/com/facebook/buck/jvm/java/CopyResourcesStepTest.java
+++ b/test/com/facebook/buck/jvm/java/CopyResourcesStepTest.java
@@ -23,9 +23,9 @@ import com.facebook.buck.jvm.core.JavaPackageFinder;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.fs.MkdirAndSymlinkFileStep;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
@@ -54,8 +54,8 @@ public class CopyResourcesStepTest {
         resolver,
         buildTarget,
         ImmutableSet.of(
-            new TestSourcePath("android/java/src/com/facebook/base/data.json"),
-            new TestSourcePath("android/java/src/com/facebook/common/util/data.json")),
+            new FakeSourcePath("android/java/src/com/facebook/base/data.json"),
+            new FakeSourcePath("android/java/src/com/facebook/common/util/data.json")),
         SCRATCH_PATH.resolve("android/java/lib__resources__classes"),
         javaPackageFinder);
 
@@ -88,8 +88,8 @@ public class CopyResourcesStepTest {
         new SourcePathResolver(new BuildRuleResolver()),
         buildTarget,
         ImmutableSet.<SourcePath>of(
-            new TestSourcePath("android/java/src/com/facebook/base/data.json"),
-            new TestSourcePath("android/java/src/com/facebook/common/util/data.json")),
+            new FakeSourcePath("android/java/src/com/facebook/base/data.json"),
+            new FakeSourcePath("android/java/src/com/facebook/common/util/data.json")),
         SCRATCH_PATH.resolve("android/java/src/lib__resources__classes"),
         javaPackageFinder);
 
@@ -123,8 +123,8 @@ public class CopyResourcesStepTest {
         new SourcePathResolver(new BuildRuleResolver()),
         buildTarget,
         ImmutableSet.of(
-            new TestSourcePath("android/java/src/com/facebook/base/data.json"),
-            new TestSourcePath("android/java/src/com/facebook/common/util/data.json")),
+            new FakeSourcePath("android/java/src/com/facebook/base/data.json"),
+            new FakeSourcePath("android/java/src/com/facebook/common/util/data.json")),
         SCRATCH_PATH.resolve("android/java/src/com/facebook/lib__resources__classes"),
         javaPackageFinder);
 

--- a/test/com/facebook/buck/jvm/java/DefaultJavaLibraryTest.java
+++ b/test/com/facebook/buck/jvm/java/DefaultJavaLibraryTest.java
@@ -47,13 +47,13 @@ import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildTargetSourcePath;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
 import com.facebook.buck.rules.FakeBuildableContext;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.ImmutableBuildContext;
 import com.facebook.buck.rules.RuleKey;
 import com.facebook.buck.rules.RuleKeyBuilderFactory;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.SourcePaths;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.keys.DefaultRuleKeyBuilderFactory;
 import com.facebook.buck.rules.keys.InputBasedRuleKeyBuilderFactory;
 import com.facebook.buck.shell.GenruleBuilder;
@@ -181,7 +181,7 @@ public class DefaultJavaLibraryTest {
     try {
       JavaLibraryBuilder
           .createBuilder(BuildTargetFactory.newInstance("//library:code"))
-          .addResource(new TestSourcePath("library"))
+          .addResource(new FakeSourcePath("library"))
           .build(new BuildRuleResolver(), filesystem);
       fail("An exception should have been thrown because a directory was passed as a resource.");
     } catch (HumanReadableException e) {
@@ -983,7 +983,7 @@ public class DefaultJavaLibraryTest {
         /* postprocessClassesCommands */ ImmutableList.<String>of(),
         exportedDeps,
         /* providedDeps */ ImmutableSortedSet.<BuildRule>of(),
-        /* abiJar */ new TestSourcePath("abi.jar"),
+        /* abiJar */ new FakeSourcePath("abi.jar"),
         /* additionalClasspathEntries */ ImmutableSet.<Path>of(),
         DEFAULT_JAVAC_OPTIONS,
         /* resourcesRoot */ Optional.<Path>absent(),
@@ -1072,10 +1072,10 @@ public class DefaultJavaLibraryTest {
         .addSrc(Paths.get("bdeafhkgcji.java"))
         .addSrc(Paths.get("bdehgaifjkc.java"))
         .addSrc(Paths.get("cfiabkjehgd.java"))
-        .addResource(new TestSourcePath("becgkaifhjd.txt"))
-        .addResource(new TestSourcePath("bkhajdifcge.txt"))
-        .addResource(new TestSourcePath("cabfghjekid.txt"))
-        .addResource(new TestSourcePath("chkdbafijge.txt"))
+        .addResource(new FakeSourcePath("becgkaifhjd.txt"))
+        .addResource(new FakeSourcePath("bkhajdifcge.txt"))
+        .addResource(new FakeSourcePath("cabfghjekid.txt"))
+        .addResource(new FakeSourcePath("chkdbafijge.txt"))
         .build(resolver1, filesystem);
 
     BuildRuleResolver resolver2 = new BuildRuleResolver();
@@ -1086,10 +1086,10 @@ public class DefaultJavaLibraryTest {
         .addSrc(Paths.get("bdehgaifjkc.java"))
         .addSrc(Paths.get("bdeafhkgcji.java"))
         .addSrc(Paths.get("agifhbkjdec.java"))
-        .addResource(new TestSourcePath("chkdbafijge.txt"))
-        .addResource(new TestSourcePath("cabfghjekid.txt"))
-        .addResource(new TestSourcePath("bkhajdifcge.txt"))
-        .addResource(new TestSourcePath("becgkaifhjd.txt"))
+        .addResource(new FakeSourcePath("chkdbafijge.txt"))
+        .addResource(new FakeSourcePath("cabfghjekid.txt"))
+        .addResource(new FakeSourcePath("bkhajdifcge.txt"))
+        .addResource(new FakeSourcePath("becgkaifhjd.txt"))
         .build(resolver2, filesystem);
 
     ImmutableMap.Builder<String, String> fileHashes = ImmutableMap.builder();
@@ -1383,13 +1383,13 @@ public class DefaultJavaLibraryTest {
       return new AndroidLibrary(
           buildRuleParams,
           new SourcePathResolver(new BuildRuleResolver()),
-          ImmutableSet.of(new TestSourcePath(src)),
+          ImmutableSet.of(new FakeSourcePath(src)),
           /* resources */ ImmutableSet.<SourcePath>of(),
           /* proguardConfig */ Optional.<SourcePath>absent(),
           /* postprocessClassesCommands */ ImmutableList.<String>of(),
           /* exportedDeps */ ImmutableSortedSet.<BuildRule>of(),
           /* providedDeps */ ImmutableSortedSet.<BuildRule>of(),
-          /* abiJar */ new TestSourcePath("abi.jar"),
+          /* abiJar */ new FakeSourcePath("abi.jar"),
           /* additionalClasspathEntries */ ImmutableSet.<Path>of(),
           options.build(),
           /* resourcesRoot */ Optional.<Path>absent(),

--- a/test/com/facebook/buck/jvm/java/JavaLibraryDescriptionTest.java
+++ b/test/com/facebook/buck/jvm/java/JavaLibraryDescriptionTest.java
@@ -37,11 +37,11 @@ import com.facebook.buck.rules.ConstructorArgMarshalException;
 import com.facebook.buck.rules.ConstructorArgMarshaller;
 import com.facebook.buck.rules.FakeBuildRule;
 import com.facebook.buck.rules.FakeExportDependenciesRule;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.NonCheckingBuildRuleFactoryParams;
 import com.facebook.buck.rules.PathSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
 import com.facebook.buck.util.HumanReadableException;
 import com.google.common.base.Optional;
@@ -185,7 +185,7 @@ public class JavaLibraryDescriptionTest {
   public void compilerArgWithPathReturnsExternalJavac() {
     Path externalJavac = Paths.get("/foo/bar/javac.exe");
     Either<BuiltInJavac, SourcePath> either =
-        Either.ofRight((SourcePath) new TestSourcePath(externalJavac.toString()));
+        Either.ofRight((SourcePath) new FakeSourcePath(externalJavac.toString()));
 
     arg.compiler = Optional.of(either);
     JavacOptions options = JavaLibraryDescription.getJavacOptions(
@@ -203,7 +203,7 @@ public class JavaLibraryDescriptionTest {
   @Test
   public void compilerArgTakesPrecedenceOverJavacPathArg() {
     Path externalJavac = Paths.get("/foo/bar/javac.exe");
-    SourcePath sourcePath = new TestSourcePath(externalJavac.toString());
+    SourcePath sourcePath = new FakeSourcePath(externalJavac.toString());
     Either<BuiltInJavac, SourcePath> either = Either.ofRight(sourcePath);
 
     arg.compiler = Optional.of(either);

--- a/test/com/facebook/buck/jvm/java/JavaSourceJarTest.java
+++ b/test/com/facebook/buck/jvm/java/JavaSourceJarTest.java
@@ -33,9 +33,9 @@ import com.facebook.buck.rules.BuildTargetSourcePath;
 import com.facebook.buck.rules.FakeBuildContext;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
 import com.facebook.buck.rules.FakeBuildableContext;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.fs.CopyStep;
 import com.google.common.base.Optional;
@@ -69,7 +69,7 @@ public class JavaSourceJarTest {
   @Test
   public void shouldOnlyIncludePathBasedSources() {
     SourcePathResolver pathResolver = new SourcePathResolver(new BuildRuleResolver());
-    SourcePath fileBased = new TestSourcePath("some/path/File.java");
+    SourcePath fileBased = new FakeSourcePath("some/path/File.java");
     SourcePath ruleBased = new BuildTargetSourcePath(
         BuildTargetFactory.newInstance("//cheese:cake"));
 

--- a/test/com/facebook/buck/jvm/java/JavacOptionsTest.java
+++ b/test/com/facebook/buck/jvm/java/JavacOptionsTest.java
@@ -24,9 +24,9 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.testutil.IdentityPathAbsolutifier;
 import com.facebook.buck.util.environment.Platform;
 import com.google.common.base.Functions;
@@ -218,7 +218,7 @@ public class JavacOptionsTest {
   @Test
   public void getInputs() {
     Path javacPath = Paths.get("javac");
-    TestSourcePath javacJarPath = new TestSourcePath("javac_jar");
+    FakeSourcePath javacJarPath = new FakeSourcePath("javac_jar");
 
     JavacOptions options = createStandardBuilder()
         .setJavacPath(javacPath)

--- a/test/com/facebook/buck/jvm/java/KeystoreTest.java
+++ b/test/com/facebook/buck/jvm/java/KeystoreTest.java
@@ -26,7 +26,7 @@ import com.facebook.buck.rules.BuildContext;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildableContext;
-import com.facebook.buck.rules.TestSourcePath;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.step.Step;
 import com.google.common.collect.ImmutableList;
 
@@ -41,8 +41,8 @@ public class KeystoreTest {
     BuildRuleResolver ruleResolver = new BuildRuleResolver();
     return (Keystore) KeystoreBuilder.createBuilder(
         BuildTargetFactory.newInstance("//keystores:debug"))
-        .setStore(new TestSourcePath("keystores/debug.keystore"))
-        .setProperties(new TestSourcePath("keystores/debug.keystore.properties"))
+        .setStore(new FakeSourcePath("keystores/debug.keystore"))
+        .setProperties(new FakeSourcePath("keystores/debug.keystore.properties"))
         .build(ruleResolver);
   }
 
@@ -51,8 +51,8 @@ public class KeystoreTest {
     Keystore keystore = createKeystoreRuleForTest();
     assertEquals("keystore", keystore.getType());
 
-    assertEquals(new TestSourcePath("keystores/debug.keystore"), keystore.getPathToStore());
-    assertEquals(new TestSourcePath("keystores/debug.keystore.properties"),
+    assertEquals(new FakeSourcePath("keystores/debug.keystore"), keystore.getPathToStore());
+    assertEquals(new FakeSourcePath("keystores/debug.keystore.properties"),
         keystore.getPathToPropertiesFile());
   }
 

--- a/test/com/facebook/buck/jvm/java/PrebuiltJarTest.java
+++ b/test/com/facebook/buck/jvm/java/PrebuiltJarTest.java
@@ -23,10 +23,10 @@ import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.PathSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
 import com.google.common.base.Optional;
 
@@ -62,9 +62,9 @@ public class PrebuiltJarTest {
     junitJarRule = new PrebuiltJar(
         buildRuleParams,
         new SourcePathResolver(new BuildRuleResolver()),
-        new TestSourcePath("abi.jar"),
+        new FakeSourcePath("abi.jar"),
         new PathSourcePath(filesystem, PATH_TO_JUNIT_JAR),
-        Optional.<SourcePath>of(new TestSourcePath("lib/junit-4.11-sources.jar")),
+        Optional.<SourcePath>of(new FakeSourcePath("lib/junit-4.11-sources.jar")),
         /* gwtJar */ Optional.<SourcePath>absent(),
         Optional.of("http://junit-team.github.io/junit/javadoc/latest/"),
         /* mavenCoords */ Optional.<String>absent());

--- a/test/com/facebook/buck/jvm/java/intellij/IjModuleFactoryTest.java
+++ b/test/com/facebook/buck/jvm/java/intellij/IjModuleFactoryTest.java
@@ -30,9 +30,9 @@ import com.facebook.buck.jvm.java.JavaLibraryBuilder;
 import com.facebook.buck.jvm.java.JavaTestBuilder;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargetFactory;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.TargetNode;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.coercer.SourceWithFlags;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
@@ -215,7 +215,7 @@ public class IjModuleFactoryTest {
 
     TargetNode<?> androidBinary = AndroidBinaryBuilder
         .createBuilder(BuildTargetFactory.newInstance("//java/com/example/test:test"))
-        .setManifest(new TestSourcePath("java/com/example/test/AndroidManifest.xml"))
+        .setManifest(new FakeSourcePath("java/com/example/test/AndroidManifest.xml"))
         .setOriginalDeps(ImmutableSortedSet.of(javaLibBase.getBuildTarget()))
         .build();
 
@@ -426,7 +426,7 @@ public class IjModuleFactoryTest {
     IjModuleFactory factory = createIjModuleFactory();
 
     String manifestName = "Manifest.xml";
-    SourcePath manifestPath = new TestSourcePath(manifestName);
+    SourcePath manifestPath = new FakeSourcePath(manifestName);
     TargetNode<?> androidBinary = AndroidBinaryBuilder
         .createBuilder(BuildTargetFactory.newInstance("//java/com/example:droid"))
         .setManifest(manifestPath)
@@ -453,7 +453,7 @@ public class IjModuleFactoryTest {
           @Override
           public Path getAndroidManifestPath(
               TargetNode<AndroidBinaryDescription.Arg> targetNode) {
-            return ((TestSourcePath) targetNode.getConstructorArg().manifest).getRelativePath();
+            return ((FakeSourcePath) targetNode.getConstructorArg().manifest).getRelativePath();
           }
 
           @Override
@@ -483,7 +483,7 @@ public class IjModuleFactoryTest {
     String sourceName = "cpp/lib/foo.cpp";
     TargetNode<?> cxxLibrary = new CxxLibraryBuilder(
         BuildTargetFactory.newInstance("//cpp/lib:foo"))
-        .setSrcs(ImmutableSortedSet.of(SourceWithFlags.of(new TestSourcePath(sourceName))))
+        .setSrcs(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath(sourceName))))
         .build();
 
     Path moduleBasePath = Paths.get("java/com/example/base");

--- a/test/com/facebook/buck/jvm/java/intellij/ProjectTest.java
+++ b/test/com/facebook/buck/jvm/java/intellij/ProjectTest.java
@@ -43,10 +43,10 @@ import com.facebook.buck.rules.ActionGraph;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildRule;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.ProjectConfig;
 import com.facebook.buck.rules.ProjectConfigBuilder;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.step.ExecutionContext;
 import com.facebook.buck.testutil.BuckTestConstant;
 import com.facebook.buck.testutil.RuleMap;
@@ -103,7 +103,7 @@ public class ProjectTest {
         AndroidResourceRuleBuilder.newBuilder()
             .setResolver(new SourcePathResolver(ruleResolver))
             .setBuildTarget(BuildTargetFactory.newInstance("//android_res/base:res"))
-            .setRes(new TestSourcePath("android_res/base/res"))
+            .setRes(new FakeSourcePath("android_res/base/res"))
             .setRDotJavaPackage("com.facebook")
             .build());
 
@@ -166,8 +166,8 @@ public class ProjectTest {
     // keystore //keystore:debug
     BuildTarget keystoreTarget = BuildTargetFactory.newInstance("//keystore:debug");
     BuildRule keystore = KeystoreBuilder.createBuilder(keystoreTarget)
-        .setStore(new TestSourcePath("keystore/debug.keystore"))
-        .setProperties(new TestSourcePath("keystore/debug.keystore.properties"))
+        .setStore(new FakeSourcePath("keystore/debug.keystore"))
+        .setProperties(new FakeSourcePath("keystore/debug.keystore.properties"))
         .build(ruleResolver);
 
     // android_binary //foo:app
@@ -176,7 +176,7 @@ public class ProjectTest {
     AndroidBinary androidBinaryRule = (AndroidBinary) AndroidBinaryBuilder.createBuilder(
         BuildTargetFactory.newInstance("//foo:app"))
             .setOriginalDeps(androidBinaryRuleDepsTarget)
-            .setManifest(new TestSourcePath("foo/AndroidManifest.xml"))
+            .setManifest(new FakeSourcePath("foo/AndroidManifest.xml"))
             .setKeystore(keystore.getBuildTarget())
             .setBuildTargetsToExcludeFromDex(
                 ImmutableSet.of(
@@ -195,7 +195,7 @@ public class ProjectTest {
     AndroidBinary barAppBuildRule = (AndroidBinary) AndroidBinaryBuilder.createBuilder(
         BuildTargetFactory.newInstance("//bar:app"))
             .setOriginalDeps(barAppBuildRuleDepsTarget)
-            .setManifest(new TestSourcePath("foo/AndroidManifest.xml"))
+            .setManifest(new FakeSourcePath("foo/AndroidManifest.xml"))
             .setKeystore(keystore.getBuildTarget())
             .build(ruleResolver);
 

--- a/test/com/facebook/buck/python/PythonBinaryDescriptionTest.java
+++ b/test/com/facebook/buck/python/PythonBinaryDescriptionTest.java
@@ -32,10 +32,10 @@ import com.facebook.buck.rules.BuildRules;
 import com.facebook.buck.rules.BuildTargetSourcePath;
 import com.facebook.buck.rules.FakeBuildContext;
 import com.facebook.buck.rules.FakeBuildableContext;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.HashedFileTool;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.Tool;
 import com.facebook.buck.rules.coercer.SourceList;
 import com.facebook.buck.shell.Genrule;
@@ -97,7 +97,7 @@ public class PythonBinaryDescriptionTest {
   public void baseModule() {
     BuildTarget target = BuildTargetFactory.newInstance("//foo:bin");
     String sourceName = "main.py";
-    SourcePath source = new TestSourcePath("foo/" + sourceName);
+    SourcePath source = new FakeSourcePath("foo/" + sourceName);
 
     // Run without a base module set and verify it defaults to using the build target
     // base name.

--- a/test/com/facebook/buck/python/PythonLibraryDescriptionTest.java
+++ b/test/com/facebook/buck/python/PythonLibraryDescriptionTest.java
@@ -22,8 +22,8 @@ import static org.junit.Assert.assertThat;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.coercer.PatternMatchedCollection;
 import com.facebook.buck.rules.coercer.SourceList;
 import com.google.common.collect.ImmutableMap;
@@ -41,7 +41,7 @@ public class PythonLibraryDescriptionTest {
   public void baseModule() {
     BuildTarget target = BuildTargetFactory.newInstance("//foo:lib");
     String sourceName = "main.py";
-    SourcePath source = new TestSourcePath("foo/" + sourceName);
+    SourcePath source = new FakeSourcePath("foo/" + sourceName);
 
     // Run without a base module set and verify it defaults to using the build target
     // base name.
@@ -72,8 +72,8 @@ public class PythonLibraryDescriptionTest {
   @Test
   public void platformSrcs() {
     BuildTarget target = BuildTargetFactory.newInstance("//foo:lib");
-    SourcePath matchedSource = new TestSourcePath("foo/a.py");
-    SourcePath unmatchedSource = new TestSourcePath("foo/b.py");
+    SourcePath matchedSource = new FakeSourcePath("foo/a.py");
+    SourcePath unmatchedSource = new FakeSourcePath("foo/b.py");
     PythonLibrary library =
         (PythonLibrary) new PythonLibraryBuilder(target)
             .setPlatformSrcs(
@@ -94,8 +94,8 @@ public class PythonLibraryDescriptionTest {
   @Test
   public void platformResources() {
     BuildTarget target = BuildTargetFactory.newInstance("//foo:lib");
-    SourcePath matchedSource = new TestSourcePath("foo/a.dat");
-    SourcePath unmatchedSource = new TestSourcePath("foo/b.dat");
+    SourcePath matchedSource = new FakeSourcePath("foo/a.dat");
+    SourcePath unmatchedSource = new FakeSourcePath("foo/b.dat");
     PythonLibrary library =
         (PythonLibrary) new PythonLibraryBuilder(target)
             .setPlatformResources(

--- a/test/com/facebook/buck/python/PythonLibraryTest.java
+++ b/test/com/facebook/buck/python/PythonLibraryTest.java
@@ -22,9 +22,9 @@ import static org.junit.Assert.assertTrue;
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.google.common.base.Functions;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
@@ -46,7 +46,7 @@ public class PythonLibraryTest {
   @Test
   public void testGetters() {
     ImmutableMap<Path, SourcePath> srcs = ImmutableMap.<Path, SourcePath>of(
-        Paths.get("dummy"), new TestSourcePath(""));
+        Paths.get("dummy"), new FakeSourcePath(""));
     PythonLibrary pythonLibrary = new PythonLibrary(
         new FakeBuildRuleParamsBuilder(
             BuildTargetFactory.newInstance("//scripts/python:foo"))

--- a/test/com/facebook/buck/python/PythonPackageableComponentsTest.java
+++ b/test/com/facebook/buck/python/PythonPackageableComponentsTest.java
@@ -22,8 +22,8 @@ import static org.junit.Assert.fail;
 
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargetFactory;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.util.HumanReadableException;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
@@ -39,13 +39,13 @@ public class PythonPackageableComponentsTest {
   @Test
   public void testMergeZipSafe() {
     PythonPackageComponents compA = PythonPackageComponents.of(
-        ImmutableMap.<Path, SourcePath>of(Paths.get("test"), new TestSourcePath("sourceA")),
+        ImmutableMap.<Path, SourcePath>of(Paths.get("test"), new FakeSourcePath("sourceA")),
         ImmutableMap.<Path, SourcePath>of(),
         ImmutableMap.<Path, SourcePath>of(),
         ImmutableSet.<SourcePath>of(),
         Optional.of(true));
     PythonPackageComponents compB = PythonPackageComponents.of(
-        ImmutableMap.<Path, SourcePath>of(Paths.get("test2"), new TestSourcePath("sourceB")),
+        ImmutableMap.<Path, SourcePath>of(Paths.get("test2"), new FakeSourcePath("sourceB")),
         ImmutableMap.<Path, SourcePath>of(),
         ImmutableMap.<Path, SourcePath>of(),
         ImmutableSet.<SourcePath>of(),
@@ -65,9 +65,9 @@ public class PythonPackageableComponentsTest {
     BuildTarget them = BuildTargetFactory.newInstance("//:them");
     PythonPackageComponents.Builder builder = new PythonPackageComponents.Builder(me);
     Path dest = Paths.get("test");
-    builder.addModule(dest, new TestSourcePath("sourceA"), them);
+    builder.addModule(dest, new FakeSourcePath("sourceA"), them);
     try {
-      builder.addModule(dest, new TestSourcePath("sourceB"), them);
+      builder.addModule(dest, new FakeSourcePath("sourceB"), them);
       fail("expected to throw");
     } catch (HumanReadableException e) {
       assertTrue(e.getMessage().contains("duplicate entries"));
@@ -80,13 +80,13 @@ public class PythonPackageableComponentsTest {
     BuildTarget them = BuildTargetFactory.newInstance("//:them");
     Path dest = Paths.get("test");
     PythonPackageComponents compA = PythonPackageComponents.of(
-        ImmutableMap.<Path, SourcePath>of(dest, new TestSourcePath("sourceA")),
+        ImmutableMap.<Path, SourcePath>of(dest, new FakeSourcePath("sourceA")),
         ImmutableMap.<Path, SourcePath>of(),
         ImmutableMap.<Path, SourcePath>of(),
         ImmutableSet.<SourcePath>of(),
         Optional.<Boolean>absent());
     PythonPackageComponents compB = PythonPackageComponents.of(
-        ImmutableMap.<Path, SourcePath>of(dest, new TestSourcePath("sourceB")),
+        ImmutableMap.<Path, SourcePath>of(dest, new FakeSourcePath("sourceB")),
         ImmutableMap.<Path, SourcePath>of(),
         ImmutableMap.<Path, SourcePath>of(),
         ImmutableSet.<SourcePath>of(),

--- a/test/com/facebook/buck/python/PythonTestDescriptionTest.java
+++ b/test/com/facebook/buck/python/PythonTestDescriptionTest.java
@@ -28,8 +28,8 @@ import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildRules;
 import com.facebook.buck.rules.FakeBuildContext;
 import com.facebook.buck.rules.FakeBuildableContext;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.coercer.PatternMatchedCollection;
 import com.facebook.buck.rules.coercer.SourceList;
 import com.facebook.buck.step.Step;
@@ -54,7 +54,7 @@ public class PythonTestDescriptionTest {
         (PythonTest) PythonTestBuilder.create(BuildTargetFactory.newInstance("//:bin"))
             .setSrcs(
                 SourceList.ofUnnamedSources(
-                    ImmutableSortedSet.<SourcePath>of(new TestSourcePath("blah.py"))))
+                    ImmutableSortedSet.<SourcePath>of(new FakeSourcePath("blah.py"))))
             .build(resolver);
     PythonBinary binRule = testRule.getBinary();
     PythonPackageComponents components = binRule.getComponents();
@@ -76,7 +76,7 @@ public class PythonTestDescriptionTest {
   public void baseModule() {
     BuildTarget target = BuildTargetFactory.newInstance("//foo:test");
     String sourceName = "main.py";
-    SourcePath source = new TestSourcePath("foo/" + sourceName);
+    SourcePath source = new FakeSourcePath("foo/" + sourceName);
 
     // Run without a base module set and verify it defaults to using the build target
     // base name.
@@ -123,8 +123,8 @@ public class PythonTestDescriptionTest {
   @Test
   public void platformSrcs() {
     BuildTarget target = BuildTargetFactory.newInstance("//foo:test");
-    SourcePath matchedSource = new TestSourcePath("foo/a.py");
-    SourcePath unmatchedSource = new TestSourcePath("foo/b.py");
+    SourcePath matchedSource = new FakeSourcePath("foo/a.py");
+    SourcePath unmatchedSource = new FakeSourcePath("foo/b.py");
     PythonTest test =
         (PythonTest) PythonTestBuilder.create(target)
             .setPlatformSrcs(
@@ -147,8 +147,8 @@ public class PythonTestDescriptionTest {
   @Test
   public void platformResources() {
     BuildTarget target = BuildTargetFactory.newInstance("//foo:test");
-    SourcePath matchedSource = new TestSourcePath("foo/a.dat");
-    SourcePath unmatchedSource = new TestSourcePath("foo/b.dat");
+    SourcePath matchedSource = new FakeSourcePath("foo/a.dat");
+    SourcePath unmatchedSource = new FakeSourcePath("foo/b.dat");
     PythonTest test =
         (PythonTest) PythonTestBuilder.create(target)
             .setPlatformResources(

--- a/test/com/facebook/buck/python/PythonUtilTest.java
+++ b/test/com/facebook/buck/python/PythonUtilTest.java
@@ -21,9 +21,9 @@ import static org.junit.Assert.assertEquals;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.coercer.SourceList;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -46,11 +46,11 @@ public class PythonUtilTest {
         ImmutableList.of(
             SourceList.ofNamedSources(
                 ImmutableSortedMap.<String, SourcePath>of(
-                    "hello.py", new TestSourcePath("goodbye.py")))));
+                    "hello.py", new FakeSourcePath("goodbye.py")))));
     assertEquals(
         ImmutableMap.<Path, SourcePath>of(
             target.getBasePath().resolve("hello.py"),
-            new TestSourcePath("goodbye.py")),
+            new FakeSourcePath("goodbye.py")),
         srcs);
   }
 

--- a/test/com/facebook/buck/rules/BUCK
+++ b/test/com/facebook/buck/rules/BUCK
@@ -11,12 +11,12 @@ java_library(
     'FakeBuildRuleParamsBuilder.java',
     'FakeExportDependenciesRule.java',
     'FakeOnDiskBuildInfo.java',
+    'FakeSourcePath.java',
     'FakeTestRule.java',
     'NonCheckingBuildRuleFactoryParams.java',
     'ProjectConfigBuilder.java',
     'RetainOrderComparator.java',
     'TestCellBuilder.java',
-    'TestSourcePath.java',
   ],
   deps = [
     '//src/com/facebook/buck/apple:rules',

--- a/test/com/facebook/buck/rules/CommandToolTest.java
+++ b/test/com/facebook/buck/rules/CommandToolTest.java
@@ -136,7 +136,7 @@ public class CommandToolTest {
   public void environment() {
     BuildRuleResolver resolver = new BuildRuleResolver();
     SourcePathResolver pathResolver = new SourcePathResolver(resolver);
-    SourcePath path = new TestSourcePath("input");
+    SourcePath path = new FakeSourcePath("input");
     CommandTool tool =
         new CommandTool.Builder()
             .addArg("runit")
@@ -152,7 +152,7 @@ public class CommandToolTest {
   public void sourcePathsContributeToRuleKeys() {
     BuildRuleResolver resolver = new BuildRuleResolver();
     SourcePathResolver pathResolver = new SourcePathResolver(resolver);
-    SourcePath path = new TestSourcePath("input");
+    SourcePath path = new FakeSourcePath("input");
     CommandTool tool =
         new CommandTool.Builder()
             .addArg("exec %s", path)

--- a/test/com/facebook/buck/rules/FakeSourcePath.java
+++ b/test/com/facebook/buck/rules/FakeSourcePath.java
@@ -19,13 +19,13 @@ package com.facebook.buck.rules;
 import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
 
-public class TestSourcePath extends PathSourcePath {
+public class FakeSourcePath extends PathSourcePath {
 
-  public TestSourcePath(String path) {
+  public FakeSourcePath(String path) {
     this(new FakeProjectFilesystem(), path);
   }
 
-  public TestSourcePath(ProjectFilesystem filesystem, String path) {
+  public FakeSourcePath(ProjectFilesystem filesystem, String path) {
     super(filesystem, filesystem.getRootPath().getFileSystem().getPath(path));
   }
 }

--- a/test/com/facebook/buck/rules/RuleKeyTest.java
+++ b/test/com/facebook/buck/rules/RuleKeyTest.java
@@ -498,7 +498,7 @@ public class RuleKeyTest {
     RuleKey nullRuleKey = new NoopSetterRuleKeyBuilder(pathResolver, hashCache)
         .build();
     RuleKey noopRuleKey = new NoopSetterRuleKeyBuilder(pathResolver, hashCache)
-        .setReflectively("key", new TestSourcePath("value"))
+        .setReflectively("key", new FakeSourcePath("value"))
         .build();
 
     assertThat(noopRuleKey, is(equalTo(nullRuleKey)));

--- a/test/com/facebook/buck/rules/SourcePathResolverTest.java
+++ b/test/com/facebook/buck/rules/SourcePathResolverTest.java
@@ -177,8 +177,8 @@ public class SourcePathResolverTest {
     resolver.addToIndex(rule);
 
     Iterable<? extends SourcePath> sourcePaths = ImmutableList.of(
-        new TestSourcePath("java/com/facebook/Main.java"),
-        new TestSourcePath("java/com/facebook/BuckConfig.java"),
+        new FakeSourcePath("java/com/facebook/Main.java"),
+        new FakeSourcePath("java/com/facebook/BuckConfig.java"),
         new BuildTargetSourcePath(rule.getBuildTarget()));
     Iterable<Path> inputs = pathResolver.filterInputsToCompareToOutput(sourcePaths);
     MoreAsserts.assertIterablesEquals(
@@ -203,9 +203,9 @@ public class SourcePathResolverTest {
     resolver.addToIndex(rule2);
 
     Iterable<? extends SourcePath> sourcePaths = ImmutableList.of(
-        new TestSourcePath("java/com/facebook/Main.java"),
+        new FakeSourcePath("java/com/facebook/Main.java"),
         new BuildTargetSourcePath(rule.getBuildTarget()),
-        new TestSourcePath("java/com/facebook/BuckConfig.java"),
+        new FakeSourcePath("java/com/facebook/BuckConfig.java"),
         new BuildTargetSourcePath(rule2.getBuildTarget()));
     Iterable<BuildRule> inputs = pathResolver.filterBuildRuleInputs(sourcePaths);
     MoreAsserts.assertIterablesEquals(

--- a/test/com/facebook/buck/rules/args/SourcePathArgTest.java
+++ b/test/com/facebook/buck/rules/args/SourcePathArgTest.java
@@ -22,9 +22,9 @@ import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildTargetSourcePath;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.shell.Genrule;
 import com.facebook.buck.shell.GenruleBuilder;
 
@@ -35,7 +35,7 @@ public class SourcePathArgTest {
 
   @Test
   public void stringify() {
-    SourcePath path = new TestSourcePath("something");
+    SourcePath path = new FakeSourcePath("something");
     SourcePathArg arg = new SourcePathArg(new SourcePathResolver(new BuildRuleResolver()), path);
     assertThat(arg.stringify(), Matchers.equalTo("something"));
   }

--- a/test/com/facebook/buck/rules/coercer/TypeCoercerTest.java
+++ b/test/com/facebook/buck/rules/coercer/TypeCoercerTest.java
@@ -28,9 +28,9 @@ import static org.junit.Assert.fail;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.Either;
 import com.facebook.buck.model.Pair;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.Label;
 import com.facebook.buck.rules.SourcePath;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
 import com.facebook.buck.util.HumanReadableException;
 import com.google.common.base.Function;
@@ -388,8 +388,8 @@ public class TypeCoercerTest {
     ImmutableList<String> input = ImmutableList.of("foo.m", "bar.m");
     Object result = coercer.coerce(cellRoots, filesystem, Paths.get(""), input);
     ImmutableList<SourceWithFlags> expectedResult = ImmutableList.of(
-        SourceWithFlags.of(new TestSourcePath("foo.m")),
-        SourceWithFlags.of(new TestSourcePath("bar.m")));
+        SourceWithFlags.of(new FakeSourcePath("foo.m")),
+        SourceWithFlags.of(new FakeSourcePath("bar.m")));
     assertEquals(expectedResult, result);
   }
 
@@ -405,9 +405,9 @@ public class TypeCoercerTest {
     Object result = coercer.coerce(cellRoots, filesystem, Paths.get(""), input);
     ImmutableList<SourceWithFlags> expectedResult = ImmutableList.of(
         SourceWithFlags.of(
-            new TestSourcePath("foo.m"), ImmutableList.of("-Wall", "-Werror")),
+            new FakeSourcePath("foo.m"), ImmutableList.of("-Wall", "-Werror")),
         SourceWithFlags.of(
-            new TestSourcePath("bar.m"), ImmutableList.of("-fobjc-arc")));
+            new FakeSourcePath("bar.m"), ImmutableList.of("-fobjc-arc")));
     assertEquals(expectedResult, result);
   }
 
@@ -424,12 +424,12 @@ public class TypeCoercerTest {
         ImmutableList.of("Group2/blech.m", ImmutableList.of("-fobjc-arc")));
     Object result = coercer.coerce(cellRoots, filesystem, Paths.get(""), input);
     ImmutableList<SourceWithFlags> expectedResult = ImmutableList.of(
-        SourceWithFlags.of(new TestSourcePath("Group1/foo.m")),
+        SourceWithFlags.of(new FakeSourcePath("Group1/foo.m")),
         SourceWithFlags.of(
-            new TestSourcePath("Group1/bar.m"), ImmutableList.of("-Wall", "-Werror")),
-        SourceWithFlags.of(new TestSourcePath("Group2/baz.m")),
+            new FakeSourcePath("Group1/bar.m"), ImmutableList.of("-Wall", "-Werror")),
+        SourceWithFlags.of(new FakeSourcePath("Group2/baz.m")),
         SourceWithFlags.of(
-            new TestSourcePath("Group2/blech.m"), ImmutableList.of("-fobjc-arc")));
+            new FakeSourcePath("Group2/blech.m"), ImmutableList.of("-fobjc-arc")));
     assertEquals(expectedResult, result);
   }
 

--- a/test/com/facebook/buck/rules/macros/ClasspathMacroExpanderTest.java
+++ b/test/com/facebook/buck/rules/macros/ClasspathMacroExpanderTest.java
@@ -27,8 +27,8 @@ import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildTargetSourcePath;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.shell.ExportFileBuilder;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
 import com.google.common.collect.ImmutableList;
@@ -103,7 +103,7 @@ public class ClasspathMacroExpanderTest {
     SourcePathResolver pathResolver = new SourcePathResolver(ruleResolver);
     BuildRule rule =
         ExportFileBuilder.newExportFileBuilder(BuildTargetFactory.newInstance("//cheese:peas"))
-          .setSrc(new TestSourcePath("some-file.jar"))
+          .setSrc(new FakeSourcePath("some-file.jar"))
           .build(ruleResolver);
 
     expander.expand(pathResolver, filesystem, rule);

--- a/test/com/facebook/buck/rust/RustLinkableTest.java
+++ b/test/com/facebook/buck/rust/RustLinkableTest.java
@@ -22,10 +22,10 @@ import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.RuleKeyBuilder;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.Tool;
 import com.facebook.buck.util.HumanReadableException;
 import com.google.common.collect.ImmutableCollection;
@@ -50,7 +50,7 @@ public class RustLinkableTest {
   public void crateRootMainInSrcs() {
     RustLinkable linkable = new FakeRustLinkable(
         "//:donotcare",
-        ImmutableSet.<SourcePath>of(new TestSourcePath("main.rs")));
+        ImmutableSet.<SourcePath>of(new FakeSourcePath("main.rs")));
     assertThat(linkable.getCrateRoot().toString(), Matchers.endsWith("main.rs"));
   }
 
@@ -58,7 +58,7 @@ public class RustLinkableTest {
   public void crateRootTargetNameInSrcs() {
     RustLinkable linkable = new FakeRustLinkable(
         "//:myname",
-        ImmutableSet.<SourcePath>of(new TestSourcePath("myname.rs")));
+        ImmutableSet.<SourcePath>of(new FakeSourcePath("myname.rs")));
     assertThat(linkable.getCrateRoot().toString(), Matchers.endsWith("myname.rs"));
   }
 
@@ -67,8 +67,8 @@ public class RustLinkableTest {
     RustLinkable linkable = new FakeRustLinkable(
         "//:myname",
         ImmutableSet.<SourcePath>of(
-            new TestSourcePath("main.rs"),
-            new TestSourcePath("myname.rs")));
+            new FakeSourcePath("main.rs"),
+            new FakeSourcePath("myname.rs")));
     linkable.getCrateRoot();
   }
 

--- a/test/com/facebook/buck/shell/ExportFileTest.java
+++ b/test/com/facebook/buck/shell/ExportFileTest.java
@@ -35,12 +35,12 @@ import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildTargetSourcePath;
 import com.facebook.buck.rules.FakeBuildRule;
 import com.facebook.buck.rules.FakeBuildableContext;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.ImmutableBuildContext;
 import com.facebook.buck.rules.PathSourcePath;
 import com.facebook.buck.rules.RuleKey;
 import com.facebook.buck.rules.RuleKeyBuilderFactory;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.keys.DefaultRuleKeyBuilderFactory;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.StepFailedException;
@@ -141,7 +141,7 @@ public class ExportFileTest {
   @Test
   public void shouldSetInputsFromSourcePaths() {
     ExportFileBuilder builder = ExportFileBuilder.newExportFileBuilder(target)
-        .setSrc(new TestSourcePath("chips"))
+        .setSrc(new FakeSourcePath("chips"))
         .setOut("cake");
 
     ExportFile exportFile = (ExportFile) builder

--- a/test/com/facebook/buck/shell/ShBinaryDescriptionTest.java
+++ b/test/com/facebook/buck/shell/ShBinaryDescriptionTest.java
@@ -20,8 +20,8 @@ import static org.junit.Assert.assertThat;
 
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
-import com.facebook.buck.rules.TestSourcePath;
 import com.google.common.collect.ImmutableSet;
 
 import org.hamcrest.Matchers;
@@ -32,7 +32,7 @@ public class ShBinaryDescriptionTest {
   @Test
   public void mainIsIncludedInCommand() {
     BuildRuleResolver resolver = new BuildRuleResolver();
-    TestSourcePath main = new TestSourcePath("main.sh");
+    FakeSourcePath main = new FakeSourcePath("main.sh");
     ShBinary shBinary =
         (ShBinary) new ShBinaryBuilder(BuildTargetFactory.newInstance("//:rule"))
             .setMain(main)
@@ -45,8 +45,8 @@ public class ShBinaryDescriptionTest {
   @Test
   public void resourcesAreIncludedInCommand() {
     BuildRuleResolver resolver = new BuildRuleResolver();
-    TestSourcePath main = new TestSourcePath("main.sh");
-    TestSourcePath resource = new TestSourcePath("resource.dat");
+    FakeSourcePath main = new FakeSourcePath("main.sh");
+    FakeSourcePath resource = new FakeSourcePath("resource.dat");
     ShBinary shBinary =
         (ShBinary) new ShBinaryBuilder(BuildTargetFactory.newInstance("//:rule"))
             .setMain(main)

--- a/test/com/facebook/buck/shell/ShTestDescriptionTest.java
+++ b/test/com/facebook/buck/shell/ShTestDescriptionTest.java
@@ -22,8 +22,8 @@ import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildTargetSourcePath;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.args.Arg;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
@@ -43,7 +43,7 @@ public class ShTestDescriptionTest {
             .build(resolver);
     ShTest shTest =
         (ShTest) new ShTestBuilder(BuildTargetFactory.newInstance("//:rule"))
-            .setTest(new TestSourcePath("test.sh"))
+            .setTest(new FakeSourcePath("test.sh"))
             .setArgs(ImmutableList.of("$(location //:dep)"))
             .build(resolver);
     assertThat(

--- a/test/com/facebook/buck/shell/ShTestTest.java
+++ b/test/com/facebook/buck/shell/ShTestTest.java
@@ -26,9 +26,9 @@ import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildRule;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.Label;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.args.Arg;
 import com.facebook.buck.step.ExecutionContext;
 import com.google.common.collect.ImmutableList;
@@ -58,7 +58,7 @@ public class ShTestTest extends EasyMockSupport {
             .setProjectFilesystem(filesystem)
             .build(),
         new SourcePathResolver(new BuildRuleResolver()),
-        new TestSourcePath("run_test.sh"),
+        new FakeSourcePath("run_test.sh"),
         /* args */ ImmutableList.<Arg>of(),
         /* labels */ ImmutableSet.<Label>of());
 
@@ -87,7 +87,7 @@ public class ShTestTest extends EasyMockSupport {
             .setExtraDeps(ImmutableSortedSet.of(extraDep))
             .build(),
         new SourcePathResolver(new BuildRuleResolver()),
-        new TestSourcePath("run_test.sh"),
+        new FakeSourcePath("run_test.sh"),
         /* args */ ImmutableList.<Arg>of(),
         /* labels */ ImmutableSet.<Label>of());
 

--- a/test/com/facebook/buck/thrift/ThriftBuckConfigTest.java
+++ b/test/com/facebook/buck/thrift/ThriftBuckConfigTest.java
@@ -26,9 +26,9 @@ import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.HashedFileTool;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.Tool;
 import com.facebook.buck.shell.ShBinary;
 import com.facebook.buck.shell.ShBinaryBuilder;
@@ -97,7 +97,7 @@ public class ThriftBuckConfigTest {
     BuildRuleResolver resolver = new BuildRuleResolver();
     ShBinary thriftRule =
         (ShBinary) new ShBinaryBuilder(BuildTargetFactory.newInstance("//thrift:target"))
-            .setMain(new TestSourcePath("thrift.sh"))
+            .setMain(new FakeSourcePath("thrift.sh"))
             .build(resolver);
 
     // Add the thrift rule to the resolver.

--- a/test/com/facebook/buck/thrift/ThriftCompilerTest.java
+++ b/test/com/facebook/buck/thrift/ThriftCompilerTest.java
@@ -27,11 +27,11 @@ import com.facebook.buck.rules.CommandTool;
 import com.facebook.buck.rules.FakeBuildContext;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
 import com.facebook.buck.rules.FakeBuildableContext;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.RuleKey;
 import com.facebook.buck.rules.RuleKeyBuilderFactory;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.Tool;
 import com.facebook.buck.rules.keys.DefaultRuleKeyBuilderFactory;
 import com.facebook.buck.step.Step;
@@ -51,10 +51,10 @@ import java.nio.file.Paths;
 public class ThriftCompilerTest {
 
   private static final Tool DEFAULT_COMPILER =
-      new CommandTool.Builder().addArg(new TestSourcePath("thrift")).build();
+      new CommandTool.Builder().addArg(new FakeSourcePath("thrift")).build();
   private static final ImmutableList<String> DEFAULT_FLAGS = ImmutableList.of("--allow-64-bits");
   private static final Path DEFAULT_OUTPUT_DIR = Paths.get("output-dir");
-  private static final SourcePath DEFAULT_INPUT = new TestSourcePath("test.thrift");
+  private static final SourcePath DEFAULT_INPUT = new FakeSourcePath("test.thrift");
   private static final String DEFAULT_LANGUAGE = "cpp";
   private static final ImmutableSet<String> DEFAULT_OPTIONS = ImmutableSet.of("templates");
   private static final ImmutableList<Path> DEFAULT_INCLUDE_ROOTS =
@@ -64,7 +64,7 @@ public class ThriftCompilerTest {
   private static final ImmutableMap<Path, SourcePath> DEFAULT_INCLUDES =
       ImmutableMap.<Path, SourcePath>of(
           Paths.get("something.thrift"),
-          new TestSourcePath("blah/something.thrift"));
+          new FakeSourcePath("blah/something.thrift"));
   private static final ImmutableSortedSet<String> DEFAULT_GENERATED_SOURCES =
       ImmutableSortedSet.of("source1", "source2");
 
@@ -107,7 +107,7 @@ public class ThriftCompilerTest {
         new ThriftCompiler(
             params,
             resolver,
-            new CommandTool.Builder().addArg(new TestSourcePath("different")).build(),
+            new CommandTool.Builder().addArg(new FakeSourcePath("different")).build(),
             DEFAULT_FLAGS,
             DEFAULT_OUTPUT_DIR,
             DEFAULT_INPUT,
@@ -164,7 +164,7 @@ public class ThriftCompilerTest {
             DEFAULT_COMPILER,
             DEFAULT_FLAGS,
             DEFAULT_OUTPUT_DIR,
-            new TestSourcePath("different"),
+            new FakeSourcePath("different"),
             DEFAULT_LANGUAGE,
             DEFAULT_OPTIONS,
             DEFAULT_INCLUDE_ROOTS,
@@ -263,7 +263,7 @@ public class ThriftCompilerTest {
             DEFAULT_HEADER_MAPS,
             ImmutableMap.<Path, SourcePath>of(
                 DEFAULT_INCLUDES.entrySet().iterator().next().getKey(),
-                new TestSourcePath("different")),
+                new FakeSourcePath("different")),
             DEFAULT_GENERATED_SOURCES));
     assertNotEquals(defaultRuleKey, includesKeyChange);
 

--- a/test/com/facebook/buck/thrift/ThriftCxxEnhancerTest.java
+++ b/test/com/facebook/buck/thrift/ThriftCxxEnhancerTest.java
@@ -37,10 +37,10 @@ import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.CommandTool;
 import com.facebook.buck.rules.FakeBuildRule;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.TargetGraph;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.rules.coercer.SourceList;
 import com.facebook.buck.rules.coercer.SourceWithFlags;
 import com.facebook.buck.rules.coercer.SourceWithFlagsList;
@@ -105,11 +105,11 @@ public class ThriftCxxEnhancerTest {
         new FakeBuildRuleParamsBuilder(BuildTargetFactory.newInstance(target)).build(),
         resolver,
         new CommandTool.Builder()
-            .addArg(new TestSourcePath("compiler"))
+            .addArg(new FakeSourcePath("compiler"))
             .build(),
         ImmutableList.<String>of(),
         Paths.get("output"),
-        new TestSourcePath("source"),
+        new FakeSourcePath("source"),
         "language",
         ImmutableSet.<String>of(),
         ImmutableList.<Path>of(),
@@ -571,10 +571,10 @@ public class ThriftCxxEnhancerTest {
     final String cppHeaderNamespace = "foo";
     final ImmutableSortedMap<String, SourcePath> cppHeaders =
         ImmutableSortedMap.<String, SourcePath>of(
-            "header.h", new TestSourcePath("header.h"));
+            "header.h", new FakeSourcePath("header.h"));
     final ImmutableSortedMap<String, SourceWithFlags> cppSrcs =
         ImmutableSortedMap.of(
-            "source.cpp", SourceWithFlags.of(new TestSourcePath("source.cpp")));
+            "source.cpp", SourceWithFlags.of(new FakeSourcePath("source.cpp")));
 
     ThriftConstructorArg arg = new ThriftConstructorArg();
     arg.cppOptions = Optional.absent();

--- a/test/com/facebook/buck/thrift/ThriftJavaEnhancerTest.java
+++ b/test/com/facebook/buck/thrift/ThriftJavaEnhancerTest.java
@@ -35,10 +35,10 @@ import com.facebook.buck.rules.CommandTool;
 import com.facebook.buck.rules.FakeBuildRule;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
 import com.facebook.buck.rules.FakeExportDependenciesRule;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.TargetGraph;
-import com.facebook.buck.rules.TestSourcePath;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -83,11 +83,11 @@ public class ThriftJavaEnhancerTest {
         new FakeBuildRuleParamsBuilder(BuildTargetFactory.newInstance(target)).build(),
         resolver,
         new CommandTool.Builder()
-            .addArg(new TestSourcePath("compiler"))
+            .addArg(new FakeSourcePath("compiler"))
             .build(),
         ImmutableList.<String>of(),
         Paths.get("output"),
-        new TestSourcePath("source"),
+        new FakeSourcePath("source"),
         "language",
         ImmutableSet.<String>of(),
         ImmutableList.<Path>of(),

--- a/test/com/facebook/buck/thrift/ThriftLibraryDescriptionTest.java
+++ b/test/com/facebook/buck/thrift/ThriftLibraryDescriptionTest.java
@@ -36,11 +36,11 @@ import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildTargetSourcePath;
 import com.facebook.buck.rules.FakeBuildRule;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.SymlinkTree;
 import com.facebook.buck.rules.TargetGraph;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.shell.Genrule;
 import com.facebook.buck.shell.GenruleBuilder;
 import com.facebook.buck.shell.ShBinary;
@@ -223,7 +223,7 @@ public class ThriftLibraryDescriptionTest {
 
     // Setup a simple thrift source.
     String sourceName = "test.thrift";
-    SourcePath sourcePath = new TestSourcePath(sourceName);
+    SourcePath sourcePath = new FakeSourcePath(sourceName);
 
     // Generate these rules using no deps.
     ImmutableMap<String, ThriftCompiler> rules =
@@ -311,7 +311,7 @@ public class ThriftLibraryDescriptionTest {
     // Create a build rule that represents the thrift rule.
     ShBinary thriftRule =
         (ShBinary) new ShBinaryBuilder(BuildTargetFactory.newInstance("//thrift:target"))
-            .setMain(new TestSourcePath("thrift.sh"))
+            .setMain(new FakeSourcePath("thrift.sh"))
             .build(resolver);
     filesystem.mkdirs(thriftRule.getBuildTarget().getBasePath());
     filesystem.touch(thriftRule.getBuildTarget().getBasePath().resolve("BUCK"));
@@ -367,7 +367,7 @@ public class ThriftLibraryDescriptionTest {
 
     // Setup the thrift source.
     String sourceName = "test.thrift";
-    SourcePath source = new TestSourcePath(sourceName);
+    SourcePath source = new FakeSourcePath(sourceName);
 
     // Create a dep and verify it gets attached.
     BuildTarget depTarget = BuildTargetFactory.newInstance("//:dep");
@@ -443,13 +443,13 @@ public class ThriftLibraryDescriptionTest {
 
     // Setup a normal thrift source file.
     final String thriftSourceName2 = "bar.thrift";
-    SourcePath thriftSource2 = new TestSourcePath(thriftSourceName2);
+    SourcePath thriftSource2 = new FakeSourcePath(thriftSourceName2);
     final ImmutableList<String> thriftServices2 = ImmutableList.of();
 
     // Create a build rule that represents the thrift rule.
     final ShBinary thriftRule =
         (ShBinary) new ShBinaryBuilder(BuildTargetFactory.newInstance("//thrift:target"))
-            .setMain(new TestSourcePath("thrift.sh"))
+            .setMain(new FakeSourcePath("thrift.sh"))
             .build(resolver);
     resolver.addToIndex(thriftRule);
     filesystem.mkdirs(thriftRule.getBuildTarget().getBasePath());

--- a/test/com/facebook/buck/thrift/ThriftPythonEnhancerTest.java
+++ b/test/com/facebook/buck/thrift/ThriftPythonEnhancerTest.java
@@ -32,10 +32,10 @@ import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.CommandTool;
 import com.facebook.buck.rules.FakeBuildRule;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.TargetGraph;
-import com.facebook.buck.rules.TestSourcePath;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -83,11 +83,11 @@ public class ThriftPythonEnhancerTest {
         new FakeBuildRuleParamsBuilder(BuildTargetFactory.newInstance(target)).build(),
         resolver,
         new CommandTool.Builder()
-            .addArg(new TestSourcePath("compiler"))
+            .addArg(new FakeSourcePath("compiler"))
             .build(),
         ImmutableList.<String>of(),
         Paths.get("output"),
-        new TestSourcePath("source"),
+        new FakeSourcePath("source"),
         "language",
         ImmutableSet.<String>of(),
         ImmutableList.<Path>of(),

--- a/test/com/facebook/buck/zip/SrcZipAwareFileBundlerTest.java
+++ b/test/com/facebook/buck/zip/SrcZipAwareFileBundlerTest.java
@@ -18,9 +18,9 @@ package com.facebook.buck.zip;
 
 import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.TestSourcePath;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
 import com.facebook.buck.util.HumanReadableException;
@@ -51,7 +51,7 @@ public class SrcZipAwareFileBundlerTest {
         new SourcePathResolver(new BuildRuleResolver()),
         ImmutableList.<Step>builder(),
         dest,
-        ImmutableSet.<SourcePath>of(new TestSourcePath("src")),
+        ImmutableSet.<SourcePath>of(new FakeSourcePath("src")),
         false);
   }
 


### PR DESCRIPTION
Summary:
We found the original name to be confusing in the context of a build
system. The new name is less ambiguous and matches naming of other
classes in the same package.

Test plan: CI