### PR TITLE
Cross-cell: Fix file system mismatch in macro expansion machinery

### DIFF
--- a/src/com/facebook/buck/android/AndroidBinaryDescription.java
+++ b/src/com/facebook/buck/android/AndroidBinaryDescription.java
@@ -251,8 +251,7 @@ public class AndroidBinaryDescription
         MACRO_HANDLER.getExpander(
             params.getBuildTarget(),
             params.getCellRoots(),
-            resolver,
-            params.getProjectFilesystem()),
+            resolver),
         args.preprocessJavaClassesBash,
         rulesToExcludeFromDex,
         result,

--- a/src/com/facebook/buck/android/NdkLibraryDescription.java
+++ b/src/com/facebook/buck/android/NdkLibraryDescription.java
@@ -357,8 +357,7 @@ public class NdkLibraryDescription implements Description<NdkLibraryDescription.
         MACRO_HANDLER.getExpander(
             params.getBuildTarget(),
             params.getCellRoots(),
-            resolver,
-            params.getProjectFilesystem()));
+            resolver));
   }
 
   @SuppressFieldNotInitialized

--- a/src/com/facebook/buck/cxx/CxxDescriptionEnhancer.java
+++ b/src/com/facebook/buck/cxx/CxxDescriptionEnhancer.java
@@ -651,8 +651,7 @@ public class CxxDescriptionEnhancer {
                     MACRO_HANDLER,
                     params.getBuildTarget(),
                     params.getCellRoots(),
-                    resolver,
-                    params.getProjectFilesystem())));
+                    resolver)));
 
     // Special handling for dynamically linked binaries.
     if (linkStyle == Linker.LinkableDepType.SHARED) {

--- a/src/com/facebook/buck/cxx/CxxLibraryDescription.java
+++ b/src/com/facebook/buck/cxx/CxxLibraryDescription.java
@@ -399,8 +399,7 @@ public class CxxLibraryDescription implements
                             MACRO_HANDLER,
                             params.getBuildTarget(),
                             params.getCellRoots(),
-                            ruleResolver,
-                            params.getProjectFilesystem())))
+                            ruleResolver)))
             .addAll(SourcePathArg.from(pathResolver, objects.values()))
             .build(),
         linkableDepType,
@@ -914,8 +913,7 @@ public class CxxLibraryDescription implements
                         MACRO_HANDLER,
                         params.getBuildTarget(),
                         params.getCellRoots(),
-                        resolver,
-                        params.getProjectFilesystem()))
+                        resolver))
                 .toList();
           }
         },

--- a/src/com/facebook/buck/cxx/CxxTestDescription.java
+++ b/src/com/facebook/buck/cxx/CxxTestDescription.java
@@ -117,8 +117,7 @@ public class CxxTestDescription implements
                     CxxDescriptionEnhancer.MACRO_HANDLER.getExpander(
                         params.getBuildTarget(),
                         params.getCellRoots(),
-                        resolver,
-                        params.getProjectFilesystem())));
+                        resolver)));
           }
         };
 
@@ -132,8 +131,7 @@ public class CxxTestDescription implements
                     CxxDescriptionEnhancer.MACRO_HANDLER.getExpander(
                         params.getBuildTarget(),
                         params.getCellRoots(),
-                        resolver,
-                        params.getProjectFilesystem()))
+                        resolver))
                 .toList();
           }
         };

--- a/src/com/facebook/buck/python/PythonTestDescription.java
+++ b/src/com/facebook/buck/python/PythonTestDescription.java
@@ -286,8 +286,7 @@ public class PythonTestDescription implements
                     MACRO_HANDLER.getExpander(
                         params.getBuildTarget(),
                         params.getCellRoots(),
-                        resolver,
-                        params.getProjectFilesystem())));
+                        resolver)));
           }
         };
 

--- a/src/com/facebook/buck/rules/args/MacroArg.java
+++ b/src/com/facebook/buck/rules/args/MacroArg.java
@@ -16,7 +16,6 @@
 
 package com.facebook.buck.rules.args;
 
