### PR TITLE
IntelliJ project support for resources

### DIFF
--- a/src/com/facebook/buck/command/intellij.py
+++ b/src/com/facebook/buck/command/intellij.py
@@ -285,6 +285,10 @@ def write_modules(modules, generate_minimum_project, android_auto_generation_dis
                 'is_test_source': str(source_folder['isTestSource']).lower(),
                 'package_prefix': package_prefix
             }
+        for resource_folder in module['resourceFolders']:
+            xml += '\n      <sourceFolder url="%(url)s" type="java-resource" />' % {
+                'url': resource_folder['url']
+            }
         for exclude_folder in module['excludeFolders']:
             xml += '\n      <excludeFolder url="%s" />' % exclude_folder['url']
         for exclude_folder in sorted(additional_excludes[module['pathToImlFile']]):

--- a/src/com/facebook/buck/jvm/java/intellij/Project.java
+++ b/src/com/facebook/buck/jvm/java/intellij/Project.java
@@ -374,6 +374,9 @@ public class Project {
         projectConfig.getSourceRoots(),
         false /* isTestSource */);
 
+    // resource folders
+    addResourceFolders(module, projectConfig.getResourceRoots());
+
     addRootExcludes(module, projectConfig.getSrcRule(), projectFilesystem);
 
     // At least one of src or tests should contribute a source folder unless this is an
@@ -663,6 +666,20 @@ public class Project {
       module.excludeFolders.add(excludeFolder);
     }
 
+    return true;
+  }
+
+  private boolean addResourceFolders(
+      SerializableModule module,
+      @Nullable ImmutableList<SourceRoot> resourceRoots) {
+    if (resourceRoots == null || resourceRoots.isEmpty()) {
+      return false;
+    }
+    for (SourceRoot resourceRoot : resourceRoots) {
+      SerializableModule.SourceFolder sourceFolder = new SerializableModule.SourceFolder(
+          String.format("file://$MODULE_DIR$/%s", resourceRoot.getName()), false);
+      module.resourceFolders.add(sourceFolder);
+    }
     return true;
   }
 

