### PR TITLE
Cross-cell: Fix file system mismatch in classpath resolution

### DIFF
--- a/src/com/facebook/buck/jvm/core/SuggestBuildRules.java
+++ b/src/com/facebook/buck/jvm/core/SuggestBuildRules.java
@@ -15,18 +15,17 @@
  */
 package com.facebook.buck.jvm.core;
 
-import com.facebook.buck.io.ProjectFilesystem;
 import com.google.common.collect.ImmutableSet;
 
 import java.nio.file.Path;
 
 public interface SuggestBuildRules {
-  ImmutableSet<String> suggest(ProjectFilesystem filesystem, ImmutableSet<String> failedImports);
+  ImmutableSet<String> suggest(ImmutableSet<String> failedImports);
 
   /**
-   * Given a jar, open it, and return all the symbols within.
+   * Given a absolute path to the jar, open it, and return all the symbols within.
    */
   interface JarResolver {
-    ImmutableSet<String> resolve(ProjectFilesystem filesystem, Path relativeClassPath);
+    ImmutableSet<String> resolve(Path absoluteClassPath);
   }
 }

--- a/src/com/facebook/buck/jvm/java/DefaultSuggestBuildRules.java
+++ b/src/com/facebook/buck/jvm/java/DefaultSuggestBuildRules.java
@@ -18,7 +18,6 @@ package com.facebook.buck.jvm.java;
 
 import com.facebook.buck.graph.DirectedAcyclicGraph;
 import com.facebook.buck.graph.TopologicalSort;