-import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
@@ -41,7 +40,6 @@ public class MacroArg extends Arg {
   private final BuildTarget target;
   private final Function<Optional<String>, Path> cellNames;
   private final BuildRuleResolver resolver;
-  private final ProjectFilesystem filesystem;
   private final String unexpanded;
 
   public MacroArg(
@@ -49,20 +47,18 @@ public class MacroArg extends Arg {
       BuildTarget target,
       Function<Optional<String>, Path> cellNames,
       BuildRuleResolver resolver,
-      ProjectFilesystem filesystem,
       String unexpanded) {
     this.expander = expander;
     this.target = target;
     this.cellNames = cellNames;
     this.resolver = resolver;
-    this.filesystem = filesystem;
     this.unexpanded = unexpanded;
   }
 
   @Override
   public void appendToCommandLine(ImmutableCollection.Builder<String> builder) {
     try {
-      builder.add(expander.expand(target, cellNames, resolver, filesystem, unexpanded));
+      builder.add(expander.expand(target, cellNames, resolver, unexpanded));
     } catch (MacroException e) {
       throw new HumanReadableException(e, "%s: %s", target, e.getMessage());
     }
@@ -117,12 +113,11 @@ public class MacroArg extends Arg {
       final MacroHandler expander,
       final BuildTarget target,
       final Function<Optional<String>, Path> cellNames,
-      final BuildRuleResolver resolver,
-      final ProjectFilesystem filesystem) {
+      final BuildRuleResolver resolver) {
     return new Function<String, Arg>() {
       @Override
       public MacroArg apply(String unexpanded) {
-        return new MacroArg(expander, target, cellNames, resolver, filesystem, unexpanded);
+        return new MacroArg(expander, target, cellNames, resolver, unexpanded);
       }
     };
   }

--- a/src/com/facebook/buck/rules/macros/BuildTargetMacroExpander.java
+++ b/src/com/facebook/buck/rules/macros/BuildTargetMacroExpander.java
@@ -16,7 +16,6 @@
 
 package com.facebook.buck.rules.macros;
 
-import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.parser.BuildTargetParseException;
 import com.facebook.buck.parser.BuildTargetParser;
@@ -41,7 +40,6 @@ public abstract class BuildTargetMacroExpander implements MacroExpander {
 
   protected abstract String expand(
       SourcePathResolver resolver,
-      ProjectFilesystem filesystem,
       BuildRule rule)
       throws MacroException;
 
@@ -73,12 +71,10 @@ public abstract class BuildTargetMacroExpander implements MacroExpander {
       BuildTarget target,
       Function<Optional<String>, Path> cellNames,
       BuildRuleResolver resolver,
-      ProjectFilesystem filesystem,
       String input)
       throws MacroException {
     return expand(
         new SourcePathResolver(resolver),
-        filesystem,
         resolve(target, cellNames, resolver, input));
   }
 

--- a/src/com/facebook/buck/rules/macros/ClasspathMacroExpander.java
+++ b/src/com/facebook/buck/rules/macros/ClasspathMacroExpander.java
@@ -16,7 +16,6 @@
 
 package com.facebook.buck.rules.macros;
 
-import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.jvm.java.HasClasspathEntries;
 import com.facebook.buck.jvm.java.JavaLibrary;
 import com.facebook.buck.model.BuildTarget;
@@ -79,18 +78,17 @@ public class ClasspathMacroExpander
       BuildTarget target,
       Function<Optional<String>, Path> cellNames,
       BuildRuleResolver resolver,
-      ProjectFilesystem filesystem,
       String input) throws MacroException {
     // javac is the canonical reader of classpaths, and its code for reading classpaths from
     // files is a little weird:
     // http://hg.openjdk.java.net/jdk7/jdk7/langtools/file/ce654f4ecfd8/src/share/classes/com/sun/tools/javac/main/CommandLine.java#l74
     // The # characters that might be present in classpaths due to flavoring would be read as
     // comments. As a simple workaround, we quote the entire classpath.
-    return String.format("'%s'", expand(target, cellNames, resolver, filesystem, input));
+    return String.format("'%s'", expand(target, cellNames, resolver, input));
   }
 
   @Override
-  protected String expand(SourcePathResolver resolver, ProjectFilesystem filesystem, BuildRule rule)
+  protected String expand(SourcePathResolver resolver, BuildRule rule)
       throws MacroException {
     return Joiner.on(File.pathSeparator).join(
         FluentIterable.from(getHasClasspathEntries(rule).getTransitiveClasspathDeps())
@@ -103,7 +101,7 @@ public class ClasspathMacroExpander
                   }
                 })
             .filter(Predicates.notNull())
-            .transform(filesystem.getAbsolutifier())
+            .transform(rule.getProjectFilesystem().getAbsolutifier())
             .transform(Functions.toStringFunction())
             .toSortedSet(Ordering.natural()));
   }

