### PR TITLE
Abstract AbstractJavacOptions away from building the command line

### DIFF
--- a/src/com/facebook/buck/jvm/java/JavacStep.java
+++ b/src/com/facebook/buck/jvm/java/JavacStep.java
@@ -38,6 +38,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -257,9 +258,24 @@ public class JavacStep implements Step {
       Path outputDirectory,
       ExecutionContext context,
       ImmutableSortedSet<Path> buildClasspathEntries) {
-    ImmutableList.Builder<String> builder = ImmutableList.builder();
+    final ImmutableList.Builder<String> builder = ImmutableList.builder();
 
-    javacOptions.appendOptionsToList(builder, filesystem.getAbsolutifier());
+    javacOptions.appendOptionsTo(new AbstractJavacOptions.OptionsConsumer() {
+      @Override
+      public void addOptionValue(String option, String value) {
+        builder.add("-" + option).add(value);
+      }
+
+      @Override
+      public void addFlag(String flagName) {
+        builder.add("-" + flagName);
+      }
+
+      @Override
+      public void addExtras(Collection<String> extras) {
+        builder.addAll(extras);
+      }
+    }, filesystem.getAbsolutifier());
 
     // verbose flag, if appropriate.
     if (context.getVerbosity().shouldUseVerbosityFlagIfAvailable()) {

--- a/test/com/facebook/buck/jvm/java/BUCK
+++ b/test/com/facebook/buck/jvm/java/BUCK
@@ -6,6 +6,7 @@ java_library(
     'JavaLibraryBuilder.java',
     'JavaTestBuilder.java',
     'KeystoreBuilder.java',
+    'OptionAccumulator.java',
     'PrebuiltJarBuilder.java',
   ],
   exported_deps = [

--- a/test/com/facebook/buck/jvm/java/OptionAccumulator.java
+++ b/test/com/facebook/buck/jvm/java/OptionAccumulator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.jvm.java;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class OptionAccumulator implements AbstractJavacOptions.OptionsConsumer {
+  public final Map<String, String> keyVals = new HashMap<String, String>();
+  public final List<String> flags = new ArrayList<String>();
+  public final List<String> extras = new ArrayList<String>();
+
+  @Override
+  public void addOptionValue(String option, String value) {
+    keyVals.put(option, value);
+  }
+
+  @Override
+  public void addFlag(String flagName) {
+    flags.add(flagName);
+  }
+
+  @Override
+  public void addExtras(Collection<String> extraArgs) {
+    extras.addAll(extraArgs);
+  }
+}


### PR DESCRIPTION
Summary:

Instead of getting it to build the list of command line strings, get
JavacStep to visit AbstractJavacOptions with an OptionConsumer
instead. This will allow other JavacOptions users to know about the
command line flags without having to filter all the hyphens, for
example when attempting to pass key value pairs to groovyc's -J flag.

Test Plan: CI