### PR TITLE
Fix new pex's windows handling.

### DIFF
--- a/third-party/py/pex/README.facebook
+++ b/third-party/py/pex/README.facebook
@@ -4,3 +4,4 @@ Git revision: 1e70fddafd480311e717e58dbf9466cf40003137
 License: Apache 2.0
 Local modifications:
  - Only imported the pex source (no tests/docs).
+ - Fixed usage of os.link (does not exist on windows).


### PR DESCRIPTION
os.link doesn't exist on windows; copy instead.