### PR TITLE
Add basic authentication support for fetching from Maven repositories

### DIFF
--- a/src/com/facebook/buck/cli/DownloadConfig.java
+++ b/src/com/facebook/buck/cli/DownloadConfig.java
@@ -18,10 +18,13 @@ package com.facebook.buck.cli;
 
 import com.facebook.buck.log.Logger;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 
 import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
 import java.net.Proxy;
 
 public class DownloadConfig {
@@ -52,13 +55,13 @@ public class DownloadConfig {
     return delegate.getValue("download", "maven_repo");
   }
 
-  public ImmutableSet<String> getAllMavenRepos() {
-    ImmutableSortedSet.Builder<String> repos = ImmutableSortedSet.naturalOrder();
-    repos.addAll(delegate.getEntriesForSection("maven_repositories").values());
+  public ImmutableMap<String, String> getAllMavenRepos() {
+    ImmutableSortedMap.Builder<String, String> repos = ImmutableSortedMap.naturalOrder();
+    repos.putAll(delegate.getEntriesForSection("maven_repositories"));
 
     Optional<String> defaultRepo = getMavenRepo();
     if (defaultRepo.isPresent()) {
-      repos.add(defaultRepo.get());
+      repos.put(defaultRepo.get(), defaultRepo.get());
     }
 
     return repos.build();
@@ -66,5 +69,15 @@ public class DownloadConfig {
 
   public boolean isDownloadAtRuntimeOk() {
     return delegate.getBooleanValue("download", "in_build", false);
+  }
+
+  public Optional<PasswordAuthentication> getRepoCredentials(String repo) {
+	  Optional<String> user = delegate.getValue("credentials", repo + "_user");
+	  Optional<String> password = delegate.getValue("credentials", repo + "_pass");
+	  if (!user.isPresent() || !password.isPresent()) {
+        return Optional.absent();
+	  }
+
+	  return Optional.of(new PasswordAuthentication(user.get(), password.get().toCharArray()));
   }
 }

--- a/src/com/facebook/buck/cli/DownloadConfig.java
+++ b/src/com/facebook/buck/cli/DownloadConfig.java
@@ -19,9 +19,7 @@ package com.facebook.buck.cli;
 import com.facebook.buck.log.Logger;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.ImmutableSortedSet;
 
 import java.net.InetSocketAddress;
 import java.net.PasswordAuthentication;

--- a/src/com/facebook/buck/cli/DownloadConfig.java
+++ b/src/com/facebook/buck/cli/DownloadConfig.java
@@ -70,12 +70,12 @@ public class DownloadConfig {
   }
 
   public Optional<PasswordAuthentication> getRepoCredentials(String repo) {
-	  Optional<String> user = delegate.getValue("credentials", repo + "_user");
-	  Optional<String> password = delegate.getValue("credentials", repo + "_pass");
-	  if (!user.isPresent() || !password.isPresent()) {
-        return Optional.absent();
-	  }
+    Optional<String> user = delegate.getValue("credentials", repo + "_user");
+    Optional<String> password = delegate.getValue("credentials", repo + "_pass");
+    if (!user.isPresent() || !password.isPresent()) {
+      return Optional.absent();
+    }
 
-	  return Optional.of(new PasswordAuthentication(user.get(), password.get().toCharArray()));
+    return Optional.of(new PasswordAuthentication(user.get(), password.get().toCharArray()));
   }
 }

--- a/src/com/facebook/buck/file/HttpDownloader.java
+++ b/src/com/facebook/buck/file/HttpDownloader.java
@@ -77,6 +77,7 @@ public class HttpDownloader implements Downloader {
           connection.addRequestProperty("Authorization", "Basic " + authEncoded);
         } else {
           LOG.info("Refusing to send basic authentication over plain http.");
+          return false;
         }
       }
 

--- a/src/com/facebook/buck/file/HttpDownloader.java
+++ b/src/com/facebook/buck/file/HttpDownloader.java
@@ -70,10 +70,14 @@ public class HttpDownloader implements Downloader {
       HttpURLConnection connection = createConnection(uri);
 
       if (authentication.isPresent()) {
-        PasswordAuthentication p = authentication.get();
-        String authStr = p.getUserName() + ":" + new String(p.getPassword());
-        String authEncoded = BaseEncoding.base64().encode(authStr.getBytes());
-        connection.addRequestProperty("Authorization", "Basic " + authEncoded);
+        if ("https".equals(uri.getScheme())) {
+          PasswordAuthentication p = authentication.get();
+          String authStr = p.getUserName() + ":" + new String(p.getPassword());
+          String authEncoded = BaseEncoding.base64().encode(authStr.getBytes());
+          connection.addRequestProperty("Authorization", "Basic " + authEncoded);
+        } else {
+          LOG.info("Refusing to send basic authentication over plain http.");
+        }
       }
 
       if (HttpURLConnection.HTTP_OK != connection.getResponseCode()) {

--- a/src/com/facebook/buck/file/HttpDownloader.java
+++ b/src/com/facebook/buck/file/HttpDownloader.java
@@ -50,7 +50,7 @@ public class HttpDownloader implements Downloader {
 
   @Override
   public boolean fetch(BuckEventBus eventBus, URI uri, Path output) throws IOException {
-	  return fetch(eventBus, uri, Optional.<PasswordAuthentication>absent(), output);
+    return fetch(eventBus, uri, Optional.<PasswordAuthentication>absent(), output);
   }
 
   public boolean fetch(

--- a/src/com/facebook/buck/file/HttpDownloader.java
+++ b/src/com/facebook/buck/file/HttpDownloader.java
@@ -34,6 +34,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
+import javax.net.ssl.HttpsURLConnection;
+
 /**
  * Download a file over HTTP.
  */
@@ -70,7 +72,7 @@ public class HttpDownloader implements Downloader {
       HttpURLConnection connection = createConnection(uri);
 
       if (authentication.isPresent()) {
-        if ("https".equals(uri.getScheme())) {
+        if ("https".equals(uri.getScheme()) && connection instanceof HttpsURLConnection) {
           PasswordAuthentication p = authentication.get();
           String authStr = p.getUserName() + ":" + new String(p.getPassword());
           String authEncoded = BaseEncoding.base64().encode(authStr.getBytes());

--- a/src/com/facebook/buck/file/RemoteMavenDownloader.java
+++ b/src/com/facebook/buck/file/RemoteMavenDownloader.java
@@ -20,6 +20,7 @@ import com.facebook.buck.event.BuckEventBus;
 import com.google.common.base.Optional;
 
 import java.io.IOException;
+import java.net.PasswordAuthentication;
 import java.net.Proxy;
 import java.net.URI;
 import java.nio.file.Path;
@@ -28,10 +29,15 @@ public class RemoteMavenDownloader implements Downloader {
 
   private final HttpDownloader downloader;
   private final Optional<String> mavenRepo;
+  private final Optional<PasswordAuthentication> passwordAuthentication;
 
-  public RemoteMavenDownloader(Optional<Proxy> proxy, String mavenRepo) {
+  public RemoteMavenDownloader(
+      Optional<Proxy> proxy,
+      String mavenRepo,
+      Optional<PasswordAuthentication> passwordAuthentication) {
     this.mavenRepo = Optional.of(mavenRepo);
     this.downloader = new HttpDownloader(proxy);
+    this.passwordAuthentication = passwordAuthentication;
   }
 
   @Override
@@ -42,6 +48,6 @@ public class RemoteMavenDownloader implements Downloader {
 
     URI httpUri = MavenUrlDecoder.toHttpUrl(mavenRepo, uri);
 
-    return downloader.fetch(eventBus, httpUri, output);
+    return downloader.fetch(eventBus, httpUri, passwordAuthentication, output);
   }
 }

--- a/src/com/facebook/buck/file/StackedDownloader.java
+++ b/src/com/facebook/buck/file/StackedDownloader.java
@@ -28,12 +28,14 @@ import com.google.common.collect.ImmutableList;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.Authenticator;
 import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
 
 /**
  * A {@link Downloader} which is composed of many other downloaders. When asked to download a
@@ -56,10 +58,13 @@ public class StackedDownloader implements Downloader {
     DownloadConfig downloadConfig = new DownloadConfig(config);
     Optional<Proxy> proxy = downloadConfig.getProxy();
 
-    for (String repo : downloadConfig.getAllMavenRepos()) {
+
+    for (Map.Entry<String, String> kv : downloadConfig.getAllMavenRepos().entrySet()) {
+      String repoName = kv.getKey();
+      String repo = kv.getValue();
       // Check the type.
       if (repo.startsWith("http:") || repo.startsWith("https://")) {
-        downloaders.add(new RemoteMavenDownloader(proxy, repo));
+        downloaders.add(new RemoteMavenDownloader(proxy, repo, downloadConfig.getRepoCredentials(repoName)));
       } else if (repo.startsWith("file:")) {
         try {
           URL url = new URL(repo);

--- a/src/com/facebook/buck/file/StackedDownloader.java
+++ b/src/com/facebook/buck/file/StackedDownloader.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableList;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.PasswordAuthentication;
 import java.net.Proxy;
 import java.net.URI;
 import java.net.URL;
@@ -59,11 +60,12 @@ public class StackedDownloader implements Downloader {
 
 
     for (Map.Entry<String, String> kv : downloadConfig.getAllMavenRepos().entrySet()) {
-      String repoName = kv.getKey();
       String repo = kv.getValue();
       // Check the type.
       if (repo.startsWith("http:") || repo.startsWith("https://")) {
-        downloaders.add(new RemoteMavenDownloader(proxy, repo, downloadConfig.getRepoCredentials(repoName)));
+        String repoName = kv.getKey();
+        Optional<PasswordAuthentication> credentials = downloadConfig.getRepoCredentials(repoName);
+        downloaders.add(new RemoteMavenDownloader(proxy, repo, credentials));
       } else if (repo.startsWith("file:")) {
         try {
           URL url = new URL(repo);

--- a/src/com/facebook/buck/file/StackedDownloader.java
+++ b/src/com/facebook/buck/file/StackedDownloader.java
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableList;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.Authenticator;
 import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URI;

--- a/test/com/facebook/buck/file/HttpDownloaderTest.java
+++ b/test/com/facebook/buck/file/HttpDownloaderTest.java
@@ -43,6 +43,8 @@ import java.nio.file.Paths;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.net.ssl.HttpsURLConnection;
+
 public class HttpDownloaderTest {
 
   private final Path neverUsed = Paths.get("never/used");
@@ -78,7 +80,7 @@ public class HttpDownloaderTest {
 
     Capture<String> capturedAuth = EasyMock.newCapture();
 
-    final HttpURLConnection connection = EasyMock.createNiceMock(HttpURLConnection.class);
+    final HttpURLConnection connection = EasyMock.createNiceMock(HttpsURLConnection.class);
     EasyMock.expect(connection.getResponseCode()).andStubReturn(HTTP_FORBIDDEN);
     connection.addRequestProperty(eq("Authorization"), capture(capturedAuth));
     EasyMock.expectLastCall();


### PR DESCRIPTION
Summary:

Ref #664.

Adds the ability to specify credentials when using Maven repositories.
These are passed using basic authentication.

One question would be whether to use `Authenticator` instead. The
worry there is that it's a global object, so I wasn't sure whether
I wanted to go that far. RFC.

Test Plan:

Have a `.buckconfig` file that looks like:

    ...
    [maven_repositories]
    central=https://repo1.maven.org/maven2
    foo=https://example.com/content/repositories/releases

    [credentials]
    foo_user=bar
    foo_pass=baz
    ...

Successfully ran `buck fetch` against a SonaType Nexus server configured to
use authentication.