--- a/src/com/facebook/buck/jvm/java/intellij/SerializableModule.java
+++ b/src/com/facebook/buck/jvm/java/intellij/SerializableModule.java
@@ -75,6 +75,8 @@ final class SerializableModule {
   @JsonProperty
   List<SourceFolder> sourceFolders = Lists.newArrayList();
   @JsonProperty
+  List<SourceFolder> resourceFolders = Lists.newArrayList();
+  @JsonProperty
   boolean isRootModule = false;
   /**
    * &lt;excludeFolder> elements must be sorted alphabetically in an .iml file.
@@ -158,6 +160,7 @@ final class SerializableModule {
 
     static final SourceFolder SRC = new SourceFolder("file://$MODULE_DIR$/src", false);
     static final SourceFolder TESTS = new SourceFolder("file://$MODULE_DIR$/tests", true);
+    static final SourceFolder RES = new SourceFolder("file://$MODULE_DIR$/res", false);
     static final SourceFolder GEN = new SourceFolder("file://$MODULE_DIR$/gen", false);
 
     @JsonProperty

--- a/src/com/facebook/buck/rules/ProjectConfig.java
+++ b/src/com/facebook/buck/rules/ProjectConfig.java
@@ -41,6 +41,9 @@ public class ProjectConfig extends NoopBuildRule {
   @Nullable
   private final ImmutableList<SourceRoot> testsSourceRoots;
 
+  @Nullable
+  private final ImmutableList<SourceRoot> resourceSourceRoots;
+
   private final boolean isIntelliJPlugin;
 
   protected ProjectConfig(
@@ -50,6 +53,7 @@ public class ProjectConfig extends NoopBuildRule {
       @Nullable List<String> srcRoots,
       @Nullable BuildRule testRule,
       @Nullable List<String> testRoots,
+      @Nullable List<String> resourceRoots,
       boolean isIntelliJPlugin) {
     super(params, resolver);
     Preconditions.checkArgument(srcRule != null || testRule != null,
@@ -86,6 +90,18 @@ public class ProjectConfig extends NoopBuildRule {
       this.testsSourceRoots = null;
     }
 
+    if (resourceRoots != null) {
+      this.resourceSourceRoots = ImmutableList.copyOf(Iterables.transform(resourceRoots,
+          new Function<String, SourceRoot>() {
+            @Override
+            public SourceRoot apply(String resourceRoots) {
+              return new SourceRoot(resourceRoots);
+            }
+          }));
+    } else {
+      this.resourceSourceRoots = null;
+    }
+
     this.isIntelliJPlugin = isIntelliJPlugin;
   }
 
@@ -120,6 +136,11 @@ public class ProjectConfig extends NoopBuildRule {
   @Nullable
   public ImmutableList<SourceRoot> getTestsSourceRoots() {
     return testsSourceRoots;
+  }
+
+  @Nullable
+  public ImmutableList<SourceRoot> getResourceRoots() {
+    return resourceSourceRoots;
   }
 
   public boolean getIsIntelliJPlugin() {

--- a/src/com/facebook/buck/rules/ProjectConfigDescription.java
+++ b/src/com/facebook/buck/rules/ProjectConfigDescription.java
@@ -46,6 +46,7 @@ public class ProjectConfigDescription implements Description<ProjectConfigDescri
         args.srcRoots.orNull(),
         args.testTarget.transform(resolver.getRuleFunction()).orNull(),
         args.testRoots.orNull(),
+        args.resourceRoots.orNull(),
         args.isIntellijPlugin.or(false));
   }
 
@@ -56,6 +57,7 @@ public class ProjectConfigDescription implements Description<ProjectConfigDescri
     public Optional<ImmutableList<String>> srcRoots;
     public Optional<BuildTarget> testTarget;
     public Optional<ImmutableList<String>> testRoots;
+    public Optional<ImmutableList<String>> resourceRoots;
     public Optional<Boolean> isIntellijPlugin;
   }
 }

--- a/test/com/facebook/buck/jvm/java/intellij/ProjectTest.java
+++ b/test/com/facebook/buck/jvm/java/intellij/ProjectTest.java
@@ -724,6 +724,31 @@ public class ProjectTest {
         moduleHasSrcFolder.sourceFolders);
   }
 
+  @Test
+  public void testResources() throws Exception {
+    BuildRuleResolver ruleResolver =
+        new BuildRuleResolver(TargetGraph.EMPTY, new BuildTargetNodeToBuildRuleTransformer());
+    BuildRule baseBuildRule = JavaLibraryBuilder
+        .createBuilder(BuildTargetFactory.newInstance("//java/com/example/base:base"))
+        .build(ruleResolver);
+    ProjectConfig packageProjectConfig = (ProjectConfig) ProjectConfigBuilder
+        .createBuilder(
+            BuildTargetFactory.newInstance("//java/com/example/base:project_config"))
+        .setSrcRule(baseBuildRule.getBuildTarget())
+        .setSrcRoots(ImmutableList.<String>of())
+        .setResourceRoots(ImmutableList.of("res"))
+        .build(ruleResolver);
+
+    ProjectWithModules projectWithDefaultJdk = getModulesForActionGraph(
+        ruleResolver,
+        ImmutableSortedSet.of(packageProjectConfig),
+        null /* javaPackageFinder */);
+    SerializableModule moduleWithDefaultJdk = projectWithDefaultJdk.modules.get(0);
+    assertListEquals(
+        ImmutableList.of(SourceFolder.RES),
+        moduleWithDefaultJdk.resourceFolders);
+  }
+
   private static class ProjectWithModules {
     private final Project project;
     private final ImmutableList<SerializableModule> modules;

--- a/test/com/facebook/buck/rules/ProjectConfigBuilder.java
+++ b/test/com/facebook/buck/rules/ProjectConfigBuilder.java
@@ -50,4 +50,10 @@ public class ProjectConfigBuilder extends AbstractNodeBuilder<ProjectConfigDescr
     arg.testRoots = Optional.fromNullable(testRoots);
     return this;
   }
+
+  public ProjectConfigBuilder setResourceRoots(@Nullable ImmutableList<String> resourceRoots) {
+    arg.resourceRoots = Optional.fromNullable(resourceRoots);
+    return this;
+  }
+
 }


### PR DESCRIPTION
Summary:
Source and test roots are supported in generated IntelliJ projects, but there is no means at present to supply resource roots. This adds an optional `resource_roots` argument to the `project_config` build rule, which adds `java-resource` `sourceFolder` elements to the project's .iml config

Test Plan:
Add a `resource_roots` declaration to a project_config, run buck project, and verify both that the `java-resource` is present in the generated iml file, and that IntelliJ picks up the resource directory.

```
project_config(
  ...normal project config... ,
  resource_roots = [ 'res' ]
)
```

results in

```
<sourceFolder url="file://$MODULE_DIR$/res" type="java-resource" />
```
