### PR TITLE
Current code style is four spaces for Python indentation

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -36,13 +36,6 @@
             <option name="TAB_SIZE" value="2" />
           </indentOptions>
         </codeStyleSettings>
-        <codeStyleSettings language="Python">
-          <indentOptions>
-            <option name="INDENT_SIZE" value="2" />
-            <option name="CONTINUATION_INDENT_SIZE" value="4" />
-            <option name="TAB_SIZE" value="2" />
-          </indentOptions>
-        </codeStyleSettings>
       </value>
     </option>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />


### PR DESCRIPTION
The code style settings for IntelliJ IDEA previously stated that, for Python
code, line indents were two spaces for indentation, and four spaces for line
continuations.  However, all Python code in Buck was actually using four
spaces for indentation, and eight spaces for line continuations.  This commit
updates IntelliJ IDEA's codeStyleSettings.xml to reflect that.

(Yes, it does so by deleting the Python section here.  Even if you go in
manually and fix the Python settings to be correct number of spaces in the
XML, IntelliJ IDEA will then unceremoneously delete the entire section as it
matches the default code style settings.)