### PR TITLE
Honor cell root during classpath entry construction

### DIFF
--- a/src/com/facebook/buck/jvm/java/JavaLibraryClasspathProvider.java
+++ b/src/com/facebook/buck/jvm/java/JavaLibraryClasspathProvider.java
@@ -55,7 +55,8 @@ public class JavaLibraryClasspathProvider {
     }
 
     if (outputJar.isPresent()) {
-      outputClasspathBuilder.put(javaLibraryRule, outputJar.get());
+      outputClasspathBuilder.put(javaLibraryRule,
+          javaLibraryRule.getProjectFilesystem().resolve(outputJar.get()));
     }
 
     return outputClasspathBuilder.build();


### PR DESCRIPTION
Rule can be provided from different cell and thus output file name
must be rellocated according to cell root. Otherwise classpath would
contain non existent entries from foreign project file system.

TEST PLAN:

1. Clone JGit with this patch: [1].
2. Clone Gerrit Code Review with this patch: [2].
3. Replace JGit cell during Gerrit build, with:

  $ buck build --config repositories.jgit=../jgit gerrit

Observe, that without this diff, the classpath contains invalid
entries: non rellocated jgit output file. This diff rellocates it to
jgit cell.

[1] https://git.eclipse.org/r/61938
[2] https://gerrit-review.googlesource.com/73000

Fixes: https://github.com/facebook/buck/issues/545