### PR TITLE
Add ability to mark a prebuilt_jar as "provided" - i.e. it's always a provided_dep

### DIFF
--- a/src/com/facebook/buck/android/AndroidPrebuiltAarDescription.java
+++ b/src/com/facebook/buck/android/AndroidPrebuiltAarDescription.java
@@ -187,7 +187,8 @@ public class AndroidPrebuiltAarDescription
         /* sourceJar */ Optional.<SourcePath>absent(),
         /* gwtJar */ Optional.<SourcePath>absent(),
         /* javadocUrl */ Optional.<String>absent(),
-        /* mavenCoords */ Optional.<String>absent());
+        /* mavenCoords */ Optional.<String>absent(),
+        /* provided */ false);
 
   }
 

--- a/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
+++ b/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
@@ -46,6 +46,7 @@ import com.facebook.buck.step.fs.MakeCleanDirectoryStep;
 import com.facebook.buck.step.fs.MkdirStep;
 import com.facebook.buck.step.fs.TouchStep;
 import com.facebook.buck.util.HumanReadableException;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicates;
@@ -370,8 +371,13 @@ public class DefaultJavaLibrary extends AbstractBuildRule
     return transitiveClasspathDepsSupplier.get();
   }
 
-  @Override
-  public ImmutableSetMultimap<JavaLibrary, Path> getDeclaredClasspathEntries() {
+  /**
+   * @return The set of entries to pass to {@code javac}'s {@code -classpath} flag in order to
+   * compile the {@code srcs} associated with this rule.  This set only contains the classpath
+   * entries for those rules that are declared as direct dependencies of this rule.
+   */
+  @VisibleForTesting
+  ImmutableSetMultimap<JavaLibrary, Path> getDeclaredClasspathEntries() {
     return declaredClasspathEntriesSupplier.get();
   }
 

--- a/src/com/facebook/buck/jvm/java/JavaLibrary.java
+++ b/src/com/facebook/buck/jvm/java/JavaLibrary.java
@@ -77,13 +77,6 @@ public interface JavaLibrary extends BuildRule, HasClasspathEntries,
 
   /**
    * @return The set of entries to pass to {@code javac}'s {@code -classpath} flag in order to
-   * compile the {@code srcs} associated with this rule.  This set only contains the classpath
-   * entries for those rules that are declared as direct dependencies of this rule.
-   */
-  public ImmutableSetMultimap<JavaLibrary, Path> getDeclaredClasspathEntries();
-
-  /**
-   * @return The set of entries to pass to {@code javac}'s {@code -classpath} flag in order to
    * compile rules that depend on this rule.
    */
   public ImmutableSetMultimap<JavaLibrary, Path> getOutputClasspathEntries();

--- a/src/com/facebook/buck/jvm/java/PrebuiltJarDescription.java
+++ b/src/com/facebook/buck/jvm/java/PrebuiltJarDescription.java
@@ -47,17 +47,6 @@ import java.nio.file.Path;
 
 public class PrebuiltJarDescription implements Description<PrebuiltJarDescription.Arg> {
 
-  @SuppressFieldNotInitialized
-  public static class Arg extends AbstractDescriptionArg {
-    public SourcePath binaryJar;
-    public Optional<SourcePath> sourceJar;
-    public Optional<SourcePath> gwtJar;
-    public Optional<String> javadocUrl;
-    public Optional<String> mavenCoords;
-
-    public Optional<ImmutableSortedSet<BuildTarget>> deps;
-  }
-
   public static final BuildRuleType TYPE = BuildRuleType.of("prebuilt_jar");
 
   @Override
@@ -97,7 +86,8 @@ public class PrebuiltJarDescription implements Description<PrebuiltJarDescriptio
         args.sourceJar,
         args.gwtJar,
         args.javadocUrl,
-        args.mavenCoords);
+        args.mavenCoords,
+        args.provided.or(false));
 
     UnflavoredBuildTarget prebuiltJarBuildTarget = params.getBuildTarget().checkUnflavored();
     BuildTarget flavoredBuildTarget = BuildTargets.createFlavoredBuildTarget(
@@ -166,5 +156,17 @@ public class PrebuiltJarDescription implements Description<PrebuiltJarDescriptio
       }
     }
     return new ExistingOuputs(params, resolver, input);
+  }
+
+  @SuppressFieldNotInitialized
+  public static class Arg extends AbstractDescriptionArg {
+    public SourcePath binaryJar;
+    public Optional<SourcePath> sourceJar;
+    public Optional<SourcePath> gwtJar;
+    public Optional<String> javadocUrl;
+    public Optional<String> mavenCoords;
+    public Optional<Boolean> provided;
+
+    public Optional<ImmutableSortedSet<BuildTarget>> deps;
   }
 }

