### PR TITLE
Make buck work under PyPy

### DIFF
--- a/src/com/facebook/buck/json/buck.py
+++ b/src/com/facebook/buck/json/buck.py
@@ -495,7 +495,7 @@ class BuildFileProcessor(object):
         # Look up the caller's stack frame and merge the include's globals
         # into it's symbol table.
         frame = inspect.currentframe()
-        while frame.f_globals['__name__'] == __name__:
+        while frame.f_globals['__name__'] in (__name__, '_functools'):
             frame = frame.f_back
         self._merge_globals(mod, frame.f_globals)
 

--- a/src/com/facebook/buck/python/PythonBuckConfig.java
+++ b/src/com/facebook/buck/python/PythonBuckConfig.java
@@ -241,7 +241,7 @@ public class PythonBuckConfig {
           CharMatcher.WHITESPACE.trimFrom(versionResult.getStderr().get()) +
           CharMatcher.WHITESPACE.trimFrom(versionResult.getStdout().get())
               .replaceAll("\u001B\\[[;\\d]*m", ""));
-      Matcher matcher = PYTHON_VERSION_REGEX.matcher(versionString);
+      Matcher matcher = PYTHON_VERSION_REGEX.matcher(versionString.split("\\r?\\n")[0]);
       if (!matcher.matches()) {
         throw new HumanReadableException(
             "`%s -V` returned an invalid version string %s",

--- a/test/com/facebook/buck/python/PythonBuckConfigTest.java
+++ b/test/com/facebook/buck/python/PythonBuckConfigTest.java
@@ -266,6 +266,32 @@ public class PythonBuckConfigTest {
   }
 
   @Test
+  public void testGetPypyVersion() throws Exception {
+    String pypyOutput =
+        "Python 2.7.10 (850edf14b2c75573720f59e95767335fb1affe55, Oct 30 2015, 00:18:28)\n" +
+        "[PyPy 4.0.0 with GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.1.76)]\n";
+
+    PythonVersion version =
+        PythonBuckConfig.extractPythonVersion(
+            Paths.get("non", "important", "path"),
+            new ProcessExecutor.Result(0, "", pypyOutput));
+    assertEquals("Python 2.7", version.toString());
+  }
+
+  @Test
+  public void testGetPypyWindowsVersion() throws Exception {
+    String pypyOutput =
+        "Python 2.7.10 (850edf14b2c75573720f59e95767335fb1affe55, Oct 30 2015, 00:18:28)\r\n" +
+        "[PyPy 4.0.0 with GCC 4.2.1 Compatible Apple LLVM 7.0.0 (ok that was a lie)]\r\n";
+
+    PythonVersion version =
+        PythonBuckConfig.extractPythonVersion(
+            Paths.get("non", "important", "path"),
+            new ProcessExecutor.Result(0, "", pypyOutput));
+    assertEquals("Python 2.7", version.toString());
+  }
+
+  @Test
   public void testDefaultPythonLibrary() throws InterruptedException {
     BuildTarget library = BuildTargetFactory.newInstance("//:library");
     PythonBuckConfig config =


### PR DESCRIPTION
Particularly: pypy outputs a two-line version string like:
   Python 2.7.10 (850edf14b2c75573720f59e95767335fb1affe55, Oct 30 2015, 00:18:28)
   [PyPy 4.0.0 with GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.1.76)]

Also functools is implemented in python so shows up on the stack.