### PR TITLE
Improve performance of get_dirty_buck_version

### DIFF
--- a/programs/buck_version.py
+++ b/programs/buck_version.py
@@ -80,20 +80,16 @@ def get_clean_buck_version(dirpath, allow_dirty=False):
 
 
 def get_dirty_buck_version(dirpath):
-    git_tree_in = check_output(
-        ['git', 'log', '-n1', '--pretty=format:%T', 'HEAD', '--'],
-        cwd=dirpath).strip()
-
     with EmptyTempFile(prefix='buck-git-index') as index_file:
+        subprocess.check_call(
+            ['git', 'read-tree', '--index-output', index_file.name, '--reset', 'HEAD'],
+            cwd=dirpath)
+
         new_environ = os.environ.copy()
         new_environ['GIT_INDEX_FILE'] = index_file.name
-        subprocess.check_call(
-            ['git', 'read-tree', git_tree_in],
-            cwd=dirpath,
-            env=new_environ)
 
         subprocess.check_call(
-            ['git', 'add', '-u'],
+            ['git', 'add', '-A'], 
             cwd=dirpath,
             env=new_environ)
 

--- a/programs/buck_version.py
+++ b/programs/buck_version.py
@@ -89,7 +89,7 @@ def get_dirty_buck_version(dirpath):
         new_environ['GIT_INDEX_FILE'] = index_file.name
 
         subprocess.check_call(
-            ['git', 'add', '-A'], 
+            ['git', 'add', '-u'],
             cwd=dirpath,
             env=new_environ)
 


### PR DESCRIPTION
When running Buck from a dirty working copy, a large amount of startup
time was spent calculating the version in get_dirty_buck_version.  git
read-tree was reading a fresh index into a temporary file, which
contained no stat() information about the working copy's current stat.
When git add -u then ran, it then had to rebuild this information for
all tracked files, which was time-consuming.

The new version re-uses the current index's stat() information when
writing the index to a temporary file.  It also shaves off one call to
git, taking advantage of the fact that HEAD counts as a tree-ish object
that can be passed to git read-tree.