### PR TITLE
Cross-cell: Fix file system mismatch in classpath macro expansion

### DIFF
--- a/src/com/facebook/buck/rules/macros/ClasspathMacroExpander.java
+++ b/src/com/facebook/buck/rules/macros/ClasspathMacroExpander.java
@@ -97,11 +97,13 @@ public class ClasspathMacroExpander
                   @Nullable
                   @Override
                   public Path apply(JavaLibrary input) {
-                    return input.getPathToOutput();
+                    return input.getPathToOutput() == null
+                        ? null
+                        : input.getProjectFilesystem()
+                              .resolve(input.getPathToOutput());
                   }
                 })
             .filter(Predicates.notNull())
-            .transform(rule.getProjectFilesystem().getAbsolutifier())
             .transform(Functions.toStringFunction())
             .toSortedSet(Ordering.natural()));
   }


### PR DESCRIPTION
Fixes: #594.

Summary: The absolutifier, used in macro owning rule may be from
different cell.

That why it's always wrong to assume, that all classpath entries
belong to the same file system. The rule own file system must be
used to resolve every single classpath entry.

Test Plan:

Build Gerrit Code Review with this change applied: [1].

* [1] https://gerrit-review.googlesource.com/73000