### PR TITLE
Always provide a pathToSrcsList in jvm related rules

### DIFF
--- a/src/com/facebook/buck/android/AaptPackageResources.java
+++ b/src/com/facebook/buck/android/AaptPackageResources.java
@@ -336,8 +336,12 @@ public class AaptPackageResources extends AbstractBuildRule
     Path rDotJavaBin = getPathToCompiledRDotJavaFiles();
     steps.add(new MakeCleanDirectoryStep(getProjectFilesystem(), rDotJavaBin));
 
+    Path pathToSrcsList = BuildTargets.getGenPath(getBuildTarget(), "__%s__srcs");
+    steps.add(new MkdirStep(getProjectFilesystem(), pathToSrcsList.getParent()));
+
     JavacStep javacStep = RDotJava.createJavacStepForUberRDotJavaFiles(
         mergeStep.getRDotJavaFiles(),
+        pathToSrcsList,
         rDotJavaBin,
         javacOptions,
         getBuildTarget(),

--- a/src/com/facebook/buck/android/DummyRDotJava.java
+++ b/src/com/facebook/buck/android/DummyRDotJava.java
@@ -35,6 +35,7 @@ import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.keys.AbiRule;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.fs.MakeCleanDirectoryStep;
+import com.facebook.buck.step.fs.MkdirStep;
 import com.facebook.buck.step.fs.WriteFileStep;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
@@ -122,10 +123,14 @@ public class DummyRDotJava extends AbstractBuildRule
     steps.add(new MakeCleanDirectoryStep(getProjectFilesystem(), pathToAbiOutputDir));
     Path pathToAbiOutputFile = pathToAbiOutputDir.resolve("abi.jar");
 
+    Path pathToSrcsList = BuildTargets.getGenPath(getBuildTarget(), "__%s__srcs");
+    steps.add(new MkdirStep(getProjectFilesystem(), pathToSrcsList.getParent()));
+
     // Compile the .java files.
     final JavacStep javacStep =
         RDotJava.createJavacStepForDummyRDotJavaFiles(
             javaSourceFilePaths,
+            pathToSrcsList,
             rDotJavaClassesFolder,
             javacOptions,
             getBuildTarget(),

--- a/src/com/facebook/buck/android/RDotJava.java
+++ b/src/com/facebook/buck/android/RDotJava.java
@@ -45,6 +45,7 @@ public class RDotJava {
 
   static JavacStep createJavacStepForUberRDotJavaFiles(
       ImmutableSortedSet<Path> javaSourceFilePaths,
+      Path pathToSrcsList,
       Path outputDirectory,
       JavacOptions javacOptions,
       BuildTarget buildTarget,
@@ -52,6 +53,7 @@ public class RDotJava {
       ProjectFilesystem filesystem) {
     return createJavacStepForDummyRDotJavaFiles(
         javaSourceFilePaths,
+        pathToSrcsList,
         outputDirectory,
         javacOptions,
         buildTarget,
@@ -61,6 +63,7 @@ public class RDotJava {
 
   static JavacStep createJavacStepForDummyRDotJavaFiles(
       ImmutableSortedSet<Path> javaSourceFilePaths,
+      Path pathToSrcsList,
       Path outputDirectory,
       JavacOptions javacOptions,
       BuildTarget buildTarget,
@@ -72,7 +75,7 @@ public class RDotJava {
         Optional.<StandardJavaFileManagerFactory>absent(),
         Optional.<Path>absent(),
         javaSourceFilePaths,
-        Optional.<Path>absent(),
+        pathToSrcsList,
         /* declared classpath */ ImmutableSortedSet.<Path>of(),
         javacOptions.getJavac(),
         JavacOptions.builder(javacOptions)

--- a/src/com/facebook/buck/jvm/groovy/GroovycToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/groovy/GroovycToJarStepFactory.java
@@ -58,7 +58,7 @@ class GroovycToJarStepFactory extends BaseCompileToJarStepFactory {
       ImmutableSortedSet<Path> declaredClasspathEntries,
       Path outputDirectory,
       Optional<Path> workingDirectory,
-      Optional<Path> pathToSrcsList,
+      Path pathToSrcsList,
       Optional<SuggestBuildRules> suggestBuildRules,
       /* out params */
       ImmutableList.Builder<Step> steps,

--- a/src/com/facebook/buck/jvm/java/BaseCompileToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/java/BaseCompileToJarStepFactory.java
@@ -48,7 +48,7 @@ public abstract class BaseCompileToJarStepFactory implements CompileToJarStepFac
       ImmutableSortedSet<Path> declaredClasspathEntries,
       Path outputDirectory,
       Optional<Path> workingDirectory,
-      Optional<Path> pathToSrcsList,
+      Path pathToSrcsList,
       Optional<SuggestBuildRules> suggestBuildRules,
       ImmutableList<String> postprocessClassesCommands,
       ImmutableSortedSet<Path> entriesToJar,

--- a/src/com/facebook/buck/jvm/java/CompileToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/java/CompileToJarStepFactory.java
@@ -45,7 +45,7 @@ public interface CompileToJarStepFactory extends RuleKeyAppendable {
       ImmutableSortedSet<Path> declaredClasspathEntries,
       Path outputDirectory,
       Optional<Path> workingDirectory,
-      Optional<Path> pathToSrcsList,
+      Path pathToSrcsList,
       Optional<SuggestBuildRules> suggestBuildRules,
       /* output params */
       ImmutableList.Builder<Step> steps,
@@ -60,7 +60,7 @@ public interface CompileToJarStepFactory extends RuleKeyAppendable {
       ImmutableSortedSet<Path> declaredClasspathEntries,
       Path outputDirectory,
       Optional<Path> workingDirectory,
-      Optional<Path> pathToSrcsList,
+      Path pathToSrcsList,
       Optional<SuggestBuildRules> suggestBuildRules,
       ImmutableList<String> postprocessClassesCommands,
       ImmutableSortedSet<Path> entriesToJar,

--- a/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
+++ b/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
@@ -483,7 +483,7 @@ public class DefaultJavaLibrary extends AbstractBuildRule
           declared,
           outputDirectory,
           workingDirectory,
-          Optional.of(pathToSrcsList),
+          pathToSrcsList,
           Optional.of(suggestBuildRule),
           postprocessClassesCommands,
           ImmutableSortedSet.of(outputDirectory),

--- a/src/com/facebook/buck/jvm/java/JarFattener.java
+++ b/src/com/facebook/buck/jvm/java/JarFattener.java
@@ -158,6 +158,9 @@ public class JarFattener extends AbstractBuildRule implements BinaryBuildRule {
         ZipCompressionLevel.MIN_COMPRESSION_LEVEL,
         fatJarDir);
 
+    Path pathToSrcsList = BuildTargets.getGenPath(getBuildTarget(), "__%s__srcs");
+    steps.add(new MkdirStep(getProjectFilesystem(), pathToSrcsList.getParent()));
+
     CompileToJarStepFactory compileStepFactory =
         new JavacToJarStepFactory(javacOptions, JavacOptionsAmender.IDENTITY);
 
@@ -170,7 +173,7 @@ public class JarFattener extends AbstractBuildRule implements BinaryBuildRule {
         /* classpathEntries */ ImmutableSortedSet.<Path>of(),
         fatJarDir,
         /* workingDir */ Optional.<Path>absent(),
-        /* pathToSrcsList */ Optional.<Path>absent(),
+        pathToSrcsList,
         /* suggestBuildRule */ Optional.<SuggestBuildRules>absent(),
         steps,
         buildableContext);

--- a/src/com/facebook/buck/jvm/java/Javac.java
+++ b/src/com/facebook/buck/jvm/java/Javac.java
@@ -52,14 +52,14 @@ public interface Javac extends RuleKeyAppendable, Tool {
       BuildTarget invokingRule,
       ImmutableList<String> options,
       ImmutableSortedSet<Path> javaSourceFilePaths,
-      Optional<Path> pathToSrcsList,
+      Path pathToSrcsList,
       Optional<Path> workingDirectory,
       Optional<StandardJavaFileManagerFactory> fileManagerFactory) throws InterruptedException;
 
   String getDescription(
       ImmutableList<String> options,
       ImmutableSortedSet<Path> javaSourceFilePaths,
-      Optional<Path> pathToSrcsList);
+      Path pathToSrcsList);
 
   String getShortName();
 

--- a/src/com/facebook/buck/jvm/java/JavacDirectToJarStep.java
+++ b/src/com/facebook/buck/jvm/java/JavacDirectToJarStep.java
@@ -52,7 +52,7 @@ public class JavacDirectToJarStep implements Step {
   private final Path outputDirectory;
   private final JavacOptions buildTimeOptions;
   private final Optional<Path> workingDirectory;
-  private final Optional<Path> pathToSrcsList;
+  private final Path pathToSrcsList;
   private final Optional<SuggestBuildRules> suggestBuildRules;
   private final ImmutableSortedSet<Path> entriesToJar;
   private final Optional<String> mainClass;
@@ -71,7 +71,7 @@ public class JavacDirectToJarStep implements Step {
       JavacOptions buildTimeOptions,
       Path outputDirectory,
       Optional<Path> workingDirectory,
-      Optional<Path> pathToSrcsList,
+      Path pathToSrcsList,
       Optional<SuggestBuildRules> suggestBuildRules,
       ImmutableSortedSet<Path> entriesToJar,
       Optional<String> mainClass,

--- a/src/com/facebook/buck/jvm/java/JavacStep.java
+++ b/src/com/facebook/buck/jvm/java/JavacStep.java
@@ -56,7 +56,7 @@ public class JavacStep implements Step {
 
   private final ImmutableSortedSet<Path> javaSourceFilePaths;
 
-  private final Optional<Path> pathToSrcsList;
+  private final Path pathToSrcsList;
 
   private final JavacOptions javacOptions;
 
@@ -103,7 +103,7 @@ public class JavacStep implements Step {
       Optional<StandardJavaFileManagerFactory> fileManagerFactory,
       Optional<Path> workingDirectory,
       ImmutableSortedSet<Path> javaSourceFilePaths,
-      Optional<Path> pathToSrcsList,
+      Path pathToSrcsList,
       ImmutableSortedSet<Path> declaredClasspathEntries,
       Javac javac,
       JavacOptions javacOptions,

--- a/src/com/facebook/buck/jvm/java/JavacToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/java/JavacToJarStepFactory.java
@@ -51,7 +51,7 @@ public class JavacToJarStepFactory extends BaseCompileToJarStepFactory {
       ImmutableSortedSet<Path> declaredClasspathEntries,
       Path outputDirectory,
       Optional<Path> workingDirectory,
-      Optional<Path> pathToSrcsList,
+      Path pathToSrcsList,
       Optional<SuggestBuildRules> suggestBuildRules,
       ImmutableList.Builder<Step> steps,
       BuildableContext buildableContext) {
@@ -87,7 +87,7 @@ public class JavacToJarStepFactory extends BaseCompileToJarStepFactory {
       ImmutableSortedSet<Path> declaredClasspathEntries,
       Path outputDirectory,
       Optional<Path> workingDirectory,
-      Optional<Path> pathToSrcsList,
+      Path pathToSrcsList,
       Optional<SuggestBuildRules> suggestBuildRules,
       ImmutableList<String> postprocessClassesCommands,
       ImmutableSortedSet<Path> entriesToJar,

--- a/src/com/facebook/buck/jvm/scala/ScalacToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/scala/ScalacToJarStepFactory.java
@@ -54,7 +54,7 @@ class ScalacToJarStepFactory extends BaseCompileToJarStepFactory {
       ImmutableSortedSet<Path> classpathEntries,
       Path outputDirectory,
       Optional<Path> workingDirectory,
-      Optional<Path> pathToSrcsList,
+      Path pathToSrcsList,
       Optional<SuggestBuildRules> suggestBuildRules,
       /* out params */
       ImmutableList.Builder<Step> steps,

--- a/test/com/facebook/buck/android/DummyRDotJavaTest.java
+++ b/test/com/facebook/buck/android/DummyRDotJavaTest.java
@@ -104,12 +104,13 @@ public class DummyRDotJavaTest {
     FakeBuildableContext buildableContext = new FakeBuildableContext();
     List<Step> steps = dummyRDotJava.getBuildSteps(EasyMock.createMock(BuildContext.class),
         buildableContext);
-    assertEquals("DummyRDotJava returns an incorrect number of Steps.", 6, steps.size());
+    assertEquals("DummyRDotJava returns an incorrect number of Steps.", 7, steps.size());
 
     String rDotJavaSrcFolder = Paths.get("buck-out/bin/java/base/__rule_rdotjava_src__").toString();
     String rDotJavaBinFolder = Paths.get("buck-out/bin/java/base/__rule_rdotjava_bin__").toString();
     String rDotJavaAbiFolder = Paths.get(
         "buck-out/gen/java/base/__rule_dummyrdotjava_abi__").toString();
+    String genFolder = targetGenPath().toString();
 
     List<String> expectedStepDescriptions = Lists.newArrayList(
         makeCleanDirDescription(filesystem.resolve(rDotJavaSrcFolder)),
@@ -119,6 +120,7 @@ public class DummyRDotJavaTest {
                 (AndroidResource) resourceRule2)),
         makeCleanDirDescription(filesystem.resolve(rDotJavaBinFolder)),
         makeCleanDirDescription(filesystem.resolve(rDotJavaAbiFolder)),
+        makeDirectoryDescription(filesystem.resolve(genFolder)),
         javacInMemoryDescription(rDotJavaBinFolder, pathResolver),
         String.format("calculate_abi %s", rDotJavaBinFolder));
 
@@ -153,6 +155,14 @@ public class DummyRDotJavaTest {
         dummyRDotJava.getRDotJavaBinFolder());
   }
 
+  private static String makeDirectoryDescription(Path dirname) {
+    return String.format("mkdir -p %s", dirname);
+  }
+
+  private static Path targetGenPath() {
+    return Paths.get("buck-out/gen/java/base/");
+  }
+
   private static String makeCleanDirDescription(Path dirname) {
     return String.format("rm -r -f %s && mkdir -p %s", dirname, dirname);
   }
@@ -164,6 +174,7 @@ public class DummyRDotJavaTest {
         Paths.get("buck-out/bin/java/base/__rule_rdotjava_src__/com/facebook/R.java"));
     return RDotJava.createJavacStepForDummyRDotJavaFiles(
         javaSourceFiles,
+        targetGenPath().resolve("__rule__srcs"),
         Paths.get(rDotJavaClassesFolder),
         ANDROID_JAVAC_OPTIONS,
         /* buildTarget */ null,

--- a/test/com/facebook/buck/jvm/java/ExternalJavacTest.java
+++ b/test/com/facebook/buck/jvm/java/ExternalJavacTest.java
@@ -35,7 +35,6 @@ import com.facebook.buck.util.FakeProcess;
 import com.facebook.buck.util.FakeProcessExecutor;
 import com.facebook.buck.util.ProcessExecutor;
 import com.facebook.buck.util.ProcessExecutorParams;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
@@ -76,18 +75,18 @@ public class ExternalJavacTest extends EasyMockSupport {
         firstOrder.getDescription(
             getArgs().add("foo.jar").build(),
             SOURCE_PATHS,
-            Optional.of(PATH_TO_SRCS_LIST)));
+            PATH_TO_SRCS_LIST));
     assertEquals("fakeJavac -source 6 -target 6 -g -d . -classpath foo.jar @" + PATH_TO_SRCS_LIST,
         warn.getDescription(
             getArgs().add("foo.jar").build(),
             SOURCE_PATHS,
-            Optional.of(PATH_TO_SRCS_LIST)));
+            PATH_TO_SRCS_LIST));
     assertEquals("fakeJavac -source 6 -target 6 -g -d . -classpath bar.jar" + File.pathSeparator +
         "foo.jar @" + PATH_TO_SRCS_LIST,
         transitive.getDescription(
             getArgs().add("bar.jar" + File.pathSeparator + "foo.jar").build(),
             SOURCE_PATHS,
-            Optional.of(PATH_TO_SRCS_LIST)));
+            PATH_TO_SRCS_LIST));
   }
 
   @Test

--- a/test/com/facebook/buck/jvm/java/Jsr199JavacIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/java/Jsr199JavacIntegrationTest.java
@@ -104,7 +104,7 @@ public class Jsr199JavacIntegrationTest {
                 "-d", pathToOutputDir,
                 "-classpath", "''"),
             SOURCE_PATHS,
-            Optional.of(pathToSrcsList)));
+            pathToSrcsList));
   }
 
   @Test
@@ -124,7 +124,7 @@ public class Jsr199JavacIntegrationTest {
         BuildTargetFactory.newInstance("//some:example"),
         ImmutableList.<String>of(),
         SOURCE_PATHS,
-        Optional.of(pathToSrcsList),
+        pathToSrcsList,
         Optional.<Path>absent(),
         Optional.<StandardJavaFileManagerFactory>absent());
     assertEquals("javac should exit with code 0.", exitCode, 0);
@@ -158,7 +158,7 @@ public class Jsr199JavacIntegrationTest {
         BuildTargetFactory.newInstance("//some:example"),
         ImmutableList.<String>of(),
         SOURCE_PATHS,
-        Optional.of(pathToSrcsList),
+        pathToSrcsList,
         Optional.<Path>absent(),
         Optional.<StandardJavaFileManagerFactory>absent());
     assertEquals("javac should exit with code 0.", exitCode, 0);
@@ -248,7 +248,7 @@ public class Jsr199JavacIntegrationTest {
           BuildTargetFactory.newInstance("//some:example"),
           ImmutableList.<String>of(),
           SOURCE_PATHS,
-          Optional.of(pathToSrcsList),
+          pathToSrcsList,
           Optional.<Path>absent(),
           Optional.<StandardJavaFileManagerFactory>absent());
       fail("Did not expect compilation to succeed");

--- a/test/com/facebook/buck/jvm/java/Jsr199JavacTest.java
+++ b/test/com/facebook/buck/jvm/java/Jsr199JavacTest.java
@@ -19,7 +19,6 @@ package com.facebook.buck.jvm.java;
 import static com.facebook.buck.jvm.java.JavaBuckConfig.TARGETED_JAVA_VERSION;
 import static org.junit.Assert.assertEquals;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 
@@ -47,21 +46,21 @@ public class Jsr199JavacTest extends EasyMockSupport {
         firstOrder.getDescription(
             getArgs().add("foo.jar").build(),
             SOURCE_FILES,
-            Optional.of(PATH_TO_SRCS_LIST)));
+            PATH_TO_SRCS_LIST));
     assertEquals(
         String.format("javac -source %s -target %s -g -d . -classpath foo.jar @%s",
             TARGETED_JAVA_VERSION, TARGETED_JAVA_VERSION, PATH_TO_SRCS_LIST),
         warn.getDescription(
             getArgs().add("foo.jar").build(),
             SOURCE_FILES,
-            Optional.of(PATH_TO_SRCS_LIST)));
+            PATH_TO_SRCS_LIST));
     assertEquals(
         String.format("javac -source %s -target %s -g -d . -classpath bar.jar%sfoo.jar @%s",
             TARGETED_JAVA_VERSION, TARGETED_JAVA_VERSION, File.pathSeparator, PATH_TO_SRCS_LIST),
         transitive.getDescription(
             getArgs().add("bar.jar" + File.pathSeparator + "foo.jar").build(),
             SOURCE_FILES,
-            Optional.of(PATH_TO_SRCS_LIST)));
+            PATH_TO_SRCS_LIST));
   }
 
   private Jsr199Javac createTestStep() {


### PR DESCRIPTION
Summary: Previously a few rules had the option to avoid doing this. It
forces the downstream implementations to branch unnecessarily, so
port the offending usages over to providing the path and then stop it 
being Optional

Test-plan: CI