--- a/src/com/facebook/buck/rules/macros/EnvironmentVariableMacroExpander.java
+++ b/src/com/facebook/buck/rules/macros/EnvironmentVariableMacroExpander.java
@@ -15,7 +15,6 @@
  */
 package com.facebook.buck.rules.macros;
 
-import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
@@ -44,7 +43,6 @@ public class EnvironmentVariableMacroExpander implements MacroExpander {
       BuildTarget target,
       Function<Optional<String>, Path> cellNames,
       BuildRuleResolver resolver,
-      ProjectFilesystem filesystem,
       String input) throws MacroException {
     if (platform == Platform.WINDOWS) {
       if ("pwd".equalsIgnoreCase(input)) {

--- a/src/com/facebook/buck/rules/macros/ExecutableMacroExpander.java
+++ b/src/com/facebook/buck/rules/macros/ExecutableMacroExpander.java
@@ -16,7 +16,6 @@
 
 package com.facebook.buck.rules.macros;
 
-import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.rules.BinaryBuildRule;
 import com.facebook.buck.rules.BuildRule;
@@ -56,7 +55,7 @@ public class ExecutableMacroExpander extends BuildTargetMacroExpander {
   }
 
   @Override
-  public String expand(SourcePathResolver resolver, ProjectFilesystem filesystem, BuildRule rule)
+  public String expand(SourcePathResolver resolver, BuildRule rule)
       throws MacroException {
     // TODO(mikekap): Pass environment variables through.
     return Joiner.on(' ').join(

--- a/src/com/facebook/buck/rules/macros/LocationMacroExpander.java
+++ b/src/com/facebook/buck/rules/macros/LocationMacroExpander.java
@@ -16,7 +16,6 @@
 
 package com.facebook.buck.rules.macros;
 
-import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.SourcePathResolver;
 
@@ -28,7 +27,7 @@ import java.nio.file.Path;
 public class LocationMacroExpander extends BuildTargetMacroExpander {
 
   @Override
-  public String expand(SourcePathResolver resolver, ProjectFilesystem filesystem, BuildRule rule)
+  public String expand(SourcePathResolver resolver, BuildRule rule)
       throws MacroException {
     Path output = rule.getPathToOutput();
     if (output == null) {
@@ -37,7 +36,7 @@ public class LocationMacroExpander extends BuildTargetMacroExpander {
               "%s used in location macro does not produce output",
               rule.getBuildTarget()));
     }
-    return filesystem.resolve(output).toString();
+    return rule.getProjectFilesystem().resolve(output).toString();
   }
 
 }

--- a/src/com/facebook/buck/rules/macros/MacroExpander.java
+++ b/src/com/facebook/buck/rules/macros/MacroExpander.java
@@ -16,7 +16,6 @@
 
 package com.facebook.buck.rules.macros;
 
-import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
@@ -35,7 +34,6 @@ public interface MacroExpander {
       BuildTarget target,
       Function<Optional<String>, Path> cellNames,
       BuildRuleResolver resolver,
-      ProjectFilesystem filesystem,
       String input)
       throws MacroException;
 

--- a/src/com/facebook/buck/rules/macros/MacroExpanderWithCustomFileOutput.java
+++ b/src/com/facebook/buck/rules/macros/MacroExpanderWithCustomFileOutput.java
@@ -16,7 +16,6 @@
 
 package com.facebook.buck.rules.macros;
 
-import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.google.common.base.Function;
@@ -37,7 +36,6 @@ public interface MacroExpanderWithCustomFileOutput {
       BuildTarget target,
       Function<Optional<String>, Path> cellNames,
       BuildRuleResolver resolver,
-      ProjectFilesystem filesystem,
       String input)
       throws MacroException;
 }

--- a/src/com/facebook/buck/rules/macros/MacroHandler.java
+++ b/src/com/facebook/buck/rules/macros/MacroHandler.java
@@ -16,7 +16,6 @@
 
 package com.facebook.buck.rules.macros;
 
-import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.Pair;
 import com.facebook.buck.rules.BuildRule;
@@ -46,13 +45,12 @@ public class MacroHandler {
   public Function<String, String> getExpander(
       final BuildTarget target,
       final Function<Optional<String>, Path> cellNames,
-      final BuildRuleResolver resolver,
-      final ProjectFilesystem filesystem) {
+      final BuildRuleResolver resolver) {
     return new Function<String, String>() {
       @Override
       public String apply(String blob) {
         try {
-          return expand(target, cellNames, resolver, filesystem, blob);
+          return expand(target, cellNames, resolver, blob);
         } catch (MacroException e) {
           throw new HumanReadableException("%s: %s", target, e.getMessage());
         }
@@ -90,7 +88,6 @@ public class MacroHandler {
       final BuildTarget target,
       final Function<Optional<String>, Path> cellNames,
       final BuildRuleResolver resolver,
-      final ProjectFilesystem filesystem,
       String blob)
       throws MacroException {
     ImmutableMap.Builder<String, MacroReplacer> replacers = ImmutableMap.builder();
@@ -104,7 +101,6 @@ public class MacroHandler {
                   target,
                   cellNames,
                   resolver,
-                  filesystem,
                   input);
             }
           });

--- a/src/com/facebook/buck/shell/AbstractGenruleDescription.java
+++ b/src/com/facebook/buck/shell/AbstractGenruleDescription.java
@@ -77,8 +77,7 @@ public abstract class AbstractGenruleDescription<T extends AbstractGenruleDescri
             MACRO_HANDLER,
             params.getBuildTarget(),
             params.getCellRoots(),
-            resolver,
-            params.getProjectFilesystem());
+            resolver);
     final Optional<com.facebook.buck.rules.args.Arg> cmd = args.cmd.transform(macroArgFunction);
     final Optional<com.facebook.buck.rules.args.Arg> bash = args.bash.transform(macroArgFunction);
     final Optional<com.facebook.buck.rules.args.Arg> cmdExe =

--- a/src/com/facebook/buck/shell/ShTestDescription.java
+++ b/src/com/facebook/buck/shell/ShTestDescription.java
@@ -78,8 +78,7 @@ public class ShTestDescription implements Description<ShTestDescription.Arg> {
                     MACRO_HANDLER,
                     params.getBuildTarget(),
                     params.getCellRoots(),
-                    resolver,
-                    params.getProjectFilesystem()))
+                    resolver))
             .toList();
     return new ShTest(
         params.appendExtraDeps(

--- a/test/com/facebook/buck/rules/args/MacroArgTest.java
+++ b/test/com/facebook/buck/rules/args/MacroArgTest.java
@@ -54,7 +54,6 @@ public class MacroArgTest {
             BuildTargetFactory.newInstance("//:rule"),
             TestCellBuilder.createCellRoots(filesystem),
             resolver,
-            filesystem,
             "$(macro)");
     assertThat(Arg.stringListFunction().apply(arg), Matchers.contains("expanded"));
   }
@@ -78,7 +77,6 @@ public class MacroArgTest {
             rule.getBuildTarget(),
             TestCellBuilder.createCellRoots(filesystem),
             resolver,
-            filesystem,
             "$(loc //:rule)");
     assertThat(
         arg.getDeps(pathResolver),

--- a/test/com/facebook/buck/rules/macros/BuildTargetMacroExpanderTest.java
+++ b/test/com/facebook/buck/rules/macros/BuildTargetMacroExpanderTest.java
@@ -58,14 +58,13 @@ public class BuildTargetMacroExpanderTest {
               @Override
               public String expand(
                   SourcePathResolver resolver,
-                  ProjectFilesystem filesystem,
                   BuildRule rule)
                   throws MacroException {
                 found.add(rule.getBuildTarget());
                 return "";
               }
             }));
