### PR TITLE
Add `library` to go_test that copies the srcs/package/deps of the library it's testing.

### DIFF
--- a/docs/rule/go_test.soy
+++ b/docs/rule/go_test.soy
@@ -35,14 +35,24 @@
 {call go_common.srcs_arg /}
 
 {call buck.arg}
+  {param name: 'library' /}
+  {param default: 'None' /}
+  {param desc}
+  Specify the library that this internal test is testing. This will copy the <code>srcs</code>,
+  {sp}<code>package_name</code> and <code>deps</code> from the target specified so you don't have
+  to duplicate them.
+  {/param}
+{/call}
+
+{call buck.arg}
   {param name : 'package_name' /}
   {param default : 'go.prefix + path relative to the buck root + "_test"' /}
   {param desc}
   Sets the full name of the test package being compiled. This defaults to the path from the buck
   root with "_test" appended. (e.g. given a ./.buckconfig, a rule in ./a/b/BUCK defaults to package "a/b_test")
 
-  <p>Note: in order to test packages internally (i.e. same package name), you will need to re-declare
-  all the sources/dependencies on this test and set package_name appropriately.</p>
+  <p>Note: if you want to test packages internally (i.e. same package name), use the <code>library</code>
+  {sp}parameter instead of setting <code>package_name</code> to include the tested source files.</p>
   {/param}
 {/call}
 
@@ -96,6 +106,15 @@ go_test(
     ':join',
   ],
 )
+
+# Or
+
+go_test(
+  name='greeting-better-internal-test',
+  srcs=['greeting_test.go'],
+  library=':greeting',
+)
+
 </pre>{/literal}
 {/param}
 

--- a/src/com/facebook/buck/go/GoLibrary.java
+++ b/src/com/facebook/buck/go/GoLibrary.java
@@ -47,7 +47,6 @@ public class GoLibrary extends GoLinkable implements HasTests {
 
   private final ImmutableSortedSet<BuildTarget> tests;
 
-
   private final GoSymlinkTree symlinkTree;
   private final Path output;
 
@@ -67,6 +66,30 @@ public class GoLibrary extends GoLinkable implements HasTests {
     this.flags = compilerFlags;
     this.compiler = compiler;
     this.tests = tests;
+    this.output = BuildTargets.getGenPath(
+        getBuildTarget(), "%s/" + getBuildTarget().getShortName() + ".a");
+  }
+
+  public GoLibrary(
+      BuildRuleParams params,
+      SourcePathResolver resolver,
+      GoLibrary baseLibrary,
+      GoSymlinkTree symlinkTree,
+      ImmutableSet<SourcePath> extraSrcs,
+      ImmutableList<String> extraCompilerFlags) {
+    super(params, resolver);
+    this.srcs = ImmutableSet.<SourcePath>builder()
+        .addAll(baseLibrary.srcs)
+        .addAll(extraSrcs)
+        .build();
+    this.symlinkTree = symlinkTree;
+    this.packageName = baseLibrary.packageName;
+    this.flags = ImmutableList.<String>builder()
+        .addAll(baseLibrary.flags)
+        .addAll(extraCompilerFlags)
+        .build();
+    this.compiler = baseLibrary.compiler;
+    this.tests = ImmutableSortedSet.of();
     this.output = BuildTargets.getGenPath(
         getBuildTarget(), "%s/" + getBuildTarget().getShortName() + ".a");
   }

--- a/test/com/facebook/buck/go/GoTestIntegrationTest.java
+++ b/test/com/facebook/buck/go/GoTestIntegrationTest.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertThat;
 import com.facebook.buck.testutil.integration.DebuggableTemporaryFolder;
 import com.facebook.buck.testutil.integration.ProjectWorkspace;
 import com.facebook.buck.testutil.integration.TestDataHelper;
+import com.facebook.buck.util.HumanReadableException;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -60,6 +62,18 @@ public class GoTestIntegrationTest {
         "`buck test` should fail because TestAdd2() failed.",
         result2.getStderr(),
         containsString("TestAdd2"));
+  }
+
+  @Test
+  public void testGoInternalTest() throws IOException {
+    ProjectWorkspace.ProcessResult result1 = workspace.runBuckCommand(
+        "test", "//:test-success-internal");
+    result1.assertSuccess();
+  }
+
+  @Test(expected = HumanReadableException.class)
+  public void testGoInternalTestInTestList() throws IOException {
+    workspace.runBuckCommand("test", "//:test-success-bad");
   }
 
   @Test

--- a/test/com/facebook/buck/go/testdata/go_test/BUCK.fixture
+++ b/test/com/facebook/buck/go/testdata/go_test/BUCK.fixture
@@ -1,13 +1,39 @@
 go_library(
+  name = 'base',
+  srcs = ['base.go'],
+  package_name = 'buck_base',
+)
+
+go_library(
   name = 'lib',
   srcs = ['lib.go'],
+  deps = [':base'],
   package_name = 'lib',
+  tests = [
+    ':test-success',
+    ':test-success-internal',
+    # test-success-bad isn't here to test for the requirement that it should be here.
+    ':test-failure'
+  ]
 )
 
 go_test(
   name = 'test-success',
   srcs = ['lib.go', 'lib_test.go'],
+  deps = [':base'],
   package_name = 'lib',
+)
+
+go_test(
+  name='test-success-internal',
+  srcs = ['lib_test.go'],
+  library = ':lib'
+)
+
+go_test(
+  name='test-success-bad',
+  srcs = ['lib_test.go'],
+  library = ':lib'
 )
 
 go_test(
@@ -19,7 +45,6 @@ go_test(
 go_test(
   name = 'test-panic',
   srcs = ['panic_test.go'],
-  deps = [':lib'],
 )
 
 go_test(

--- a/test/com/facebook/buck/go/testdata/go_test/base.go
+++ b/test/com/facebook/buck/go/testdata/go_test/base.go
@@ -1,0 +1,5 @@
+package buck_base
+
+func Add(n1, n2 int) int {
+	return n1 + n2
+}

--- a/test/com/facebook/buck/go/testdata/go_test/lib.go
+++ b/test/com/facebook/buck/go/testdata/go_test/lib.go
@@ -1,7 +1,9 @@
 package lib
 
+import "buck_base"
+
 func add1(n int) int {
-	return n + 1
+	return buck_base.Add(n, 1)
 }
 
 func BadAdd2(n int) int {


### PR DESCRIPTION
This saves the trouble of duplicating the srcs/deps on the test target if you're testing the same package.