### PR TITLE
Remove redundant mkdir step from DefaultJavaLibrary

### DIFF
--- a/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
+++ b/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
@@ -43,7 +43,6 @@ import com.facebook.buck.rules.SourcePaths;
 import com.facebook.buck.rules.keys.SupportsInputBasedRuleKey;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.fs.MakeCleanDirectoryStep;
-import com.facebook.buck.step.fs.MkdirStep;
 import com.facebook.buck.step.fs.TouchStep;
 import com.facebook.buck.util.HumanReadableException;
 import com.google.common.base.Function;
@@ -467,12 +466,10 @@ public class DefaultJavaLibrary extends AbstractBuildRule
     // Only run javac if there are .java files to compile.
     if (!getJavaSrcs().isEmpty()) {
       // This adds the javac command, along with any supporting commands.
-      Path pathToSrcsList = BuildTargets.getGenPath(getBuildTarget(), "__%s__srcs");
-      steps.add(new MkdirStep(getProjectFilesystem(), pathToSrcsList.getParent()));
-
       Path scratchDir = BuildTargets.getGenPath(target, "lib__%s____working_directory");
       steps.add(new MakeCleanDirectoryStep(getProjectFilesystem(), scratchDir));
       Optional<Path> workingDirectory = Optional.of(scratchDir);
+      Path pathToSrcsList = BuildTargets.getGenPath(getBuildTarget(), "__%s__srcs");
 
       compileStepFactory.createCompileToJarStep(
           context,

--- a/test/com/facebook/buck/jvm/java/DefaultJavaLibraryTest.java
+++ b/test/com/facebook/buck/jvm/java/DefaultJavaLibraryTest.java
@@ -1235,8 +1235,8 @@ public class DefaultJavaLibraryTest {
         FakeBuildContext.NOOP_CONTEXT,
         new FakeBuildableContext());
 
-    assertEquals(11, steps.size());
-    assertTrue(((JavacStep) steps.get(6)).getJavac() instanceof Jsr199Javac);
+    assertEquals(10, steps.size());
+    assertTrue(((JavacStep) steps.get(5)).getJavac() instanceof Jsr199Javac);
   }
 
   @Test
@@ -1257,8 +1257,8 @@ public class DefaultJavaLibraryTest {
     DefaultJavaLibrary buildable = (DefaultJavaLibrary) rule;
     ImmutableList<Step> steps =
         buildable.getBuildSteps(FakeBuildContext.NOOP_CONTEXT, new FakeBuildableContext());
-    assertEquals(11, steps.size());
-    Javac javacStep = ((JavacStep) steps.get(6)).getJavac();
+    assertEquals(10, steps.size());
+    Javac javacStep = ((JavacStep) steps.get(5)).getJavac();
     assertTrue(javacStep instanceof Jsr199Javac);
     JarBackedJavac jsrJavac = ((JarBackedJavac) javacStep);
     assertEquals(


### PR DESCRIPTION
Summary: Presumably the gen path for a build target already exists by
the time we execute the steps. At least, not explicitly creating it in
DefaultJavaLibrary appears to have no ill effects.

Test-plan: CI