### PR TITLE
Add go.prefix for better interoperability with the `go` tool.

### DIFF
--- a/docs/__go_common.soy
+++ b/docs/__go_common.soy
@@ -32,7 +32,7 @@ Note: Buck is currently tested with (and therefore supports) version 1.5 of Go.
 {template .package_name_arg}
 {call buck.arg}
   {param name : 'package_name' /}
-  {param default : 'path relative to the buck root' /}
+  {param default : 'go.prefix + path relative to the buck root' /}
   {param desc}
   Sets the full name of the package being compiled. This defaults to the path from the buck root.
   (e.g. given a ./.buckconfig, a rule in ./a/b/BUCK defaults to package "a/b")

--- a/docs/concept/buckconfig.soy
+++ b/docs/concept/buckconfig.soy
@@ -514,6 +514,15 @@ This section defines the go <code>compiler</code> and <code>linker</code> used b
 </pre>{/literal}
 
 <p>
+  For interoperability with the go tool, you may specify a prefix for your default package
+  names.
+</p>
+{literal}<pre class="prettyprint lang-ini">
+[go]
+  prefix = github.com/facebook/buck
+</pre>{/literal}
+
+<p>
   You can specify the path to find the <code>go</code> tool.  This in turn will
   allow Buck to discover the compiler/linker by default. This defaults to
   {sp}<code>${lb}go.root{rb}/bin/go</code>.

--- a/docs/rule/go_test.soy
+++ b/docs/rule/go_test.soy
@@ -36,7 +36,7 @@
 
 {call buck.arg}
   {param name : 'package_name' /}
-  {param default : 'path relative to the buck root + "_test"' /}
+  {param default : 'go.prefix + path relative to the buck root + "_test"' /}
   {param desc}
   Sets the full name of the test package being compiled. This defaults to the path from the buck
   root with "_test" appended. (e.g. given a ./.buckconfig, a rule in ./a/b/BUCK defaults to package "a/b_test")

--- a/src/com/facebook/buck/go/GoBuckConfig.java
+++ b/src/com/facebook/buck/go/GoBuckConfig.java
@@ -17,6 +17,7 @@
 package com.facebook.buck.go;
 
 import com.facebook.buck.cli.BuckConfig;
+import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.CommandTool;
 import com.facebook.buck.rules.HashedFileTool;
@@ -81,6 +82,11 @@ public class GoBuckConfig {
     return getGoTool("linker", "link");
   }
 
+  Path getDefaultPackageName(BuildTarget target) {
+    Path prefix = Paths.get(delegate.getValue("go", "prefix").or(""));
+    return prefix.resolve(target.getBasePath());
+  }
+
   Optional<Tool> getGoTestMainGenerator(BuildRuleResolver resolver) {
     return delegate.getTool("go", "test_main_gen", resolver);
   }