-import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.jvm.core.SuggestBuildRules;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleDependencyVisitors;
@@ -75,7 +74,6 @@ final class DefaultSuggestBuildRules implements SuggestBuildRules {
 
   @Override
   public ImmutableSet<String> suggest(
-      ProjectFilesystem filesystem,
       ImmutableSet<String> failedImports) {
     ImmutableSet.Builder<String> suggestedDeps = ImmutableSet.builder();
 
@@ -83,7 +81,6 @@ final class DefaultSuggestBuildRules implements SuggestBuildRules {
 
     for (JavaLibrary transitiveNotDeclaredDep : sortedTransitiveNotDeclaredDeps.get()) {
       if (isMissingBuildRule(
-          filesystem,
           transitiveNotDeclaredDep,
           remainingImports,
           jarResolver)) {
@@ -113,7 +110,6 @@ final class DefaultSuggestBuildRules implements SuggestBuildRules {
    *      rule would have satisfied one of the {@code failedImports}.
    */
   private boolean isMissingBuildRule(
-      ProjectFilesystem filesystem,
       BuildRule transitiveNotDeclaredRule,
       Set<String> failedImports,
       JarResolver jarResolver) {
@@ -129,7 +125,7 @@ final class DefaultSuggestBuildRules implements SuggestBuildRules {
     // the exception of rules that export their dependencies, this will result in a single
     // classpath.
     for (Path classPath : classPaths) {
-      ImmutableSet<String> topLevelSymbols = jarResolver.resolve(filesystem, classPath);
+      ImmutableSet<String> topLevelSymbols = jarResolver.resolve(classPath);
 
       for (String symbolName : topLevelSymbols) {
         if (failedImports.contains(symbolName)) {

--- a/src/com/facebook/buck/jvm/java/JavaLibraryClasspathProvider.java
+++ b/src/com/facebook/buck/jvm/java/JavaLibraryClasspathProvider.java
@@ -18,6 +18,8 @@ package com.facebook.buck.jvm.java;
 
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.ExportDependencies;
+import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.rules.SourcePathResolver;
 import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableSet;
@@ -33,7 +35,8 @@ public class JavaLibraryClasspathProvider {
 
   public static ImmutableSetMultimap<JavaLibrary, Path> getOutputClasspathEntries(
       JavaLibrary javaLibraryRule,
-      Optional<Path> outputJar) {
+      SourcePathResolver resolver,
+      Optional<SourcePath> outputJar) {
     ImmutableSetMultimap.Builder<JavaLibrary, Path> outputClasspathBuilder =
         ImmutableSetMultimap.builder();
     Iterable<JavaLibrary> javaExportedLibraryDeps;
@@ -55,7 +58,7 @@ public class JavaLibraryClasspathProvider {
     }
 
     if (outputJar.isPresent()) {
-      outputClasspathBuilder.put(javaLibraryRule, outputJar.get());
+      outputClasspathBuilder.put(javaLibraryRule, resolver.getAbsolutePath(outputJar.get()));
     }
 
     return outputClasspathBuilder.build();
@@ -63,7 +66,8 @@ public class JavaLibraryClasspathProvider {
 
   public static ImmutableSetMultimap<JavaLibrary, Path> getTransitiveClasspathEntries(
       JavaLibrary javaLibraryRule,
-      Optional<Path> outputJar) {
+      SourcePathResolver resolver,
+      Optional<SourcePath> outputJar) {
     final ImmutableSetMultimap.Builder<JavaLibrary, Path> classpathEntries =
         ImmutableSetMultimap.builder();
     ImmutableSetMultimap<JavaLibrary, Path> classpathEntriesForDeps =
@@ -90,7 +94,7 @@ public class JavaLibraryClasspathProvider {
 
     // Only add ourselves to the classpath if there's a jar to be built.
     if (outputJar.isPresent()) {
-      classpathEntries.put(javaLibraryRule, outputJar.get());
+      classpathEntries.put(javaLibraryRule, resolver.getAbsolutePath(outputJar.get()));
     }
 
     return classpathEntries.build();
@@ -98,7 +102,7 @@ public class JavaLibraryClasspathProvider {
 
   public static ImmutableSet<JavaLibrary> getTransitiveClasspathDeps(
       JavaLibrary javaLibrary,
-      Optional<Path> outputJar) {
+      Optional<SourcePath> outputJar) {
     ImmutableSet.Builder<JavaLibrary> classpathDeps = ImmutableSet.builder();
 
     classpathDeps.addAll(

--- a/src/com/facebook/buck/jvm/java/JavacStep.java
+++ b/src/com/facebook/buck/jvm/java/JavacStep.java
@@ -30,7 +30,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
@@ -160,9 +159,7 @@ public class JavacStep implements Step {
 
         if (suggestBuildRules.isPresent()) {
           ImmutableSet<String> failedImports = findFailedImports(firstOrderStderr);
-          ImmutableSet<String> suggestions = suggestBuildRules.get().suggest(
-              filesystem,
-              failedImports);
+          ImmutableSet<String> suggestions = suggestBuildRules.get().suggest(failedImports);
 
           if (!suggestions.isEmpty()) {
             String invoker = invokingRule.toString();
@@ -283,14 +280,12 @@ public class JavacStep implements Step {
     }
 
     // Specify the output directory.
-    Function<Path, Path> pathRelativizer = filesystem.getAbsolutifier();
-    builder.add("-d").add(pathRelativizer.apply(outputDirectory).toString());
+    Function<Path, Path> pathAbsolutifier = filesystem.getAbsolutifier();
+    builder.add("-d").add(pathAbsolutifier.apply(outputDirectory).toString());
 
     // Build up and set the classpath.
     if (!buildClasspathEntries.isEmpty()) {
-      String classpath = Joiner.on(File.pathSeparator).join(
-          FluentIterable.from(buildClasspathEntries)
-              .transform(pathRelativizer));
+      String classpath = Joiner.on(File.pathSeparator).join(buildClasspathEntries);
       builder.add("-classpath", classpath);
     } else {
       builder.add("-classpath", "''");

--- a/test/com/facebook/buck/android/AndroidBinaryTest.java
+++ b/test/com/facebook/buck/android/AndroidBinaryTest.java
@@ -150,7 +150,9 @@ public class AndroidBinaryTest {
                     "gen/java/src/com/facebook/base/lib__libraryOne__output/" +
                     "libraryOne-obfuscated.jar")),
         ImmutableSet.of(
-            GEN_PATH.resolve("java/src/com/facebook/base/lib__libraryTwo__output/libraryTwo.jar")),
+            libraryTwo.getBuildTarget().getUnflavoredBuildTarget().getCellPath().resolve(
+                GEN_PATH.resolve(
+                    "java/src/com/facebook/base/lib__libraryTwo__output/libraryTwo.jar"))),
         GEN_PATH.resolve("java/src/com/facebook/base/__apk#aapt_package__proguard__/.proguard"),
         buildableContext,
         expectedSteps);

--- a/test/com/facebook/buck/cli/AuditClasspathCommandTest.java
+++ b/test/com/facebook/buck/cli/AuditClasspathCommandTest.java
@@ -42,6 +42,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.SortedSet;
@@ -146,10 +147,13 @@ public class AuditClasspathCommandTest {
         ImmutableSet.of(
             testAndroidTarget));
 
+    Path root = javaLibraryTarget.getUnflavoredBuildTarget().getCellPath();
     SortedSet<String> expectedPaths = Sets.newTreeSet(
         Arrays.asList(
-            GEN_DIR + "/lib__test-android-library__output/test-android-library.jar",
-            GEN_DIR + "/lib__test-java-library__output/test-java-library.jar"));
+            root.resolve(GEN_DIR +
+                "/lib__test-android-library__output/test-android-library.jar").toString(),
+            root.resolve(GEN_DIR +
+                "/lib__test-java-library__output/test-java-library.jar").toString()));
     String expectedClasspath = Joiner.on("\n").join(expectedPaths) + "\n";
 
     assertEquals(expectedClasspath, console.getTextWrittenToStdOut());
@@ -176,7 +180,8 @@ public class AuditClasspathCommandTest {
             androidLibraryTarget,
             testJavaTarget));
 
-    expectedPaths.add(GEN_DIR + "/lib__project-tests__output/project-tests.jar");
+    expectedPaths.add(root.resolve(GEN_DIR +
+        "/lib__project-tests__output/project-tests.jar").toString());
     expectedClasspath = Joiner.on("\n").join(expectedPaths) + "\n";
     assertEquals(expectedClasspath, console.getTextWrittenToStdOut());
     assertEquals("", console.getTextWrittenToStdErr());
@@ -186,12 +191,12 @@ public class AuditClasspathCommandTest {
       "{",
       "\"//:test-android-library\":",
       "[",
-      "\"buck-out/gen/lib__test-java-library__output/test-java-library.jar\",",
-      "\"buck-out/gen/lib__test-android-library__output/test-android-library.jar\"",
+      "\"%s\",",
+      "\"%s\"",
       "],",
       "\"//:test-java-library\":",
       "[",
-      "\"buck-out/gen/lib__test-java-library__output/test-java-library.jar\"",
+      "\"%s\"",
       "]",
       "}");
 
@@ -223,8 +228,16 @@ public class AuditClasspathCommandTest {
             androidTarget,
             javaTarget));
 
-    assertEquals(EXPECTED_JSON, console.getTextWrittenToStdOut());
+    Path root = javaTarget.getCellPath();
+    String expected = String.format(EXPECTED_JSON,
+        root.resolve(
+            "buck-out/gen/lib__test-java-library__output/test-java-library.jar"),
+        root.resolve(
+            "buck-out/gen/lib__test-android-library__output/test-android-library.jar"),
+        root.resolve(
+            "buck-out/gen/lib__test-java-library__output/test-java-library.jar"));
+    assertEquals(expected, console.getTextWrittenToStdOut());
+
     assertEquals("", console.getTextWrittenToStdErr());
   }
-
 }

--- a/test/com/facebook/buck/jvm/java/DefaultJavaLibraryTest.java
+++ b/test/com/facebook/buck/jvm/java/DefaultJavaLibraryTest.java
@@ -316,14 +316,15 @@ public class DefaultJavaLibraryTest {
         .addDep(libraryTwo.getBuildTarget())
         .build(ruleResolver);
 
+    Path root = libraryOne.getProjectFilesystem().getRootPath();
     assertEquals(
         ImmutableSetMultimap.of(
             getJavaLibrary(libraryOne),
-            Paths.get("buck-out/gen/lib__libone__output/libone.jar"),
+            root.resolve("buck-out/gen/lib__libone__output/libone.jar"),
             getJavaLibrary(libraryTwo),
-            Paths.get("buck-out/gen/lib__libtwo__output/libtwo.jar"),
+            root.resolve("buck-out/gen/lib__libtwo__output/libtwo.jar"),
             getJavaLibrary(parent),
-            Paths.get("buck-out/gen/lib__parent__output/parent.jar")),
+            root.resolve("buck-out/gen/lib__parent__output/parent.jar")),
         ((HasClasspathEntries) parent).getTransitiveClasspathEntries());
   }
 
@@ -522,28 +523,29 @@ public class DefaultJavaLibraryTest {
         .addDep(libraryTwo.getBuildTarget())
         .build(ruleResolver);
 
+    Path root = parent.getProjectFilesystem().getRootPath();
     assertEquals(
         "A java_library that depends on //:libone should include only libone.jar in its " +
             "classpath when compiling itself.",
         ImmutableSetMultimap.of(
             getJavaLibrary(notIncluded),
-            Paths.get("buck-out/gen/lib__not_included__output/not_included.jar")),
+            root.resolve("buck-out/gen/lib__not_included__output/not_included.jar")),
         getJavaLibrary(notIncluded).getOutputClasspathEntries());
 
     assertEquals(
         ImmutableSetMultimap.of(
             getJavaLibrary(included),
-            Paths.get("buck-out/gen/lib__included__output/included.jar")),
+            root.resolve("buck-out/gen/lib__included__output/included.jar")),
         getJavaLibrary(included).getOutputClasspathEntries());
 
     assertEquals(
         ImmutableSetMultimap.of(
             getJavaLibrary(included),
-            Paths.get("buck-out/gen/lib__included__output/included.jar"),
+            root.resolve("buck-out/gen/lib__included__output/included.jar"),
             getJavaLibrary(libraryOne),
-            Paths.get("buck-out/gen/lib__libone__output/libone.jar"),
+            root.resolve("buck-out/gen/lib__libone__output/libone.jar"),
             getJavaLibrary(libraryOne),
-            Paths.get("buck-out/gen/lib__included__output/included.jar")),
+            root.resolve("buck-out/gen/lib__included__output/included.jar")),
         getJavaLibrary(libraryOne).getOutputClasspathEntries());
 
     assertEquals(
@@ -551,15 +553,15 @@ public class DefaultJavaLibraryTest {
             "both libone.jar and libtwo.jar in its classpath when compiling itself.",
         ImmutableSetMultimap.of(
             getJavaLibrary(libraryOne),
-            Paths.get("buck-out/gen/lib__libone__output/libone.jar"),
+            root.resolve("buck-out/gen/lib__libone__output/libone.jar"),
             getJavaLibrary(libraryOne),
-            Paths.get("buck-out/gen/lib__included__output/included.jar"),
+            root.resolve("buck-out/gen/lib__included__output/included.jar"),
             getJavaLibrary(libraryTwo),
-            Paths.get("buck-out/gen/lib__libone__output/libone.jar"),
+            root.resolve("buck-out/gen/lib__libone__output/libone.jar"),
             getJavaLibrary(libraryTwo),
-            Paths.get("buck-out/gen/lib__libtwo__output/libtwo.jar"),
+            root.resolve("buck-out/gen/lib__libtwo__output/libtwo.jar"),
             getJavaLibrary(libraryTwo),
-            Paths.get("buck-out/gen/lib__included__output/included.jar")),
+            root.resolve("buck-out/gen/lib__included__output/included.jar")),
         getJavaLibrary(libraryTwo).getOutputClasspathEntries());
 
     assertEquals(
@@ -568,21 +570,22 @@ public class DefaultJavaLibraryTest {
         ImmutableSetMultimap.<JavaLibrary, Path>builder()
             .put(
                 getJavaLibrary(included),
-                Paths.get("buck-out/gen/lib__included__output/included.jar"))
+                root.resolve("buck-out/gen/lib__included__output/included.jar"))
             .put(
                 getJavaLibrary(notIncluded),
-                Paths.get("buck-out/gen/lib__not_included__output/not_included.jar"))
+                root.resolve("buck-out/gen/lib__not_included__output/not_included.jar"))
             .putAll(
                 getJavaLibrary(libraryOne),
-                Paths.get("buck-out/gen/lib__included__output/included.jar"),
-                Paths.get("buck-out/gen/lib__libone__output/libone.jar"))
+                root.resolve("buck-out/gen/lib__included__output/included.jar"),
+                root.resolve("buck-out/gen/lib__libone__output/libone.jar"))
             .putAll(
                 getJavaLibrary(libraryTwo),
-                Paths.get("buck-out/gen/lib__included__output/included.jar"),
-                Paths.get("buck-out/gen/lib__not_included__output/not_included.jar"),
-                Paths.get("buck-out/gen/lib__libone__output/libone.jar"),
-                Paths.get("buck-out/gen/lib__libtwo__output/libtwo.jar"))
-            .put(getJavaLibrary(parent), Paths.get("buck-out/gen/lib__parent__output/parent.jar"))
+                root.resolve("buck-out/gen/lib__included__output/included.jar"),
+                root.resolve("buck-out/gen/lib__not_included__output/not_included.jar"),
+                root.resolve("buck-out/gen/lib__libone__output/libone.jar"),
+                root.resolve("buck-out/gen/lib__libtwo__output/libtwo.jar"))
+            .put(getJavaLibrary(parent),
+                root.resolve("buck-out/gen/lib__parent__output/parent.jar"))
             .build(),
         getJavaLibrary(parent).getTransitiveClasspathEntries());
 
@@ -602,7 +605,7 @@ public class DefaultJavaLibraryTest {
             "-classpath when compiling itself.",
         ImmutableSetMultimap.of(
             getJavaLibrary(parent),
-            Paths.get("buck-out/gen/lib__parent__output/parent.jar")),
+            root.resolve("buck-out/gen/lib__parent__output/parent.jar")),
         getJavaLibrary(parent).getOutputClasspathEntries());
   }
 

--- a/test/com/facebook/buck/jvm/java/DefaultSuggestBuildRulesTest.java
+++ b/test/com/facebook/buck/jvm/java/DefaultSuggestBuildRulesTest.java
@@ -63,8 +63,8 @@ public class DefaultSuggestBuildRulesTest {
     BuildRule grandparent = javaLibrary("//:grandparent", "com/parent/OldManRiver.java", parent);
 
     ImmutableMap<Path, String> jarPathToSymbols = ImmutableMap.of(
-        parent.getPathToOutput(), "com.facebook.Foo",
-        libraryTwo.getPathToOutput(), "com.facebook.Foo");
+        projectFilesystem.resolve(parent.getPathToOutput()), "com.facebook.Foo",
+        projectFilesystem.resolve(libraryTwo.getPathToOutput()), "com.facebook.Foo");
     ImmutableSetMultimap<JavaLibrary, Path> transitiveClasspathEntries =
         fromLibraries(libraryTwo, parent, grandparent);
 
@@ -80,9 +80,7 @@ public class DefaultSuggestBuildRulesTest {
             ImmutableList.of(libraryTwo, parent, grandparent));
 
     final ImmutableSet<String> suggestions =
-        suggestFn.suggest(
-            projectFilesystem,
-            ImmutableSet.of("com.facebook.Foo"));
+        suggestFn.suggest(ImmutableSet.of("com.facebook.Foo"));
 
     assertEquals(ImmutableSet.of("//:parent"), suggestions);
   }
@@ -95,8 +93,8 @@ public class DefaultSuggestBuildRulesTest {
     BuildRule grandparent = javaLibrary("//:grandparent", "com/parent/OldManRiver.java", parent);
 
     ImmutableMap<Path, String> jarPathToSymbols = ImmutableMap.of(
-        parent.getPathToOutput(), "com.facebook.Foo",
-        libraryTwo.getPathToOutput(), "com.facebook.Bar");
+        projectFilesystem.resolve(parent.getPathToOutput()), "com.facebook.Foo",
+        projectFilesystem.resolve(libraryTwo.getPathToOutput()), "com.facebook.Bar");
     ImmutableSetMultimap<JavaLibrary, Path> transitiveClasspathEntries =
         fromLibraries(libraryTwo, parent, grandparent);
 
@@ -112,9 +110,7 @@ public class DefaultSuggestBuildRulesTest {
             ImmutableList.of(libraryTwo, parent, grandparent));
 
     final ImmutableSet<String> suggestions =
-        suggestFn.suggest(
-            projectFilesystem,
-            ImmutableSet.of("com.facebook.Bar"));
+        suggestFn.suggest(ImmutableSet.of("com.facebook.Bar"));
 
     assertEquals(ImmutableSet.of("//:libtwo"), suggestions);
   }
@@ -125,7 +121,7 @@ public class DefaultSuggestBuildRulesTest {
 
     for (BuildRule buildRule : buildRules) {
       //noinspection ConstantConditions
-      builder.put((JavaLibrary) buildRule, buildRule.getPathToOutput());
+      builder.put((JavaLibrary) buildRule, projectFilesystem.resolve(buildRule.getPathToOutput()));
     }
 
     return builder.build();
@@ -148,9 +144,9 @@ public class DefaultSuggestBuildRulesTest {
 
     return new SuggestBuildRules.JarResolver() {
       @Override
-      public ImmutableSet<String> resolve(ProjectFilesystem filesystem, Path relativeClassPath) {
-        if (resolveMap.containsKey(relativeClassPath)) {
-          return resolveMap.get(relativeClassPath);
+      public ImmutableSet<String> resolve(Path absoluteClassPath) {
+        if (resolveMap.containsKey(absoluteClassPath)) {
+          return resolveMap.get(absoluteClassPath);
         } else {
           return ImmutableSet.of();
         }
@@ -170,6 +166,6 @@ public class DefaultSuggestBuildRulesTest {
     for (BuildRule dep : deps) {
       builder = builder.addDep(dep.getBuildTarget());
     }
-    return builder.build(ruleResolver);
+    return builder.build(ruleResolver, projectFilesystem);
   }
 }

--- a/test/com/facebook/buck/jvm/java/FakeJavaLibrary.java
+++ b/test/com/facebook/buck/jvm/java/FakeJavaLibrary.java
@@ -83,14 +83,17 @@ public class FakeJavaLibrary extends FakeBuildRule implements JavaLibrary, Andro
   public ImmutableSetMultimap<JavaLibrary, Path> getTransitiveClasspathEntries() {
     return JavaLibraryClasspathProvider.getTransitiveClasspathEntries(
         this,
-        Optional.fromNullable(getPathToOutput()));
+        getResolver(),
+        Optional.<SourcePath>of(new BuildTargetSourcePath(getBuildTarget(),
+            getPathToOutput())));
   }
 
   @Override
   public ImmutableSet<JavaLibrary> getTransitiveClasspathDeps() {
     return JavaLibraryClasspathProvider.getTransitiveClasspathDeps(
         this,
-        Optional.fromNullable(getPathToOutput()));
+        Optional.<SourcePath>of(new BuildTargetSourcePath(getBuildTarget(),
+            getPathToOutput())));
   }
 
   @Override


### PR DESCRIPTION
Rule can be provided from different cell and thus output file name
must be relocated according to cell root. Change all the methods on
JavaLibraryClasspathProvider that take Optional<Path> outputJar to
take Optional<SourcePath> outputJar instead.

SourcePaths are much safer because they encapsulate the project
filesystem. That way we know they can always be resolved correctly.

Closes #545

TEST PLAN:

Clone JGit with this patch: [1].
Clone Gerrit Code Review with this patch: [2].
Replace JGit cell during Gerrit build, with:

$ buck build --config repositories.jgit=../jgit gerrit

Observe, that without this diff, the classpath contains invalid
entries: non relocated jgit output file. This diff relocates it to
jgit cell.

[1] https://git.eclipse.org/r/61938
[2] https://gerrit-review.googlesource.com/73000