### PR TITLE
Fix python test case reporting.

### DIFF
--- a/src/com/facebook/buck/python/__test_main__.py
+++ b/src/com/facebook/buck/python/__test_main__.py
@@ -117,10 +117,10 @@ class FbJsonTestResult(unittest._TextTestResult):
             test = self._current_setup_class_test
 
         self._results.append({
-            'testCaseName': test._testMethodName,
-            'testCase': '{0}.{1}'.format(
+            'testCaseName': '{0}.{1}'.format(
                 test.__class__.__module__,
                 test.__class__.__name__),
+            'testCase': test._testMethodName,
             'type': self._current_status,
             'time': int((time.time() - self._test_start_time) * 1000),
             'message': os.linesep.join(self._messages),

--- a/test/com/facebook/buck/python/PythonTestIntegrationTest.java
+++ b/test/com/facebook/buck/python/PythonTestIntegrationTest.java
@@ -115,8 +115,8 @@ public class PythonTestIntegrationTest {
     assumePythonVersionIsAtLeast("2.7", "`setUpClass` support was added in Python-2.7");
     TestResultSummary result =
         getOnlyValue(flatten(workspace.runBuckTest("//:test-setup-class-failure")));
-    assertThat(result.getTestName(), Matchers.equalTo("test_setup_class_failure.Test"));
-    assertThat(result.getTestCaseName(), Matchers.equalTo("test_that_passes"));
+    assertThat(result.getTestCaseName(), Matchers.equalTo("test_setup_class_failure.Test"));
+    assertThat(result.getTestName(), Matchers.equalTo("test_that_passes"));
     assertThat(result.getType(), Matchers.equalTo(ResultType.FAILURE));
     assertThat(result.getMessage(), Matchers.containsString("setup failure!"));
   }


### PR DESCRIPTION
Test case name and test case were inverted (found when using grep to construct the failure list for windows).