### PR TITLE
Untracked files now affect get_dirty_buck_version

### DIFF
--- a/programs/buck_version.py
+++ b/programs/buck_version.py
@@ -89,7 +89,7 @@ def get_dirty_buck_version(dirpath):
         new_environ['GIT_INDEX_FILE'] = index_file.name
 
         subprocess.check_call(
-            ['git', 'add', '-u'],
+            ['git', 'add', '-A'],
             cwd=dirpath,
             env=new_environ)
 


### PR DESCRIPTION
Before, the presence of untracked files caused Buck to return a dirty
version, but those untracked files were not used in calculating the
dirty version. This meant that creating the first untracked file
caused the buck daemon to restart, but any subsequent modifications to
any untracked files did not. Now, any change to files tracked or
untracked (but not ignored) will affect the dirty version.

Quick way to see the behavior before and after:
```
git clean -fd # remove any untracked changes
./bin/buck # daemon starts/restarts
touch a
./bin/buck # daemon restarts
touch b
./bin/buck # previously, daemon does not restart.  now, daemon restarts.
```

(Sadly, a little slower, but overall still much faster than before combined with the previous change to re-use index.)
