### PR TITLE
Cross compile groovy and java where appropriate

### DIFF
--- a/src/com/facebook/buck/jvm/groovy/GroovyLibraryDescription.java
+++ b/src/com/facebook/buck/jvm/groovy/GroovyLibraryDescription.java
@@ -112,8 +112,7 @@ public class GroovyLibraryDescription implements Description<GroovyLibraryDescri
                         params,
                         resolver,
                         pathResolver,
-                        args
-                    )),
+                        args)),
                 Optional.<Path>absent(),
                 Optional.<String>absent(),
                 ImmutableSortedSet.<BuildTarget>of()));

--- a/src/com/facebook/buck/jvm/groovy/GroovyLibraryDescription.java
+++ b/src/com/facebook/buck/jvm/groovy/GroovyLibraryDescription.java
@@ -20,6 +20,9 @@ import static com.facebook.buck.jvm.common.ResourceValidator.validateResources;
 
 import com.facebook.buck.jvm.java.CalculateAbi;
 import com.facebook.buck.jvm.java.DefaultJavaLibrary;
+import com.facebook.buck.jvm.java.JavacOptions;
+import com.facebook.buck.jvm.java.JavacOptionsFactory;
+import com.facebook.buck.jvm.java.JvmLibraryArg;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleParams;
@@ -45,10 +48,14 @@ public class GroovyLibraryDescription implements Description<GroovyLibraryDescri
   public static final BuildRuleType TYPE = BuildRuleType.of("groovy_library");
 
   private final GroovyBuckConfig groovyBuckConfig;
+  // For cross compilation
+  private final JavacOptions defaultJavacOptions;
 
   public GroovyLibraryDescription(
-      GroovyBuckConfig groovyBuckConfig) {
+      GroovyBuckConfig groovyBuckConfig,
+      JavacOptions defaultJavacOptions) {
     this.groovyBuckConfig = groovyBuckConfig;
+    this.defaultJavacOptions = defaultJavacOptions;
   }
 
   @Override
@@ -99,7 +106,14 @@ public class GroovyLibraryDescription implements Description<GroovyLibraryDescri
                 /* additionalClasspathEntries */ ImmutableSet.<Path>of(),
                 new GroovycToJarStepFactory(
                     groovyBuckConfig.getGroovyCompiler().get(),
-                    args.extraArguments),
+                    args.extraGroovycArguments,
+                    JavacOptionsFactory.create(
+                        defaultJavacOptions,
+                        params,
+                        resolver,
+                        pathResolver,
+                        args
+                    )),
                 Optional.<Path>absent(),
                 Optional.<String>absent(),
                 ImmutableSortedSet.<BuildTarget>of()));
@@ -115,13 +129,12 @@ public class GroovyLibraryDescription implements Description<GroovyLibraryDescri
   }
 
   @SuppressFieldNotInitialized
-  public static class Arg {
+  public static class Arg extends JvmLibraryArg {
     public Optional<ImmutableSortedSet<SourcePath>> srcs;
     public Optional<ImmutableSortedSet<SourcePath>> resources;
-    public Optional<ImmutableList<String>> extraArguments;
+    public Optional<ImmutableList<String>> extraGroovycArguments;
     public Optional<ImmutableSortedSet<BuildTarget>> providedDeps;
     public Optional<ImmutableSortedSet<BuildTarget>> exportedDeps;
     public Optional<ImmutableSortedSet<BuildTarget>> deps;
   }
-
 }

--- a/src/com/facebook/buck/jvm/groovy/GroovycStep.java
+++ b/src/com/facebook/buck/jvm/groovy/GroovycStep.java
@@ -102,7 +102,8 @@ class GroovycStep implements Step {
 
     command.addAll(groovyc.getCommandPrefix(resolver));
 
-    String classpath = Joiner.on(File.pathSeparator).join(transform(declaredClasspathEntries, toStringFunction()));
+    String classpath =
+        Joiner.on(File.pathSeparator).join(transform(declaredClasspathEntries, toStringFunction()));
     command
         .add("-cp")
         .add(classpath.isEmpty() ? "''" : classpath)
@@ -125,9 +126,10 @@ class GroovycStep implements Step {
           // The implementation of `appendOptionsTo` provides a blank default, which
           // confuses the cross compilations step's javac (it won't find any class files
           // compiled by groovyc).
-          if (!option.equals("sourcepath")) {
-            command.add("-J" + String.format("%s=%s", option, value));
+          if (option.equals("sourcepath")) {
+            return;
           }
+          command.add("-J" + String.format("%s=%s", option, value));
         }
 
         @Override

--- a/src/com/facebook/buck/jvm/groovy/GroovycStep.java
+++ b/src/com/facebook/buck/jvm/groovy/GroovycStep.java
@@ -17,25 +17,31 @@
 package com.facebook.buck.jvm.groovy;
 
 import static com.google.common.base.Functions.toStringFunction;
+import static com.google.common.collect.Iterables.any;
 import static com.google.common.collect.Iterables.transform;
 
 import com.facebook.buck.io.ProjectFilesystem;
+import com.facebook.buck.jvm.java.JavacOptions;
+import com.facebook.buck.jvm.java.OptionsConsumer;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.Tool;
 import com.facebook.buck.step.ExecutionContext;
 import com.facebook.buck.step.Step;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Map;
 
 class GroovycStep implements Step {
   private final Tool groovyc;
   private final Optional<ImmutableList<String>> extraArguments;
+  private final JavacOptions javacOptions;
   private final SourcePathResolver resolver;
   private final Path outputDirectory;
   private final ImmutableSortedSet<Path> sourceFilePaths;
@@ -45,6 +51,7 @@ class GroovycStep implements Step {
   GroovycStep(
       Tool groovyc,
       Optional<ImmutableList<String>> extraArguments,
+      JavacOptions javacOptions,
       SourcePathResolver resolver,
       Path outputDirectory,
       ImmutableSortedSet<Path> sourceFilePaths,
@@ -52,6 +59,7 @@ class GroovycStep implements Step {
       ProjectFilesystem filesystem) {
     this.groovyc = groovyc;
     this.extraArguments = extraArguments;
+    this.javacOptions = javacOptions;
     this.resolver = resolver;
     this.outputDirectory = outputDirectory;
     this.sourceFilePaths = sourceFilePaths;
@@ -61,8 +69,8 @@ class GroovycStep implements Step {
 
   @Override
   public int execute(ExecutionContext context) throws IOException, InterruptedException {
-
-    ProcessBuilder processBuilder = new ProcessBuilder(createCommand());
+    ImmutableList<String> command = createCommand();
+    ProcessBuilder processBuilder = new ProcessBuilder(command);
 
     Map<String, String> env = processBuilder.environment();
     env.clear();
@@ -74,7 +82,6 @@ class GroovycStep implements Step {
       exitCode = context.getProcessExecutor().execute(processBuilder.start()).getExitCode();
     } catch (IOException e) {
       e.printStackTrace(context.getStdErr());
-      return exitCode;
     }
 
     return exitCode;
@@ -91,14 +98,61 @@ class GroovycStep implements Step {
   }
 
   private ImmutableList<String> createCommand() {
-    ImmutableList.Builder<String> command = ImmutableList.builder();
-    command.addAll(groovyc.getCommandPrefix(resolver))
+    final ImmutableList.Builder<String> command = ImmutableList.builder();
+
+    command.addAll(groovyc.getCommandPrefix(resolver));
+
+    String classpath = Joiner.on(":").join(transform(declaredClasspathEntries, toStringFunction()));
+    command
         .add("-cp")
-        .add(Joiner.on(":").join(transform(declaredClasspathEntries, toStringFunction())))
+        .add(classpath.isEmpty() ? "''" : classpath)
         .add("-d")
-        .add(outputDirectory.toString())
-        .addAll(extraArguments.or(ImmutableList.<String>of()))
-        .addAll(transform(sourceFilePaths, toStringFunction()));
+        .add(outputDirectory.toString());
+    addCrossCompilationOptions(command);
+
+    command.addAll(extraArguments.or(ImmutableList.<String>of()))
+           .addAll(transform(sourceFilePaths, toStringFunction()));
     return command.build();
+  }
+
+  private void addCrossCompilationOptions(final ImmutableList.Builder<String> command) {
+    if (shouldCrossCompile()) {
+      command.add("-j");
+      javacOptions.appendOptionsTo(new OptionsConsumer() {
+        @Override
+        public void addOptionValue(String option, String value) {
+          // javac won't find things compiled with groovyc otherwise.
+          // alternatively, we could convert all the paths to be absolute.
+          if (!option.equals("sourcepath")) {
+            command.add("-J" + String.format("%s=%s", option, value));
+          }
+        }
+
+        @Override
+        public void addFlag(String flagName) {
+          command.add("-F" + flagName);
+        }
+
+        @Override
+        public void addExtras(Collection<String> extras) {
+          for (String extra : extras) {
+            if (extra.startsWith("-")) {
+              addFlag(extra.substring(1));
+            } else {
+              addFlag(extra);
+            }
+          }
+        }
+      }, filesystem.getAbsolutifier());
+    }
+  }
+
+  private boolean shouldCrossCompile() {
+    return any(sourceFilePaths, new Predicate<Path>() {
+      @Override
+      public boolean apply(Path input) {
+        return input.toString().endsWith(".java");
+      }
+    });
   }
 }

--- a/src/com/facebook/buck/jvm/groovy/GroovycToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/groovy/GroovycToJarStepFactory.java
@@ -19,6 +19,7 @@ package com.facebook.buck.jvm.groovy;
 import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.jvm.core.SuggestBuildRules;
 import com.facebook.buck.jvm.java.BaseCompileToJarStepFactory;
+import com.facebook.buck.jvm.java.JavacOptions;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.rules.BuildContext;
 import com.facebook.buck.rules.BuildableContext;
@@ -36,12 +37,15 @@ class GroovycToJarStepFactory extends BaseCompileToJarStepFactory {
 
   private final Tool groovyc;
   private final Optional<ImmutableList<String>> extraArguments;
+  private final JavacOptions javacOptions;
 
   public GroovycToJarStepFactory(
       Tool groovyc,
-      Optional<ImmutableList<String>> extraArguments) {
+      Optional<ImmutableList<String>> extraArguments,
+      JavacOptions javacOptions) {
     this.groovyc = groovyc;
     this.extraArguments = extraArguments;
+    this.javacOptions = javacOptions;
   }
 
   @Override
@@ -63,6 +67,7 @@ class GroovycToJarStepFactory extends BaseCompileToJarStepFactory {
         new GroovycStep(
             groovyc,
             extraArguments,
+            javacOptions,
             resolver,
             outputDirectory,
             sourceFilePaths,
@@ -73,6 +78,8 @@ class GroovycToJarStepFactory extends BaseCompileToJarStepFactory {
   @Override
   public RuleKeyBuilder appendToRuleKey(RuleKeyBuilder builder) {
     groovyc.appendToRuleKey(builder);
-    return builder.setReflectively("extraArguments", extraArguments);
+    return builder
+        .setReflectively("extraArguments", extraArguments)
+        .setReflectively("javacOptions", javacOptions);
   }
 }

--- a/src/com/facebook/buck/jvm/java/AbstractJavacOptions.java
+++ b/src/com/facebook/buck/jvm/java/AbstractJavacOptions.java
@@ -39,7 +39,6 @@ import org.immutables.value.Value;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -122,11 +121,6 @@ abstract class AbstractJavacOptions implements RuleKeyAppendable {
     return new JdkProvidedInMemoryJavac();
   }
 
-  public interface OptionsConsumer {
-    void addOptionValue(final String option, final String value);
-    void addFlag(final String flagName);
-    void addExtras(final Collection<String> extras);
-  }
 
   public void appendOptionsTo(
       OptionsConsumer optionsConsumer,

--- a/src/com/facebook/buck/jvm/java/BUCK
+++ b/src/com/facebook/buck/jvm/java/BUCK
@@ -64,6 +64,7 @@ java_immutables_library(
     'JavaInMemoryFileObject.java',
     'Jsr199Javac.java',
     'MavenPublishable.java',
+    'OptionsConsumer.java',
     'StandardJavaFileManagerFactory.java',
     'TracingProcessorWrapper.java',
   ],

--- a/src/com/facebook/buck/jvm/java/JavacStep.java
+++ b/src/com/facebook/buck/jvm/java/JavacStep.java
@@ -260,7 +260,7 @@ public class JavacStep implements Step {
       ImmutableSortedSet<Path> buildClasspathEntries) {
     final ImmutableList.Builder<String> builder = ImmutableList.builder();
 
-    javacOptions.appendOptionsTo(new AbstractJavacOptions.OptionsConsumer() {
+    javacOptions.appendOptionsTo(new OptionsConsumer() {
       @Override
       public void addOptionValue(String option, String value) {
         builder.add("-" + option).add(value);

--- a/src/com/facebook/buck/jvm/java/OptionsConsumer.java
+++ b/src/com/facebook/buck/jvm/java/OptionsConsumer.java
@@ -13,32 +13,14 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.facebook.buck.jvm.java;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
-class OptionAccumulator implements OptionsConsumer {
-  public final Map<String, String> keyVals = new HashMap<String, String>();
-  public final List<String> flags = new ArrayList<String>();
-  public final List<String> extras = new ArrayList<String>();
+public interface OptionsConsumer {
+  void addOptionValue(final String option, final String value);
 
-  @Override
-  public void addOptionValue(String option, String value) {
-    keyVals.put(option, value);
-  }
+  void addFlag(final String flagName);
 
-  @Override
-  public void addFlag(String flagName) {
-    flags.add(flagName);
-  }
-
-  @Override
-  public void addExtras(Collection<String> extraArgs) {
-    extras.addAll(extraArgs);
-  }
+  void addExtras(final Collection<String> extras);
 }

--- a/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
+++ b/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
@@ -547,7 +547,10 @@ public class KnownBuildRuleTypes {
             goBuckConfig,
             defaultTestRuleTimeoutMs,
             defaultCxxPlatform));
-    builder.register(new GroovyLibraryDescription(new GroovyBuckConfig(config)));
+    builder.register(
+        new GroovyLibraryDescription(
+            new GroovyBuckConfig(config),
+            defaultJavacOptions));
     builder.register(new GwtBinaryDescription());
     builder.register(
       new HalideLibraryDescription(

--- a/test/com/facebook/buck/jvm/groovy/GroovyLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/groovy/GroovyLibraryIntegrationTest.java
@@ -82,7 +82,7 @@ public class GroovyLibraryIntegrationTest {
 
   @Test
   public void javaOptionsArePassedThroughToTheJavacCompiler() throws Exception {
-    // code requires java 7, source set to java 6
+    // The code inside requires java 7, but the source level is set to java 6.
     ProjectWorkspace.ProcessResult buildResult =
         workspace.runBuckCommand("build", "//com/example/modern:xcompile");
 

--- a/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/javacextras/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/javacextras/BUCK.fixture
@@ -1,0 +1,10 @@
+groovy_library(
+  name = 'javacextras',
+  srcs = ['UnsafeGenerics.java'],
+  visibility = [
+    'PUBLIC',
+  ],
+  extra_arguments = [
+    '-Werror',
+  ]
+)

--- a/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/javacextras/UnsafeGenerics.java
+++ b/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/javacextras/UnsafeGenerics.java
@@ -1,0 +1,13 @@
+package com.example.javacextras;
+
+import java.util.List;
+import java.util.ArrayList;
+
+class UnsafeGenerics {
+  public static void main(String[] args) {
+    final List noGenerics = new ArrayList();
+    noGenerics.add("foo");
+
+    System.out.println(noGenerics.size());
+  }
+}

--- a/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/modern/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/modern/BUCK.fixture
@@ -1,0 +1,8 @@
+groovy_library(
+  name = 'xcompile',
+  srcs = ['Token.groovy', 'SwitchOnStrings.java'],
+  visibility = [
+    'PUBLIC',
+  ],
+  source = "1.6"
+)

--- a/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/modern/SwitchOnStrings.java
+++ b/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/modern/SwitchOnStrings.java
@@ -1,0 +1,12 @@
+package com.example.modern;
+
+public class SwitchOnStrings {
+  public static String result(final String input) {
+    switch (input) {
+      case "foo":
+        return "OK";
+      default:
+        return "Oh dear";
+    }
+  }
+}

--- a/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/modern/Token.groovy
+++ b/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/modern/Token.groovy
@@ -1,0 +1,7 @@
+package com.example.modern
+
+class Token {
+    public static void main(String[] args) {
+        println SwitchOnStrings.result("foo")
+    }
+}

--- a/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/xcompile/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/xcompile/BUCK.fixture
@@ -1,0 +1,7 @@
+groovy_library(
+  name = 'xcompile',
+  srcs = ['Bar.groovy', 'Baz.java'],
+  visibility = [
+    'PUBLIC',
+  ]
+)

--- a/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/xcompile/Bar.groovy
+++ b/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/xcompile/Bar.groovy
@@ -1,0 +1,13 @@
+package com.example.xcompile
+
+class Bar {
+    static String banana() {
+        return "banana"
+    }
+}
+
+class Quux extends Baz {
+    public static void main(String[] args) {
+        println (new Quux().banana())
+    }
+}

--- a/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/xcompile/Baz.java
+++ b/test/com/facebook/buck/jvm/groovy/testdata/groovy_library_description/com/example/xcompile/Baz.java
@@ -1,0 +1,7 @@
+package com.example.xcompile;
+
+public class Baz {
+  public String banana() {
+    return Bar.banana();
+  }
+}

--- a/test/com/facebook/buck/testutil/integration/ProjectWorkspace.java
+++ b/test/com/facebook/buck/testutil/integration/ProjectWorkspace.java
@@ -396,7 +396,11 @@ public class ProjectWorkspace {
         "ANDROID_NDK",
         "ANDROID_NDK_REPOSITORY",
         "ANDROID_SDK",
+        // TODO(grumpyjames) Write an equivalent of the groovyc and startGroovy
+        // scripts provided by the groovy distribution in order to remove these two.
         "GROOVY_HOME",
+        "JAVA_HOME",
+
         "NDK_HOME",
         "PATH",
         "PATHEXT",


### PR DESCRIPTION
Summary:

groovyc is able to collaborate with javac in order to compile .java
and .groovy files that express circular dependencies. No comment is
made as to whether this is a good idea, but it is now possible with
buck if one wished to.

By default, the inner javac will be parametrised in the same we it
would be as in a java library rule; these parameters can be overridden
in the same way they can be for a java_library rule.

Test plan: CI (there are new cases in GroovyLibraryIntegrationTest)