### PR TITLE
Extract population of JavacOptions from JavaLibraryDescription

### DIFF
--- a/src/com/facebook/buck/android/AndroidLibraryDescription.java
+++ b/src/com/facebook/buck/android/AndroidLibraryDescription.java
@@ -17,11 +17,11 @@
 package com.facebook.buck.android;
 
 import com.facebook.buck.jvm.common.ResourceValidator;
-import com.facebook.buck.jvm.java.AnnotationProcessingParams;
 import com.facebook.buck.jvm.java.CalculateAbi;
 import com.facebook.buck.jvm.java.JavaLibrary;
 import com.facebook.buck.jvm.java.JavaLibraryDescription;
 import com.facebook.buck.jvm.java.JavaSourceJar;
+import com.facebook.buck.jvm.java.JavacArgInterpreter;
 import com.facebook.buck.jvm.java.JavacOptions;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.Flavor;
@@ -82,19 +82,13 @@ public class AndroidLibraryDescription
       return new JavaSourceJar(params, pathResolver, args.srcs.get(), args.mavenCoords);
     }
 
-    JavacOptions.Builder javacOptionsBuilder =
-        JavaLibraryDescription.getJavacOptions(
-            pathResolver,
-            args,
-            defaultOptions);
-
-    AnnotationProcessingParams annotationParams = args.buildAnnotationProcessingParams(
-        params.getBuildTarget(),
-        params.getProjectFilesystem(),
-        resolver);
-    javacOptionsBuilder.setAnnotationProcessingParams(annotationParams);
-
-    JavacOptions javacOptions = javacOptionsBuilder.build();
+    JavacOptions javacOptions = JavacArgInterpreter.populateJavacOptions(
+        defaultOptions,
+        params,
+        resolver,
+        pathResolver,
+        args
+    );
 
     AndroidLibraryGraphEnhancer graphEnhancer = new AndroidLibraryGraphEnhancer(
         params.getBuildTarget(),

--- a/src/com/facebook/buck/android/RobolectricTestDescription.java
+++ b/src/com/facebook/buck/android/RobolectricTestDescription.java
@@ -19,10 +19,9 @@ package com.facebook.buck.android;
 import static com.facebook.buck.jvm.common.ResourceValidator.validateResources;
 
 import com.facebook.buck.cxx.CxxPlatform;
-import com.facebook.buck.jvm.java.AnnotationProcessingParams;
 import com.facebook.buck.jvm.java.CalculateAbi;
-import com.facebook.buck.jvm.java.JavaLibraryDescription;
 import com.facebook.buck.jvm.java.JavaTestDescription;
+import com.facebook.buck.jvm.java.JavacArgInterpreter;
 import com.facebook.buck.jvm.java.JavacOptions;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.parser.NoSuchBuildTargetException;
@@ -86,18 +85,14 @@ public class RobolectricTestDescription implements Description<RobolectricTestDe
     SourcePathResolver pathResolver = new SourcePathResolver(resolver);
     ImmutableList<String> vmArgs = args.vmArgs.get();
 
-    JavacOptions.Builder javacOptionsBuilder =
-        JavaLibraryDescription.getJavacOptions(
+    JavacOptions javacOptions =
+        JavacArgInterpreter.populateJavacOptions(
+            templateOptions,
+            params,
+            resolver,
             pathResolver,
-            args,
-            templateOptions);
-    AnnotationProcessingParams annotationParams =
-        args.buildAnnotationProcessingParams(
-            params.getBuildTarget(),
-            params.getProjectFilesystem(),
-            resolver);
-    javacOptionsBuilder.setAnnotationProcessingParams(annotationParams);
-    JavacOptions javacOptions = javacOptionsBuilder.build();
+            args
+        );
 
     AndroidLibraryGraphEnhancer graphEnhancer = new AndroidLibraryGraphEnhancer(
         params.getBuildTarget(),

--- a/src/com/facebook/buck/jvm/java/BUCK
+++ b/src/com/facebook/buck/jvm/java/BUCK
@@ -130,6 +130,8 @@ java_library(
     'JarFattener.java',
     'JavaBinary.java',
     'JavaBinaryDescription.java',
+    'JavacArg.java',
+    'JavacArgInterpreter.java',
     'JavaLibraryDescription.java',
     'JavaLibraryClasspathProvider.java',
     'JavaLibraryRules.java',

--- a/src/com/facebook/buck/jvm/java/JavaTestDescription.java
+++ b/src/com/facebook/buck/jvm/java/JavaTestDescription.java
@@ -87,18 +87,14 @@ public class JavaTestDescription implements Description<JavaTestDescription.Arg>
       A args) throws NoSuchBuildTargetException {
     SourcePathResolver pathResolver = new SourcePathResolver(resolver);
 
-    JavacOptions.Builder javacOptionsBuilder =
-        JavaLibraryDescription.getJavacOptions(
+    JavacOptions javacOptions =
+        JavacArgInterpreter.populateJavacOptions(
+            templateOptions,
+            params,
+            resolver,
             pathResolver,
-            args,
-            templateOptions);
-    AnnotationProcessingParams annotationParams =
-        args.buildAnnotationProcessingParams(
-            params.getBuildTarget(),
-            params.getProjectFilesystem(),
-            resolver);
-    javacOptionsBuilder.setAnnotationProcessingParams(annotationParams);
-    JavacOptions javacOptions = javacOptionsBuilder.build();
+            args
+        );
 
     CxxLibraryEnhancement cxxLibraryEnhancement = new CxxLibraryEnhancement(
         params,

--- a/src/com/facebook/buck/jvm/java/JavacArg.java
+++ b/src/com/facebook/buck/jvm/java/JavacArg.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.buck.jvm.java;
+
+import com.facebook.buck.io.ProjectFilesystem;
+import com.facebook.buck.model.BuildTarget;
+import com.facebook.buck.model.Either;
+import com.facebook.buck.rules.BuildRule;
+import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.SourcePath;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+
+import java.nio.file.Path;
+
+public class JavacArg {
+  public Optional<String> source;
+  public Optional<String> target;
+  public Optional<String> javaVersion;
+  public Optional<Path> javac;
+  public Optional<SourcePath> javacJar;
+  public Optional<Either<BuiltInJavac, SourcePath>> compiler;
+  public Optional<ImmutableList<String>> extraArguments;
+  public Optional<ImmutableSortedSet<BuildTarget>> annotationProcessorDeps;
+  public Optional<ImmutableList<String>> annotationProcessorParams;
+  public Optional<ImmutableSet<String>> annotationProcessors;
+  public Optional<Boolean> annotationProcessorOnly;
+
+  public AnnotationProcessingParams buildAnnotationProcessingParams(
+      BuildTarget owner,
+      ProjectFilesystem filesystem,
+      BuildRuleResolver resolver) {
+    ImmutableSet<String> annotationProcessors =
+        this.annotationProcessors.or(ImmutableSet.<String>of());
+
+    if (annotationProcessors.isEmpty()) {
+      return AnnotationProcessingParams.EMPTY;
+    }
+
+    AnnotationProcessingParams.Builder builder = new AnnotationProcessingParams.Builder();
+    builder.setOwnerTarget(owner);
+    builder.addAllProcessors(annotationProcessors);
+    builder.setProjectFilesystem(filesystem);
+    ImmutableSortedSet<BuildRule> processorDeps =
+        resolver.getAllRules(annotationProcessorDeps.or(ImmutableSortedSet.<BuildTarget>of()));
+    for (BuildRule processorDep : processorDeps) {
+      builder.addProcessorBuildTarget(processorDep);
+    }
+    for (String processorParam : annotationProcessorParams.or(ImmutableList.<String>of())) {
+      builder.addParameter(processorParam);
+    }
+    builder.setProcessOnly(annotationProcessorOnly.or(Boolean.FALSE));
+
+    return builder.build();
+  }
+}

--- a/src/com/facebook/buck/jvm/java/JavacArgInterpreter.java
+++ b/src/com/facebook/buck/jvm/java/JavacArgInterpreter.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.buck.jvm.java;
+
+import com.facebook.buck.model.Either;
+import com.facebook.buck.rules.BuildRule;
+import com.facebook.buck.rules.BuildRuleParams;
+import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.BuildTargetSourcePath;
+import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.buck.util.HumanReadableException;
+import com.google.common.base.Optional;
+
+public final class JavacArgInterpreter {
+  public static JavacOptions populateJavacOptions(
+      JavacOptions defaultOptions,
+      BuildRuleParams params,
+      BuildRuleResolver resolver,
+      SourcePathResolver pathResolver,
+      JavacArg javacArg) {
+    if ((javacArg.source.isPresent() || javacArg.target.isPresent()) &&
+        javacArg.javaVersion.isPresent()) {
+      throw new HumanReadableException("Please set either source and target or java_version.");
+    }
+
+    JavacOptions.Builder builder = JavacOptions.builder(defaultOptions);
+
+    if (javacArg.javaVersion.isPresent()) {
+      builder.setSourceLevel(javacArg.javaVersion.get());
+      builder.setTargetLevel(javacArg.javaVersion.get());
+    }
+
+    if (javacArg.source.isPresent()) {
+      builder.setSourceLevel(javacArg.source.get());
+    }
+
+    if (javacArg.target.isPresent()) {
+      builder.setTargetLevel(javacArg.target.get());
+    }
+
+    if (javacArg.extraArguments.isPresent()) {
+      builder.addAllExtraArguments(javacArg.extraArguments.get());
+    }
+
+    if (javacArg.compiler.isPresent()) {
+      Either<BuiltInJavac, SourcePath> either = javacArg.compiler.get();
+
+      if (either.isRight()) {
+        SourcePath sourcePath = either.getRight();
+
+        Optional<BuildRule> possibleRule = pathResolver.getRule(sourcePath);
+        if (possibleRule.isPresent()) {
+          BuildRule rule = possibleRule.get();
+          if (rule instanceof PrebuiltJar) {
+            builder.setJavacJarPath(
+                new BuildTargetSourcePath(rule.getBuildTarget()));
+          } else {
+            throw new HumanReadableException("Only prebuilt_jar targets can be used as a javac");
+          }
+        } else {
+          builder.setJavacPath(pathResolver.getAbsolutePath(sourcePath));
+        }
+      }
+    } else {
+      if (javacArg.javac.isPresent() || javacArg.javacJar.isPresent()) {
+        if (javacArg.javac.isPresent() && javacArg.javacJar.isPresent()) {
+          throw new HumanReadableException("Cannot set both javac and javacjar");
+        }
+        builder.setJavacPath(javacArg.javac);
+        builder.setJavacJarPath(javacArg.javacJar);
+      }
+    }
+
+    AnnotationProcessingParams annotationParams =
+        javacArg.buildAnnotationProcessingParams(
+            params.getBuildTarget(),
+            params.getProjectFilesystem(),
+            resolver);
+    builder.setAnnotationProcessingParams(annotationParams);
+
+    return builder.build();
+  }
+
+  private JavacArgInterpreter() {}
+}

--- a/test/com/facebook/buck/android/AndroidLibraryBuilder.java
+++ b/test/com/facebook/buck/android/AndroidLibraryBuilder.java
@@ -43,7 +43,9 @@ public class AndroidLibraryBuilder extends AbstractNodeBuilder<AndroidLibraryDes
   }
 
   public AndroidLibraryBuilder addProcessorBuildTarget(BuildTarget processorRule) {
-    arg.annotationProcessorDeps = amend(arg.annotationProcessorDeps, processorRule);
+    arg.annotationProcessorDeps = amend(
+        arg.annotationProcessorDeps,
+        processorRule);
     return this;
   }
 

--- a/test/com/facebook/buck/jvm/java/JavaLibraryDescriptionTest.java
+++ b/test/com/facebook/buck/jvm/java/JavaLibraryDescriptionTest.java
@@ -16,271 +16,41 @@
 
 package com.facebook.buck.jvm.java;
 
-import static com.facebook.buck.jvm.java.BuiltInJavac.DEFAULT;
-import static com.facebook.buck.rules.TestCellBuilder.createCellRoots;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import com.facebook.buck.cli.BuildTargetNodeToBuildRuleTransformer;
-import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargetFactory;
-import com.facebook.buck.model.BuildTargetPattern;
-import com.facebook.buck.model.Either;
-import com.facebook.buck.parser.NoSuchBuildTargetException;
 import com.facebook.buck.rules.BuildRule;
-import com.facebook.buck.rules.BuildRuleFactoryParams;
 import com.facebook.buck.rules.BuildRuleResolver;
-import com.facebook.buck.rules.BuildTargetSourcePath;
-import com.facebook.buck.rules.ConstructorArgMarshalException;
-import com.facebook.buck.rules.ConstructorArgMarshaller;
 import com.facebook.buck.rules.FakeBuildRule;
 import com.facebook.buck.rules.FakeExportDependenciesRule;
-import com.facebook.buck.rules.FakeSourcePath;
-import com.facebook.buck.rules.NonCheckingBuildRuleFactoryParams;
-import com.facebook.buck.rules.PathSourcePath;
-import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
-import com.facebook.buck.rules.coercer.DefaultTypeCoercerFactory;
 import com.facebook.buck.rules.TargetGraph;
-import com.facebook.buck.testutil.FakeProjectFilesystem;
-import com.facebook.buck.util.HumanReadableException;
-import com.google.common.base.Optional;
-import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
 public class JavaLibraryDescriptionTest {
 
-  private JavacOptions defaults;
-  private JavaLibraryDescription.Arg arg;
-  private BuildRuleResolver ruleResolver;
-  private SourcePathResolver resolver;
+  private FakeExportDependenciesRule exportingRule;
+  private BuildRuleResolver resolver;
+  private FakeBuildRule exportedRule;
 
   @Before
-  public void createHelpers() {
-    defaults = JavacOptions.builder()
-        .setSourceLevel("8")
-        .setTargetLevel("8")
-        .build();
-
-    arg = new JavaLibraryDescription(defaults).createUnpopulatedConstructorArg();
-    populateWithDefaultValues(arg);
-
-    ruleResolver =
+  public void setUp() {
+    resolver =
         new BuildRuleResolver(TargetGraph.EMPTY, new BuildTargetNodeToBuildRuleTransformer());
-    resolver = new SourcePathResolver(ruleResolver);
-  }
+    SourcePathResolver pathResolver = new SourcePathResolver(resolver);
 
-  @Test
-  public void javaVersionSetsBothSourceAndTargetLevels() {
-    JavaLibraryDescription.Arg arg =
-        new JavaLibraryDescription(defaults).createUnpopulatedConstructorArg();
-    populateWithDefaultValues(arg);
-
-    arg.source = Optional.absent();
-    arg.target = Optional.absent();
-    arg.javaVersion = Optional.of("1.4");  // Set in the past, so if we ever bump the default....
-
-    JavacOptions options = JavaLibraryDescription.getJavacOptions(
-        resolver,
-        arg,
-        defaults).build();
-
-    assertEquals("1.4", options.getSourceLevel());
-    assertEquals("1.4", options.getTargetLevel());
-  }
-
-  @Test
-  public void settingJavaVersionAndSourceLevelIsAnError() {
-    JavaLibraryDescription.Arg arg =
-        new JavaLibraryDescription(defaults).createUnpopulatedConstructorArg();
-    populateWithDefaultValues(arg);
-
-    arg.source = Optional.of("1.4");
-    arg.target = Optional.absent();
-    arg.javaVersion = Optional.of("1.4");
-
-    try {
-      JavaLibraryDescription.getJavacOptions(
-          resolver,
-          arg,
-          defaults).build();
-      fail();
-    } catch (HumanReadableException e) {
-      assertTrue(
-          e.getMessage(),
-          e.getHumanReadableErrorMessage().contains("either source and target or java_version"));
-    }
-  }
-
-  @Test
-  public void settingJavaVersionAndTargetLevelIsAnError() {
-    JavaLibraryDescription.Arg arg =
-        new JavaLibraryDescription(defaults).createUnpopulatedConstructorArg();
-    populateWithDefaultValues(arg);
-
-    arg.source = Optional.absent();
-    arg.target = Optional.of("1.4");
-    arg.javaVersion = Optional.of("1.4");
-
-    try {
-      JavaLibraryDescription.getJavacOptions(
-          resolver,
-          arg,
-          defaults).build();
-      fail();
-    } catch (HumanReadableException e) {
-      assertTrue(
-          e.getMessage(),
-          e.getHumanReadableErrorMessage().contains("either source and target or java_version"));
-    }
-  }
-
-  @Test
-  public void compilerArgWithDefaultValueReturnsJsr199Javac() {
-    Either<BuiltInJavac, SourcePath> either = Either.ofLeft(DEFAULT);
-    arg.compiler = Optional.of(either);
-    JavacOptions options = JavaLibraryDescription.getJavacOptions(
-        resolver,
-        arg,
-        defaults).build();
-
-    Javac javac = options.getJavac();
-
-    assertEquals(Optional.<SourcePath>absent(), options.getJavacJarPath());
-    assertEquals(Optional.<Path>absent(), options.getJavacPath());
-    assertTrue(javac.getClass().getName(), javac instanceof Jsr199Javac);
-  }
-
-  @Test
-  public void compilerArgWithPrebuiltJarValueReturnsJsr199Javac() throws Exception {
-    Path javacJarPath = Paths.get("langtools").resolve("javac.jar");
-    BuildTarget target = BuildTargetFactory.newInstance("//langtools:javac");
-    PrebuiltJarBuilder.createBuilder(target)
-        .setBinaryJar(javacJarPath)
-        .build(ruleResolver);
-    SourcePath sourcePath = new BuildTargetSourcePath(target);
-    Either<BuiltInJavac, SourcePath> either = Either.ofRight(sourcePath);
-
-    arg.compiler = Optional.of(either);
-    JavacOptions options = JavaLibraryDescription.getJavacOptions(
-        resolver,
-        arg,
-        defaults).build();
-
-    Javac javac = options.getJavac();
-
-    assertEquals(Optional.of(sourcePath), options.getJavacJarPath());
-    assertEquals(Optional.<Path>absent(), options.getJavacPath());
-    assertTrue(javac.getClass().getName(), javac instanceof Jsr199Javac);
-  }
-
-  @Test
-  public void compilerArgWithPathReturnsExternalJavac() {
-    Path externalJavac = Paths.get("/foo/bar/javac.exe");
-    Either<BuiltInJavac, SourcePath> either =
-        Either.ofRight((SourcePath) new FakeSourcePath(externalJavac.toString()));
-
-    arg.compiler = Optional.of(either);
-    JavacOptions options = JavaLibraryDescription.getJavacOptions(
-        resolver,
-        arg,
-        defaults).build();
-
-    Javac javac = options.getJavac();
-
-    assertEquals(Optional.<SourcePath>absent(), options.getJavacJarPath());
-    assertEquals(Optional.of(externalJavac), options.getJavacPath());
-    assertTrue(javac.getClass().getName(), javac instanceof ExternalJavac);
-  }
-
-  @Test
-  public void compilerArgTakesPrecedenceOverJavacPathArg() {
-    Path externalJavac = Paths.get("/foo/bar/javac.exe");
-    SourcePath sourcePath = new FakeSourcePath(externalJavac.toString());
-    Either<BuiltInJavac, SourcePath> either = Either.ofRight(sourcePath);
-
-    arg.compiler = Optional.of(either);
-    arg.javac = Optional.of(Paths.get("does-not-exist"));
-    JavacOptions options = JavaLibraryDescription.getJavacOptions(
-        resolver,
-        arg,
-        defaults).build();
-
-    Javac javac = options.getJavac();
-
-    assertEquals(Optional.<SourcePath>absent(), options.getJavacJarPath());
-    assertEquals(Optional.of(externalJavac), options.getJavacPath());
-    assertTrue(javac.getClass().getName(), javac instanceof ExternalJavac);
-  }
-
-  @Test
-  public void compilerArgTakesPrecedenceOverJavacJarArg() throws Exception {
-    Path javacJarPath = Paths.get("langtools").resolve("javac.jar");
-    BuildTarget target = BuildTargetFactory.newInstance("//langtools:javac");
-    PrebuiltJarBuilder.createBuilder(target)
-        .setBinaryJar(javacJarPath)
-        .build(ruleResolver);
-    SourcePath sourcePath = new BuildTargetSourcePath(target);
-    Either<BuiltInJavac, SourcePath> either = Either.ofRight(sourcePath);
-
-    arg.compiler = Optional.of(either);
-    arg.javacJar = Optional.<SourcePath>of(
-        new PathSourcePath(new FakeProjectFilesystem(), Paths.get("does-not-exist")));
-    JavacOptions options = JavaLibraryDescription.getJavacOptions(
-        resolver,
-        arg,
-        defaults).build();
-
-    Javac javac = options.getJavac();
-
-    assertEquals(Optional.of(sourcePath), options.getJavacJarPath());
-    assertEquals(Optional.<Path>absent(), options.getJavacPath());
-    assertTrue(javac.getClass().getName(), javac instanceof Jsr199Javac);
-  }
-
-  @Test
-  public void omittingTheCompilerArgMeansThatExistingBehaviourIsMaintained() {
-    ProjectFilesystem filesystem = new FakeProjectFilesystem();
-    Path expected = Paths.get("does-not-exist");
-
-    arg.compiler = Optional.absent();
-    arg.javacJar = Optional.<SourcePath>of(
-        new PathSourcePath(new FakeProjectFilesystem(), expected));
-    JavacOptions options = JavaLibraryDescription.getJavacOptions(
-        resolver,
-        arg,
-        defaults).build();
-
-    Javac javac = options.getJavac();
-
-    assertEquals(Optional.of(new PathSourcePath(filesystem, expected)), options.getJavacJarPath());
-    assertEquals(Optional.<Path>absent(), options.getJavacPath());
-    assertTrue(javac.getClass().getName(), javac instanceof Jsr199Javac);
+    exportedRule = resolver.addToIndex(new FakeBuildRule("//:exported_rule", pathResolver));
+    exportingRule = resolver.addToIndex(
+       new FakeExportDependenciesRule("//:exporting_rule", pathResolver, exportedRule));
   }
 
   @Test
   public void rulesExportedFromDepsBecomeFirstOrderDeps() throws Exception {
-    BuildRuleResolver resolver =
-        new BuildRuleResolver(TargetGraph.EMPTY, new BuildTargetNodeToBuildRuleTransformer());
-    SourcePathResolver pathResolver = new SourcePathResolver(resolver);
-
-    FakeBuildRule exportedRule =
-        resolver.addToIndex(new FakeBuildRule("//:exported_rule", pathResolver));
-    FakeExportDependenciesRule exportingRule =
-        resolver.addToIndex(
-            new FakeExportDependenciesRule("//:exporting_rule", pathResolver, exportedRule));
-
     BuildTarget target = BuildTargetFactory.newInstance("//:rule");
     BuildRule javaLibrary = JavaLibraryBuilder.createBuilder(target)
         .addDep(exportingRule.getBuildTarget())
@@ -291,40 +61,11 @@ public class JavaLibraryDescriptionTest {
 
   @Test
   public void rulesExportedFromProvidedDepsBecomeFirstOrderDeps() throws Exception {
-    BuildRuleResolver resolver =
-        new BuildRuleResolver(TargetGraph.EMPTY, new BuildTargetNodeToBuildRuleTransformer());
-    SourcePathResolver pathResolver = new SourcePathResolver(resolver);
-
-    FakeBuildRule exportedRule =
-        resolver.addToIndex(new FakeBuildRule("//:exported_rule", pathResolver));
-    FakeExportDependenciesRule exportingRule =
-        resolver.addToIndex(
-            new FakeExportDependenciesRule("//:exporting_rule", pathResolver, exportedRule));
-
     BuildTarget target = BuildTargetFactory.newInstance("//:rule");
     BuildRule javaLibrary = JavaLibraryBuilder.createBuilder(target)
         .addProvidedDep(exportingRule.getBuildTarget())
         .build(resolver);
 
     assertThat(javaLibrary.getDeps(), Matchers.<BuildRule>hasItem(exportedRule));
-  }
-
-  private void populateWithDefaultValues(Object arg) {
-    BuildRuleFactoryParams factoryParams =
-        NonCheckingBuildRuleFactoryParams.createNonCheckingBuildRuleFactoryParams(
-            BuildTargetFactory.newInstance("//example:target"));
-
-    try {
-      new ConstructorArgMarshaller(new DefaultTypeCoercerFactory()).populate(
-          createCellRoots(factoryParams.getProjectFilesystem()),
-          factoryParams.getProjectFilesystem(),
-          factoryParams,
-          arg,
-          ImmutableSet.<BuildTarget>builder(),
-          ImmutableSet.<BuildTargetPattern>builder(),
-          ImmutableMap.<String, Object>of());
-    } catch (ConstructorArgMarshalException | NoSuchBuildTargetException error) {
-      throw Throwables.propagate(error);
-    }
   }
 }

--- a/test/com/facebook/buck/jvm/java/JavacArgInterpreterTest.java
+++ b/test/com/facebook/buck/jvm/java/JavacArgInterpreterTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.jvm.java;
+
+import static com.facebook.buck.jvm.java.BuiltInJavac.DEFAULT;
+import static com.facebook.buck.rules.TestCellBuilder.createCellRoots;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.facebook.buck.cli.BuildTargetNodeToBuildRuleTransformer;
+import com.facebook.buck.io.ProjectFilesystem;
+import com.facebook.buck.model.BuildTarget;
+import com.facebook.buck.model.BuildTargetFactory;
+import com.facebook.buck.model.BuildTargetPattern;
+import com.facebook.buck.model.Either;
+import com.facebook.buck.parser.NoSuchBuildTargetException;
+import com.facebook.buck.rules.BuildRuleFactoryParams;
+import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.BuildTargetSourcePath;
+import com.facebook.buck.rules.ConstructorArgMarshalException;
+import com.facebook.buck.rules.ConstructorArgMarshaller;
+import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeSourcePath;
+import com.facebook.buck.rules.NonCheckingBuildRuleFactoryParams;
+import com.facebook.buck.rules.PathSourcePath;
+import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.buck.rules.TargetGraph;
+import com.facebook.buck.rules.coercer.DefaultTypeCoercerFactory;
+import com.facebook.buck.testutil.FakeProjectFilesystem;
+import com.facebook.buck.util.HumanReadableException;
+import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class JavacArgInterpreterTest {
+  private JavacOptions defaults;
+  private JavacArg arg;
+  private BuildRuleResolver ruleResolver;
+  private SourcePathResolver resolver;
+
+  @Before
+  public void createHelpers() {
+    defaults = JavacOptions.builder()
+        .setSourceLevel("8")
+        .setTargetLevel("8")
+        .build();
+
+    arg = new JavacArg();
+    populateWithDefaultValues(arg);
+
+    ruleResolver =
+        new BuildRuleResolver(TargetGraph.EMPTY, new BuildTargetNodeToBuildRuleTransformer());
+    resolver = new SourcePathResolver(ruleResolver);
+  }
+
+  @Test
+  public void javaVersionSetsBothSourceAndTargetLevels() {
+    arg.source = Optional.absent();
+    arg.target = Optional.absent();
+    arg.javaVersion = Optional.of("1.4");  // Set in the past, so if we ever bump the default....
+
+    JavacOptions options = createJavacOptions(arg);
+
+    assertEquals("1.4", options.getSourceLevel());
+    assertEquals("1.4", options.getTargetLevel());
+  }
+
+  @Test
+  public void settingJavaVersionAndSourceLevelIsAnError() {
+    arg.source = Optional.of("1.4");
+    arg.target = Optional.absent();
+    arg.javaVersion = Optional.of("1.4");
+
+    try {
+      createJavacOptions(arg);
+      fail();
+    } catch (HumanReadableException e) {
+      assertTrue(
+          e.getMessage(),
+          e.getHumanReadableErrorMessage().contains("either source and target or java_version"));
+    }
+  }
+
+  @Test
+  public void settingJavaVersionAndTargetLevelIsAnError() {
+    arg.source = Optional.absent();
+    arg.target = Optional.of("1.4");
+    arg.javaVersion = Optional.of("1.4");
+
+    try {
+      createJavacOptions(arg);
+      fail();
+    } catch (HumanReadableException e) {
+      assertTrue(
+          e.getMessage(),
+          e.getHumanReadableErrorMessage().contains("either source and target or java_version"));
+    }
+  }
+
+  @Test
+  public void compilerArgWithDefaultValueReturnsJsr199Javac() {
+    Either<BuiltInJavac, SourcePath> either = Either.ofLeft(DEFAULT);
+    arg.compiler = Optional.of(either);
+    JavacOptions options = createJavacOptions(arg);
+
+    Javac javac = options.getJavac();
+
+    assertEquals(Optional.<SourcePath>absent(), options.getJavacJarPath());
+    assertEquals(Optional.<Path>absent(), options.getJavacPath());
+    assertTrue(javac.getClass().getName(), javac instanceof Jsr199Javac);
+  }
+
+  @Test
+  public void compilerArgWithPrebuiltJarValueReturnsJsr199Javac() throws Exception {
+    Path javacJarPath = Paths.get("langtools").resolve("javac.jar");
+    BuildTarget target = BuildTargetFactory.newInstance("//langtools:javac");
+    PrebuiltJarBuilder.createBuilder(target)
+        .setBinaryJar(javacJarPath)
+        .build(ruleResolver);
+    SourcePath sourcePath = new BuildTargetSourcePath(target);
+    Either<BuiltInJavac, SourcePath> either = Either.ofRight(sourcePath);
+
+    arg.compiler = Optional.of(either);
+    JavacOptions options = createJavacOptions(arg);
+
+    Javac javac = options.getJavac();
+
+    assertEquals(Optional.of(sourcePath), options.getJavacJarPath());
+    assertEquals(Optional.<Path>absent(), options.getJavacPath());
+    assertTrue(javac.getClass().getName(), javac instanceof Jsr199Javac);
+  }
+
+  @Test
+  public void compilerArgWithPathReturnsExternalJavac() {
+    Path externalJavac = Paths.get("/foo/bar/javac.exe");
+    Either<BuiltInJavac, SourcePath> either =
+        Either.ofRight((SourcePath) new FakeSourcePath(externalJavac.toString()));
+
+    arg.compiler = Optional.of(either);
+    JavacOptions options = createJavacOptions(arg);
+
+    Javac javac = options.getJavac();
+
+    assertEquals(Optional.<SourcePath>absent(), options.getJavacJarPath());
+    assertEquals(Optional.of(externalJavac), options.getJavacPath());
+    assertTrue(javac.getClass().getName(), javac instanceof ExternalJavac);
+  }
+
+  @Test
+  public void compilerArgTakesPrecedenceOverJavacPathArg() {
+    Path externalJavac = Paths.get("/foo/bar/javac.exe");
+    SourcePath sourcePath = new FakeSourcePath(externalJavac.toString());
+    Either<BuiltInJavac, SourcePath> either = Either.ofRight(sourcePath);
+
+    arg.compiler = Optional.of(either);
+    arg.javac = Optional.of(Paths.get("does-not-exist"));
+    JavacOptions options = createJavacOptions(arg);
+
+    Javac javac = options.getJavac();
+
+    assertEquals(Optional.<SourcePath>absent(), options.getJavacJarPath());
+    assertEquals(Optional.of(externalJavac), options.getJavacPath());
+    assertTrue(javac.getClass().getName(), javac instanceof ExternalJavac);
+  }
+
+  @Test
+  public void compilerArgTakesPrecedenceOverJavacJarArg() throws Exception {
+    Path javacJarPath = Paths.get("langtools").resolve("javac.jar");
+    BuildTarget target = BuildTargetFactory.newInstance("//langtools:javac");
+    PrebuiltJarBuilder.createBuilder(target)
+        .setBinaryJar(javacJarPath)
+        .build(ruleResolver);
+    SourcePath sourcePath = new BuildTargetSourcePath(target);
+    Either<BuiltInJavac, SourcePath> either = Either.ofRight(sourcePath);
+
+    arg.compiler = Optional.of(either);
+    arg.javacJar = Optional.<SourcePath>of(
+        new PathSourcePath(new FakeProjectFilesystem(), Paths.get("does-not-exist")));
+    JavacOptions options = createJavacOptions(arg);
+
+    Javac javac = options.getJavac();
+
+    assertEquals(Optional.of(sourcePath), options.getJavacJarPath());
+    assertEquals(Optional.<Path>absent(), options.getJavacPath());
+    assertTrue(javac.getClass().getName(), javac instanceof Jsr199Javac);
+  }
+
+  @Test
+  public void omittingTheCompilerArgMeansThatExistingBehaviourIsMaintained() {
+    ProjectFilesystem filesystem = new FakeProjectFilesystem();
+    Path expected = Paths.get("does-not-exist");
+
+    arg.compiler = Optional.absent();
+    arg.javacJar = Optional.<SourcePath>of(
+        new PathSourcePath(new FakeProjectFilesystem(), expected));
+    JavacOptions options = createJavacOptions(arg);
+
+    Javac javac = options.getJavac();
+
+    assertEquals(Optional.of(new PathSourcePath(filesystem, expected)), options.getJavacJarPath());
+    assertEquals(Optional.<Path>absent(), options.getJavacPath());
+    assertTrue(javac.getClass().getName(), javac instanceof Jsr199Javac);
+  }
+
+  private JavacOptions createJavacOptions(JavacArg arg) {
+    return JavacArgInterpreter.populateJavacOptions(
+        defaults,
+        new FakeBuildRuleParamsBuilder("//not:real").build(),
+        ruleResolver,
+        resolver,
+        arg);
+  }
+
+  private void populateWithDefaultValues(Object arg) {
+    BuildRuleFactoryParams factoryParams =
+        NonCheckingBuildRuleFactoryParams.createNonCheckingBuildRuleFactoryParams(
+            BuildTargetFactory.newInstance("//example:target"));
+
+    try {
+      new ConstructorArgMarshaller(new DefaultTypeCoercerFactory()).populate(
+          createCellRoots(factoryParams.getProjectFilesystem()),
+          factoryParams.getProjectFilesystem(),
+          factoryParams,
+          arg,
+          ImmutableSet.<BuildTarget>builder(),
+          ImmutableSet.<BuildTargetPattern>builder(),
+          ImmutableMap.<String, Object>of());
+    } catch (ConstructorArgMarshalException | NoSuchBuildTargetException error) {
+      throw Throwables.propagate(error);
+    }
+  }
+}


### PR DESCRIPTION
Summary:

Shortly we will want to be able to pass a JavacOptions around in
groovy land to support cross compilation. In addition, many classes
currently depend on (and also duplicate an extra piece of)
JavaLibraryDescription's population of JavacOptions from its Arg. In
this change we extract a parent class, JavacArg, and move all
JavacOptions related behaviour to JavacArgInterpreter.

Test-plan: CI