### PR TITLE
Run groovy related tests in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
       - ia32-libs
       - ia32-libs-multiarch
       - gcc-multilib
+      - groovy
 
 before_install:
   # Set up the Android environment.
@@ -23,6 +24,8 @@ before_install:
   - ./scripts/travisci_install_android_sdk.sh
   # Install go 1.5
   - eval "$(gimme 1.5)"
+  # Set up the Groovy environment
+  - export GROOVY_HOME=/usr/share/groovy/
 
 cache:
   directories:


### PR DESCRIPTION
Summary:
We want to run the groovy tests in CI, so we install groovy in travis
and set GROOVY_HOME appropriately.

Test-plan: Look at the travis output, check that 
GroovyLibraryIntegrationTest and GroovyBuckConfigTest PASS 
rather than ASSUME