### PR TITLE
IntelliJ modules inherit JDK versions from config

### DIFF
--- a/src/com/facebook/buck/jvm/java/intellij/Project.java
+++ b/src/com/facebook/buck/jvm/java/intellij/Project.java
@@ -474,7 +474,10 @@ public class Project {
       if (module.isIntelliJPlugin()) {
         jdkDependency = SerializableDependentModule.newIntelliJPluginJdk();
       } else {
-        jdkDependency = SerializableDependentModule.newStandardJdk();
+        jdkDependency = SerializableDependentModule.newStandardJdk(
+            intellijConfig.getJdkName(),
+            intellijConfig.getJdkType()
+        );
       }
     }
 

--- a/src/com/facebook/buck/jvm/java/intellij/SerializableDependentModule.java
+++ b/src/com/facebook/buck/jvm/java/intellij/SerializableDependentModule.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 
 import javax.annotation.Nullable;
@@ -108,10 +109,11 @@ class SerializableDependentModule {
     return new SerializableDependentModule("inheritedJdk", null);
   }
 
-  static SerializableDependentModule newStandardJdk() {
+  static SerializableDependentModule newStandardJdk(Optional<String> jdkName,
+      Optional<String> jdkType) {
     SerializableDependentModule dependentModule = new SerializableDependentModule("jdk", null);
-    dependentModule.jdkName = "1.7";
-    dependentModule.jdkType = "JavaSDK";
+    dependentModule.jdkName = jdkName.or("1.7");
+    dependentModule.jdkType = jdkType.or("JavaSDK");
     return dependentModule;
   }
 

--- a/test/com/facebook/buck/jvm/java/intellij/ProjectTest.java
+++ b/test/com/facebook/buck/jvm/java/intellij/ProjectTest.java
@@ -217,7 +217,8 @@ public class ProjectTest {
             projectConfigForResource,
             projectConfigUsingNoDx,
             projectConfig),
-        javaPackageFinder),
+        javaPackageFinder,
+        null  /* intellijConfig */),
         ruleResolver);
   }
 
@@ -279,7 +280,7 @@ public class ProjectTest {
         ImmutableList.of(
             SerializableDependentModule.newSourceFolder(),
             guavaAsProvidedDep,
-            SerializableDependentModule.newStandardJdk()),
+            SerializableDependentModule.newStandardJdk(Optional.<String>absent(), Optional.<String>absent())),
         javaLibraryModule.getDependencies());
 
     // Check the values of the module that corresponds to the android_library.
@@ -473,7 +474,8 @@ public class ProjectTest {
     ProjectWithModules projectWithModules = getModulesForActionGraph(
         ruleResolver,
         ImmutableSortedSet.of(projectConfig),
-        null /* javaPackageFinder */);
+        null /* javaPackageFinder */,
+        null /* intellijConfig */);
     List<SerializableModule> modules = projectWithModules.modules;
 
     // Verify that the single Module that is created transitively includes all JAR files.
@@ -529,7 +531,8 @@ public class ProjectTest {
     ProjectWithModules projectWithModules = getModulesForActionGraph(
         ruleResolver,
         ImmutableSortedSet.of(projectConfig),
-        null /* javaPackageFinder */);
+        null /* javaPackageFinder */,
+        null /*intellijConfig */);
     List<SerializableModule> modules = projectWithModules.modules;
     assertEquals(1, modules.size());
     SerializableModule comExampleBaseModule = Iterables.getOnlyElement(modules);
@@ -540,7 +543,7 @@ public class ProjectTest {
             SerializableDependentModule.newLibrary(
                 guava.getBuildTarget(),
                 "buck_out_gen_third_party_java_guava_guava_jar"),
-            SerializableDependentModule.newStandardJdk()),
+            SerializableDependentModule.newStandardJdk(Optional.<String>absent(), Optional.<String>absent())),
         comExampleBaseModule.getDependencies());
   }
 
@@ -591,7 +594,8 @@ public class ProjectTest {
     ProjectWithModules projectWithModules = getModulesForActionGraph(
         ruleResolver,
         ImmutableSortedSet.of(projectConfig),
-        null /* javaPackageFinder */);
+        null /* javaPackageFinder */,
+        null /* intellijConfig */);
     List<SerializableModule> modules = projectWithModules.modules;
     assertEquals("Should be one module for the android_library", 1, modules.size());
     SerializableModule robolectricModule = Iterables.getOnlyElement(modules);
@@ -608,7 +612,7 @@ public class ProjectTest {
                 "buck_out_gen_third_party_java_httpcore_httpcore_jar"),
             SerializableDependentModule.newModule(
                 supportV4.getBuildTarget(), "module_java_com_android_support_v4"),
-            SerializableDependentModule.newStandardJdk()),
+            SerializableDependentModule.newStandardJdk(Optional.<String>absent(), Optional.<String>absent())),
         robolectricModule.getDependencies());
   }
 
@@ -650,7 +654,8 @@ public class ProjectTest {
     ProjectWithModules projectWithModules1 = getModulesForActionGraph(
         ruleResolver1,
         ImmutableSortedSet.of(projectConfigNullSrcRoots),
-        null /* javaPackageFinder */);
+        null /* javaPackageFinder */,
+        null /* intellijConfig */);
 
     // Verify that the correct source folders are created.
     assertEquals(1, projectWithModules1.modules.size());
@@ -684,7 +689,8 @@ public class ProjectTest {
     ProjectWithModules projectWithModules2 = getModulesForActionGraph(
         ruleResolver2,
         ImmutableSortedSet.of(inPackageProjectConfig),
-        javaPackageFinder);
+        javaPackageFinder,
+        null /* intellijConfig */);
     EasyMock.verify(javaPackageFinder);
     assertEquals(1, projectWithModules2.modules.size());
     SerializableModule moduleWithPackagePrefix = projectWithModules2.modules.get(0);
