### PR TITLE
Allow list config entries to use a different separator

### DIFF
--- a/src/com/facebook/buck/cli/Config.java
+++ b/src/com/facebook/buck/cli/Config.java
@@ -133,6 +133,12 @@ public class Config {
     return getOptionalListWithoutComments(sectionName, propertyName).or(ImmutableList.<String>of());
   }
 
+  public ImmutableList<String> getListWithoutComments(
+      String sectionName, String propertyName, char splitChar) {
+    return getOptionalListWithoutComments(sectionName, propertyName, splitChar)
+        .or(ImmutableList.<String>of());
+  }
+
   /**
    * ini4j leaves things that look like comments in the values of entries in the file. Generally,
    * we don't want to include these in our parameters, so filter them out where necessary. In an INI
@@ -145,12 +151,17 @@ public class Config {
    */
   public Optional<ImmutableList<String>> getOptionalListWithoutComments(
       String sectionName, String propertyName) {
+    // Default split character for lists is comma.
+    return getOptionalListWithoutComments(sectionName, propertyName, ',');
+  }
+  public Optional<ImmutableList<String>> getOptionalListWithoutComments(
+      String sectionName, String propertyName, char splitChar) {
     Optional<String> value = getValue(sectionName, propertyName);
     if (!value.isPresent()) {
       return Optional.absent();
     }
 
-    Iterable<String> allValues = Splitter.on(',')
+    Iterable<String> allValues = Splitter.on(splitChar)
         .omitEmptyStrings()
         .trimResults()
         .split(value.get());

--- a/test/com/facebook/buck/cli/ConfigTest.java
+++ b/test/com/facebook/buck/cli/ConfigTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 import com.facebook.buck.util.HumanReadableException;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import org.hamcrest.Matchers;
@@ -93,6 +94,37 @@ public class ConfigTest {
     assertEquals(
         Optional.of(0.333f),
         ConfigBuilder.createFromText("[a]", "  f = 0.333").getFloat("a", "f")
+    );
+  }
+
+  @Test
+  public void testGetList() throws IOException {
+    String[] config = {"[a]", "  b = foo,bar,baz"};
+    ImmutableList.Builder<String> builder = ImmutableList.builder();
+    ImmutableList<String> expected = builder.add("foo").add("bar").add("baz").build();
+    assertEquals(
+        expected,
+        ConfigBuilder.createFromText(config[0], config[1]).getListWithoutComments("a", "b")
+    );
+    assertEquals(
+        Optional.of(expected),
+        ConfigBuilder.createFromText(config[0], config[1]).getOptionalListWithoutComments("a", "b")
+    );
+  }
+
+  @Test
+  public void testGetListWithCustomSplitChar() throws IOException {
+    String[] config = {"[a]", "  b = cool;story;bro"};
+    ImmutableList.Builder<String> builder = ImmutableList.builder();
+    ImmutableList<String> expected = builder.add("cool").add("story").add("bro").build();
+    assertEquals(
+        expected,
+        ConfigBuilder.createFromText(config[0], config[1]).getListWithoutComments("a", "b", ';')
+    );
+    assertEquals(
+        Optional.of(expected),
+        ConfigBuilder.createFromText(config[0], config[1])
+            .getOptionalListWithoutComments("a", "b", ';')
     );
   }
 


### PR DESCRIPTION
This is needed for a future change that will allow http headers to
be set in the config. Because ',' is valid in headers, it cannot be used
to split.