### PR TITLE
Switch to the new pex (v1.1.1)

### DIFF
--- a/src/com/facebook/buck/python/BUCK
+++ b/src/com/facebook/buck/python/BUCK
@@ -101,7 +101,7 @@ python_binary(
   name = 'pex',
   main = 'make_pex.py',
   deps = [
-    '//third-party/py/twitter-commons/src/python:twitter-commons',
+    '//third-party/py/pex:pex',
   ],
   visibility = [
     'PUBLIC',

--- a/src/com/facebook/buck/python/make_pex.py
+++ b/src/com/facebook/buck/python/make_pex.py
@@ -16,23 +16,17 @@ import zipfile
 # setuptools at runtime.  Also, locate the `pkg_resources` modules
 # via our local setuptools import.
 if not zipfile.is_zipfile(sys.argv[0]):
-    # Remove twitter.common.python from the import path - it may be eagerly
-    # loaded as part of site-packages.
-    sys.modules.pop('twitter', None)
-    sys.modules.pop('twitter.common', None)
-    sys.modules.pop('twitter.common.python', None)
-
     buck_root = os.sep.join(__file__.split(os.sep)[:-6])
     sys.path.insert(0, os.path.join(
         buck_root,
-        'third-party/py/twitter-commons/src/python'))
+        'third-party/py/pex'))
     sys.path.insert(0, os.path.join(
         buck_root, 'third-party/py/setuptools'))
 
 import pkg_resources
 
-from twitter.common.python.pex_builder import PEXBuilder
-from twitter.common.python.interpreter import PythonInterpreter
+from pex.pex_builder import PEXBuilder
+from pex.interpreter import PythonInterpreter
 
 
 def dereference_symlinks(src):

--- a/third-party/py/pex/BUCK
+++ b/third-party/py/pex/BUCK
@@ -1,0 +1,14 @@
+python_library(
+  name = 'pex',
+  base_module = '',
+  srcs = glob(['pex/**/*.py']),
+  deps = [
+    # Although the twitter sources actually import `pkg_resources`, we
+    # intentionally avoid a dependency here, as our custom PEX-builder
+    # frontend manually finds the `pkg_resources` locations.
+    #'//third-party/py/setuptools:pkg_resources',
+  ],
+  visibility = [
+    'PUBLIC',
+  ],
+)


### PR DESCRIPTION
The new release properly does site-packages isolation, so pexs will no longer pull in locally installed packages on newer distros.

The old pex source isn't deleted here, although I could definitely do that.