### PR TITLE
Remove unnecessary 'workspace.verify()' calls from two test cases.

### DIFF
--- a/test/com/facebook/buck/jvm/groovy/GroovyLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/groovy/GroovyLibraryIntegrationTest.java
@@ -49,8 +49,6 @@ public class GroovyLibraryIntegrationTest {
     ProjectWorkspace.ProcessResult buildResult =
         workspace.runBuckCommand("build", "//com/example/good:example");
     buildResult.assertSuccess("Build should have succeeded.");
-
-    workspace.verify();
   }
 
   @Test
@@ -58,8 +56,6 @@ public class GroovyLibraryIntegrationTest {
     ProjectWorkspace.ProcessResult buildResult =
         workspace.runBuckCommand("build", "//com/example/child:child");
     buildResult.assertSuccess("Build should have succeeded.");
-
-    workspace.verify();
   }
 
   @Test
@@ -67,8 +63,6 @@ public class GroovyLibraryIntegrationTest {
     ProjectWorkspace.ProcessResult buildResult =
         workspace.runBuckCommand("build", "//com/example/bad:fail");
     buildResult.assertFailure();
-
-    workspace.verify();
   }
 
   @Test
@@ -76,8 +70,6 @@ public class GroovyLibraryIntegrationTest {
     ProjectWorkspace.ProcessResult buildResult =
         workspace.runBuckCommand("build", "//com/example/xcompile:xcompile");
     buildResult.assertSuccess();
-
-    workspace.verify();
   }
 
   @Test
@@ -87,8 +79,6 @@ public class GroovyLibraryIntegrationTest {
         workspace.runBuckCommand("build", "//com/example/modern:xcompile");
 
     buildResult.assertFailure();
-
-    workspace.verify();
   }
 
   @Test
@@ -97,7 +87,5 @@ public class GroovyLibraryIntegrationTest {
         workspace.runBuckCommand("build", "//com/example/javacextras:javacextras");
 
     buildResult.assertFailure();
-
-    workspace.verify();
   }
 }

--- a/test/com/facebook/buck/jvm/groovy/GroovyTestIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/groovy/GroovyTestIntegrationTest.java
@@ -49,8 +49,6 @@ public class GroovyTestIntegrationTest {
     ProjectWorkspace.ProcessResult buildResult =
         workspace.runBuckCommand("test", "//com/example/spock:passing");
     buildResult.assertSuccess("Build should have succeeded.");
-
-    workspace.verify();
   }
 
   @Test
@@ -58,8 +56,6 @@ public class GroovyTestIntegrationTest {
     ProjectWorkspace.ProcessResult buildResult =
         workspace.runBuckCommand("test", "//com/example/spock:failing");
     buildResult.assertTestFailure();
-
-    workspace.verify();
   }
 
   @Test
@@ -67,7 +63,5 @@ public class GroovyTestIntegrationTest {
     ProjectWorkspace.ProcessResult buildResult =
         workspace.runBuckCommand("test", "//com/example/spock:will_not_compile");
     buildResult.assertFailure();
-
-    workspace.verify();
   }
 }


### PR DESCRIPTION
Summary:

These tests don't have any .expected files in their test data area;
there's no need to verify anything.

Test-plan:

CI