-    handler.expand(rule.getBuildTarget(), createCellRoots(filesystem), resolver, filesystem, blob);
+    handler.expand(rule.getBuildTarget(), createCellRoots(filesystem), resolver, blob);
     return Optional.fromNullable(Iterables.getFirst(found, null));
   }
 

--- a/test/com/facebook/buck/rules/macros/ClasspathMacroExpanderTest.java
+++ b/test/com/facebook/buck/rules/macros/ClasspathMacroExpanderTest.java
@@ -111,7 +111,7 @@ public class ClasspathMacroExpanderTest {
           .setSrc(new FakeSourcePath("some-file.jar"))
           .build(ruleResolver);
 
-    expander.expand(pathResolver, filesystem, rule);
+    expander.expand(pathResolver, rule);
   }
 
   @Test
@@ -169,12 +169,11 @@ public class ClasspathMacroExpanderTest {
       BuildRule rule,
       BuildRuleResolver buildRuleResolver,
       String expectedClasspath) throws MacroException {
-    String classpath = expander.expand(new SourcePathResolver(buildRuleResolver), filesystem, rule);
+    String classpath = expander.expand(new SourcePathResolver(buildRuleResolver), rule);
     String fileClasspath = expander.expandForFile(
         rule.getBuildTarget(),
         createCellRoots(filesystem),
         buildRuleResolver,
-        filesystem,
         ':' + rule.getBuildTarget().getShortName());
 
     assertEquals(expectedClasspath, classpath);

--- a/test/com/facebook/buck/rules/macros/ExecutableMacroExpanderTest.java
+++ b/test/com/facebook/buck/rules/macros/ExecutableMacroExpanderTest.java
@@ -87,7 +87,6 @@ public class ExecutableMacroExpanderTest {
         target,
         createCellRoots(filesystem),
         ruleResolver,
-        filesystem,
         originalCmd);
 
     // Verify that the correct cmd was created.
@@ -117,7 +116,6 @@ public class ExecutableMacroExpanderTest {
         rule.getBuildTarget(),
         createCellRoots(filesystem),
         ruleResolver,
-        filesystem,
         originalCmd);
 
     // Verify that the correct cmd was created.
@@ -147,7 +145,6 @@ public class ExecutableMacroExpanderTest {
         rule.getBuildTarget(),
         createCellRoots(filesystem),
         ruleResolver,
-        filesystem,
         originalCmd);
 
     // Verify that the correct cmd was created.
@@ -198,7 +195,7 @@ public class ExecutableMacroExpanderTest {
             "//:rule"),
         Matchers.containsInAnyOrder(dep1, dep2));
     assertThat(
-        expander.expand(target, createCellRoots(filesystem), ruleResolver, filesystem, "//:rule"),
+        expander.expand(target, createCellRoots(filesystem), ruleResolver, "//:rule"),
         Matchers.equalTo(
             String.format(
                 "%s %s",

--- a/test/com/facebook/buck/rules/macros/LocationMacroExpanderTest.java
+++ b/test/com/facebook/buck/rules/macros/LocationMacroExpanderTest.java
@@ -81,7 +81,6 @@ public class LocationMacroExpanderTest {
           target,
           createCellRoots(filesystem),
           resolver,
-          filesystem,
           "$(location //cheese:java)");
       fail("Location was null. Expected HumanReadableException with helpful message.");
     } catch (MacroException e) {
@@ -115,7 +114,6 @@ public class LocationMacroExpanderTest {
         javaBinary.getBuildTarget(),
         createCellRoots(filesystem),
         ruleResolver,
-        filesystem,
         originalCmd);
 
     // Verify that the correct cmd was created.

--- a/test/com/facebook/buck/rules/macros/MacroHandlerTest.java
+++ b/test/com/facebook/buck/rules/macros/MacroHandlerTest.java
@@ -60,7 +60,6 @@ public class MacroHandlerTest {
           target,
           createCellRoots(filesystem),
           resolver,
-          filesystem,
           "$(badmacro hello)");
     } catch (MacroException e) {
       assertTrue(e.getMessage().contains("no such macro \"badmacro\""));
@@ -80,7 +79,6 @@ public class MacroHandlerTest {
         target,
         createCellRoots(filesystem),
         resolver,
-        filesystem,
         raw);
     assertEquals("hello $(notamacro hello)", expanded);
   }
@@ -93,7 +91,6 @@ public class MacroHandlerTest {
         target,
         createCellRoots(filesystem),
         resolver,
-        filesystem,
         "Hello $(@foo //:test)");
 
     assertTrue(expanded, expanded.startsWith("Hello @"));

--- a/test/com/facebook/buck/rules/macros/OutputToFileExpanderTest.java
+++ b/test/com/facebook/buck/rules/macros/OutputToFileExpanderTest.java
@@ -61,7 +61,6 @@ public class OutputToFileExpanderTest {
         target,
         createCellRoots(filesystem),
         new BuildRuleResolver(TargetGraph.EMPTY, new BuildTargetNodeToBuildRuleTransformer()),
-        filesystem,
         "totally ignored");
 
     assertTrue(result, result.startsWith("@"));

--- a/test/com/facebook/buck/rules/macros/StringExpander.java
+++ b/test/com/facebook/buck/rules/macros/StringExpander.java
@@ -16,7 +16,6 @@
 
 package com.facebook.buck.rules.macros;
 
-import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
@@ -39,7 +38,6 @@ public class StringExpander implements MacroExpander {
       BuildTarget target,
       Function<Optional<String>, Path> cellNames,
       BuildRuleResolver resolver,
-      ProjectFilesystem filesystem,
       String input)
       throws MacroException {
     return toReturn;


### PR DESCRIPTION
Owning rule must not necessary belong to the same cell as the macros
it contains:

  genrule(
    name = 'foo',
    cmd = 'echo "$(location @bar//:baz)" > $OUT',
    out = 'qux',
  )

Cell can be located in the same project, but can be hijacked by the
command line parameter. Consider the following configuration in
.buckconfig for the example above:

  [repositories]
    bar = lib/bar

It can optionally be relocated with --config CLI parameter:

  $ buck build //:foo
  $ buck build --config repositories.bar=/path/to/hijacked/bar //:foo

IOW it is always wrong to assume that the owning rule and all macros
it contains belong to the same cell. Remove filesystem parameter from
the macro expansion machinery and rely on the rule that has access
to its own filesystem to perform correct path resolution.

TEST PLAN:

1. Clone JGit with this patch: [1].
2. Clone Gerrit Code Review with this patch: [2].
3. Replace JGit cell during Gerrit build, with:

  $ buck build --config repositories.jgit=/path/to/jgit gerrit

Observe that without this diff, '$(location @jgit//:jgit_src)' is
expanded to <path-to-gerrit>/buck-out/gen/jgit_src.jar. With this diff,
file system mismatch is fixed and the expansion is correct:
/path/to/jgit/buck-out/gen/jgit_src.jar

[1] https://git.eclipse.org/r/61938
[2] https://gerrit-review.googlesource.com/73000

Fixes: https://github.com/facebook/buck/issues/544