### PR TITLE
Reduce timeout time when parallel build file parsing is activated

### DIFF
--- a/src/com/facebook/buck/parser/ParallelPerBuildState.java
+++ b/src/com/facebook/buck/parser/ParallelPerBuildState.java
@@ -393,7 +393,7 @@ class ParallelPerBuildState implements PerBuildState, AutoCloseable {
   }
 
   private abstract class Worker implements Runnable {
-    static final int WAIT_FOR_WORK_TIMEOUT_SECONDS = 5;
+    static final int WAIT_FOR_WORK_TIMEOUT_MILLIS = 100;
 
     protected boolean shouldWaitForWork() {
       return pendingWorkQueueCount.get() > 0;
@@ -487,8 +487,8 @@ class ParallelPerBuildState implements PerBuildState, AutoCloseable {
     private BuildTargetProcessingScope startProcessingBuildTarget()
         throws InterruptedException, TimeoutException {
       BuildTarget target = pendingBuildTargets.poll(
-          WAIT_FOR_WORK_TIMEOUT_SECONDS,
-          TimeUnit.SECONDS);
+          WAIT_FOR_WORK_TIMEOUT_MILLIS,
+          TimeUnit.MILLISECONDS);
       if (target == null) {
         throw new TimeoutException();
       }
@@ -544,8 +544,8 @@ class ParallelPerBuildState implements PerBuildState, AutoCloseable {
     private BuildFileProcessingScope startProcessingBuildFile()
         throws InterruptedException, TimeoutException {
       Path buildFile = pendingBuildFiles.poll(
-          WAIT_FOR_WORK_TIMEOUT_SECONDS,
-          TimeUnit.SECONDS);
+          WAIT_FOR_WORK_TIMEOUT_MILLIS,
+          TimeUnit.MILLISECONDS);
       if (buildFile == null) {
         throw new TimeoutException();
       }


### PR DESCRIPTION
Fixes: https://github.com/facebook/buck/issues/604

Test plan:

Build Gerrit Code Review and observe, that No-op build doesn't take > 5
seconds:

  $ time buck build //gerrit-gwtui:ui_safari
  [-] PROCESSING BUCK FILES...FINISHED 0.0s
  [-] BUILDING...FINISHED 0.1s [100%] (1/191 JOBS, 0 UPDATED, 0.0% CACHE MISS)
  real 0m1.443s
  user 0m1.207s
  sys  0m0.105s