### PR TITLE
Cross-cell: Fix file system mismatch in classpath resolution

### DIFF
--- a/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
+++ b/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
@@ -273,7 +273,8 @@ public class DefaultJavaLibrary extends AbstractBuildRule
           public ImmutableSetMultimap<JavaLibrary, Path> get() {
             return JavaLibraryClasspathProvider.getOutputClasspathEntries(
                 DefaultJavaLibrary.this,
-                outputJar);
+                getResolver(),
+                sourcePathForOutputJar());
           }
         });
 
@@ -283,7 +284,8 @@ public class DefaultJavaLibrary extends AbstractBuildRule
           public ImmutableSetMultimap<JavaLibrary, Path> get() {
             return JavaLibraryClasspathProvider.getTransitiveClasspathEntries(
                 DefaultJavaLibrary.this,
-                outputJar);
+                getResolver(),
+                sourcePathForOutputJar());
           }
         });
 
@@ -294,7 +296,7 @@ public class DefaultJavaLibrary extends AbstractBuildRule
               public ImmutableSet<JavaLibrary> get() {
                 return JavaLibraryClasspathProvider.getTransitiveClasspathDeps(
                     DefaultJavaLibrary.this,
-                    outputJar);
+                    sourcePathForOutputJar());
               }
             });
 
@@ -317,6 +319,12 @@ public class DefaultJavaLibrary extends AbstractBuildRule
 
   private static Path getOutputJarDirPath(BuildTarget target) {
     return BuildTargets.getGenPath(target, "lib__%s__output");
+  }
+
+  private Optional<SourcePath> sourcePathForOutputJar() {
+    return outputJar.isPresent()
+        ? Optional.<SourcePath>of(new BuildTargetSourcePath(getBuildTarget(), outputJar.get()))
+        : Optional.<SourcePath>absent();
   }
 
   static Path getOutputJarPath(BuildTarget target) {

--- a/src/com/facebook/buck/jvm/java/JavaLibraryClasspathProvider.java
+++ b/src/com/facebook/buck/jvm/java/JavaLibraryClasspathProvider.java
@@ -18,6 +18,8 @@ package com.facebook.buck.jvm.java;
 
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.ExportDependencies;
+import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.rules.SourcePathResolver;
 import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableSet;
@@ -33,7 +35,8 @@ public class JavaLibraryClasspathProvider {
 
   public static ImmutableSetMultimap<JavaLibrary, Path> getOutputClasspathEntries(
       JavaLibrary javaLibraryRule,
-      Optional<Path> outputJar) {
+      SourcePathResolver resolver,
+      Optional<SourcePath> outputJar) {
     ImmutableSetMultimap.Builder<JavaLibrary, Path> outputClasspathBuilder =
         ImmutableSetMultimap.builder();
     Iterable<JavaLibrary> javaExportedLibraryDeps;
@@ -55,7 +58,7 @@ public class JavaLibraryClasspathProvider {
     }
 
     if (outputJar.isPresent()) {
-      outputClasspathBuilder.put(javaLibraryRule, outputJar.get());
+      outputClasspathBuilder.put(javaLibraryRule, resolver.getAbsolutePath(outputJar.get()));
     }
 
     return outputClasspathBuilder.build();
@@ -63,7 +66,8 @@ public class JavaLibraryClasspathProvider {
 
   public static ImmutableSetMultimap<JavaLibrary, Path> getTransitiveClasspathEntries(
       JavaLibrary javaLibraryRule,
-      Optional<Path> outputJar) {
+      SourcePathResolver resolver,
+      Optional<SourcePath> outputJar) {
     final ImmutableSetMultimap.Builder<JavaLibrary, Path> classpathEntries =
         ImmutableSetMultimap.builder();
     ImmutableSetMultimap<JavaLibrary, Path> classpathEntriesForDeps =
@@ -90,7 +94,7 @@ public class JavaLibraryClasspathProvider {
 
     // Only add ourselves to the classpath if there's a jar to be built.
     if (outputJar.isPresent()) {
-      classpathEntries.put(javaLibraryRule, outputJar.get());
+      classpathEntries.put(javaLibraryRule, resolver.getAbsolutePath(outputJar.get()));
     }
 
     return classpathEntries.build();
@@ -98,7 +102,7 @@ public class JavaLibraryClasspathProvider {
 
   public static ImmutableSet<JavaLibrary> getTransitiveClasspathDeps(
       JavaLibrary javaLibrary,
-      Optional<Path> outputJar) {
+      Optional<SourcePath> outputJar) {
     ImmutableSet.Builder<JavaLibrary> classpathDeps = ImmutableSet.builder();
 
     classpathDeps.addAll(

--- a/test/com/facebook/buck/jvm/java/FakeJavaLibrary.java
+++ b/test/com/facebook/buck/jvm/java/FakeJavaLibrary.java
@@ -83,14 +83,17 @@ public class FakeJavaLibrary extends FakeBuildRule implements JavaLibrary, Andro
   public ImmutableSetMultimap<JavaLibrary, Path> getTransitiveClasspathEntries() {
     return JavaLibraryClasspathProvider.getTransitiveClasspathEntries(
         this,
-        Optional.fromNullable(getPathToOutput()));
+        getResolver(),
+        Optional.<SourcePath>of(new BuildTargetSourcePath(getBuildTarget(),
+            getPathToOutput())));
   }
 
   @Override
   public ImmutableSet<JavaLibrary> getTransitiveClasspathDeps() {
     return JavaLibraryClasspathProvider.getTransitiveClasspathDeps(
         this,
-        Optional.fromNullable(getPathToOutput()));
+        Optional.<SourcePath>of(new BuildTargetSourcePath(getBuildTarget(),
+            getPathToOutput())));
   }
 
   @Override


### PR DESCRIPTION
Rule can be provided from different cell and thus output file name
must be relocated according to cell root. Change all the methods on
JavaLibraryClasspathProvider that take Optional<Path> outputJar to
take Optional<SourcePath> outputJar instead.

SourcePaths are much safer because they encapsulate the project
filesystem. That way we know they can always be resolved correctly.

Closes #545

TEST PLAN:

Clone JGit with this patch: [1].
Clone Gerrit Code Review with this patch: [2].
Replace JGit cell during Gerrit build, with:

$ buck build --config repositories.jgit=../jgit gerrit

Observe, that without this diff, the classpath contains invalid
entries: non relocated jgit output file. This diff relocates it to
jgit cell.

[1] https://git.eclipse.org/r/61938
[2] https://gerrit-review.googlesource.com/73000