@@ -711,7 +717,8 @@ public class ProjectTest {
     ProjectWithModules projectWithModules3 = getModulesForActionGraph(
         ruleResolver3,
         ImmutableSortedSet.of(hasSrcFolderProjectConfig),
-        null /* javaPackageFinder */);
+        null /* javaPackageFinder */,
+        null /* intellijConfig */);
 
     // Verify that the correct source folders are created.
     assertEquals(1, projectWithModules3.modules.size());
@@ -722,6 +729,50 @@ public class ProjectTest {
             new SourceFolder("file://$MODULE_DIR$/src", false /* isTestSource */),
             SerializableModule.SourceFolder.GEN),
         moduleHasSrcFolder.sourceFolders);
+  }
+
+  @Test
+  public void testIntellijJdkConfig() throws Exception {
+    IntellijConfig intellijConfig = new IntellijConfig(
+        FakeBuckConfig.builder().setSections(
+            ImmutableMap.of("intellij", ImmutableMap.of("jdk_name", "1.8")))
+            .build()
+    );
+    BuildRuleResolver ruleResolver =
+        new BuildRuleResolver(TargetGraph.EMPTY, new BuildTargetNodeToBuildRuleTransformer());
+    BuildRule baseBuildRule = JavaLibraryBuilder
+        .createBuilder(BuildTargetFactory.newInstance("//java/com/example/base:base"))
+        .build(ruleResolver);
+    ProjectConfig packageProjectConfig = (ProjectConfig) ProjectConfigBuilder
+        .createBuilder(
+            BuildTargetFactory.newInstance("//java/com/example/base:project_config"))
+        .setSrcRule(baseBuildRule.getBuildTarget())
+        .setSrcRoots(ImmutableList.<String>of())
+        .build(ruleResolver);
+
+    ProjectWithModules projectWithJdkOverride = getModulesForActionGraph(
+        ruleResolver,
+        ImmutableSortedSet.of(packageProjectConfig),
+        null /* javaPackageFinder */,
+        intellijConfig);
+    SerializableModule moduleWithJdkOverride = projectWithJdkOverride.modules.get(0);
+    assertListEquals(
+        ImmutableList.of(
+            SerializableDependentModule.newSourceFolder(),
+            SerializableDependentModule.newStandardJdk(Optional.of("1.8"), Optional.of("JavaSDK"))),
+        moduleWithJdkOverride.getDependencies());
+
+    ProjectWithModules projectWithDefaultJdk = getModulesForActionGraph(
+        ruleResolver,
+        ImmutableSortedSet.of(packageProjectConfig),
+        null /* javaPackageFinder */,
+        null /* intellijConfig */);
+    SerializableModule moduleWithDefaultJdk = projectWithDefaultJdk.modules.get(0);
+    assertListEquals(
+        ImmutableList.of(
+            SerializableDependentModule.newSourceFolder(),
+            SerializableDependentModule.newStandardJdk(Optional.of("1.7"), Optional.of("JavaSDK"))),
+        moduleWithDefaultJdk.getDependencies());
   }
 
   private static class ProjectWithModules {
@@ -736,9 +787,13 @@ public class ProjectTest {
   private ProjectWithModules getModulesForActionGraph(
       BuildRuleResolver ruleResolver,
       ImmutableSortedSet<ProjectConfig> projectConfigs,
-      @Nullable JavaPackageFinder javaPackageFinder) throws IOException {
+      @Nullable JavaPackageFinder javaPackageFinder,
+      @Nullable IntellijConfig intellijConfig) throws IOException {
     if (javaPackageFinder == null) {
       javaPackageFinder = new FakeJavaPackageFinder();
+    }
+    if (intellijConfig == null) {
+      intellijConfig = new IntellijConfig(FakeBuckConfig.builder().build());
     }
 
     ActionGraph actionGraph = new ActionGraph(ruleResolver.getBuildRules());
@@ -777,7 +832,7 @@ public class ProjectTest {
                 BuildTarget.TO_TARGET)),
         projectFilesystem,
         /* pathToDefaultAndroidManifest */ Optional.<String>absent(),
-        new IntellijConfig(FakeBuckConfig.builder().build()),
+        intellijConfig,
         /* pathToPostProcessScript */ Optional.<String>absent(),
         BuckTestConstant.PYTHON_INTERPRETER,
         new ObjectMapper(),
@@ -829,7 +884,8 @@ public class ProjectTest {
     ProjectWithModules projectWithModules = getModulesForActionGraph(
         ruleResolver,
         ImmutableSortedSet.of(ndkProjectConfig),
-        null /* javaPackageFinder */);
+        null /* javaPackageFinder */,
+        null /* intellijConfig */);
     List<SerializableModule> modules = projectWithModules.modules;
 
     assertEquals("Should be one module for the ndk_library.", 1, modules.size());


### PR DESCRIPTION
IntelliJ project JDK versions are configurable in the ```[intellij]``` section of ```.buckconfig``` via ```jdk_name``` and ```language_level```. These affect the project-wide versions configured in ```.idea/misc.xml```

JDK versions in .iml module configs, however, are hardcoded to JDK 1.7. This needs to be configurable from somewhere - I've taken it to be the ```[intellij]``` configuration section.

i.e. given the following configuration
```
[intellij]
  jdk_name = 1.8
  jdk_type = JavaSDK
  language_level = JDK_1_8
```
then the .iml dep

```<orderEntry type="jdk" jdkName="1.7" jdkType="JavaSDK" />```

should be 

```<orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />```