### PR TITLE
Add resource union options to AndroidResource.

### DIFF
--- a/src/com/facebook/buck/android/AndroidResource.java
+++ b/src/com/facebook/buck/android/AndroidResource.java
@@ -131,6 +131,9 @@ public class AndroidResource extends AbstractBuildRule
   @AddToRuleKey
   private final boolean hasWhitelistedStrings;
 
+  @AddToRuleKey
+  private final boolean resourceUnion;
+
   private final ImmutableSortedSet<BuildRule> deps;
 
   private final BuildOutputInitializer<BuildOutput> buildOutputInitializer;
@@ -171,7 +174,8 @@ public class AndroidResource extends AbstractBuildRule
       Optional<SourcePath> additionalAssetsKey,
       @Nullable SourcePath manifestFile,
       Supplier<ImmutableSortedSet<? extends SourcePath>> symbolFilesFromDeps,
-      boolean hasWhitelistedStrings) {
+      boolean hasWhitelistedStrings,
+      boolean resourceUnion) {
     super(
         buildRuleParams.appendExtraDeps(
             Suppliers.compose(resolver.filterBuildRuleInputsFunction(), symbolFilesFromDeps)),
@@ -192,6 +196,7 @@ public class AndroidResource extends AbstractBuildRule
     this.manifestFile = manifestFile;
     this.symbolsOfDeps = symbolFilesFromDeps;
     this.hasWhitelistedStrings = hasWhitelistedStrings;
+    this.resourceUnion = resourceUnion;
 
     BuildTarget buildTarget = buildRuleParams.getBuildTarget();
     if (res == null) {
@@ -254,6 +259,36 @@ public class AndroidResource extends AbstractBuildRule
         assetsSrcs,
         additionalAssetsKey,
         manifestFile,
+        hasWhitelistedStrings,
+        false);
+  }
+
+  public AndroidResource(
+      final BuildRuleParams buildRuleParams,
+      SourcePathResolver resolver,
+      final ImmutableSortedSet<BuildRule> deps,
+      @Nullable final SourcePath res,
+      ImmutableSortedSet<? extends SourcePath> resSrcs,
+      Optional<SourcePath> additionalResKey,
+      @Nullable String rDotJavaPackageArgument,
+      @Nullable SourcePath assets,
+      ImmutableSortedSet<? extends SourcePath> assetsSrcs,
+      Optional<SourcePath> additionalAssetsKey,
+      @Nullable SourcePath manifestFile,
+      boolean hasWhitelistedStrings,
+      boolean resourceUnion) {
+    this(
+        buildRuleParams,
+        resolver,
+        deps,
+        res,
+        resSrcs,
+        additionalResKey,
+        rDotJavaPackageArgument,
+        assets,
+        assetsSrcs,
+        additionalAssetsKey,
+        manifestFile,
         new Supplier<ImmutableSortedSet<? extends SourcePath>>() {
           @Override
           public ImmutableSortedSet<? extends SourcePath> get() {
@@ -264,7 +299,8 @@ public class AndroidResource extends AbstractBuildRule
                 .toSortedSet(Ordering.natural());
           }
         },
-        hasWhitelistedStrings);
+        hasWhitelistedStrings,
+        resourceUnion);
   }
 
   @Override
@@ -332,7 +368,8 @@ public class AndroidResource extends AbstractBuildRule
             getProjectFilesystem(),
             Preconditions.checkNotNull(res),
             Preconditions.checkNotNull(pathToTextSymbolsFile),
-            pathsToSymbolsOfDeps));
+            pathsToSymbolsOfDeps,
+            resourceUnion));
 
     buildableContext.recordArtifact(Preconditions.checkNotNull(pathToTextSymbolsFile));
 

--- a/src/com/facebook/buck/android/AndroidResourceDescription.java
+++ b/src/com/facebook/buck/android/AndroidResourceDescription.java
@@ -124,7 +124,8 @@ public class AndroidResourceDescription implements Description<AndroidResourceDe
         assetsInputsAndKey.getFirst(),
         assetsInputsAndKey.getSecond(),
         args.manifest.orNull(),
-        args.hasWhitelistedStrings.or(false));
+        args.hasWhitelistedStrings.or(false),
+        args.resourceUnion.or(false));
   }
 
   private Pair<ImmutableSortedSet<SourcePath>, Optional<SourcePath>> collectInputFilesAndKey(
@@ -214,5 +215,6 @@ public class AndroidResourceDescription implements Description<AndroidResourceDe
     public Optional<SourcePath> manifest;
 
     public Optional<ImmutableSortedSet<BuildTarget>> deps;
+    public Optional<Boolean> resourceUnion;
   }
 }

--- a/src/com/facebook/buck/android/aapt/AaptResourceCollector.java
+++ b/src/com/facebook/buck/android/aapt/AaptResourceCollector.java
@@ -90,13 +90,13 @@ public class AaptResourceCollector {
   }
 
   String getNextIdValue(RDotTxtEntry rDotTxtEntry) {
-      if(rDotTxtEntry.idType == IdType.INT_ARRAY) {
+      if (rDotTxtEntry.idType == IdType.INT_ARRAY) {
         return getNextArrayIdValue(rDotTxtEntry.type, rDotTxtEntry.getNumArrayValues());
-      } else if (rDotTxtEntry.type == RType.STYLEABLE ) {
+      } else if (rDotTxtEntry.type == RType.STYLEABLE) {
         // styleable int entries are just incremented ints that receive a value when created as
         // siblings of a style (non unique within R.txt)
         return rDotTxtEntry.idValue;
-      } else if(rDotTxtEntry.custom) {
+      } else if (rDotTxtEntry.custom) {
         return getNextCustomIdValue(rDotTxtEntry.type);
       } else {
         return getNextIdValue(rDotTxtEntry.type);

--- a/src/com/facebook/buck/android/aapt/RDotTxtEntry.java
+++ b/src/com/facebook/buck/android/aapt/RDotTxtEntry.java
@@ -151,7 +151,9 @@ public class RDotTxtEntry implements Comparable<RDotTxtEntry> {
     this.custom = custom;
   }
 
-  public int numValues() {
+  public int getNumArrayValues() {
+    Preconditions.checkState(idType == IdType.INT_ARRAY);
+
     Matcher matcher = INT_ARRAY_VALUES.matcher(idValue);
     if(!matcher.matches() || matcher.group(1) == null) {
       return 0;

--- a/src/com/facebook/buck/android/aapt/RDotTxtEntry.java
+++ b/src/com/facebook/buck/android/aapt/RDotTxtEntry.java
@@ -155,7 +155,7 @@ public class RDotTxtEntry implements Comparable<RDotTxtEntry> {
     Preconditions.checkState(idType == IdType.INT_ARRAY);
 
     Matcher matcher = INT_ARRAY_VALUES.matcher(idValue);
-    if(!matcher.matches() || matcher.group(1) == null) {
+    if (!matcher.matches() || matcher.group(1) == null) {
       return 0;
     }
 

--- a/src/com/facebook/buck/android/aapt/RDotTxtEntry.java
+++ b/src/com/facebook/buck/android/aapt/RDotTxtEntry.java
@@ -99,6 +99,8 @@ public class RDotTxtEntry implements Comparable<RDotTxtEntry> {
 
   // An identifier for custom drawables.
   public static final String CUSTOM_DRAWABLE_IDENTIFIER = "#";
+  public static final String INT_ARRAY_SEPARATOR = ",";
+  private static final Pattern INT_ARRAY_VALUES = Pattern.compile("\\s*\\{\\s*(\\S+)?\\s*\\}\\s*");
   private static final Pattern TEXT_SYMBOLS_LINE =
       Pattern.compile(
           "(\\S+) (\\S+) (\\S+) ([^" + CUSTOM_DRAWABLE_IDENTIFIER + "]+)" +
@@ -147,6 +149,15 @@ public class RDotTxtEntry implements Comparable<RDotTxtEntry> {
     this.name = name;
     this.idValue = idValue;
     this.custom = custom;
+  }
+
+  public int numValues() {
+    Matcher matcher = INT_ARRAY_VALUES.matcher(idValue);
+    if(!matcher.matches() || matcher.group(1) == null) {
+      return 0;
+    }
+
+    return matcher.group(1).split(INT_ARRAY_SEPARATOR).length;
   }
 
   public RDotTxtEntry copyWithNewIdValue(String newIdValue) {

--- a/test/com/facebook/buck/android/aapt/AaptResourceCollectorTest.java
+++ b/test/com/facebook/buck/android/aapt/AaptResourceCollectorTest.java
@@ -76,29 +76,29 @@ public class AaptResourceCollectorTest {
 
   @Test
   public void testGetNextIdValueIfNonCustomType() {
-    Assert.assertEquals("0x7f010001", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID, false));
-    Assert.assertEquals("0x7f010002", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID, false));
-    Assert.assertEquals("0x7f020001", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.INTEGER, false));
-    Assert.assertEquals("0x7f020002", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.INTEGER, false));
-    Assert.assertEquals("0x7f010003", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID, false));
-    Assert.assertEquals("0x7f020003", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.INTEGER, false));
+    Assert.assertEquals("0x7f010001", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID));
+    Assert.assertEquals("0x7f010002", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID));
+    Assert.assertEquals("0x7f020001", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.INTEGER));
+    Assert.assertEquals("0x7f020002", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.INTEGER));
+    Assert.assertEquals("0x7f010003", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID));
+    Assert.assertEquals("0x7f020003", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.INTEGER));
   }
 
   @Test
   public void testGetNextIdValueIfCustomType() {
-    Assert.assertEquals("0x7f010001 #", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID, true));
-    Assert.assertEquals("0x7f010002", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID, false));
-    Assert.assertEquals("0x7f010003 #", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID, true));
+    Assert.assertEquals("0x7f010001 #", aaptResourceCollector.getNextCustomIdValue(RDotTxtEntry.RType.ID));
+    Assert.assertEquals("0x7f010002", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID));
+    Assert.assertEquals("0x7f010003 #", aaptResourceCollector.getNextCustomIdValue(RDotTxtEntry.RType.ID));
   }
 
   @Test
   public void testGetNextIdValueIfArrayType() {
-    Assert.assertEquals("{  }", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID, 0));
-    Assert.assertEquals("{ 0x7f010001 }", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID, 1));
-    Assert.assertEquals("{ 0x7f010002,0x7f010003,0x7f010004 }", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID, 3));
+    Assert.assertEquals("{  }", aaptResourceCollector.getNextArrayIdValue(RDotTxtEntry.RType.ID, 0));
+    Assert.assertEquals("{ 0x7f010001 }", aaptResourceCollector.getNextArrayIdValue(RDotTxtEntry.RType.ID, 1));
+    Assert.assertEquals("{ 0x7f010002,0x7f010003,0x7f010004 }", aaptResourceCollector.getNextArrayIdValue(RDotTxtEntry.RType.ID, 3));
 
-    Assert.assertEquals("{  }", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.INTEGER, 0));
-    Assert.assertEquals("{ 0x7f020001,0x7f020002,0x7f020003 }", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.INTEGER, 3));
+    Assert.assertEquals("{  }", aaptResourceCollector.getNextArrayIdValue(RDotTxtEntry.RType.INTEGER, 0));
+    Assert.assertEquals("{ 0x7f020001,0x7f020002,0x7f020003 }", aaptResourceCollector.getNextArrayIdValue(RDotTxtEntry.RType.INTEGER, 3));
   }
 
   protected RDotTxtEntry findResource(Set<RDotTxtEntry> resources, RDotTxtEntry rDotTxtEntry) {

--- a/test/com/facebook/buck/android/aapt/AaptResourceCollectorTest.java
+++ b/test/com/facebook/buck/android/aapt/AaptResourceCollectorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.facebook.buck.android.aapt;
 
 import org.junit.Assert;
@@ -20,7 +36,10 @@ public class AaptResourceCollectorTest {
   public void testAddResourceIfNotPresent() {
     Assert.assertEquals(0, aaptResourceCollector.getResources().size());
 
-    RDotTxtEntry rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT, RDotTxtEntry.RType.ID, "test_int_id_1", "0x7ffffffe");
+    RDotTxtEntry rDotTxtEntry = new RDotTxtEntry(
+        RDotTxtEntry.IdType.INT,
+        RDotTxtEntry.RType.ID,
+        "test_int_id_1", "0x7ffffffe");
     aaptResourceCollector.addResourceIfNotPresent(rDotTxtEntry);
 
     Set<RDotTxtEntry> resources = aaptResourceCollector.getResources();
@@ -31,9 +50,15 @@ public class AaptResourceCollectorTest {
 
   @Test
   public void testAddResourceIfNotPresentIfRDotTxtEntryAlreadyPresent() {
-    RDotTxtEntry rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT, RDotTxtEntry.RType.ID, "test_int_id_1", "0x7ffffffe");
+    RDotTxtEntry rDotTxtEntry = new RDotTxtEntry(
+        RDotTxtEntry.IdType.INT,
+        RDotTxtEntry.RType.ID,
+        "test_int_id_1",
+        "0x7ffffffe");
     aaptResourceCollector.addResourceIfNotPresent(rDotTxtEntry);
-    RDotTxtEntry addedRDotTxtEntry = findResource(aaptResourceCollector.getResources(), rDotTxtEntry);
+    RDotTxtEntry addedRDotTxtEntry = findResource(
+        aaptResourceCollector.getResources(),
+        rDotTxtEntry);
     aaptResourceCollector.addResourceIfNotPresent(rDotTxtEntry);
 
     Set<RDotTxtEntry> resources = aaptResourceCollector.getResources();
@@ -44,65 +69,117 @@ public class AaptResourceCollectorTest {
 
   @Test
   public void testGetNextIdValue() {
-    RDotTxtEntry rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT, RDotTxtEntry.RType.ID, "test_int_id", "0");
+    RDotTxtEntry rDotTxtEntry = new RDotTxtEntry(
+        RDotTxtEntry.IdType.INT,
+        RDotTxtEntry.RType.ID,
+        "test_int_id",
+        "0");
     Assert.assertEquals("0x7f010001", aaptResourceCollector.getNextIdValue(rDotTxtEntry));
     Assert.assertEquals("0x7f010002", aaptResourceCollector.getNextIdValue(rDotTxtEntry));
 
-    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT, RDotTxtEntry.RType.INTEGER, "test_int_integer", "0");
+    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT, RDotTxtEntry.RType.INTEGER,
+        "test_int_integer",
+        "0");
     Assert.assertEquals("0x7f020001", aaptResourceCollector.getNextIdValue(rDotTxtEntry));
     Assert.assertEquals("0x7f020002", aaptResourceCollector.getNextIdValue(rDotTxtEntry));
   }
 
   @Test
   public void testGetNextIdValueIfIntStyleable() {
-    RDotTxtEntry rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT, RDotTxtEntry.RType.STYLEABLE, "test_int_styleable", "1");
+    RDotTxtEntry rDotTxtEntry = new RDotTxtEntry(
+        RDotTxtEntry.IdType.INT,
+        RDotTxtEntry.RType.STYLEABLE,
+        "test_int_styleable",
+        "1");
     Assert.assertEquals("1", aaptResourceCollector.getNextIdValue(rDotTxtEntry));
 
-    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT, RDotTxtEntry.RType.STYLEABLE, "test_int_styleable", "2");
+    rDotTxtEntry = new RDotTxtEntry(
+        RDotTxtEntry.IdType.INT,
+        RDotTxtEntry.RType.STYLEABLE,
+        "test_int_styleable",
+        "2");
     Assert.assertEquals("2", aaptResourceCollector.getNextIdValue(rDotTxtEntry));
   }
 
   @Test
   public void testGetNextIdValueIfIntArray() {
-    RDotTxtEntry rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.STYLEABLE, "test_int_styleable", "{  }");
+    RDotTxtEntry rDotTxtEntry = new RDotTxtEntry(
+        RDotTxtEntry.IdType.INT_ARRAY,
+        RDotTxtEntry.RType.STYLEABLE,
+        "test_int_styleable",
+        "{  }");
     Assert.assertEquals("{  }", aaptResourceCollector.getNextIdValue(rDotTxtEntry));
 
-    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.STYLEABLE, "test_int_styleable", "{ 0x7fffffff }");
+    rDotTxtEntry = new RDotTxtEntry(
+        RDotTxtEntry.IdType.INT_ARRAY,
+        RDotTxtEntry.RType.STYLEABLE,
+        "test_int_styleable",
+        "{ 0x7fffffff }");
     Assert.assertEquals("{ 0x7f010001 }", aaptResourceCollector.getNextIdValue(rDotTxtEntry));
 
-    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.STYLEABLE, "test_int_styleable", "{ 0x7ffffffe,0x7fffffff }");
-    Assert.assertEquals("{ 0x7f010002,0x7f010003 }", aaptResourceCollector.getNextIdValue(rDotTxtEntry));
+    rDotTxtEntry = new RDotTxtEntry(
+        RDotTxtEntry.IdType.INT_ARRAY,
+        RDotTxtEntry.RType.STYLEABLE,
+        "test_int_styleable",
+        "{ 0x7ffffffe,0x7fffffff }");
+    Assert.assertEquals(
+        "{ 0x7f010002,0x7f010003 }",
+        aaptResourceCollector.getNextIdValue(rDotTxtEntry));
   }
 
   @Test
   public void testGetNextIdValueIfNonCustomType() {
     Assert.assertEquals("0x7f010001", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID));
     Assert.assertEquals("0x7f010002", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID));
