### PR TITLE
Make native libraries work in the pex package style.

### DIFF
--- a/src/com/facebook/buck/cxx/CxxLinkableEnhancer.java
+++ b/src/com/facebook/buck/cxx/CxxLinkableEnhancer.java
@@ -176,6 +176,14 @@ public class CxxLinkableEnhancer {
     // the soname.
     if (linkType == Linker.LinkType.SHARED) {
       argsBuilder.add(new StringArg("-shared"));
+
+      argsBuilder.addAll(
+          StringArg.from(
+              Linkers.iXlinker(
+                  "-rpath",
+                  String.format(
+                      "%s/",
+                      cxxPlatform.getLd().resolve(ruleResolver).libOrigin()))));
     } else if (linkType == Linker.LinkType.MACH_O_BUNDLE) {
       argsBuilder.add(new StringArg("-bundle"));
       // It's possible to build a Mach-O bundle without a bundle loader (logic tests, for example).
@@ -333,6 +341,12 @@ public class CxxLinkableEnhancer {
       ImmutableList<? extends Arg> args) {
     ImmutableList.Builder<Arg> linkArgsBuilder = ImmutableList.builder();
     linkArgsBuilder.add(new StringArg("-shared"));
+    linkArgsBuilder.addAll(StringArg.from(
+        Linkers.iXlinker(
+            "-rpath",
+            String.format(
+                "%s/",
+                cxxPlatform.getLd().resolve(ruleResolver).libOrigin()))));
     if (soname.isPresent()) {
       linkArgsBuilder.addAll(
           StringArg.from(cxxPlatform.getLd().resolve(ruleResolver).soname(soname.get())));

--- a/src/com/facebook/buck/python/PythonUtil.java
+++ b/src/com/facebook/buck/python/PythonUtil.java
@@ -18,13 +18,13 @@ package com.facebook.buck.python;
 
 import com.facebook.buck.cxx.CxxBuckConfig;
 import com.facebook.buck.cxx.CxxPlatform;
+import com.facebook.buck.cxx.NativeLinkable;
 import com.facebook.buck.cxx.NativeLinkables;
+import com.facebook.buck.cxx.Omnibus;
 import com.facebook.buck.cxx.OmnibusLibraries;
 import com.facebook.buck.cxx.OmnibusLibrary;
 import com.facebook.buck.cxx.OmnibusRoot;
 import com.facebook.buck.cxx.SharedNativeLinkTarget;
-import com.facebook.buck.cxx.NativeLinkable;
-import com.facebook.buck.cxx.Omnibus;
 import com.facebook.buck.graph.AbstractBreadthFirstThrowingTraversal;
 import com.facebook.buck.graph.AbstractBreadthFirstTraversal;
 import com.facebook.buck.io.MorePaths;
@@ -307,6 +307,11 @@ public class PythonUtil {
       }
     }
 
+    // If we're linking to C/C++ without extensions (i.e. just including .so), mark the
+    // result as non-zip safe, since the loader can't load .sos from zips.
+    if (!nativeLinkableRoots.isEmpty() || !nativeLinkTargetRoots.isEmpty()) {
+      allComponents.addZipSafe(Optional.of(false));
+    }
 
     return allComponents.build();
   }

--- a/src/com/facebook/buck/python/run_inplace.py.in
+++ b/src/com/facebook/buck/python/run_inplace.py.in
@@ -20,6 +20,9 @@ if native_libs_dir is not None:
 
 # Update the environment variable for the dynamic loader to find libraries
 # to preload.
+# TODO(mikekap): Remove this. It should not be needed, assuming callers properly
+# use pkg_resources to access .so files when using ctypes. Unfortunately, it's
+# still needed for Windows.
 old_native_libs_preload = os.environ.get(native_libs_preload_env_var)
 if native_libs_preload is not None:
     os.environ[native_libs_preload_env_var] = native_libs_preload

--- a/test/com/facebook/buck/python/PythonBinaryIntegrationTest.java
+++ b/test/com/facebook/buck/python/PythonBinaryIntegrationTest.java
@@ -162,11 +162,6 @@ public class PythonBinaryIntegrationTest {
 
   @Test
   public void nativeLibraries() throws IOException {
-    assumeThat(packageStyle, equalTo(PythonBuckConfig.PackageStyle.INPLACE));
-    assumeThat(
-        "TODO(8667197): Native libs currently don't work on El Capitan",
-        Platform.detect(),
-        not(equalTo(Platform.MACOS)));
     ProjectWorkspace.ProcessResult result =
         workspace.runBuckCommand("run", ":bin-with-native-libs").assertSuccess();
     assertThat(
@@ -198,7 +193,7 @@ public class PythonBinaryIntegrationTest {
         new BuildRuleResolver(TargetGraph.EMPTY, new DefaultTargetNodeToBuildRuleTransformer());
 
     assumeThat(
-        "TODO(8667197): Native libs currently don't work on El Capitan",
+        "TODO(8667197): El Capitan strips all DYLD_* variables",
         Platform.detect(),
         not(equalTo(Platform.MACOS)));
 
@@ -273,7 +268,9 @@ public class PythonBinaryIntegrationTest {
 
   @Test
   public void externalPexToolAffectsRuleKey() throws IOException {
-    assumeThat(packageStyle, equalTo(PythonBuckConfig.PackageStyle.STANDALONE));
+    if (packageStyle != PythonBuckConfig.PackageStyle.STANDALONE) {
+      return;
+    }
 
     ProjectWorkspace.ProcessResult firstResult =
         workspace.runBuckCommand(
@@ -300,7 +297,10 @@ public class PythonBinaryIntegrationTest {
 
   @Test
   public void multiplePythonHomes() throws Exception {
-    assumeThat(Platform.detect(), not(Matchers.is(Platform.WINDOWS)));
+    if (Platform.detect() == Platform.WINDOWS) {
+      return;
+    }
+
     ProjectWorkspace.ProcessResult result =
         workspace.runBuckBuild(
             "-c", "python#a.library=//:platform_a",
@@ -312,13 +312,18 @@ public class PythonBinaryIntegrationTest {
 
   @Test
   public void mainModuleNameIsSetProperly() throws Exception {
-    assumeThat(packageStyle, not(Matchers.is(PythonBuckConfig.PackageStyle.STANDALONE)));
+    if (packageStyle == PythonBuckConfig.PackageStyle.STANDALONE) {
+      return;
+    }
     workspace.runBuckCommand("run", "//:main_module_bin").assertSuccess();
   }
 
   @Test
   public void disableCachingForPackagedBinaries() throws IOException {
-    assumeThat(packageStyle, Matchers.is(PythonBuckConfig.PackageStyle.STANDALONE));
+    if (packageStyle != PythonBuckConfig.PackageStyle.STANDALONE) {
+      return;
+    }
+
     workspace.enableDirCache();
     workspace.runBuckBuild("-c", "python.cache_binaries=false", ":bin").assertSuccess();
     workspace.runBuckCommand("clean").assertSuccess();
@@ -334,7 +339,9 @@ public class PythonBinaryIntegrationTest {
    */
   @Test
   public void omnibusExcludedNativeLinkableRoot() throws IOException {
-    assumeThat(nativeLinkStrategy, Matchers.is(NativeLinkStrategy.MERGED));
+    if (nativeLinkStrategy != NativeLinkStrategy.MERGED) {
+      return;
+    }
     workspace.runBuckCommand("targets", "--show-output", "//omnibus_excluded_root:bin")
         .assertSuccess();
   }

--- a/test/com/facebook/buck/python/testdata/python_binary/main_with_native_libs.py
+++ b/test/com/facebook/buck/python/testdata/python_binary/main_with_native_libs.py
@@ -1,5 +1,6 @@
 import ctypes
 import platform
+import pkg_resources
 
 lib = 'libfoo'
 if platform.system() == 'Linux':
@@ -11,4 +12,7 @@ elif platform.system() == 'Windows':
 else:
     raise Exception('unknown system: ' + platform.system())
 
-ctypes.CDLL(lib).foo()
+if __name__ == '__main__':
+    # Due to a pecularity of Python, we can't use __name__ here, because this is
+    # __main__ and Python loses track of where the resources are.
+    ctypes.CDLL(pkg_resources.resource_filename('main_with_native_libs', lib)).foo()


### PR DESCRIPTION
This follows up (and fixes) using -rpath in python extensions to load the dependent libraries.

The one downside is that you can't simply load a library with `ctypes` by name - you have to
load it by full path (pkg_resources.resource_filename). I think this is acceptable since that's
"normal" in python (although definitely annoying).
