### PR TITLE
Fix OnDiskMavenDownloader path not resolving properly on windows

### DIFF
--- a/src/com/facebook/buck/file/OnDiskMavenDownloader.java
+++ b/src/com/facebook/buck/file/OnDiskMavenDownloader.java
@@ -35,7 +35,7 @@ public class OnDiskMavenDownloader implements Downloader {
   private static final Optional<String> SPOOF_MAVEN_REPO = Optional.of("http://example.com");
   private final Path root;
 
-  public OnDiskMavenDownloader(Path root) throws FileNotFoundException{
+  public OnDiskMavenDownloader(Path root) throws FileNotFoundException {
 
     if (!Files.exists(root)) {
       throw new FileNotFoundException(String.format("Maven root %s doesn't exist",
@@ -54,9 +54,6 @@ public class OnDiskMavenDownloader implements Downloader {
     // Get the URL that the maven item is located at.
     uri = MavenUrlDecoder.toHttpUrl(SPOOF_MAVEN_REPO, uri);
 
-    // Now grab the path from the URI and resolve it against the root
-    uri = root.resolve(uri.getPath()).toUri();
-
     // The path is absolute, which we don't want. Make it relative by just ignoring the leading
     // slash.
     Path target = root.resolve(uri.getPath().substring(1));
@@ -65,7 +62,7 @@ public class OnDiskMavenDownloader implements Downloader {
       throw new IOException(String.format("Unable to download %s (derived from %s)", target, uri));
     }
 
-    DownloadEvent.Started started = DownloadEvent.started(uri);
+    DownloadEvent.Started started = DownloadEvent.started(target.toUri());
     eventBus.post(started);
 
     try (InputStream is = new BufferedInputStream(Files.newInputStream(target))) {

--- a/test/com/facebook/buck/file/OnDiskMavenDownloaderTest.java
+++ b/test/com/facebook/buck/file/OnDiskMavenDownloaderTest.java
@@ -17,7 +17,6 @@
 package com.facebook.buck.file;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
@@ -86,7 +85,7 @@ public class OnDiskMavenDownloaderTest {
   }
 
   @Test
-  public void shouldDownloadFileFromLocalMavenRepoOnWindows() throws URISyntaxException, IOException {
+  public void shouldDownloadFileFromLocalMavenRepoWindows() throws URISyntaxException, IOException {
     FileSystem filesystem = Jimfs.newFileSystem(Configuration.windows());
     Path root = filesystem.getPath("C:\\Users\\bob\\.m2");
     Files.createDirectories(root);

--- a/test/com/facebook/buck/file/OnDiskMavenDownloaderTest.java
+++ b/test/com/facebook/buck/file/OnDiskMavenDownloaderTest.java
@@ -19,11 +19,13 @@ package com.facebook.buck.file;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 
 import com.facebook.buck.event.BuckEventBusFactory;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -80,13 +82,11 @@ public class OnDiskMavenDownloaderTest {
 
     String result = new String(Files.readAllBytes(output), UTF_8);
 
-    assertEquals("cake", result);
+    assertThat("cake", Matchers.equalTo(result));
   }
 
   @Test
   public void shouldDownloadFileFromLocalMavenRepoOnWindows() throws URISyntaxException, IOException {
-    // Same test as `shouldDownloadFileFromLocalMavenRepo` but using a windows
-    // mock filesystem.
     FileSystem filesystem = Jimfs.newFileSystem(Configuration.windows());
     Path root = filesystem.getPath("C:\\Users\\bob\\.m2");
     Files.createDirectories(root);
@@ -103,7 +103,7 @@ public class OnDiskMavenDownloaderTest {
 
     String result = new String(Files.readAllBytes(output), UTF_8);
 
-    assertEquals("cake", result);
+    assertThat("cake", Matchers.equalTo(result));
   }
 
   @Test

--- a/test/com/facebook/buck/file/OnDiskMavenDownloaderTest.java
+++ b/test/com/facebook/buck/file/OnDiskMavenDownloaderTest.java
@@ -84,6 +84,29 @@ public class OnDiskMavenDownloaderTest {
   }
 
   @Test
+  public void shouldDownloadFileFromLocalMavenRepoOnWindows() throws URISyntaxException, IOException {
+    // Same test as `shouldDownloadFileFromLocalMavenRepo` but using a windows
+    // mock filesystem.
+    FileSystem filesystem = Jimfs.newFileSystem(Configuration.windows());
+    Path root = filesystem.getPath("C:\\Users\\bob\\.m2");
+    Files.createDirectories(root);
+
+    URI uri = new URI("mvn:group:project:jar:0.1");
+    Path output = filesystem.getPath("output.txt");
+
+    Path source = root.resolve("group/project/0.1/project-0.1.jar");
+    Files.createDirectories(source.getParent());
+    Files.write(source, "cake".getBytes(UTF_8));
+
+    Downloader downloader = new OnDiskMavenDownloader(root);
+    downloader.fetch(BuckEventBusFactory.newInstance(), uri, output);
+
+    String result = new String(Files.readAllBytes(output), UTF_8);
+
+    assertEquals("cake", result);
+  }
+
+  @Test
   public void shouldThrowFileNotFoundExceptionWhenPathDoesntExist() throws FileNotFoundException {
     Path rootNotExist = filesystem.getPath("not/a/valid/path");
 


### PR DESCRIPTION
OnDiskMavenDownloader#fetch used root.resolve to convert the uri returned from the MavenUrlDecoder to a local file scheme. This did not work on Windows because of the drive letter.
```
file:///C:/com/android/support/support-v4/23.0.1/support-v4-23.0.1.aar
```
on windows vs
```
file:///com/android/support/support-v4/23.0.1/support-v4-23.0.1.aar
```
on mac/linux

This removes the extra uri conversion that was breaking the path because it is only used to log the DownloadEvent which can use the actual target path instead.

Tested by downloading support-v4 while building react-native on both mac and windows.

Fixes the 2nd issue in #649