### PR TITLE
Fix prebuilt package resolution in the new pex when pexs have '#' in the name.

### DIFF
--- a/third-party/py/pex/README.facebook
+++ b/third-party/py/pex/README.facebook
@@ -5,3 +5,4 @@ License: Apache 2.0
 Local modifications:
  - Only imported the pex source (no tests/docs).
  - Fixed usage of os.link (does not exist on windows).
+ - Fixed prebuilt package resolution when pexs have '#' in the name.

--- a/third-party/py/pex/pex/link.py
+++ b/third-party/py/pex/pex/link.py
@@ -73,7 +73,9 @@ class Link(object):
     """
     purl = urlparse.urlparse(url)
     if purl.scheme == '':
-      purl = urlparse.urlparse(self._normalize(url))
+      purl = urlparse.urlparse(self._normalize(url), allow_fragments=False)
+    elif purl.scheme == 'file':
+      purl = urlparse.urlparse(url, allow_fragments=False)
     self._url = purl
 
   def __ne__(self, other):


### PR DESCRIPTION
Buck-based python tests tend to have these.