-    Assert.assertEquals("0x7f020001", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.INTEGER));
-    Assert.assertEquals("0x7f020002", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.INTEGER));
-    Assert.assertEquals("0x7f010003", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID));
-    Assert.assertEquals("0x7f020003", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.INTEGER));
+    Assert.assertEquals(
+        "0x7f020001",
+        aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.INTEGER));
+    Assert.assertEquals(
+        "0x7f020002",
+        aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.INTEGER));
+    Assert.assertEquals(
+        "0x7f010003",
+        aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID));
+    Assert.assertEquals(
+        "0x7f020003",
+        aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.INTEGER));
   }
 
   @Test
   public void testGetNextIdValueIfCustomType() {
-    Assert.assertEquals("0x7f010001 #", aaptResourceCollector.getNextCustomIdValue(RDotTxtEntry.RType.ID));
-    Assert.assertEquals("0x7f010002", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID));
-    Assert.assertEquals("0x7f010003 #", aaptResourceCollector.getNextCustomIdValue(RDotTxtEntry.RType.ID));
+    Assert.assertEquals(
+        "0x7f010001 #",
+        aaptResourceCollector.getNextCustomIdValue(RDotTxtEntry.RType.ID));
+    Assert.assertEquals(
+        "0x7f010002",
+        aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID));
+    Assert.assertEquals(
+        "0x7f010003 #",
+        aaptResourceCollector.getNextCustomIdValue(RDotTxtEntry.RType.ID));
   }
 
   @Test
   public void testGetNextIdValueIfArrayType() {
-    Assert.assertEquals("{  }", aaptResourceCollector.getNextArrayIdValue(RDotTxtEntry.RType.ID, 0));
-    Assert.assertEquals("{ 0x7f010001 }", aaptResourceCollector.getNextArrayIdValue(RDotTxtEntry.RType.ID, 1));
-    Assert.assertEquals("{ 0x7f010002,0x7f010003,0x7f010004 }", aaptResourceCollector.getNextArrayIdValue(RDotTxtEntry.RType.ID, 3));
+    Assert.assertEquals(
+        "{  }",
+        aaptResourceCollector.getNextArrayIdValue(RDotTxtEntry.RType.ID, 0));
+    Assert.assertEquals(
+        "{ 0x7f010001 }",
+        aaptResourceCollector.getNextArrayIdValue(RDotTxtEntry.RType.ID, 1));
+    Assert.assertEquals(
+        "{ 0x7f010002,0x7f010003,0x7f010004 }",
+        aaptResourceCollector.getNextArrayIdValue(RDotTxtEntry.RType.ID, 3));
 
-    Assert.assertEquals("{  }", aaptResourceCollector.getNextArrayIdValue(RDotTxtEntry.RType.INTEGER, 0));
-    Assert.assertEquals("{ 0x7f020001,0x7f020002,0x7f020003 }", aaptResourceCollector.getNextArrayIdValue(RDotTxtEntry.RType.INTEGER, 3));
+    Assert.assertEquals(
+        "{  }",
+        aaptResourceCollector.getNextArrayIdValue(RDotTxtEntry.RType.INTEGER, 0));
+    Assert.assertEquals(
+        "{ 0x7f020001,0x7f020002,0x7f020003 }",
+        aaptResourceCollector.getNextArrayIdValue(RDotTxtEntry.RType.INTEGER, 3));
   }
 
   protected RDotTxtEntry findResource(Set<RDotTxtEntry> resources, RDotTxtEntry rDotTxtEntry) {
-    for(RDotTxtEntry resource : resources) {
+    for (RDotTxtEntry resource : resources) {
       if (rDotTxtEntry.equals(resource)) {
         return resource;
       }

--- a/test/com/facebook/buck/android/aapt/AaptResourceCollectorTest.java
+++ b/test/com/facebook/buck/android/aapt/AaptResourceCollectorTest.java
@@ -1,0 +1,113 @@
+package com.facebook.buck.android.aapt;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Set;
+
+public class AaptResourceCollectorTest {
+
+  private AaptResourceCollector aaptResourceCollector;
+
+  @Before
+  public void setUp() throws IOException {
+    aaptResourceCollector = new AaptResourceCollector();
+  }
+
+  @Test
+  public void testAddResourceIfNotPresent() {
+    Assert.assertEquals(0, aaptResourceCollector.getResources().size());
+
+    RDotTxtEntry rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT, RDotTxtEntry.RType.ID, "test_int_id_1", "0x7ffffffe");
+    aaptResourceCollector.addResourceIfNotPresent(rDotTxtEntry);
+
+    Set<RDotTxtEntry> resources = aaptResourceCollector.getResources();
+    Assert.assertEquals(1, resources.size());
+    Assert.assertTrue(resources.contains(rDotTxtEntry));
+    Assert.assertNotEquals(rDotTxtEntry.idValue, findResource(resources, rDotTxtEntry).idValue);
+  }
+
+  @Test
+  public void testAddResourceIfNotPresentIfRDotTxtEntryAlreadyPresent() {
+    RDotTxtEntry rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT, RDotTxtEntry.RType.ID, "test_int_id_1", "0x7ffffffe");
+    aaptResourceCollector.addResourceIfNotPresent(rDotTxtEntry);
+    RDotTxtEntry addedRDotTxtEntry = findResource(aaptResourceCollector.getResources(), rDotTxtEntry);
+    aaptResourceCollector.addResourceIfNotPresent(rDotTxtEntry);
+
+    Set<RDotTxtEntry> resources = aaptResourceCollector.getResources();
+    Assert.assertEquals(1, resources.size());
+    Assert.assertTrue(resources.contains(rDotTxtEntry));
+    Assert.assertEquals(addedRDotTxtEntry.idValue, findResource(resources, rDotTxtEntry).idValue);
+  }
+
+  @Test
+  public void testGetNextIdValue() {
+    RDotTxtEntry rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT, RDotTxtEntry.RType.ID, "test_int_id", "0");
+    Assert.assertEquals("0x7f010001", aaptResourceCollector.getNextIdValue(rDotTxtEntry));
+    Assert.assertEquals("0x7f010002", aaptResourceCollector.getNextIdValue(rDotTxtEntry));
+
+    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT, RDotTxtEntry.RType.INTEGER, "test_int_integer", "0");
+    Assert.assertEquals("0x7f020001", aaptResourceCollector.getNextIdValue(rDotTxtEntry));
+    Assert.assertEquals("0x7f020002", aaptResourceCollector.getNextIdValue(rDotTxtEntry));
+  }
+
+  @Test
+  public void testGetNextIdValueIfIntStyleable() {
+    RDotTxtEntry rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT, RDotTxtEntry.RType.STYLEABLE, "test_int_styleable", "1");
+    Assert.assertEquals("1", aaptResourceCollector.getNextIdValue(rDotTxtEntry));
+
+    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT, RDotTxtEntry.RType.STYLEABLE, "test_int_styleable", "2");
+    Assert.assertEquals("2", aaptResourceCollector.getNextIdValue(rDotTxtEntry));
+  }
+
+  @Test
+  public void testGetNextIdValueIfIntArray() {
+    RDotTxtEntry rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.STYLEABLE, "test_int_styleable", "{  }");
+    Assert.assertEquals("{  }", aaptResourceCollector.getNextIdValue(rDotTxtEntry));
+
+    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.STYLEABLE, "test_int_styleable", "{ 0x7fffffff }");
+    Assert.assertEquals("{ 0x7f010001 }", aaptResourceCollector.getNextIdValue(rDotTxtEntry));
+
+    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.STYLEABLE, "test_int_styleable", "{ 0x7ffffffe,0x7fffffff }");
+    Assert.assertEquals("{ 0x7f010002,0x7f010003 }", aaptResourceCollector.getNextIdValue(rDotTxtEntry));
+  }
+
+  @Test
+  public void testGetNextIdValueIfNonCustomType() {
+    Assert.assertEquals("0x7f010001", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID, false));
+    Assert.assertEquals("0x7f010002", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID, false));
+    Assert.assertEquals("0x7f020001", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.INTEGER, false));
+    Assert.assertEquals("0x7f020002", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.INTEGER, false));
+    Assert.assertEquals("0x7f010003", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID, false));
+    Assert.assertEquals("0x7f020003", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.INTEGER, false));
+  }
+
+  @Test
+  public void testGetNextIdValueIfCustomType() {
+    Assert.assertEquals("0x7f010001 #", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID, true));
+    Assert.assertEquals("0x7f010002", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID, false));
+    Assert.assertEquals("0x7f010003 #", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID, true));
+  }
+
+  @Test
+  public void testGetNextIdValueIfArrayType() {
+    Assert.assertEquals("{  }", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID, 0));
+    Assert.assertEquals("{ 0x7f010001 }", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID, 1));
+    Assert.assertEquals("{ 0x7f010002,0x7f010003,0x7f010004 }", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.ID, 3));
+
+    Assert.assertEquals("{  }", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.INTEGER, 0));
+    Assert.assertEquals("{ 0x7f020001,0x7f020002,0x7f020003 }", aaptResourceCollector.getNextIdValue(RDotTxtEntry.RType.INTEGER, 3));
+  }
+
+  protected RDotTxtEntry findResource(Set<RDotTxtEntry> resources, RDotTxtEntry rDotTxtEntry) {
+    for(RDotTxtEntry resource : resources) {
+      if (rDotTxtEntry.equals(resource)) {
+        return resource;
+      }
+    }
+
+    return null;
+  }
+}