@@ -88,7 +94,7 @@ public class GoBuckConfig {
   ImmutableList<String> getCompilerFlags() {
     return ImmutableList.copyOf(
         Splitter.on(" ").omitEmptyStrings().split(
-          delegate.getValue("go", "compiler_flags").or("")));
+            delegate.getValue("go", "compiler_flags").or("")));
   }
 
   ImmutableList<String> getLinkerFlags() {

--- a/src/com/facebook/buck/go/GoLibraryDescription.java
+++ b/src/com/facebook/buck/go/GoLibraryDescription.java
@@ -66,7 +66,7 @@ public class GoLibraryDescription implements Description<GoLibraryDescription.Ar
         resolver,
         goBuckConfig,
         args.packageName.transform(MorePaths.TO_PATH)
-            .or(params.getBuildTarget().getBasePath()),
+            .or(goBuckConfig.getDefaultPackageName(params.getBuildTarget())),
         args.srcs,
         args.compilerFlags.or(ImmutableList.<String>of()),
         args.tests.get()

--- a/src/com/facebook/buck/go/GoTestDescription.java
+++ b/src/com/facebook/buck/go/GoTestDescription.java
@@ -107,7 +107,7 @@ public class GoTestDescription implements Description<GoTestDescription.Arg> {
             .addFlavors(ImmutableFlavor.of("test-library"))
             .build();
 
-    Path defaultPackageName = params.getBuildTarget().getBasePath();
+    Path defaultPackageName = goBuckConfig.getDefaultPackageName(params.getBuildTarget());
     defaultPackageName = defaultPackageName.resolveSibling(
         defaultPackageName.getFileName() + "_test");
 

--- a/test/com/facebook/buck/go/GoBinaryIntegrationTest.java
+++ b/test/com/facebook/buck/go/GoBinaryIntegrationTest.java
@@ -88,6 +88,17 @@ public class GoBinaryIntegrationTest {
   }
 
   @Test
+  public void libraryWithPrefix() throws IOException, InterruptedException {
+    ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(
+        this, "library_with_prefix", tmp);
+    workspace.setUp();
+
+    assertThat(
+        workspace.runBuckCommand("run", "//:hello").assertSuccess().getStdout(),
+        Matchers.containsString("Hello, world!"));
+  }
+
+  @Test
   public void nonGoLibraryDepErrors() throws IOException, InterruptedException {
     thrown.expect(HumanReadableException.class);
     thrown.expectMessage(Matchers.containsString("is not an instance of go_library"));

--- a/test/com/facebook/buck/go/testdata/library_with_prefix/.buckconfig
+++ b/test/com/facebook/buck/go/testdata/library_with_prefix/.buckconfig
@@ -1,0 +1,2 @@
+[go]
+  prefix = github.com/facebook/buck

--- a/test/com/facebook/buck/go/testdata/library_with_prefix/BUCK.fixture
+++ b/test/com/facebook/buck/go/testdata/library_with_prefix/BUCK.fixture
@@ -1,0 +1,9 @@
+go_binary(
+  name = "hello",
+  srcs = [
+    "main.go",
+  ],
+  deps = [
+    "//messenger:messenger",
+  ],
+)

--- a/test/com/facebook/buck/go/testdata/library_with_prefix/main.go
+++ b/test/com/facebook/buck/go/testdata/library_with_prefix/main.go
@@ -1,0 +1,8 @@
+package main
+
+import "github.com/facebook/buck/messenger"
+
+func main() {
+	messenger := messenger.NewMessenger("Hello, world!")
+	messenger.Deliver()
+}

--- a/test/com/facebook/buck/go/testdata/library_with_prefix/messenger/BUCK.fixture
+++ b/test/com/facebook/buck/go/testdata/library_with_prefix/messenger/BUCK.fixture
@@ -1,0 +1,20 @@
+go_library(
+  name = 'messenger',
+  srcs = [
+    'messenger.go',
+  ],
+  deps = [
+    ':printer',
+  ],
+  visibility = [
+    'PUBLIC',
+  ],
+)
+
+go_library(
+  name = 'printer',
+  package_name = 'github.com/facebook/buck/messenger/printer',
+  srcs = [
+    'printer.go',
+  ]
+)

--- a/test/com/facebook/buck/go/testdata/library_with_prefix/messenger/messenger.go
+++ b/test/com/facebook/buck/go/testdata/library_with_prefix/messenger/messenger.go
@@ -1,0 +1,15 @@
+package messenger
+
+import "github.com/facebook/buck/messenger/printer"
+
+type Messenger struct {
+	message string
+}
+
+func NewMessenger(message string) *Messenger {
+	return &Messenger{message: message}
+}
+
+func (m *Messenger) Deliver() {
+	printer.Print(m.message)
+}

--- a/test/com/facebook/buck/go/testdata/library_with_prefix/messenger/printer.go
+++ b/test/com/facebook/buck/go/testdata/library_with_prefix/messenger/printer.go
@@ -1,0 +1,7 @@
+package printer
+
+import "fmt"
+
+func Print(m string) {
+	fmt.Println(m)
+}


### PR DESCRIPTION
Inspiration from https://github.com/bazelbuild/bazel/tree/master/tools/build_rules/go#go_prefix .