### PR TITLE
Fix exception catch in buck.py etc for Python 3.5 sytanx

### DIFF
--- a/programs/buck_tool.py
+++ b/programs/buck_tool.py
@@ -235,7 +235,7 @@ class BuckTool(object):
             # Make sure the Unix domain socket doesn't exist before this call.
             try:
                 os.unlink(buck_socket_path)
-            except OSError, e:
+            except OSError as e:
                 if e.errno == errno.ENOENT:
                     # Socket didn't previously exist.
                     pass

--- a/programs/gen_buck_info.py
+++ b/programs/gen_buck_info.py
@@ -31,7 +31,7 @@ def main(argv):
             with open(os.path.join(path, '.buckrelease')) as f:
                 timestamp = int(os.fstat(f.fileno()).st_mtime)
                 version = f.read().strip()
-        except IOError, e:
+        except IOError as e:
             if e.errno == errno.ENOENT:
                 # No .buckrelease file. Do the best that we can.
                 version = '(unknown version)'

--- a/src/com/facebook/buck/json/buck.py
+++ b/src/com/facebook/buck/json/buck.py
@@ -193,7 +193,7 @@ def glob(includes, excludes=[], include_dotfiles=False, build_env=None, search_b
                 build_env.sync_cookie_state,
                 build_env.watchman_client,
                 build_env.diagnostics)
-        except build_env.watchman_error, e:
+        except build_env.watchman_error as e:
             build_env.diagnostics.add(
                 DiagnosticMessageAndLevel(
                     message='Watchman error, falling back to slow glob: {0}'.format(e),


### PR DESCRIPTION
Python 3.5 no longer accepts the comma style of naming an exception.

With .buckconfig interpreter set to python3.5:
```
~/projects/mt/redacted[alex/buck]$ buck build redacted:server
Warning raised by BUCK file parser:   File "/Users/alex/projects/mt/redacted/.buckd/tmp/buck_run.r7CpLP/buck3671387140942854562.py", line 200
Warning raised by BUCK file parser:     except build_env.watchman_error, e:
Warning raised by BUCK file parser:                                    ^
Warning raised by BUCK file parser: SyntaxError: invalid syntax
Parse error for build file /Users/alex/projects/mt/redacted/redacted/BUCK: Parser exited unexpectedly
```