### PR TITLE
Add missing http libraries for buck publish command to work

### DIFF
--- a/programs/buck_repo.py
+++ b/programs/buck_repo.py
@@ -43,6 +43,8 @@ JAVA_CLASSPATHS = [
     "third-party/java/guice/guice-3.0.jar",
     "third-party/java/guice/guice-assistedinject-3.0.jar",
     "third-party/java/guice/guice-multibindings-3.0.jar",
+    "third-party/java/httpcomponents/httpclient-4.2.6.jar",
+    "third-party/java/httpcomponents/httpcore-4.2.5.jar",
     "third-party/java/icu4j/icu4j-54.1.1.jar",
     "third-party/java/infer-annotations/infer-annotations-1.5.jar",
     "third-party/java/ini4j/ini4j-0.5.2.jar",


### PR DESCRIPTION
TEST PLAN:

  $ buck publish --remote-repo <foo> //:bar

isn't failing with:

  java.lang.NoClassDefFoundError: org/apache/http/client/HttpResponseException