--- a/test/com/facebook/buck/android/aapt/RDotTxtEntryTest.java
+++ b/test/com/facebook/buck/android/aapt/RDotTxtEntryTest.java
@@ -1,5 +1,20 @@
-package com.facebook.buck.android.aapt;
+/*
+ * Copyright 2016-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 
+package com.facebook.buck.android.aapt;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -7,36 +22,75 @@ import org.junit.Test;
 public class RDotTxtEntryTest {
   @Test
   public void testGetNumArrayValues() {
-    RDotTxtEntry rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "");
+    RDotTxtEntry rDotTxtEntry = new RDotTxtEntry(
+        RDotTxtEntry.IdType.INT_ARRAY,
+        RDotTxtEntry.RType.ID,
+        "test_int_array_id",
+        "");
     Assert.assertEquals(0, rDotTxtEntry.getNumArrayValues());
 
-    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "0x7f010001");
+    rDotTxtEntry = new RDotTxtEntry(
+        RDotTxtEntry.IdType.INT_ARRAY,
+        RDotTxtEntry.RType.ID,
+        "test_int_array_id",
+        "0x7f010001");
     Assert.assertEquals(0, rDotTxtEntry.getNumArrayValues());
 
-    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "{}");
+    rDotTxtEntry = new RDotTxtEntry(
+        RDotTxtEntry.IdType.INT_ARRAY,
+        RDotTxtEntry.RType.ID,
+        "test_int_array_id",
+        "{}");
     Assert.assertEquals(0, rDotTxtEntry.getNumArrayValues());
 
-    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "{  }");
+    rDotTxtEntry = new RDotTxtEntry(
+        RDotTxtEntry.IdType.INT_ARRAY,
+        RDotTxtEntry.RType.ID,
+        "test_int_array_id",
+        "{  }");
     Assert.assertEquals(0, rDotTxtEntry.getNumArrayValues());
 
-    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "  {  }  ");
+    rDotTxtEntry = new RDotTxtEntry(
+        RDotTxtEntry.IdType.INT_ARRAY,
+        RDotTxtEntry.RType.ID,
+        "test_int_array_id",
+        "  {  }  ");
     Assert.assertEquals(0, rDotTxtEntry.getNumArrayValues());
 
-    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "{ 0x7f010001 }");
+    rDotTxtEntry = new RDotTxtEntry(
+        RDotTxtEntry.IdType.INT_ARRAY,
+        RDotTxtEntry.RType.ID,
+        "test_int_array_id",
+        "{ 0x7f010001 }");
     Assert.assertEquals(1, rDotTxtEntry.getNumArrayValues());
 
-    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "{ 0x7f010001,0x7f010002,0x7f010003 }");
+    rDotTxtEntry = new RDotTxtEntry(
+        RDotTxtEntry.IdType.INT_ARRAY,
+        RDotTxtEntry.RType.ID,
+        "test_int_array_id",
+        "{ 0x7f010001,0x7f010002,0x7f010003 }");
     Assert.assertEquals(3, rDotTxtEntry.getNumArrayValues());
 
-    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "{0x7f010001,0x7f010002,0x7f010003}");
+    rDotTxtEntry = new RDotTxtEntry(
+        RDotTxtEntry.IdType.INT_ARRAY,
+        RDotTxtEntry.RType.ID,
+        "test_int_array_id",
+        "{0x7f010001,0x7f010002,0x7f010003}");
     Assert.assertEquals(3, rDotTxtEntry.getNumArrayValues());
 
-    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "  {  0x7f010001,0x7f010002,0x7f010003  }  ");
+    rDotTxtEntry = new RDotTxtEntry(
+        RDotTxtEntry.IdType.INT_ARRAY,
+        RDotTxtEntry.RType.ID,
+        "test_int_array_id",
+        "  {  0x7f010001,0x7f010002,0x7f010003  }  ");
     Assert.assertEquals(3, rDotTxtEntry.getNumArrayValues());
   }
 
   @Test(expected = IllegalStateException.class)
   public void testGetNumArrayValuesIfIdTypeNotIntArray() {
-    new RDotTxtEntry(RDotTxtEntry.IdType.INT, RDotTxtEntry.RType.ID, "test_int_array_id", "0x7f010001").getNumArrayValues();
+    new RDotTxtEntry(
+        RDotTxtEntry.IdType.INT,
+        RDotTxtEntry.RType.ID,
+        "test_int_array_id", "0x7f010001").getNumArrayValues();
   }
 }

--- a/test/com/facebook/buck/android/aapt/RDotTxtEntryTest.java
+++ b/test/com/facebook/buck/android/aapt/RDotTxtEntryTest.java
@@ -1,0 +1,37 @@
+package com.facebook.buck.android.aapt;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RDotTxtEntryTest {
+  @Test
+  public void testNumValues() {
+    RDotTxtEntry rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "");
+    Assert.assertEquals(0, rDotTxtEntry.numValues());
+
+    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "0x7f010001");
+    Assert.assertEquals(0, rDotTxtEntry.numValues());
+
+    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "{}");
+    Assert.assertEquals(0, rDotTxtEntry.numValues());
+
+    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "{  }");
+    Assert.assertEquals(0, rDotTxtEntry.numValues());
+
+    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "  {  }  ");
+    Assert.assertEquals(0, rDotTxtEntry.numValues());
+
+    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "{ 0x7f010001 }");
+    Assert.assertEquals(1, rDotTxtEntry.numValues());
+
+    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "{ 0x7f010001,0x7f010002,0x7f010003 }");
+    Assert.assertEquals(3, rDotTxtEntry.numValues());
+
+    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "{0x7f010001,0x7f010002,0x7f010003}");
+    Assert.assertEquals(3, rDotTxtEntry.numValues());
+
+    rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "  {  0x7f010001,0x7f010002,0x7f010003  }  ");
+    Assert.assertEquals(3, rDotTxtEntry.numValues());
+  }
+}

--- a/test/com/facebook/buck/android/aapt/RDotTxtEntryTest.java
+++ b/test/com/facebook/buck/android/aapt/RDotTxtEntryTest.java
@@ -6,32 +6,37 @@ import org.junit.Test;
 
 public class RDotTxtEntryTest {
   @Test
-  public void testNumValues() {
+  public void testGetNumArrayValues() {
     RDotTxtEntry rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "");
-    Assert.assertEquals(0, rDotTxtEntry.numValues());
+    Assert.assertEquals(0, rDotTxtEntry.getNumArrayValues());
 
     rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "0x7f010001");
-    Assert.assertEquals(0, rDotTxtEntry.numValues());
+    Assert.assertEquals(0, rDotTxtEntry.getNumArrayValues());
 
     rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "{}");
-    Assert.assertEquals(0, rDotTxtEntry.numValues());
+    Assert.assertEquals(0, rDotTxtEntry.getNumArrayValues());
 
     rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "{  }");
-    Assert.assertEquals(0, rDotTxtEntry.numValues());
+    Assert.assertEquals(0, rDotTxtEntry.getNumArrayValues());
 
     rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "  {  }  ");
-    Assert.assertEquals(0, rDotTxtEntry.numValues());
+    Assert.assertEquals(0, rDotTxtEntry.getNumArrayValues());
 
     rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "{ 0x7f010001 }");
-    Assert.assertEquals(1, rDotTxtEntry.numValues());
+    Assert.assertEquals(1, rDotTxtEntry.getNumArrayValues());
 
     rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "{ 0x7f010001,0x7f010002,0x7f010003 }");
-    Assert.assertEquals(3, rDotTxtEntry.numValues());
+    Assert.assertEquals(3, rDotTxtEntry.getNumArrayValues());
 
     rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "{0x7f010001,0x7f010002,0x7f010003}");
-    Assert.assertEquals(3, rDotTxtEntry.numValues());
+    Assert.assertEquals(3, rDotTxtEntry.getNumArrayValues());
 
     rDotTxtEntry = new RDotTxtEntry(RDotTxtEntry.IdType.INT_ARRAY, RDotTxtEntry.RType.ID, "test_int_array_id", "  {  0x7f010001,0x7f010002,0x7f010003  }  ");
-    Assert.assertEquals(3, rDotTxtEntry.numValues());
+    Assert.assertEquals(3, rDotTxtEntry.getNumArrayValues());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testGetNumArrayValuesIfIdTypeNotIntArray() {
+    new RDotTxtEntry(RDotTxtEntry.IdType.INT, RDotTxtEntry.RType.ID, "test_int_array_id", "0x7f010001").getNumArrayValues();
   }
 }


### PR DESCRIPTION
Provide an option to union an android_resource with its deps. This results in a merged R.txt file and allows for integrating buck with libraries that rely heavily on resource merging to reference dependent library resources. 

test plan: Add unit tests to MiniAppt, RDotTxtEntry, and AaptResourceCollector
 
this commit resolves #643 
