### PR TITLE
Initial groovy library support

### DIFF
--- a/buck.iml
+++ b/buck.iml
@@ -30,6 +30,7 @@
       <excludeFolder url="file://$MODULE_DIR$/test/com/facebook/buck/event/listener/integration/testdata" />
       <excludeFolder url="file://$MODULE_DIR$/test/com/facebook/buck/gwt/testdata" />
       <excludeFolder url="file://$MODULE_DIR$/test/com/facebook/buck/js/testdata" />
+      <excludeFolder url="file://$MODULE_DIR$/test/com/facebook/buck/jvm/groovy/testdata" />
       <excludeFolder url="file://$MODULE_DIR$/test/com/facebook/buck/jvm/java/intellij/testdata" />
       <excludeFolder url="file://$MODULE_DIR$/test/com/facebook/buck/jvm/java/testdata" />
       <excludeFolder url="file://$MODULE_DIR$/test/com/facebook/buck/ocaml/testdata" />

--- a/src/com/facebook/buck/cli/BUCK
+++ b/src/com/facebook/buck/cli/BUCK
@@ -79,6 +79,7 @@ java_library(
     '//src/com/facebook/buck/file:downloader',
     '//src/com/facebook/buck/jvm/java:autodeps',
     '//src/com/facebook/buck/jvm/java:config',
+    '//src/com/facebook/buck/jvm/groovy:rules',
     '//src/com/facebook/buck/jvm/java/intellij:intellij',
     '//src/com/facebook/buck/js:js',
     '//src/com/facebook/buck/ocaml:rules',

--- a/src/com/facebook/buck/jvm/groovy/BUCK
+++ b/src/com/facebook/buck/jvm/groovy/BUCK
@@ -1,0 +1,33 @@
+java_library(
+  name = 'rules',
+  srcs = [
+    'GroovyBuckConfig.java',
+    'GroovyLibraryDescription.java',
+    'GroovycStepFactory.java',
+    'GroovycStep.java',
+  ],
+  tests = [
+    '//test/com/facebook/buck/jvm/groovy:groovy',
+  ],
+  deps = [
+    '//src/com/facebook/buck/android:packageable',
+    '//src/com/facebook/buck/cli:config',
+    '//src/com/facebook/buck/io:io',
+    '//src/com/facebook/buck/jvm/common:resources',
+    '//src/com/facebook/buck/jvm/core:classhash',
+    '//src/com/facebook/buck/jvm/core:suggestbuildrules',
+    '//src/com/facebook/buck/jvm/java:rules',
+    '//src/com/facebook/buck/jvm/java:steps',
+    '//src/com/facebook/buck/jvm/java:support',
+    '//src/com/facebook/buck/model:model',
+    '//src/com/facebook/buck/parser:rule_pattern',
+    '//src/com/facebook/buck/rules:build_rule',
+    '//src/com/facebook/buck/rules:rules',
+    '//src/com/facebook/buck/rules/keys:keys',
+    '//src/com/facebook/buck/step:step',
+    '//src/com/facebook/buck/util:io',
+    '//third-party/java/guava:guava',
+    '//third-party/java/infer-annotations:infer-annotations'
+  ],
+  visibility = ['PUBLIC'],
+)

--- a/src/com/facebook/buck/jvm/groovy/GroovyBuckConfig.java
+++ b/src/com/facebook/buck/jvm/groovy/GroovyBuckConfig.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.buck.jvm.groovy;
+
+import com.facebook.buck.cli.BuckConfig;
+import com.facebook.buck.io.ExecutableFinder;
+import com.facebook.buck.rules.HashedFileTool;
+import com.facebook.buck.rules.Tool;
+import com.facebook.buck.util.HumanReadableException;
+import com.google.common.base.Optional;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class GroovyBuckConfig {
+  private final BuckConfig delegate;
+
+  public GroovyBuckConfig(BuckConfig delegate) {
+    this.delegate = delegate;
+  }
+
+  Supplier<Tool> getGroovyCompiler() {
+
+    Optional<Path> path = delegate.getPath("groovy", "groovy_home");
+    final Path groovyHomePath;
+    if (path.isPresent()) {
+      groovyHomePath = path.get();
+    } else {
+      String defaultGroovyHome = delegate.getEnvironment().get("GROOVY_HOME");
+      if (defaultGroovyHome == null) {
+        throw new HumanReadableException(
+            "Unable to locate groovy compiler:" +
+                " GROOVY_HOME is not set, and groovy.groovy_home was not provided");
+      } else {
+        groovyHomePath = Paths.get(defaultGroovyHome);
+      }
+    }
+
+    Path compiler =
+        new ExecutableFinder().getExecutable(
+            groovyHomePath.resolve("bin/groovyc"),
+            delegate.getEnvironment());
+
+    return Suppliers.<Tool>ofInstance(new HashedFileTool(compiler));
+  }
+}

--- a/src/com/facebook/buck/jvm/groovy/GroovyLibraryDescription.java
+++ b/src/com/facebook/buck/jvm/groovy/GroovyLibraryDescription.java
@@ -21,8 +21,6 @@ import static com.facebook.buck.jvm.common.ResourceValidator.validateResources;
 import com.facebook.buck.jvm.java.CalculateAbi;
 import com.facebook.buck.jvm.java.DefaultJavaLibrary;
 import com.facebook.buck.model.BuildTarget;
-import com.facebook.buck.model.Flavor;
-import com.facebook.buck.model.Flavored;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildRuleResolver;
@@ -42,11 +40,9 @@ import com.google.common.collect.Iterables;
 
 import java.nio.file.Path;
 
-public class GroovyLibraryDescription implements
-    Description<GroovyLibraryDescription.Arg>, Flavored {
+public class GroovyLibraryDescription implements Description<GroovyLibraryDescription.Arg> {
 
   public static final BuildRuleType TYPE = BuildRuleType.of("groovy_library");
-  public static final ImmutableSet<Flavor> SUPPORTED_FLAVORS = ImmutableSet.of();
 
   private final GroovyBuckConfig groovyBuckConfig;
 
@@ -58,11 +54,6 @@ public class GroovyLibraryDescription implements
   @Override
   public BuildRuleType getBuildRuleType() {
     return TYPE;
-  }
-
-  @Override
-  public boolean hasFlavors(ImmutableSet<Flavor> flavors) {
-    return SUPPORTED_FLAVORS.containsAll(flavors);
   }
 
   @Override

--- a/src/com/facebook/buck/jvm/groovy/GroovyLibraryDescription.java
+++ b/src/com/facebook/buck/jvm/groovy/GroovyLibraryDescription.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.jvm.groovy;
+
+import static com.facebook.buck.jvm.common.ResourceValidator.validateResources;
+
+import com.facebook.buck.jvm.java.CalculateAbi;
+import com.facebook.buck.jvm.java.DefaultJavaLibrary;
+import com.facebook.buck.model.BuildTarget;
+import com.facebook.buck.model.Flavor;
+import com.facebook.buck.model.Flavored;
+import com.facebook.buck.rules.BuildRule;
+import com.facebook.buck.rules.BuildRuleParams;
+import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.BuildRuleType;
+import com.facebook.buck.rules.BuildRules;
+import com.facebook.buck.rules.BuildTargetSourcePath;
+import com.facebook.buck.rules.Description;
+import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.buck.rules.TargetGraph;
+import com.facebook.infer.annotation.SuppressFieldNotInitialized;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Iterables;
+
+import java.nio.file.Path;
+
+public class GroovyLibraryDescription implements
+    Description<GroovyLibraryDescription.Arg>, Flavored {
+
+  public static final BuildRuleType TYPE = BuildRuleType.of("groovy_library");
+  public static final ImmutableSet<Flavor> SUPPORTED_FLAVORS = ImmutableSet.of();
+
+  private final GroovyBuckConfig groovyBuckConfig;
+
+  public GroovyLibraryDescription(
+      GroovyBuckConfig groovyBuckConfig) {
+    this.groovyBuckConfig = groovyBuckConfig;
+  }
+
+  @Override
+  public BuildRuleType getBuildRuleType() {
+    return TYPE;
+  }
+
+  @Override
+  public boolean hasFlavors(ImmutableSet<Flavor> flavors) {
+    return SUPPORTED_FLAVORS.containsAll(flavors);
+  }
+
+  @Override
+  public Arg createUnpopulatedConstructorArg() {
+    return new Arg();
+  }
+
+  @Override
+  public <A extends Arg> BuildRule createBuildRule(
+      TargetGraph targetGraph,
+      BuildRuleParams params,
+      BuildRuleResolver resolver,
+      A args) {
+    SourcePathResolver pathResolver = new SourcePathResolver(resolver);
+
+    BuildTarget abiJarTarget =
+        BuildTarget.builder(params.getBuildTarget())
+            .addFlavors(CalculateAbi.FLAVOR)
+            .build();
+
+    ImmutableSortedSet<BuildRule> exportedDeps = resolver.getAllRules(args.exportedDeps.get());
+    DefaultJavaLibrary defaultJavaLibrary =
+        resolver.addToIndex(
+            new DefaultJavaLibrary(
+                params.appendExtraDeps(
+                        BuildRules.getExportedRules(
+                            Iterables.concat(
+                                params.getDeclaredDeps().get(),
+                                exportedDeps,
+                                resolver.getAllRules(args.providedDeps.get())))),
+                pathResolver,
+                args.srcs.get(),
+                validateResources(
+                    pathResolver,
+                    params.getProjectFilesystem(),
+                    args.resources.get()),
+                Optional.<Path>absent(),
+                Optional.<SourcePath>absent(),
+                ImmutableList.<String>of(),
+                exportedDeps,
+                resolver.getAllRules(args.providedDeps.get()),
+                new BuildTargetSourcePath(abiJarTarget),
+                /* additionalClasspathEntries */ ImmutableSet.<Path>of(),
+                new GroovycStepFactory(
+                    groovyBuckConfig.getGroovyCompiler().get(),
+                    args.extraArguments),
+                Optional.<Path>absent(),
+                Optional.<String>absent(),
+                ImmutableSortedSet.<BuildTarget>of()));
+
+    resolver.addToIndex(
+        CalculateAbi.of(
+            abiJarTarget,
+            pathResolver,
+            params,
+            new BuildTargetSourcePath(defaultJavaLibrary.getBuildTarget())));
+
+    return defaultJavaLibrary;
+  }
+
+  @SuppressFieldNotInitialized
+  public static class Arg {
+    public Optional<ImmutableSortedSet<SourcePath>> srcs;
+    public Optional<ImmutableSortedSet<SourcePath>> resources;
+    public Optional<ImmutableList<String>> extraArguments;
+    public Optional<ImmutableSortedSet<BuildTarget>> providedDeps;
+    public Optional<ImmutableSortedSet<BuildTarget>> exportedDeps;
+    public Optional<ImmutableSortedSet<BuildTarget>> deps;
+  }
+
+}

--- a/src/com/facebook/buck/jvm/groovy/GroovycStep.java
+++ b/src/com/facebook/buck/jvm/groovy/GroovycStep.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.jvm.groovy;
+
+import com.facebook.buck.io.ProjectFilesystem;
+import com.facebook.buck.model.BuildTarget;
+import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.buck.rules.Tool;
+import com.facebook.buck.step.ExecutionContext;
+import com.facebook.buck.step.Step;
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Iterables;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+
+class GroovycStep implements Step {
+  private final Tool groovyc;
+  private final Optional<ImmutableList<String>> extraArguments;
+  private final SourcePathResolver resolver;
+  private final Path outputDirectory;
+  private final ImmutableSortedSet<Path> sourceFilePaths;
+  private final ImmutableSortedSet<Path> declaredClasspathEntries;
+  private final BuildTarget invokingRule;
+  private final ProjectFilesystem filesystem;
+
+  GroovycStep(
+      Tool groovyc,
+      Optional<ImmutableList<String>> extraArguments,
+      SourcePathResolver resolver,
+      Path outputDirectory,
+      ImmutableSortedSet<Path> sourceFilePaths,
+      ImmutableSortedSet<Path> declaredClasspathEntries,
+      BuildTarget invokingRule,
+      ProjectFilesystem filesystem) {
+    this.groovyc = groovyc;
+    this.extraArguments = extraArguments;
+    this.resolver = resolver;
+    this.outputDirectory = outputDirectory;
+    this.sourceFilePaths = sourceFilePaths;
+    this.declaredClasspathEntries = declaredClasspathEntries;
+    this.invokingRule = invokingRule;
+    this.filesystem = filesystem;
+  }
+
+  @Override
+  public int execute(ExecutionContext context) throws IOException, InterruptedException {
+    ImmutableList.Builder<String> command = createCommandList();
+
+    ProcessBuilder processBuilder = new ProcessBuilder(command.build());
+
+    // Set environment to client environment and add additional information.
+    Map<String, String> env = processBuilder.environment();
+    env.clear();
+    env.putAll(context.getEnvironment());
+    env.put("BUCK_INVOKING_RULE", invokingRule.toString());
+    env.put("BUCK_TARGET", invokingRule.toString());
+    env.put("BUCK_DIRECTORY_ROOT", filesystem.getRootPath().toAbsolutePath().toString());
+
+    processBuilder.directory(filesystem.getRootPath().toAbsolutePath().toFile());
+    // Run the command
+    int exitCode = -1;
+    try {
+      exitCode = context.getProcessExecutor().execute(processBuilder.start()).getExitCode();
+    } catch (IOException e) {
+      e.printStackTrace(context.getStdErr());
+      return exitCode;
+    }
+
+    return exitCode;
+  }
+
+  private ImmutableList.Builder<String> createCommandList() {
+    ImmutableList.Builder<String> command = ImmutableList.builder();
+    command.addAll(groovyc.getCommandPrefix(resolver))
+        .add("-cp")
+        .add(Joiner.on(":").join(Iterables.transform(
+            declaredClasspathEntries,
+            new Function<Path, String>() {
+              @Override
+              public String apply(Path input) {
+                return input.toString();
+              }
+            })))
+        .add("-d")
+        .add(outputDirectory.toString())
+        .addAll(extraArguments.or(ImmutableList.<String>of()))
+        .addAll(Iterables.transform(
+            sourceFilePaths,
+            new Function<Path, String>() {
+              @Override
+              public String apply(Path input) {
+                return input.toString();
+              }
+            }));
+    return command;
+  }
+
+  @Override
+  public String getShortName() {
+    return Joiner.on(" ").join(groovyc.getCommandPrefix(resolver));
+  }
+
+  @Override
+  public String getDescription(ExecutionContext context) {
+    return Joiner.on(" ").join(createCommandList().build());
+  }
+}

--- a/src/com/facebook/buck/jvm/groovy/GroovycStepFactory.java
+++ b/src/com/facebook/buck/jvm/groovy/GroovycStepFactory.java
@@ -66,7 +66,6 @@ class GroovycStepFactory implements CompileStepFactory {
             outputDirectory,
             sourceFilePaths,
             declaredClasspathEntries,
-            invokingRule,
             filesystem));
   }
 

--- a/src/com/facebook/buck/jvm/groovy/GroovycStepFactory.java
+++ b/src/com/facebook/buck/jvm/groovy/GroovycStepFactory.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.jvm.groovy;
+
+import com.facebook.buck.io.ProjectFilesystem;
+import com.facebook.buck.jvm.core.SuggestBuildRules;
+import com.facebook.buck.jvm.java.CompileStepFactory;
+import com.facebook.buck.model.BuildTarget;
+import com.facebook.buck.rules.BuildContext;
+import com.facebook.buck.rules.BuildableContext;
+import com.facebook.buck.rules.RuleKeyBuilder;
+import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.buck.rules.Tool;
+import com.facebook.buck.step.Step;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
+
+import java.nio.file.Path;
+
+class GroovycStepFactory implements CompileStepFactory {
+  private final Tool groovyc;
+  private final Optional<ImmutableList<String>> extraArguments;
+
+  public GroovycStepFactory(
+      Tool groovyc,
+      Optional<ImmutableList<String>> extraArguments) {
+    this.groovyc = groovyc;
+    this.extraArguments = extraArguments;
+  }
+
+  @Override
+  public void createCompileStep(
+      BuildContext context,
+      ImmutableSortedSet<Path> sourceFilePaths,
+      BuildTarget invokingRule,
+      SourcePathResolver resolver,
+      ProjectFilesystem filesystem,
+      ImmutableSortedSet<Path> declaredClasspathEntries,
+      Path outputDirectory,
+      Optional<Path> workingDirectory,
+      Optional<Path> pathToSrcsList,
+      Optional<SuggestBuildRules> suggestBuildRules,
+      /* out params */
+      ImmutableList.Builder<Step> steps,
+      BuildableContext buildableContext) {
+    steps.add(
+        new GroovycStep(
+            groovyc,
+            extraArguments,
+            resolver,
+            outputDirectory,
+            sourceFilePaths,
+            declaredClasspathEntries,
+            invokingRule,
+            filesystem));
+  }
+
+  @Override
+  public RuleKeyBuilder appendToRuleKey(RuleKeyBuilder builder) {
+    groovyc.appendToRuleKey(builder);
+    return builder.setReflectively("extraArguments", extraArguments);
+  }
+}

--- a/src/com/facebook/buck/rules/BUCK
+++ b/src/com/facebook/buck/rules/BUCK
@@ -30,6 +30,7 @@ java_library(
     '//src/com/facebook/buck/io:watchman',
     '//src/com/facebook/buck/js:js',
     '//src/com/facebook/buck/json:json',
+    '//src/com/facebook/buck/jvm/groovy:rules',
     '//src/com/facebook/buck/jvm/java:config',
     '//src/com/facebook/buck/jvm/java:rules',
     '//src/com/facebook/buck/jvm/java:support',

--- a/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
+++ b/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
@@ -92,6 +92,8 @@ import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.js.AndroidReactNativeLibraryDescription;
 import com.facebook.buck.js.IosReactNativeLibraryDescription;
 import com.facebook.buck.js.ReactNativeBuckConfig;
+import com.facebook.buck.jvm.groovy.GroovyBuckConfig;
+import com.facebook.buck.jvm.groovy.GroovyLibraryDescription;
 import com.facebook.buck.jvm.java.JavaBinaryDescription;
 import com.facebook.buck.jvm.java.JavaBuckConfig;
 import com.facebook.buck.jvm.java.JavaLibraryDescription;
@@ -544,6 +546,7 @@ public class KnownBuildRuleTypes {
             goBuckConfig,
             defaultTestRuleTimeoutMs,
             defaultCxxPlatform));
+    builder.register(new GroovyLibraryDescription(new GroovyBuckConfig(config)));
     builder.register(new GwtBinaryDescription());
     builder.register(
       new HalideLibraryDescription(

--- a/test/com/facebook/buck/jvm/groovy/BUCK
+++ b/test/com/facebook/buck/jvm/groovy/BUCK
@@ -1,0 +1,15 @@
+java_test(
+  name = 'groovy',
+  srcs = glob(['*Test.java']),
+  resources = glob(['testdata/**'], include_dotfiles=True),
+  deps = [
+    '//src/com/facebook/buck/util/environment:platform',
+    '//src/com/facebook/buck/cli:config',
+    '//src/com/facebook/buck/io:io',
+    '//src/com/facebook/buck/jvm/groovy:rules',
+    '//test/com/facebook/buck/testutil/integration:integration',
+    '//third-party/java/hamcrest:hamcrest',
+    '//third-party/java/guava:guava',
+    '//third-party/java/junit:junit',
+  ],
+)

--- a/test/com/facebook/buck/jvm/groovy/GroovyBuckConfigTest.java
+++ b/test/com/facebook/buck/jvm/groovy/GroovyBuckConfigTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.buck.jvm.groovy;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assume.assumeTrue;
+
+import com.facebook.buck.cli.BuckConfig;
+import com.facebook.buck.cli.Config;
+import com.facebook.buck.io.ProjectFilesystem;
+import com.facebook.buck.testutil.integration.DebuggableTemporaryFolder;
+import com.facebook.buck.util.environment.Architecture;
+import com.facebook.buck.util.environment.Platform;
+import com.google.common.collect.ImmutableMap;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class GroovyBuckConfigTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  @Rule
+  public DebuggableTemporaryFolder temporaryFolder = new DebuggableTemporaryFolder();
+
+  @Test
+  public void refuseToContinueWhenInsufficientInformationToFindGroovycIsProvided() {
+    thrown.expectMessage(
+        allOf(
+            containsString("Unable to locate groovy compiler"),
+            containsString("GROOVY_HOME is not set, and groovy.groovy_home was not provided")));
+
+    ImmutableMap<String, String> environment = ImmutableMap.of();
+    ImmutableMap<String, ImmutableMap<String, String>> rawConfig = ImmutableMap.of();
+    final GroovyBuckConfig groovyBuckConfig =
+        createGroovyConfig(environment, rawConfig);
+
+    groovyBuckConfig.getGroovyCompiler();
+  }
+
+  @Test
+  public void refuseToContinueWhenInformationResultsInANonExistentGroovycPath() {
+    thrown.expectMessage(
+        containsString("Unable to locate /oops/bin/groovyc on PATH"));
+
+    ImmutableMap<String, String> environment = ImmutableMap.of("GROOVY_HOME", "/oops");
+    ImmutableMap<String, ImmutableMap<String, String>> rawConfig = ImmutableMap.of();
+    final GroovyBuckConfig groovyBuckConfig =
+        createGroovyConfig(environment, rawConfig);
+
+    groovyBuckConfig.getGroovyCompiler();
+  }
+
+  @Test
+  public void byDefaultFindGroovycFromGroovyHome() {
+    String systemGroovyHome = System.getenv("GROOVY_HOME");
+    assumeTrue(systemGroovyHome != null);
+
+    //noinspection ConstantConditions
+    ImmutableMap<String, String> environment = ImmutableMap.of("GROOVY_HOME", systemGroovyHome);
+    ImmutableMap<String, ImmutableMap<String, String>> rawConfig = ImmutableMap.of();
+    final GroovyBuckConfig groovyBuckConfig =
+        createGroovyConfig(environment, rawConfig);
+
+    // it's enough that this doesn't throw.
+    groovyBuckConfig.getGroovyCompiler();
+  }
+
+  @Test
+  public void explicitConfigurationOverridesTheEnvironment() {
+    String systemGroovyHome = System.getenv("GROOVY_HOME");
+    assumeTrue(systemGroovyHome != null);
+
+    // deliberately break the env
+    ImmutableMap<String, String> environment = ImmutableMap.of("GROOVY_HOME", "/oops");
+    //noinspection ConstantConditions
+    ImmutableMap<String, ImmutableMap<String, String>> rawConfig =
+        ImmutableMap.of("groovy", ImmutableMap.of("groovy_home", systemGroovyHome));
+    final GroovyBuckConfig groovyBuckConfig =
+        createGroovyConfig(environment, rawConfig);
+
+    // it's enough that this doesn't throw.
+    groovyBuckConfig.getGroovyCompiler();
+  }
+
+  private GroovyBuckConfig createGroovyConfig(
+      ImmutableMap<String, String> environment,
+      ImmutableMap<String, ImmutableMap<String, String>> rawConfig) {
+    ProjectFilesystem projectFilesystem = new ProjectFilesystem(temporaryFolder.getRootPath());
+    BuckConfig config = new BuckConfig(
+         new Config(rawConfig),
+        projectFilesystem,
+        Architecture.detect(),
+        Platform.detect(),
+        environment);
+
+    return new GroovyBuckConfig(config);
+  }
+}

--- a/test/com/facebook/buck/jvm/groovy/GroovyLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/groovy/GroovyLibraryIntegrationTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2013-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.jvm.groovy;
+
+import static org.junit.Assume.assumeTrue;
+
+import com.facebook.buck.testutil.integration.DebuggableTemporaryFolder;
+import com.facebook.buck.testutil.integration.ProjectWorkspace;
+import com.facebook.buck.testutil.integration.TestDataHelper;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+
+public class GroovyLibraryIntegrationTest {
+  @Rule
+  public DebuggableTemporaryFolder tmp = new DebuggableTemporaryFolder();
+
+  private ProjectWorkspace workspace;
+
+  @Test
+  public void shouldCompileGroovyClass() throws Exception {
+    assumeTrue(System.getenv("GROOVY_HOME") != null);
+
+    workspace = TestDataHelper.createProjectWorkspaceForScenario(
+        this, "groovy_library_description", tmp);
+    workspace.setUp();
+
+    // Run `buck build`.
+    ProjectWorkspace.ProcessResult buildResult =
+        workspace.runBuckCommand("build", "//com/example/good:example");
+    buildResult.assertSuccess("Build should have succeeded.");
+
+    workspace.verify();
+  }
+
+  @Test
+  public void shouldCompileLibraryWithDependencyOnAnother() throws Exception {
+    assumeTrue(System.getenv("GROOVY_HOME") != null);
+
+    workspace = TestDataHelper.createProjectWorkspaceForScenario(
+        this, "groovy_library_description", tmp);
+    workspace.setUp();
+
+    // Run `buck build`.
+    ProjectWorkspace.ProcessResult buildResult =
+        workspace.runBuckCommand("build", "//com/example/child:child");
+    buildResult.assertSuccess("Build should have succeeded.");
+
+    workspace.verify();
+  }
+
+  @Test
+  public void shouldFailToCompileInvalidGroovyClass() throws Exception {
+    assumeTrue(System.getenv("GROOVY_HOME") != null);
+
+    workspace = TestDataHelper.createProjectWorkspaceForScenario(
+        this, "groovy_library_description", tmp);
+    workspace.setUp();
+
+    // Run `buck build`.
+    ProjectWorkspace.ProcessResult buildResult =
+        workspace.runBuckCommand("build", "//com/example/bad:fail");
+    buildResult.assertFailure();
+
+    workspace.verify();
+  }
+}

--- a/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/bad/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/bad/BUCK.fixture
@@ -1,0 +1,7 @@
+groovy_library(
+  name = 'fail',
+  srcs = ['Fail.groovy'],
+  visibility = [
+    'PUBLIC',
+  ]
+)

--- a/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/bad/Fail.groovy
+++ b/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/bad/Fail.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2013-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example.bad
+
+class Fail {
+    static final String helloWorld = "Hello World"
+
+    static void main(String... args) {
+        println helloWorld2
+    }
+}

--- a/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/child/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/child/BUCK.fixture
@@ -1,0 +1,10 @@
+groovy_library(
+  name = 'child',
+  srcs = ['Foo.groovy'],
+  deps = [
+    '//com/example/good:example',
+  ],
+  visibility = [
+    'PUBLIC',
+  ]
+)

--- a/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/child/Foo.groovy
+++ b/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/child/Foo.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example.child
+
+import com.example.good.Example
+
+class Foo {
+    static void main(String... args) {
+        Example.main(args)
+    }
+}

--- a/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/good/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/good/BUCK.fixture
@@ -1,0 +1,7 @@
+groovy_library(
+  name = 'example',
+  srcs = ['Example.groovy'],
+  visibility = [
+    'PUBLIC',
+  ]
+)

--- a/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/good/Example.groovy
+++ b/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/good/Example.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2013-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example.good
+
+class Example {
+    static final String helloWorld = "Hello World"
+
+    static void main(String... args) {
+        println helloWorld
+    }
+}

--- a/test/com/facebook/buck/testutil/integration/ProjectWorkspace.java
+++ b/test/com/facebook/buck/testutil/integration/ProjectWorkspace.java
@@ -395,6 +395,7 @@ public class ProjectWorkspace {
         "ANDROID_NDK",
         "ANDROID_NDK_REPOSITORY",
         "ANDROID_SDK",
+        "GROOVY_HOME",
         "NDK_HOME",
         "PATH",
         "PATHEXT",


### PR DESCRIPTION
Summary:
First cut of groovy_library support. Only very simple to begin with:
no cross compilation, no maven or source jar flavours.

Test-plan:

CI, but with extras: two new tests only provide coverage when
GROOVY_HOME is set; we recommend this be added to CI.