### PR TITLE
Disable the part of the pex builder that pulls in the local setuptools package

### DIFF
--- a/third-party/py/pex/README.facebook
+++ b/third-party/py/pex/README.facebook
@@ -4,5 +4,7 @@ Git revision: 1e70fddafd480311e717e58dbf9466cf40003137
 License: Apache 2.0
 Local modifications:
  - Only imported the pex source (no tests/docs).
+ - Disabled the part of the twitter PEX code that auto-detects the setuptools package from the
+   system, as this got more problematic to fake in our own `pkg_resources` module.
  - Fixed usage of os.link (does not exist on windows).
  - Fixed prebuilt package resolution when pexs have '#' in the name.

--- a/third-party/py/pex/pex/pex_builder.py
+++ b/third-party/py/pex/pex/pex_builder.py
@@ -356,26 +356,6 @@ class PEXBuilder(object):
     # Writes enough of setuptools into the .pex .bootstrap directory so that we can be fully
     # self-contained.
 
-    wrote_setuptools = False
-    setuptools = DistributionHelper.distribution_from_path(
-        self._interpreter.get_location('setuptools'),
-        name='setuptools')
-
-    if setuptools is None:
-      raise RuntimeError('Failed to find setuptools while building pex!')
-
-    for fn, content_stream in DistributionHelper.walk_data(setuptools):
-      if fn.startswith('pkg_resources') or fn.startswith('_markerlib'):
-        if not fn.endswith('.pyc'):  # We'll compile our own .pyc's later.
-          dst = os.path.join(self.BOOTSTRAP_DIR, fn)
-          self._chroot.write(content_stream.read(), dst, 'bootstrap')
-          wrote_setuptools = True
-
-    if not wrote_setuptools:
-      raise RuntimeError(
-          'Failed to extract pkg_resources from setuptools.  Perhaps pants was linked with an '
-          'incompatible setuptools.')
-
     libraries = {
       'pex': '_pex',
     }


### PR DESCRIPTION
This messes with our ability to specify the path to the vendored pkg_resources.