### PR TITLE
Fix invalid syntax in .hgignore

### DIFF
--- a/src/com/facebook/buck/cli/quickstart/android/.hgignore
+++ b/src/com/facebook/buck/cli/quickstart/android/.hgignore
@@ -1,3 +1,4 @@
+syntax: glob
 *.iml
 /.idea/compiler.xml
 /.idea/libraries/*.xml

--- a/test/com/facebook/buck/cli/testdata/quickstart_expected_project/.hgignore.expected
+++ b/test/com/facebook/buck/cli/testdata/quickstart_expected_project/.hgignore.expected
@@ -1,3 +1,4 @@
+syntax: glob
 *.iml
 /.idea/compiler.xml
 /.idea/libraries/*.xml


### PR DESCRIPTION
Fixes #619 

Fix invalid syntax in .hgignore file generated for the Android quickstart project