### PR TITLE
More pex fixes for windows.

### DIFF
--- a/bin/buck.bat
+++ b/bin/buck.bat
@@ -1,2 +1,3 @@
 @echo off
+set PYTHONPATH=%~dp0..\third-party\nailgun
 python %~dp0..\programs\buck.py %*

--- a/third-party/py/pex/pex/common.py
+++ b/third-party/py/pex/pex/common.py
@@ -269,17 +269,8 @@ class Chroot(object):
     self._ensure_parent(dst)
     abs_src = src
     abs_dst = os.path.join(self.chroot, dst)
-    try:
-      os.link(abs_src, abs_dst)
-    except OSError as e:
-      if e.errno == errno.EEXIST:
-        # File already exists, skip XXX -- ensure target and dest are same?
-        pass
-      elif e.errno == errno.EXDEV:
-        # Hard link across devices, fall back on copying
-        shutil.copyfile(abs_src, abs_dst)
-      else:
-        raise
+    safe_copy(abs_src, abs_dst, overwrite=False)
+    # If the file already exists, skip XXX -- ensure target and dest are same?
 
   def write(self, data, dst, label=None, mode='wb'):
     """Write data to ``chroot/dst`` with optional label.

--- a/third-party/py/pex/pex/compiler.py
+++ b/third-party/py/pex/pex/compiler.py
@@ -3,6 +3,8 @@
 
 from __future__ import absolute_import
 
+import contextlib
+import os
 import subprocess
 import tempfile
 
@@ -58,6 +60,17 @@ main(root, relpaths)
 """
 
 
+@contextlib.contextmanager
+def named_temporary_file():
+    fp, path = tempfile.mkstemp()
+    os.close(fp)
+    try:
+        with open(path, 'w') as fp:
+            yield fp
+    finally:
+        os.remove(path)
+
+
 class Compiler(object):
   class Error(Exception):
     """Indicates an error compiling one or more python source files."""
@@ -78,7 +91,7 @@ class Compiler(object):
     :returns: A list of relative paths of the compiled bytecode files.
     :raises: A :class:`Compiler.Error` if there was a problem bytecode compiling any of the files.
     """
-    with tempfile.NamedTemporaryFile() as fp:
+    with named_temporary_file() as fp:
       fp.write(to_bytes(_COMPILER_MAIN % {'root': root, 'relpaths': relpaths}, encoding='utf-8'))
       fp.flush()
       process = subprocess.Popen([self._interpreter.binary, fp.name],

--- a/third-party/py/pex/pex/pex.py
+++ b/third-party/py/pex/pex/pex.py
@@ -104,6 +104,9 @@ class PEX(object):  # noqa: T000
       site_libs = set()
     site_libs.update([sysconfig.get_python_lib(plat_specific=False),
                       sysconfig.get_python_lib(plat_specific=True)])
+    # On windows getsitepackages() returns the python stdlib too.
+    if sys.prefix in site_libs:
+      site_libs.remove(sys.prefix)
     real_site_libs = set(os.path.realpath(path) for path in site_libs)
     return site_libs | real_site_libs
 


### PR DESCRIPTION
Aside from the two issues @sdwilsh found, the last bit was convincing pex to not remove sys.prefix from sys.path.