### PR TITLE
Add the ability to mark a genrule output as executable.

### DIFF
--- a/docs/rule/genrule.soy
+++ b/docs/rule/genrule.soy
@@ -37,6 +37,16 @@
 
 {call genrule_common.out_arg /}
 
+{call buck.arg}
+  {param name: 'executable' /}
+  {param default : 'False' /}
+  {param desc}
+  Whether the output of the genrule is itself executable. Marking an output as
+  executable makes <code>buck run</code> and <code>$(exe ...)</code> macro
+  expansion work with this target.
+  {/param}
+{/call}
+
 {call buck.visibility_arg /}
 
 {/param} // args

--- a/src/com/facebook/buck/shell/BUCK
+++ b/src/com/facebook/buck/shell/BUCK
@@ -5,6 +5,7 @@ java_library(
     'ExportFile.java',
     'ExportFileDescription.java',
     'Genrule.java',
+    'GenruleBinary.java',
     'GenruleDescription.java',
     'ShBinary.java',
     'ShBinaryDescription.java',

--- a/src/com/facebook/buck/shell/GenruleBinary.java
+++ b/src/com/facebook/buck/shell/GenruleBinary.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.shell;
+
+import com.facebook.buck.rules.BinaryBuildRule;
+import com.facebook.buck.rules.BuildRuleParams;
+import com.facebook.buck.rules.BuildTargetSourcePath;
+import com.facebook.buck.rules.CommandTool;
+import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.buck.rules.Tool;
+import com.facebook.buck.rules.args.Arg;
+import com.google.common.base.Optional;
+
+import java.util.List;
+
+/**
+ * Same as a Genrule, but marked as a binary.
+ */
+public class GenruleBinary extends Genrule implements BinaryBuildRule {
+  protected GenruleBinary(
+      BuildRuleParams params,
+      SourcePathResolver resolver,
+      List<SourcePath> srcs,
+      Optional<Arg> cmd,
+      Optional<Arg> bash,
+      Optional<Arg> cmdExe,
+      String out) {
+    super(params, resolver, srcs, cmd, bash, cmdExe, out);
+  }
+
+  @Override
+  public Tool getExecutableCommand() {
+    return new CommandTool.Builder()
+        .addArg(new BuildTargetSourcePath(getBuildTarget(), getPathToOutput()))
+        .build();
+  }
+
+}

--- a/src/com/facebook/buck/shell/GenruleDescription.java
+++ b/src/com/facebook/buck/shell/GenruleDescription.java
@@ -22,10 +22,11 @@ import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildRuleType;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.infer.annotation.SuppressFieldNotInitialized;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 
-public class GenruleDescription extends AbstractGenruleDescription<AbstractGenruleDescription.Arg> {
+public class GenruleDescription extends AbstractGenruleDescription<GenruleDescription.Arg> {
 
   public static final BuildRuleType TYPE = BuildRuleType.of("genrule");
 
@@ -40,7 +41,7 @@ public class GenruleDescription extends AbstractGenruleDescription<AbstractGenru
   }
 
   @Override
-  protected <A extends Arg> BuildRule createBuildRule(
+  protected <A extends GenruleDescription.Arg> BuildRule createBuildRule(
       BuildRuleParams params,
       BuildRuleResolver resolver,
       A args,
@@ -49,14 +50,31 @@ public class GenruleDescription extends AbstractGenruleDescription<AbstractGenru
       Optional<com.facebook.buck.rules.args.Arg> bash,
       Optional<com.facebook.buck.rules.args.Arg> cmdExe,
       String out) {
-    return new Genrule(
-        params,
-        new SourcePathResolver(resolver),
-        srcs,
-        cmd,
-        bash,
-        cmdExe,
-        out);
+    if (!args.executable.or(false)) {
+      return new Genrule(
+          params,
+          new SourcePathResolver(resolver),
+          srcs,
+          cmd,
+          bash,
+          cmdExe,
+          out);
+    } else {
+      return new GenruleBinary(
+          params,
+          new SourcePathResolver(resolver),
+          srcs,
+          cmd,
+          bash,
+          cmdExe,
+          out
+      );
+    }
+  }
+
+  @SuppressFieldNotInitialized
+  public static class Arg extends AbstractGenruleDescription.Arg {
+    public Optional<Boolean> executable;
   }
 
 }

--- a/test/com/facebook/buck/cli/testdata/audit_rules/stdout.all
+++ b/test/com/facebook/buck/cli/testdata/audit_rules/stdout.all
@@ -5,6 +5,7 @@ genrule(
   bash = "cat $SRCS > $OUT",
   cmd = None,
   cmdExe = None,
+  executable = None,
   out = "baz.txt",
   srcs = [
     "foo.txt",

--- a/test/com/facebook/buck/cli/testdata/audit_rules/stdout.genrule
+++ b/test/com/facebook/buck/cli/testdata/audit_rules/stdout.genrule
@@ -5,6 +5,7 @@ genrule(
   bash = "cat $SRCS > $OUT",
   cmd = None,
   cmdExe = None,
+  executable = None,
   out = "baz.txt",
   srcs = [
     "foo.txt",

--- a/test/com/facebook/buck/cli/testdata/output_path/output_path_json.js
+++ b/test/com/facebook/buck/cli/testdata/output_path/output_path_json.js
@@ -7,6 +7,7 @@
   "buck.type":"genrule",
   "cmd":null,
   "cmdExe":null,
+  "executable":null,
   "name":"test",
   "out":"test-output",
   "srcs":[],

--- a/test/com/facebook/buck/cli/testdata/target_command/TargetsCommandTestBuckJson2.js
+++ b/test/com/facebook/buck/cli/testdata/target_command/TargetsCommandTestBuckJson2.js
@@ -6,6 +6,7 @@
   "buck.type" : "genrule",
   "cmd" : "$(classpath :test-library)",
   "cmdExe" : null,
+  "executable" : null,
   "name" : "B",
   "out" : "B.txt",
   "srcs" : [":A"],

--- a/test/com/facebook/buck/shell/GenruleIntegrationTest.java
+++ b/test/com/facebook/buck/shell/GenruleIntegrationTest.java
@@ -239,4 +239,15 @@ public class GenruleIntegrationTest {
 
     assertEquals(originalOutput, originalOutput2);
   }
+
+  @Test
+  public void executableGenrule() throws IOException {
+    ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(
+        this, "genrule_executable", temporaryFolder);
+    workspace.setUp();
+
+    ProcessResult buildResult = workspace.runBuckCommand("run", "//:binary");
+    buildResult.assertSuccess();
+  }
+
 }

--- a/test/com/facebook/buck/shell/testdata/genrule_executable/BUCK.fixture
+++ b/test/com/facebook/buck/shell/testdata/genrule_executable/BUCK.fixture
@@ -1,0 +1,6 @@
+genrule(
+  name = 'binary',
+  cmd = '(echo "#!/bin/sh"; echo "echo hi") > $OUT && chmod +x $OUT',
+  executable = True,
+  out = 'out.sh',
+)


### PR DESCRIPTION
Similar to bazel, genrule(..., executable=True) will let you `buck run` it & uses `$(exe ...)` in macros.