### PR TITLE
Encapsulate javacOptions within DefaultJavaLibrary

### DIFF
--- a/src/com/facebook/buck/jvm/java/BUCK
+++ b/src/com/facebook/buck/jvm/java/BUCK
@@ -194,7 +194,7 @@ java_library(
     'CalculateAbiStep.java',
     'CopyResourcesStep.java',
     'GenerateCodeCoverageReportStep.java',
-    'JavacToJarStepFactory.java',
+    'JavacStepFactory.java',
     'JarDirectoryStep.java',
     'JarDirectoryStepHelper.java',
     'JavacStep.java',

--- a/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
+++ b/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
@@ -63,6 +63,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.hash.HashCode;
 import com.google.common.reflect.ClassPath;
@@ -347,7 +348,7 @@ public class DefaultJavaLibrary extends AbstractBuildRule
       commands.add(new MakeCleanDirectoryStep(getProjectFilesystem(), scratchDir));
       workingDirectory = Optional.of(scratchDir);
 
-      JavacToJarStepFactory javacToJarStepFactory = new JavacToJarStepFactory(
+      JavacStepFactory javacStepFactory = new JavacStepFactory(
           outputDirectory,
           workingDirectory,
           getJavaSrcs(),
@@ -357,14 +358,18 @@ public class DefaultJavaLibrary extends AbstractBuildRule
           target,
           suggestBuildRules,
           getResolver(),
-          getProjectFilesystem(),
-          pathToOutputFile,
-          ImmutableSortedSet.of(outputDirectory),
-          null,
-          null,
-          intermediateCommands);
+          getProjectFilesystem()
+      );
 
-      javacToJarStepFactory.getJavacToJarStep(commands);
+      commands.add(javacStepFactory.createCompileStep());
+      commands.addAll(Lists.newCopyOnWriteArrayList(intermediateCommands));
+      commands.add(
+          new JarDirectoryStep(
+              getProjectFilesystem(),
+              pathToOutputFile,
+              ImmutableSortedSet.of(outputDirectory),
+              /* mainClass */null,
+              /* manifestFile */null));
   }
 
   private Path getPathToAbiOutputDir() {

--- a/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
+++ b/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
@@ -323,54 +323,6 @@ public class DefaultJavaLibrary extends AbstractBuildRule
     this.buildOutputInitializer = new BuildOutputInitializer<>(params.getBuildTarget(), this);
   }
 
-  /**
-   * @param outputDirectory Directory to write class files to
-   * @param declaredClasspathEntries Classpaths of all declared dependencies.
-   * @param javacOptions javac configuration.
-   * @param suggestBuildRules Function to convert from missing symbols to the suggested rules.
-   * @param commands List of steps to add to.
-   */
-  private void createCommandsForJavacJar(
-      Path outputDirectory,
-      ImmutableSortedSet<Path> declaredClasspathEntries,
-      JavacOptions javacOptions,
-      Optional<JavacStep.SuggestBuildRules> suggestBuildRules,
-      ImmutableList.Builder<Step> commands,
-      BuildTarget target,
-      Path pathToOutputFile,
-      ImmutableList<Step> intermediateCommands) {
-      Path pathToSrcsList = BuildTargets.getGenPath(getBuildTarget(), "__%s__srcs");
-      commands.add(new MkdirStep(getProjectFilesystem(), pathToSrcsList.getParent()));
-
-      Optional<Path> workingDirectory;
-      Path scratchDir = BuildTargets.getGenPath(target, "lib__%s____working_directory");
-      commands.add(new MakeCleanDirectoryStep(getProjectFilesystem(), scratchDir));
-      workingDirectory = Optional.of(scratchDir);
-
-      JavacStepFactory javacStepFactory = new JavacStepFactory(
-          outputDirectory,
-          workingDirectory,
-          getJavaSrcs(),
-          Optional.of(pathToSrcsList),
-          declaredClasspathEntries,
-          javacOptions,
-          target,
-          suggestBuildRules,
-          getResolver(),
-          getProjectFilesystem()
-      );
-
-      commands.add(javacStepFactory.createCompileStep());
-      commands.addAll(Lists.newCopyOnWriteArrayList(intermediateCommands));
-      commands.add(
-          new JarDirectoryStep(
-              getProjectFilesystem(),
-              pathToOutputFile,
-              ImmutableSortedSet.of(outputDirectory),
-              /* mainClass */null,
-              /* manifestFile */null));
-  }
-
   private Path getPathToAbiOutputDir() {
     return BuildTargets.getGenPath(getBuildTarget(), "lib__%s__abi");
   }
