### PR TITLE
Use pathToSrcsList in GroovycStep (fixes #629)

### DIFF
--- a/src/com/facebook/buck/jvm/groovy/GroovycToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/groovy/GroovycToJarStepFactory.java
@@ -71,6 +71,7 @@ class GroovycToJarStepFactory extends BaseCompileToJarStepFactory {
             resolver,
             outputDirectory,
             sourceFilePaths,
+            pathToSrcsList,
             declaredClasspathEntries,
             filesystem));
   }


### PR DESCRIPTION
Summary: Previously we ignored the provided path, but it turns out
groovyc does support it, so let's be the same as everyone else.

Test-plan: CI