### PR TITLE
Add missing whitespace to overview article

### DIFF
--- a/docs/about/overview.soy
+++ b/docs/about/overview.soy
@@ -26,8 +26,8 @@ Buck has three primary concepts:
   <li>
     A {call buck.concept_link}{param name: 'build file' /}{param page: 'build_file' /}{/call} that
     defines one or more build rules.  In Make, this would be a <code>Makefile</code>, but in Buck,
-    these files are named <code>BUCK</code>.  A project using Buck is expected to have many
-    <code>BUCK</code> files.
+    these files are named <code>BUCK</code>.  A project using Buck is expected to have
+    many <code>BUCK</code> files.
   </li>
 </ul>
 


### PR DESCRIPTION
Fixes the following:

> A project using Buck is expected to have **manyBUCK** files