@@ -539,18 +491,37 @@ public class DefaultJavaLibrary extends AbstractBuildRule
     if (!getJavaSrcs().isEmpty()) {
       Path output = outputJar.get();
       // This adds the javac command, along with any supporting commands.
-      createCommandsForJavacJar(
+      Path pathToSrcsList = BuildTargets.getGenPath(getBuildTarget(), "__%s__srcs");
+      steps.add(new MkdirStep(getProjectFilesystem(), pathToSrcsList.getParent()));
+
+      Path scratchDir = BuildTargets.getGenPath(target, "lib__%s____working_directory");
+      steps.add(new MakeCleanDirectoryStep(getProjectFilesystem(), scratchDir));
+      Optional<Path> workingDirectory = Optional.of(scratchDir);
+      JavacStepFactory javacStepFactory = new JavacStepFactory(
           outputDirectory,
+          workingDirectory,
+          getJavaSrcs(),
+          Optional.of(pathToSrcsList),
           declared,
           javacOptions,
-          suggestBuildRule,
-          steps,
           target,
-          output,
-          addPostprocessClassesCommands(
+          suggestBuildRule,
+          getResolver(),
+          getProjectFilesystem()
+      );
+
+      steps.add(javacStepFactory.createCompileStep());
+      steps.addAll(Lists.newCopyOnWriteArrayList(addPostprocessClassesCommands(
               getProjectFilesystem().getRootPath(),
               postprocessClassesCommands,
-              outputDirectory));
+              outputDirectory)));
+      steps.add(
+          new JarDirectoryStep(
+              getProjectFilesystem(),
+              output,
+              ImmutableSortedSet.of(outputDirectory),
+              /* mainClass */null,
+              /* manifestFile */null));
     }
 
 

--- a/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
+++ b/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
@@ -398,10 +398,6 @@ public class DefaultJavaLibrary extends AbstractBuildRule
     return exportedDeps;
   }
 
-  public JavacOptions getJavacOptions() {
-    return javacOptions;
-  }
-
   /**
    * Building a java_library() rule entails compiling the .java files specified in the srcs
    * attribute. They are compiled into a directory under

--- a/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
+++ b/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
@@ -330,8 +330,7 @@ public class DefaultJavaLibrary extends AbstractBuildRule
    * @param suggestBuildRules Function to convert from missing symbols to the suggested rules.
    * @param commands List of steps to add to.
    */
