### PR TITLE
Break out DefaultSuggestBuildRules from DefaultJavaLibrary

### DIFF
--- a/src/com/facebook/buck/jvm/core/SuggestBuildRules.java
+++ b/src/com/facebook/buck/jvm/core/SuggestBuildRules.java
@@ -18,6 +18,15 @@ package com.facebook.buck.jvm.core;
 import com.facebook.buck.io.ProjectFilesystem;
 import com.google.common.collect.ImmutableSet;
 
+import java.nio.file.Path;
+
 public interface SuggestBuildRules {
   ImmutableSet<String> suggest(ProjectFilesystem filesystem, ImmutableSet<String> failedImports);
+
+  /**
+   * Given a jar, open it, and return all the symbols within.
+   */
+  interface JarResolver {
+    ImmutableSet<String> resolve(ProjectFilesystem filesystem, Path relativeClassPath);
+  }
 }

--- a/src/com/facebook/buck/jvm/java/BUCK
+++ b/src/com/facebook/buck/jvm/java/BUCK
@@ -121,6 +121,7 @@ java_library(
     'CalculateAbi.java',
     'Classpaths.java',
     'DefaultJavaLibrary.java',
+    'DefaultSuggestBuildRules.java',
     'GwtModule.java',
     'JarFattener.java',
     'JavaBinary.java',

--- a/src/com/facebook/buck/jvm/java/DefaultSuggestBuildRules.java
+++ b/src/com/facebook/buck/jvm/java/DefaultSuggestBuildRules.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2012-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.jvm.java;
+
+import com.facebook.buck.graph.DirectedAcyclicGraph;
+import com.facebook.buck.graph.TopologicalSort;
+import com.facebook.buck.io.ProjectFilesystem;
+import com.facebook.buck.jvm.core.SuggestBuildRules;
+import com.facebook.buck.rules.BuildRule;
+import com.facebook.buck.rules.BuildRuleDependencyVisitors;
+import com.google.common.base.Predicates;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Sets;
+
+import java.nio.file.Path;
+import java.util.Set;
+
+final class DefaultSuggestBuildRules implements SuggestBuildRules {
+  private final Supplier<ImmutableList<JavaLibrary>> sortedTransitiveNotDeclaredDeps;
+  private final JarResolver jarResolver;
+
+  /**
+   * @return A function that takes a list of failed imports from a javac invocation and returns a
+   *    set of rules to suggest that the developer import to satisfy those imports.
+   */
+  static SuggestBuildRules createSuggestBuildFunction(
+      final JarResolver jarResolver,
+      final ImmutableSetMultimap<JavaLibrary, Path> declaredClasspathEntries,
+      final ImmutableSetMultimap<JavaLibrary, Path> transitiveClasspathEntries,
+      final Iterable<BuildRule> buildRules) {
+
+    final Supplier<ImmutableList<JavaLibrary>> sortedTransitiveNotDeclaredDeps =
+        Suppliers.memoize(
+            new Supplier<ImmutableList<JavaLibrary>>() {
+              @Override
+              public ImmutableList<JavaLibrary> get() {
+                Set<JavaLibrary> transitiveNotDeclaredDeps = Sets.difference(
+                    transitiveClasspathEntries.keySet(),
+                    Sets.union(ImmutableSet.of(this), declaredClasspathEntries.keySet()));
+                DirectedAcyclicGraph<BuildRule> graph =
+                    BuildRuleDependencyVisitors.getBuildRuleDirectedGraphFilteredBy(
+                        buildRules,
+                        Predicates.instanceOf(JavaLibrary.class),
+                        Predicates.instanceOf(JavaLibrary.class));
+                return FluentIterable
+                    .from(TopologicalSort.sort(graph, Predicates.<BuildRule>alwaysTrue()))
+                    .filter(JavaLibrary.class)
+                    .filter(Predicates.in(transitiveNotDeclaredDeps))
+                    .toList()
+                    .reverse();
+              }
+            });
+
+    return new DefaultSuggestBuildRules(sortedTransitiveNotDeclaredDeps, jarResolver);
+  }
+
+  @Override
+  public ImmutableSet<String> suggest(
+      ProjectFilesystem filesystem,
+      ImmutableSet<String> failedImports) {
+    ImmutableSet.Builder<String> suggestedDeps = ImmutableSet.builder();
+
+    Set<String> remainingImports = Sets.newHashSet(failedImports);
+
+    for (JavaLibrary transitiveNotDeclaredDep : sortedTransitiveNotDeclaredDeps.get()) {
+      if (isMissingBuildRule(
+          filesystem,
+          transitiveNotDeclaredDep,
+          remainingImports,
+          jarResolver)) {
+        suggestedDeps.add(transitiveNotDeclaredDep.getFullyQualifiedName());
+      }
+      // If we've wiped out all remaining imports, break the loop looking for them.
+      if (remainingImports.isEmpty()) {
+        break;
+      }
+    }
+    return suggestedDeps.build();
+  }
+
+  private DefaultSuggestBuildRules(
+      Supplier<ImmutableList<JavaLibrary>> sortedTransitiveNotDeclaredDeps,
+      JarResolver jarResolver) {
+    this.sortedTransitiveNotDeclaredDeps = sortedTransitiveNotDeclaredDeps;
+    this.jarResolver = jarResolver;
+  }
+
+  /**
+   *  @param transitiveNotDeclaredRule A {@link BuildRule} that is contained in the transitive
+   *      dependency list but is not declared as a dependency.
+   *  @param failedImports A Set of remaining failed imports.  This function will mutate this set
+   *      and remove any imports satisfied by {@code transitiveNotDeclaredDep}.
+   *  @return whether or not adding {@code transitiveNotDeclaredDep} as a dependency to this build
+   *      rule would have satisfied one of the {@code failedImports}.
+   */
+  private boolean isMissingBuildRule(
+      ProjectFilesystem filesystem,
+      BuildRule transitiveNotDeclaredRule,
+      Set<String> failedImports,
+      JarResolver jarResolver) {
+    if (!(transitiveNotDeclaredRule instanceof JavaLibrary)) {
+      return false;
+    }
+
+    ImmutableSet<Path> classPaths =
+        ImmutableSet.copyOf(
+            ((JavaLibrary) transitiveNotDeclaredRule).getOutputClasspathEntries().values());
+    boolean containsMissingBuildRule = false;
+    // Open the output jar for every jar contained as the output of transitiveNotDeclaredDep.  With
+    // the exception of rules that export their dependencies, this will result in a single
+    // classpath.
+    for (Path classPath : classPaths) {
+      ImmutableSet<String> topLevelSymbols = jarResolver.resolve(filesystem, classPath);
+
+      for (String symbolName : topLevelSymbols) {
+        if (failedImports.contains(symbolName)) {
+          failedImports.remove(symbolName);
+          containsMissingBuildRule = true;
+
+          // If we've found all of the missing imports, bail out early.
+          if (failedImports.isEmpty()) {
+            return true;
+          }
+        }
+      }
+    }
+    return containsMissingBuildRule;
+  }
+}

--- a/test/com/facebook/buck/jvm/java/DefaultSuggestBuildRulesTest.java
+++ b/test/com/facebook/buck/jvm/java/DefaultSuggestBuildRulesTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2012-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.jvm.java;
+
+import static org.junit.Assert.assertEquals;
+
+import com.facebook.buck.cli.BuildTargetNodeToBuildRuleTransformer;
+import com.facebook.buck.io.ProjectFilesystem;
+import com.facebook.buck.jvm.core.SuggestBuildRules;
+import com.facebook.buck.model.BuildTarget;
+import com.facebook.buck.model.BuildTargetFactory;
+import com.facebook.buck.parser.NoSuchBuildTargetException;
+import com.facebook.buck.rules.BuildRule;
+import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.TargetGraph;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+public class DefaultSuggestBuildRulesTest {
+  @Rule
+  public TemporaryFolder tmp = new TemporaryFolder();
+
+  private BuildRuleResolver ruleResolver;
+  private ProjectFilesystem projectFilesystem;
+
+  @Before
+  public void before() {
+    ruleResolver =
+        new BuildRuleResolver(TargetGraph.EMPTY, new BuildTargetNodeToBuildRuleTransformer());
+    projectFilesystem = new ProjectFilesystem(tmp.getRoot().toPath());
+  }
+
+  @Test
+  public void suggestTheTopologicallyNearestDependency() throws NoSuchBuildTargetException {
+    // TODO(grumpyjames): stop duplicating source/symbol names if possible
+    BuildRule libraryTwo = javaLibrary("//:libtwo", "com/facebook/Foo.java");
+    BuildRule parent = javaLibrary("//:parent", "com/facebook/Foo.java", libraryTwo);
+    BuildRule grandparent = javaLibrary("//:grandparent", "com/parent/OldManRiver.java", parent);
+
+    ImmutableMap<Path, String> jarPathToSymbols = ImmutableMap.of(
+        parent.getPathToOutput(), "com.facebook.Foo",
+        libraryTwo.getPathToOutput(), "com.facebook.Foo");
+    ImmutableSetMultimap<JavaLibrary, Path> transitiveClasspathEntries =
+        fromLibraries(libraryTwo, parent, grandparent);
+
+    SuggestBuildRules.JarResolver jarResolver = createJarResolver(jarPathToSymbols);
+
+    SuggestBuildRules suggestFn =
+        DefaultSuggestBuildRules.createSuggestBuildFunction(
+            jarResolver,
+            ImmutableSetMultimap.<JavaLibrary, Path>of(),
+            ImmutableSetMultimap.<JavaLibrary, Path>builder()
+                .putAll(transitiveClasspathEntries)
+                .build(),
+            ImmutableList.of(libraryTwo, parent, grandparent));
+
+    final ImmutableSet<String> suggestions =
+        suggestFn.suggest(
+            projectFilesystem,
+            ImmutableSet.of("com.facebook.Foo"));
+
+    assertEquals(ImmutableSet.of("//:parent"), suggestions);
+  }
+
+  @Test
+  public void suggestTopologicallyDistantDependency() throws NoSuchBuildTargetException {
+    // TODO(grumpyjames): stop duplicating source/symbol names if possible
+    BuildRule libraryTwo = javaLibrary("//:libtwo", "com/facebook/Bar.java");
+    BuildRule parent = javaLibrary("//:parent", "com/facebook/Foo.java", libraryTwo);
+    BuildRule grandparent = javaLibrary("//:grandparent", "com/parent/OldManRiver.java", parent);
+
+    ImmutableMap<Path, String> jarPathToSymbols = ImmutableMap.of(
+        parent.getPathToOutput(), "com.facebook.Foo",
+        libraryTwo.getPathToOutput(), "com.facebook.Bar");
+    ImmutableSetMultimap<JavaLibrary, Path> transitiveClasspathEntries =
+        fromLibraries(libraryTwo, parent, grandparent);
+
+    SuggestBuildRules.JarResolver jarResolver = createJarResolver(jarPathToSymbols);
+
+    SuggestBuildRules suggestFn =
+        DefaultSuggestBuildRules.createSuggestBuildFunction(
+            jarResolver,
+            ImmutableSetMultimap.<JavaLibrary, Path>of(),
+            ImmutableSetMultimap.<JavaLibrary, Path>builder()
+                .putAll(transitiveClasspathEntries)
+                .build(),
+            ImmutableList.of(libraryTwo, parent, grandparent));
+
+    final ImmutableSet<String> suggestions =
+        suggestFn.suggest(
+            projectFilesystem,
+            ImmutableSet.of("com.facebook.Bar"));
+
+    assertEquals(ImmutableSet.of("//:libtwo"), suggestions);
+  }
+
+  private ImmutableSetMultimap<JavaLibrary, Path> fromLibraries(BuildRule...buildRules) {
+    ImmutableSetMultimap.Builder<JavaLibrary, Path> builder =
+        ImmutableSetMultimap.builder();
+
+    for (BuildRule buildRule : buildRules) {
+      //noinspection ConstantConditions
+      builder.put((JavaLibrary) buildRule, buildRule.getPathToOutput());
+    }
+
+    return builder.build();
+  }
+
+  private SuggestBuildRules.JarResolver createJarResolver(
+      final ImmutableMap<Path, String> classToSymbols) {
+
+    ImmutableSetMultimap.Builder<Path, String> resolveMapBuilder =
+        ImmutableSetMultimap.builder();
+
+    for (Map.Entry<Path, String> entry : classToSymbols.entrySet()) {
+      String fullyQualified = entry.getValue();
+      String packageName = fullyQualified.substring(0, fullyQualified.lastIndexOf('.'));
+      String className = fullyQualified.substring(fullyQualified.lastIndexOf('.'));
+      resolveMapBuilder.putAll(entry.getKey(), fullyQualified, packageName, className);
+    }
+
+    final ImmutableSetMultimap<Path, String> resolveMap = resolveMapBuilder.build();
+
+    return new SuggestBuildRules.JarResolver() {
+      @Override
+      public ImmutableSet<String> resolve(ProjectFilesystem filesystem, Path relativeClassPath) {
+        if (resolveMap.containsKey(relativeClassPath)) {
+          return resolveMap.get(relativeClassPath);
+        } else {
+          return ImmutableSet.of();
+        }
+      }
+    };
+  }
+
+  private BuildRule javaLibrary(
+      String name,
+      String pathToClass,
+      BuildRule... deps) throws NoSuchBuildTargetException {
+    BuildTarget target = BuildTargetFactory.newInstance(name);
+
+    JavaLibraryBuilder builder = JavaLibraryBuilder
+        .createBuilder(target)
+        .addSrc(Paths.get("java/src/" + pathToClass));
+    for (BuildRule dep : deps) {
+      builder = builder.addDep(dep.getBuildTarget());
+    }
+    return builder.build(ruleResolver);
+  }
+}


### PR DESCRIPTION
Summary:

It feels like it would be nice to test it without having to rely on
DefaultJavaLibrary, so we extract out the previously anonymous
SuggestBuildRules implementation, rework its inputs to make it look a
little more like a pure function. We also split the existing test into
two cases and substantially rework the tests to make adding further
cases a little simpler.

Test-plan: CI