--- a/test/com/facebook/buck/jvm/java/DefaultJavaLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/java/DefaultJavaLibraryIntegrationTest.java
@@ -343,20 +343,22 @@ public class DefaultJavaLibraryIntegrationTest {
     workspace.setUp();
 
     // Run `buck build`.
-    ProcessResult buildResult = workspace.runBuckCommand("build", "//:binary");
+    ProcessResult buildResult = workspace.runBuckCommand("build", "//:binary", "//:binary_2");
     buildResult.assertSuccess("Successful build should exit with 0.");
 
-    Path file = workspace.getPath("buck-out/gen/binary.jar");
-    try (Zip zip = new Zip(file, /* for writing? */ false)) {
-      Set<String> allNames = zip.getFileNames();
-      // Representative file from provided_deps we don't expect to be there.
-      assertFalse(allNames.contains("org/junit/Test.class"));
+    for (String filename : new String[]{"buck-out/gen/binary.jar", "buck-out/gen/binary_2.jar"}) {
+      Path file = workspace.getPath(filename);
+      try (Zip zip = new Zip(file, /* for writing? */ false)) {
+        Set<String> allNames = zip.getFileNames();
+        // Representative file from provided_deps we don't expect to be there.
+        assertFalse(allNames.contains("org/junit/Test.class"));
 
-      // Representative file from the deps that we do expect to be there.
-      assertTrue(allNames.contains("com/google/common/collect/Sets.class"));
+        // Representative file from the deps that we do expect to be there.
+        assertTrue(allNames.contains("com/google/common/collect/Sets.class"));
 
-      // The file we built.
-      assertTrue(allNames.contains("com/facebook/buck/example/Example.class"));
+        // The file we built.
+        assertTrue(allNames.contains("com/facebook/buck/example/Example.class"));
+      }
     }
   }
 

--- a/test/com/facebook/buck/jvm/java/DefaultJavaLibraryTest.java
+++ b/test/com/facebook/buck/jvm/java/DefaultJavaLibraryTest.java
@@ -377,13 +377,6 @@ public class DefaultJavaLibraryTest {
       }
 
       @Override
-      public ImmutableSetMultimap<JavaLibrary, Path> getDeclaredClasspathEntries() {
-        return ImmutableSetMultimap.of(
-            (JavaLibrary) this,
-            Paths.get("java/src/com/libone/bar.jar"));
-      }
-
-      @Override
       public ImmutableSetMultimap<JavaLibrary, Path> getOutputClasspathEntries() {
         return ImmutableSetMultimap.of(
             (JavaLibrary) this,
@@ -427,7 +420,7 @@ public class DefaultJavaLibraryTest {
             " should contain only bar.jar.",
         ImmutableSet.of(libraryOne.getProjectFilesystem().resolve("java/src/com/libone/bar.jar")),
         ImmutableSet.copyOf(
-            ((JavaLibrary) libraryTwo).getDeclaredClasspathEntries().values()));
+            ((DefaultJavaLibrary) libraryTwo).getDeclaredClasspathEntries().values()));
     assertEquals(
         "The classpath for the javac step to compile //:libtwo should contain only bar.jar.",
         ImmutableSet.of(libraryOne.getProjectFilesystem().resolve("java/src/com/libone/bar.jar")),

--- a/test/com/facebook/buck/jvm/java/FakeJavaLibrary.java
+++ b/test/com/facebook/buck/jvm/java/FakeJavaLibrary.java
@@ -65,11 +65,6 @@ public class FakeJavaLibrary extends FakeBuildRule implements JavaLibrary, Andro
   }
 
   @Override
-  public ImmutableSetMultimap<JavaLibrary, Path> getDeclaredClasspathEntries() {
-    return ImmutableSetMultimap.of();
-  }
-
-  @Override
   public ImmutableSetMultimap<JavaLibrary, Path> getOutputClasspathEntries() {
     return ImmutableSetMultimap.of();
   }

--- a/test/com/facebook/buck/jvm/java/PrebuiltJarTest.java
+++ b/test/com/facebook/buck/jvm/java/PrebuiltJarTest.java
@@ -70,7 +70,8 @@ public class PrebuiltJarTest {
         Optional.<SourcePath>of(new FakeSourcePath("lib/junit-4.11-sources.jar")),
         /* gwtJar */ Optional.<SourcePath>absent(),
         Optional.of("http://junit-team.github.io/junit/javadoc/latest/"),
-        /* mavenCoords */ Optional.<String>absent());
+        /* mavenCoords */ Optional.<String>absent(),
+        /* provided */ false);
   }
 
   @Test

--- a/test/com/facebook/buck/jvm/java/testdata/provided_deps/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/java/testdata/provided_deps/BUCK.fixture
@@ -22,3 +22,22 @@ prebuilt_jar(
   name = 'junit',
   binary_jar = 'junit.jar',
 )
+
+java_library(
+  name = 'library_2',
+  srcs = [ 'Example.java' ],
+  deps = [ ':guava', ':junit_provided' ],
+)
+
+java_binary(
+  name = 'binary_2',
+  deps = [
+    ':library_2',
+  ],
+)
+
+prebuilt_jar(
+  name = 'junit_provided',
+  binary_jar = 'junit.jar',
+  provided = True,
+)


### PR DESCRIPTION
This can be useful for e.g. hadoop-client jars which should never be packaged into a fat jar. This also moves getDeclaredClasspathEntries out of the JavaLibrary interface since it's only used in DefaultJavaLibrary.