-  @VisibleForTesting
-  void createCommandsForJavacJar(
+  private void createCommandsForJavacJar(
       Path outputDirectory,
       ImmutableSortedSet<Path> declaredClasspathEntries,
       JavacOptions javacOptions,

--- a/src/com/facebook/buck/jvm/java/JarFattener.java
+++ b/src/com/facebook/buck/jvm/java/JarFattener.java
@@ -156,7 +156,7 @@ public class JarFattener extends AbstractBuildRule implements BinaryBuildRule {
             /* compressionLevel */ 0,
         fatJarDir);
 
-    JavacToJarStepFactory javacToJarStepFactory = new JavacToJarStepFactory(
+    JavacStepFactory javacStepFactory = new JavacStepFactory(
         fatJarDir,
         Optional.<Path>absent(),
         ImmutableSortedSet.copyOf(javaSourceFilePaths),
@@ -166,15 +166,21 @@ public class JarFattener extends AbstractBuildRule implements BinaryBuildRule {
         getBuildTarget(),
         Optional.<JavacStep.SuggestBuildRules>absent(),
         getResolver(),
-        getProjectFilesystem(),
-        getOutputPath(),
-        ImmutableSortedSet.of(zipped),
-        FatJarMain.class.getName(),
-        /* manifestFile */ null,
-        ImmutableList.of(zipStep)
+        getProjectFilesystem()
+        /* manifestFile */
     );
 
-    javacToJarStepFactory.getJavacToJarStep(steps);
+    steps.add(javacStepFactory.createCompileStep());
+    steps.add(zipStep);
+    steps.add(
+        new JarDirectoryStep(
+            getProjectFilesystem(),
+            getOutputPath(),
+            ImmutableSortedSet.of(zipped),
+            FatJarMain.class.getName(),
+            /* manifestFile */ null));
+
+
     return steps.build();
   }
 

--- a/src/com/facebook/buck/jvm/java/JavacStepFactory.java
+++ b/src/com/facebook/buck/jvm/java/JavacStepFactory.java
@@ -21,17 +21,11 @@ import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.step.Step;
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Lists;
 
 import java.nio.file.Path;
-import java.util.List;
 
-import javax.annotation.Nullable;
-
-public class JavacToJarStepFactory {
-  // JavacStep parameters
+public class JavacStepFactory {
   private Path outputDirectory;
   private Optional<Path> workingDirectory;
   private ImmutableSortedSet<Path> javaSourceFilePaths;
@@ -43,15 +37,8 @@ public class JavacToJarStepFactory {
   private SourcePathResolver resolver;
   private ProjectFilesystem filesystem;
 
-  // JarDirectoryStep parameters
-  private Path pathToOutputFile;
-  private ImmutableSortedSet<Path> entriesToJar;
-  @Nullable private String mainClass;
-  @Nullable private Path manifestFile;
-
-  private final List<Step> intermediateCommands;
-
-  public JavacToJarStepFactory(Path outputDirectory,
+  public JavacStepFactory(
+      Path outputDirectory,
       Optional<Path> workingDirectory,
       ImmutableSortedSet<Path> javaSourceFilePaths,
       Optional<Path> pathToSrcsList,
@@ -60,14 +47,8 @@ public class JavacToJarStepFactory {
       BuildTarget invokingRule,
       Optional<JavacStep.SuggestBuildRules> suggestBuildRules,
       SourcePathResolver resolver,
-      ProjectFilesystem filesystem,
-      Path pathToOutputFile,
-      ImmutableSortedSet<Path> entriesToJar,
-      @Nullable String mainClass,
-      @Nullable Path manifestFile,
-      List<Step> intermediateCommands
+      ProjectFilesystem filesystem
   ) {
-    // JavacStep parameters
     this.outputDirectory = outputDirectory;
     this.workingDirectory = workingDirectory;
     this.javaSourceFilePaths = javaSourceFilePaths;
@@ -78,18 +59,10 @@ public class JavacToJarStepFactory {
     this.suggestBuildRules = suggestBuildRules;
     this.resolver = resolver;
     this.filesystem = filesystem;
-
-    // JarDirectoryStep parameters
-    this.pathToOutputFile = pathToOutputFile;
-    this.entriesToJar = entriesToJar;
-    this.mainClass = mainClass;
-    this.manifestFile = manifestFile;
-
-    this.intermediateCommands = intermediateCommands;
   }
 
-  void getJavacToJarStep(ImmutableList.Builder<Step> steps) {
-    JavacStep javacStep = new JavacStep(
+  Step createCompileStep() {
+    return new JavacStep(
         outputDirectory,
         workingDirectory,
         javaSourceFilePaths,
@@ -101,15 +74,5 @@ public class JavacToJarStepFactory {
         suggestBuildRules,
         resolver,
         filesystem);
-
-    steps.add(javacStep);
-    steps.addAll(Lists.newCopyOnWriteArrayList(intermediateCommands));
-    steps.add(
-        new JarDirectoryStep(
-            filesystem,
-            pathToOutputFile,
-            entriesToJar,
-            mainClass,
-            manifestFile));
   }
 }

--- a/test/com/facebook/buck/jvm/java/DefaultJavaLibraryTest.java
+++ b/test/com/facebook/buck/jvm/java/DefaultJavaLibraryTest.java
@@ -45,6 +45,7 @@ import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildTargetSourcePath;
+import com.facebook.buck.rules.FakeBuildContext;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
 import com.facebook.buck.rules.FakeBuildableContext;
 import com.facebook.buck.rules.FakeSourcePath;
@@ -1121,22 +1122,13 @@ public class DefaultJavaLibraryTest {
         .createBuilder(libraryOneTarget)
         .addSrc(Paths.get("java/src/com/libone/Bar.java"))
         .build(ruleResolver);
-    DefaultJavaLibrary buildable = (DefaultJavaLibrary) rule;
+    DefaultJavaLibrary buildRule = (DefaultJavaLibrary) rule;
+    ImmutableList<Step> steps = buildRule.getBuildSteps(
+        FakeBuildContext.NOOP_CONTEXT,
+        new FakeBuildableContext());
 
-    ImmutableList.Builder<Step> stepsBuilder = ImmutableList.builder();
-    buildable.createCommandsForJavacJar(
-        buildable.getPathToOutput(),
-        ImmutableSortedSet.copyOf(buildable.getDeclaredClasspathEntries().values()),
-        DEFAULT_JAVAC_OPTIONS,
-        Optional.<JavacStep.SuggestBuildRules>absent(),
-        stepsBuilder,
-        libraryOneTarget,
-        buildable.getPathToOutput().resolve("output.jar"),
-        ImmutableList.<Step>of());
-
-    List<Step> steps = stepsBuilder.build();
-    assertEquals(steps.size(), 4);
-    assertTrue(((JavacStep) steps.get(2)).getJavac() instanceof Jsr199Javac);
+    assertEquals(11, steps.size());
+    assertTrue(((JavacStep) steps.get(6)).getJavac() instanceof Jsr199Javac);
   }
 
   @Test
@@ -1154,27 +1146,15 @@ public class DefaultJavaLibraryTest {
         .setCompiler(javac)
         .build(ruleResolver);
     DefaultJavaLibrary buildable = (DefaultJavaLibrary) rule;
-
-    ImmutableList.Builder<Step> stepsBuilder = ImmutableList.builder();
-    buildable.createCommandsForJavacJar(
-        buildable.getPathToOutput(),
-        ImmutableSortedSet.copyOf(buildable.getDeclaredClasspathEntries().values()),
-        buildable.getJavacOptions(),
-        Optional.<JavacStep.SuggestBuildRules>absent(),
-        stepsBuilder,
-        libraryOneTarget,
-        buildable.getPathToOutput().resolve("output.jar"),
-        ImmutableList.<Step>of()
-    );
-
-    List<Step> steps = stepsBuilder.build();
-    assertEquals(steps.size(), 4);
-    assertTrue(((JavacStep) steps.get(2)).getJavac() instanceof Jsr199Javac);
-    JarBackedJavac jsrJavac = ((JarBackedJavac) (((JavacStep) steps.get(2)).getJavac()));
+    ImmutableList<Step> steps =
+        buildable.getBuildSteps(FakeBuildContext.NOOP_CONTEXT, new FakeBuildableContext());
+    assertEquals(11, steps.size());
+    Javac javacStep = ((JavacStep) steps.get(6)).getJavac();
+    assertTrue(javacStep instanceof Jsr199Javac);
+    JarBackedJavac jsrJavac = ((JarBackedJavac) javacStep);
     assertEquals(
         jsrJavac.getCompilerClassPath(),
-        ImmutableSet.of(
-            new BuildTargetSourcePath(javac.getBuildTarget())));
+        ImmutableSet.of(new BuildTargetSourcePath(javac.getBuildTarget())));
   }
 
   @Test

--- a/test/com/facebook/buck/rules/KnownBuildRuleTypesTest.java
+++ b/test/com/facebook/buck/rules/KnownBuildRuleTypesTest.java
@@ -21,8 +21,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.facebook.buck.android.AndroidLibrary;
-import com.facebook.buck.android.AndroidLibraryDescription;
 import com.facebook.buck.android.FakeAndroidDirectoryResolver;
 import com.facebook.buck.cli.BuckConfig;
 import com.facebook.buck.cli.FakeBuckConfig;
@@ -30,10 +28,7 @@ import com.facebook.buck.cxx.CxxPlatform;
 import com.facebook.buck.cxx.CxxPlatformUtils;
 import com.facebook.buck.io.MorePaths;
 import com.facebook.buck.jvm.java.DefaultJavaLibrary;
-import com.facebook.buck.jvm.java.ExternalJavac;
 import com.facebook.buck.jvm.java.JavaLibraryDescription;
-import com.facebook.buck.jvm.java.Javac;
-import com.facebook.buck.jvm.java.Jsr199Javac;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.model.Flavor;
@@ -151,47 +146,6 @@ public class KnownBuildRuleTypesTest {
   }
 
   @Test
-  public void whenJavacIsNotSetInBuckConfigConfiguredRulesCreateJavaLibraryRuleWithJsr199Javac()
-      throws IOException, NoSuchBuildTargetException, InterruptedException {
-    BuckConfig buckConfig = FakeBuckConfig.builder().build();
-
-    KnownBuildRuleTypes buildRuleTypes = KnownBuildRuleTypes.createBuilder(
-        buckConfig,
-        createExecutor(),
-        new FakeAndroidDirectoryResolver(),
-        Optional.<Path>absent()).build();
-    DefaultJavaLibrary libraryRule = createJavaLibrary(buildRuleTypes);
-
-    Javac javac = libraryRule.getJavacOptions().getJavac();
-    assertTrue(javac.getClass().toString(), javac instanceof Jsr199Javac);
-  }
-
-  @Test
-  public void whenJavacIsSetInBuckConfigConfiguredRulesCreateJavaLibraryRuleWithJavacSet()
-      throws IOException, NoSuchBuildTargetException, InterruptedException {
-    final File javac = temporaryFolder.newFile();
-    javac.setExecutable(true);
-
-    ImmutableMap<String, ImmutableMap<String, String>> sections = ImmutableMap.of(
-        "tools", ImmutableMap.of("javac", javac.toString()));
-    BuckConfig buckConfig = FakeBuckConfig.builder().setSections(sections).build();
-
-    ProcessExecutor processExecutor = createExecutor(javac.toString(), "");
-
-    KnownBuildRuleTypes buildRuleTypes = KnownBuildRuleTypes.createBuilder(
-        buckConfig,
-        processExecutor,
-        new FakeAndroidDirectoryResolver(),
-        Optional.<Path>absent())
-        .build();
-
-    DefaultJavaLibrary libraryRule = createJavaLibrary(buildRuleTypes);
-    assertEquals(
-        javac.toPath(),
-        ((ExternalJavac) libraryRule.getJavacOptions().getJavac()).getPath());
-  }
-
-  @Test
   public void whenJavacIsSetInBuckConfigConfiguredRulesCreateJavaLibraryRuleWithDifferentRuleKey()
       throws IOException, NoSuchBuildTargetException, InterruptedException {
     final File javac = temporaryFolder.newFile();
@@ -226,59 +180,6 @@ public class KnownBuildRuleTypesTest {
     RuleKey libraryKey = factory.build(libraryRule);
 
     assertNotEquals(libraryKey, configuredKey);
-  }
-
-  @Test
-  public void whenJavacIsNotSetInBuckConfigConfiguredRulesCreateAndroidLibraryRuleWithJsr199Javac()
-      throws IOException, NoSuchBuildTargetException, InterruptedException {
-    BuckConfig buckConfig = FakeBuckConfig.builder().build();
-
-    KnownBuildRuleTypes buildRuleTypes = KnownBuildRuleTypes.createBuilder(
-        buckConfig,
-        createExecutor(),
-        new FakeAndroidDirectoryResolver(),
-        Optional.<Path>absent()).build();
-    AndroidLibraryDescription description =
-        (AndroidLibraryDescription) buildRuleTypes.getDescription(AndroidLibraryDescription.TYPE);
-
-    AndroidLibraryDescription.Arg arg = new AndroidLibraryDescription.Arg();
-    populateJavaArg(arg);
-    arg.manifest = Optional.absent();
-    AndroidLibrary rule = (AndroidLibrary) description
-        .createBuildRule(TargetGraph.EMPTY, buildRuleParams, new BuildRuleResolver(), arg);
-
-    Javac javac = rule.getJavacOptions().getJavac();
-    assertTrue(javac.getClass().toString(), javac instanceof Jsr199Javac);
-  }
-
-  @Test
-  public void whenJavacIsSetInBuckConfigConfiguredRulesCreateAndroidLibraryBuildRuleWithJavacSet()
-      throws IOException, NoSuchBuildTargetException, InterruptedException {
-    final File javac = temporaryFolder.newFile();
-    javac.setExecutable(true);
-
-    ImmutableMap<String, ImmutableMap<String, String>> sections = ImmutableMap.of(
-        "tools", ImmutableMap.of("javac", javac.toString()));
-    BuckConfig buckConfig = FakeBuckConfig.builder().setSections(sections).build();
-
-    ProcessExecutor processExecutor = createExecutor(javac.toString(), "");
-
-    KnownBuildRuleTypes buildRuleTypes = KnownBuildRuleTypes.createBuilder(
-        buckConfig,
-        processExecutor,
-        new FakeAndroidDirectoryResolver(),
-        Optional.<Path>absent())
-        .build();
-    AndroidLibraryDescription description =
-        (AndroidLibraryDescription) buildRuleTypes.getDescription(AndroidLibraryDescription.TYPE);
-
-    AndroidLibraryDescription.Arg arg = new AndroidLibraryDescription.Arg();
-    populateJavaArg(arg);
-    arg.manifest = Optional.absent();
-    AndroidLibrary rule = (AndroidLibrary) description
-        .createBuildRule(TargetGraph.EMPTY, buildRuleParams, new BuildRuleResolver(), arg);
-
-    assertEquals(javac.toPath(), ((ExternalJavac) rule.getJavacOptions().getJavac()).getPath());
   }
 
   @Test


### PR DESCRIPTION
Summary: Work towards decoupling the two completely. We don't let
javacOptions escape from DefaultJavaLibrary, and we begin to move the
main point of use into the newly renamed JavacStepFactory, which at
some point will sprout a CompileStepFactory interface.

Test-plan: CI