### PR TITLE
Pex in-place packages, take 2

### DIFF
--- a/src/com/facebook/buck/python/AbstractPythonVersion.java
+++ b/src/com/facebook/buck/python/AbstractPythonVersion.java
@@ -25,11 +25,14 @@ import org.immutables.value.Value;
 abstract class AbstractPythonVersion {
 
   @Value.Parameter
-  public abstract String getVersionString();
+  public abstract String getInterpreterName();
+
+  @Value.Parameter
+  public abstract String getVersionString();  // X.Y.Z
 
   @Override
   public String toString() {
-    return getVersionString();
+    return getInterpreterName() + " " + getVersionString();
   }
 
 }

--- a/src/com/facebook/buck/python/AbstractPythonVersion.java
+++ b/src/com/facebook/buck/python/AbstractPythonVersion.java
@@ -28,7 +28,7 @@ abstract class AbstractPythonVersion {
   public abstract String getInterpreterName();
 
   @Value.Parameter
-  public abstract String getVersionString();  // X.Y.Z
+  public abstract String getVersionString();  // X.Y
 
   @Override
   public String toString() {

--- a/src/com/facebook/buck/python/BUCK.autodeps
+++ b/src/com/facebook/buck/python/BUCK.autodeps
@@ -1,8 +1,9 @@
-#@# GENERATED FILE: DO NOT MODIFY fb312efc1992e40a07e4a27a8f5870af149e0818 #@#
+#@# GENERATED FILE: DO NOT MODIFY d73855d452b659158901ef1db466c5fa0ecc8eba #@#
 {
   "config" : {
     "deps" : [
       "//src/com/facebook/buck/cxx:platform",
+      "//src/com/facebook/buck/rules:command_tool",
       "//src/com/facebook/buck/util:exceptions",
       "//src/com/facebook/buck/util:util",
       "//third-party/java/jsr:jsr305"

--- a/src/com/facebook/buck/python/PexStep.java
+++ b/src/com/facebook/buck/python/PexStep.java
@@ -41,7 +41,7 @@ public class PexStep extends ShellStep {
   // The PEX builder command prefix.
   private final ImmutableList<String> commandPrefix;
 
-  // The path to the executable to create.
+  // The path to the executable/directory to create.
   private final Path destination;
 
   // The main module that begins execution in the PEX.
@@ -52,6 +52,7 @@ public class PexStep extends ShellStep {
 
   // The map of resources to include in the PEX.
   private final ImmutableMap<Path, Path> resources;
+  private final PythonVersion pythonVersion;
   private final Path pythonPath;
   private final Path tempDir;
 
@@ -71,6 +72,7 @@ public class PexStep extends ShellStep {
       ImmutableMap<String, String> environment,
       ImmutableList<String> commandPrefix,
       Path pythonPath,
+      PythonVersion pythonVersion,
       Path tempDir,
       Path destination,
       String entry,
@@ -86,6 +88,7 @@ public class PexStep extends ShellStep {
     this.environment = environment;
     this.commandPrefix = commandPrefix;
     this.pythonPath = pythonPath;
+    this.pythonVersion = pythonVersion;
     this.tempDir = tempDir;
     this.destination = destination;
     this.entry = entry;
@@ -152,6 +155,8 @@ public class PexStep extends ShellStep {
     builder.addAll(commandPrefix);
     builder.add("--python");
     builder.add(pythonPath.toString());
+    builder.add("--python-version");
+    builder.add(pythonVersion.toString());
     builder.add("--entry-point");
     builder.add(entry);
 

--- a/src/com/facebook/buck/python/PythonBuckConfig.java
+++ b/src/com/facebook/buck/python/PythonBuckConfig.java
@@ -25,6 +25,7 @@ import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.Flavor;
 import com.facebook.buck.model.ImmutableFlavor;
 import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.CommandTool;
 import com.facebook.buck.rules.PathSourcePath;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.Tool;
@@ -36,6 +37,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
+import com.google.common.base.Splitter;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -46,8 +48,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.EnumSet;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.annotation.Nonnull;
 
@@ -57,9 +57,6 @@ public class PythonBuckConfig {
 
   private static final String SECTION = "python";
   private static final String PYTHON_PLATFORM_SECTION_PREFIX = "python#";
-
-  private static final Pattern PYTHON_VERSION_REGEX =
-      Pattern.compile(".*?(\\wy(thon|run) \\d+\\.\\d+).*");
 
   // Prefer "python2" where available (Linux), but fall back to "python" (Mac).
   private static final ImmutableList<String> PYTHON_INTERPRETER_NAMES =
@@ -213,6 +210,16 @@ public class PythonBuckConfig {
   }
 
   public Tool getPexTool(BuildRuleResolver resolver) {
+    CommandTool.Builder builder = new CommandTool.Builder(getRawPexTool(resolver));
+    for (String flag : Splitter.on(' ').omitEmptyStrings().split(
+        delegate.getValue(SECTION, "pex_flags").or(""))) {
+      builder.addArg(flag);
+    }
+
+    return builder.build();
+  }
+
+  private Tool getRawPexTool(BuildRuleResolver resolver) {
     Optional<Tool> executable = delegate.getTool(SECTION, "path_to_pex", resolver);
     if (executable.isPresent()) {
       return executable.get();
@@ -244,17 +251,31 @@ public class PythonBuckConfig {
   private static PythonVersion getPythonVersion(ProcessExecutor processExecutor, Path pythonPath)
       throws InterruptedException {
     try {
+      // Taken from pex's interpreter.py.
+      String versionId = "import sys\n" +
+          "\n" +
+          "if hasattr(sys, 'pypy_version_info'):\n" +
+          "  subversion = 'PyPy'\n" +
+          "elif sys.platform.startswith('java'):\n" +
+          "  subversion = 'Jython'\n" +
+          "else:\n" +
+          "  subversion = 'CPython'\n" +
+          "\n" +
+          "print('%s %s %s %s' % (subversion, sys.version_info[0], " +
+          "sys.version_info[1], sys.version_info[2]))\n";
+
       ProcessExecutor.Result versionResult = processExecutor.launchAndExecute(
-          ProcessExecutorParams.builder().addCommand(pythonPath.toString(), "-V").build(),
-          EnumSet.of(ProcessExecutor.Option.EXPECTING_STD_ERR),
-          /* stdin */ Optional.<String>absent(),
+          ProcessExecutorParams.builder().addCommand(pythonPath.toString(), "-").build(),
+          EnumSet.of(ProcessExecutor.Option.EXPECTING_STD_OUT,
+                     ProcessExecutor.Option.EXPECTING_STD_ERR),
+          Optional.of(versionId),
           /* timeOutMs */ Optional.<Long>absent(),
           /* timeoutHandler */ Optional.<Function<Process, Void>>absent());
       return extractPythonVersion(pythonPath, versionResult);
     } catch (IOException e) {
       throw new HumanReadableException(
           e,
-          "Could not run \"%s --version\": %s",
+          "Could not run \"%s - < [code]\": %s",
           pythonPath,
           e.getMessage());
     }
@@ -267,16 +288,21 @@ public class PythonBuckConfig {
     if (versionResult.getExitCode() == 0) {
       String versionString = CharMatcher.whitespace().trimFrom(
           CharMatcher.whitespace().trimFrom(versionResult.getStderr().get()) +
-          CharMatcher.whitespace().trimFrom(versionResult.getStdout().get())
-              .replaceAll("\u001B\\[[;\\d]*m", ""));
-      Matcher matcher = PYTHON_VERSION_REGEX.matcher(versionString.split("\\r?\\n")[0]);
-      if (!matcher.matches()) {
+              CharMatcher.whitespace().trimFrom(versionResult.getStdout().get())
+                  .replaceAll("\u001B\\[[;\\d]*m", ""));
+      String[] versionLines = versionString.split("\\r?\\n");
+
+      String[] compatibilityVersion = versionLines[0].split(" ");
+      if (compatibilityVersion.length != 4) {
         throw new HumanReadableException(
-            "`%s -V` returned an invalid version string %s",
+            "`%s - < [code]` returned an invalid version string %s",
             pythonPath,
             versionString);
       }
-      return PythonVersion.of(matcher.group(1));
+
+      return PythonVersion.of(
+          compatibilityVersion[0],
+          compatibilityVersion[1] + "." + compatibilityVersion[2] + "." + compatibilityVersion[3]);
     } else {
       throw new HumanReadableException(versionResult.getStderr().get());
     }

--- a/src/com/facebook/buck/python/PythonBuckConfig.java
+++ b/src/com/facebook/buck/python/PythonBuckConfig.java
@@ -261,8 +261,8 @@ public class PythonBuckConfig {
           "else:\n" +
           "  subversion = 'CPython'\n" +
           "\n" +
-          "print('%s %s %s %s' % (subversion, sys.version_info[0], " +
-          "sys.version_info[1], sys.version_info[2]))\n";
+          "print('%s %s %s' % (subversion, sys.version_info[0], " +
+          "sys.version_info[1]))\n";
 
       ProcessExecutor.Result versionResult = processExecutor.launchAndExecute(
           ProcessExecutorParams.builder().addCommand(pythonPath.toString(), "-").build(),
@@ -293,7 +293,7 @@ public class PythonBuckConfig {
       String[] versionLines = versionString.split("\\r?\\n");
 
       String[] compatibilityVersion = versionLines[0].split(" ");
-      if (compatibilityVersion.length != 4) {
+      if (compatibilityVersion.length != 3) {
         throw new HumanReadableException(
             "`%s - < [code]` returned an invalid version string %s",
             pythonPath,
@@ -302,7 +302,7 @@ public class PythonBuckConfig {
 
       return PythonVersion.of(
           compatibilityVersion[0],
-          compatibilityVersion[1] + "." + compatibilityVersion[2] + "." + compatibilityVersion[3]);
+          compatibilityVersion[1] + "." + compatibilityVersion[2]);
     } else {
       throw new HumanReadableException(versionResult.getStderr().get());
     }

--- a/src/com/facebook/buck/python/PythonPackagedBinary.java
+++ b/src/com/facebook/buck/python/PythonPackagedBinary.java
@@ -34,6 +34,7 @@ import com.facebook.buck.rules.args.SourcePathArg;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.fs.MakeCleanDirectoryStep;
 import com.facebook.buck.step.fs.MkdirStep;
+import com.facebook.buck.step.fs.RmStep;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
@@ -109,6 +110,9 @@ public class PythonPackagedBinary extends PythonBinary implements HasRuntimeDeps
     // Make sure the parent directory exists.
     steps.add(new MkdirStep(getProjectFilesystem(), binPath.getParent()));
 
+    // Delete any other pex that was there (when switching between pex styles).
+    steps.add(new RmStep(getProjectFilesystem(), binPath, /* force */ true, /* recurse */ true));
+
     Path workingDirectory = BuildTargets.getGenPath(
         getBuildTarget(), "__%s__working_directory");
     steps.add(new MakeCleanDirectoryStep(getProjectFilesystem(), workingDirectory));
@@ -123,6 +127,7 @@ public class PythonPackagedBinary extends PythonBinary implements HasRuntimeDeps
                 .addAll(buildArgs)
                 .build(),
             pythonEnvironment.getPythonPath(),
+            pythonEnvironment.getPythonVersion(),
             workingDirectory,
             binPath,
             mainModule,

--- a/src/com/facebook/buck/python/make_pex.py
+++ b/src/com/facebook/buck/python/make_pex.py
@@ -26,7 +26,7 @@ if not zipfile.is_zipfile(sys.argv[0]):
 import pkg_resources
 
 from pex.pex_builder import PEXBuilder
-from pex.interpreter import PythonInterpreter
+from pex.interpreter import PythonInterpreter, PythonIdentity
 
 
 def dereference_symlinks(src):
@@ -56,7 +56,6 @@ def closable_named_temporary_file():
         os.remove(fp.name)
 
 
-
 def copy_package(pex_builder, package, resource='', prefix=''):
     """
     Copies the code of a package to the pex using the pkg_resources API.
@@ -84,8 +83,10 @@ def copy_package(pex_builder, package, resource='', prefix=''):
 def main():
     parser = optparse.OptionParser(usage="usage: %prog [options] output")
     parser.add_option('--entry-point', default='__main__')
+    parser.add_option('--directory', action='store_true', default=False)
     parser.add_option('--no-zip-safe', action='store_false', dest='zip_safe', default=True)
-    parser.add_option('--python', default=sys.executable)
+    parser.add_option('--python', default='')
+    parser.add_option('--python-version', default='')
     parser.add_option('--preload', action='append', default=[])
     options, args = parser.parse_args()
     if len(args) == 1:
@@ -98,71 +99,76 @@ def main():
     # to be passed as a CLA.
     manifest = json.load(sys.stdin)
 
-    # Setup a temp dir that the PEX builder will use as its scratch dir.
-    tmp_dir = tempfile.mkdtemp()
-    try:
+    # The version of pkg_resources.py (from setuptools) on some distros is
+    # too old for PEX.  So we keep a recent version in the buck repo and
+    # force it into the process by constructing a custom PythonInterpreter
+    # instance using it.
+    if not options.python:
+        options.python = sys.executable
+        identity = PythonIdentity.get()
+    elif not options.python_version:
+        # Note: this is expensive (~500ms). prefer passing --python-version when possible.
+        identity = PythonInterpreter.from_binary(options.python).identity
+    else:
+        # Convert "CPython 2.7.9" to "CPython 2 7 9"
+        identity = PythonIdentity.from_id_string(
+            options.python_version.replace('.', ' '))
 
-        # The version of pkg_resources.py (from setuptools) on some distros is
-        # too old for PEX.  So we keep a recent version in the buck repo and
-        # force it into the process by constructing a custom PythonInterpreter
-        # instance using it.
-        interpreter = PythonInterpreter(
-            options.python,
-            PythonInterpreter.from_binary(options.python).identity,
-            extras={})
+    interpreter = PythonInterpreter(
+        options.python,
+        identity,
+        extras={})
 
-        pex_builder = PEXBuilder(
-            path=tmp_dir,
-            interpreter=interpreter,
-        )
+    pex_builder = PEXBuilder(
+        path=output if options.directory else None,
+        interpreter=interpreter,
+    )
 
-        # Set whether this PEX as zip-safe, meaning everything will stayed zipped up
-        # and we'll rely on python's zip-import mechanism to load modules from
-        # the PEX.  This may not work in some situations (e.g. native
-        # libraries, libraries that want to find resources via the FS).
-        pex_builder.info.zip_safe = options.zip_safe
+    # Set whether this PEX as zip-safe, meaning everything will stayed zipped up
+    # and we'll rely on python's zip-import mechanism to load modules from
+    # the PEX.  This may not work in some situations (e.g. native
+    # libraries, libraries that want to find resources via the FS).
+    pex_builder.info.zip_safe = options.zip_safe
 
-        # Set the starting point for this PEX.
-        pex_builder.info.entry_point = options.entry_point
+    # Set the starting point for this PEX.
+    pex_builder.info.entry_point = options.entry_point
 
-        # Copy in our version of `pkg_resources`.
-        copy_package(pex_builder, 'pkg_resources', prefix=pex_builder.BOOTSTRAP_DIR)
+    # Copy in our version of `pkg_resources`.
+    copy_package(pex_builder, 'pkg_resources', prefix=pex_builder.BOOTSTRAP_DIR)
 
-        # Add the sources listed in the manifest.
-        for dst, src in manifest['modules'].iteritems():
-            # NOTE(agallagher): calls the `add_source` and `add_resource` below
-            # hard-link the given source into the PEX temp dir.  Since OS X and
-            # Linux behave different when hard-linking a source that is a
-            # symbolic link (Linux does *not* follow symlinks), resolve any
-            # layers of symlinks here to get consistent behavior.
-            try:
-                pex_builder.add_source(dereference_symlinks(src), dst)
-            except OSError as e:
-                raise Exception("Failed to add {}: {}".format(src, e))
+    # Add the sources listed in the manifest.
+    for dst, src in manifest['modules'].iteritems():
+        # NOTE(agallagher): calls the `add_source` and `add_resource` below
+        # hard-link the given source into the PEX temp dir.  Since OS X and
+        # Linux behave different when hard-linking a source that is a
+        # symbolic link (Linux does *not* follow symlinks), resolve any
+        # layers of symlinks here to get consistent behavior.
+        try:
+            pex_builder.add_source(dereference_symlinks(src), dst)
+        except OSError as e:
+            raise Exception("Failed to add {}: {}".format(src, e))
 
-        # Add resources listed in the manifest.
-        for dst, src in manifest['resources'].iteritems():
-            # NOTE(agallagher): see rationale above.
-            pex_builder.add_resource(dereference_symlinks(src), dst)
+    # Add resources listed in the manifest.
+    for dst, src in manifest['resources'].iteritems():
+        # NOTE(agallagher): see rationale above.
+        pex_builder.add_resource(dereference_symlinks(src), dst)
 
-        # Add prebuilt libraries listed in the manifest.
-        for req in manifest.get('prebuiltLibraries', []):
-            try:
-                pex_builder.add_dist_location(req)
-            except Exception as e:
-                raise Exception("Failed to add {}: {}".format(req, e))
+    # Add prebuilt libraries listed in the manifest.
+    for req in manifest.get('prebuiltLibraries', []):
+        try:
+            pex_builder.add_dist_location(req)
+        except Exception as e:
+            raise Exception("Failed to add {}: {}".format(req, e))
 
-        # Add resources listed in the manifest.
-        for dst, src in manifest['nativeLibraries'].iteritems():
-            # NOTE(agallagher): see rationale above.
-            pex_builder.add_resource(dereference_symlinks(src), dst)
+    # Add resources listed in the manifest.
+    for dst, src in manifest['nativeLibraries'].iteritems():
+        # NOTE(agallagher): see rationale above.
+        pex_builder.add_resource(dereference_symlinks(src), dst)
 
-        # Generate the PEX file.
+    if options.directory:
+        pex_builder.freeze(code_hash=False, bytecode_compile=False)
+    else:
         pex_builder.build(output)
-
-    # Always try cleaning up the scratch dir, ignoring failures.
-    finally:
-        shutil.rmtree(tmp_dir, True)
 
 
 sys.exit(main())

--- a/src/com/facebook/buck/python/make_pex.py
+++ b/src/com/facebook/buck/python/make_pex.py
@@ -110,9 +110,11 @@ def main():
         # Note: this is expensive (~500ms). prefer passing --python-version when possible.
         identity = PythonInterpreter.from_binary(options.python).identity
     else:
-        # Convert "CPython 2.7.9" to "CPython 2 7 9"
-        identity = PythonIdentity.from_id_string(
-            options.python_version.replace('.', ' '))
+        # Convert "CPython 2.7" to "CPython 2 7 0"
+        python_version = options.python_version.replace('.', ' ').split()
+        if len(python_version) == 3:
+            python_version.append('0')
+        identity = PythonIdentity.from_id_string(' '.join(python_version))
 
     interpreter = PythonInterpreter(
         options.python,

--- a/test/com/facebook/buck/python/CxxPythonExtensionDescriptionTest.java
+++ b/test/com/facebook/buck/python/CxxPythonExtensionDescriptionTest.java
@@ -73,7 +73,7 @@ public class CxxPythonExtensionDescriptionTest {
   private static final PythonPlatform PY2 =
       PythonPlatform.of(
           ImmutableFlavor.of("py2"),
-          new PythonEnvironment(Paths.get("python2"), PythonVersion.of("2.6")),
+          new PythonEnvironment(Paths.get("python2"), PythonVersion.of("CPython", "2.6.9")),
           Optional.of(PYTHON2_DEP_TARGET));
 
   private static final BuildTarget PYTHON3_DEP_TARGET =
@@ -81,7 +81,7 @@ public class CxxPythonExtensionDescriptionTest {
   private static final PythonPlatform PY3 =
       PythonPlatform.of(
           ImmutableFlavor.of("py3"),
-          new PythonEnvironment(Paths.get("python3"), PythonVersion.of("3.5")),
+          new PythonEnvironment(Paths.get("python3"), PythonVersion.of("CPython", "3.5.0")),
           Optional.of(PYTHON3_DEP_TARGET));
 
   @Test

--- a/test/com/facebook/buck/python/CxxPythonExtensionDescriptionTest.java
+++ b/test/com/facebook/buck/python/CxxPythonExtensionDescriptionTest.java
@@ -73,7 +73,7 @@ public class CxxPythonExtensionDescriptionTest {
   private static final PythonPlatform PY2 =
       PythonPlatform.of(
           ImmutableFlavor.of("py2"),
-          new PythonEnvironment(Paths.get("python2"), PythonVersion.of("CPython", "2.6.9")),
+          new PythonEnvironment(Paths.get("python2"), PythonVersion.of("CPython", "2.6")),
           Optional.of(PYTHON2_DEP_TARGET));
 
   private static final BuildTarget PYTHON3_DEP_TARGET =
@@ -81,7 +81,7 @@ public class CxxPythonExtensionDescriptionTest {
   private static final PythonPlatform PY3 =
       PythonPlatform.of(
           ImmutableFlavor.of("py3"),
-          new PythonEnvironment(Paths.get("python3"), PythonVersion.of("CPython", "3.5.0")),
+          new PythonEnvironment(Paths.get("python3"), PythonVersion.of("CPython", "3.5")),
           Optional.of(PYTHON3_DEP_TARGET));
 
   @Test

--- a/test/com/facebook/buck/python/PexStepTest.java
+++ b/test/com/facebook/buck/python/PexStepTest.java
@@ -44,7 +44,7 @@ import java.util.Map;
 public class PexStepTest {
 
   private static final Path PYTHON_PATH = Paths.get("/usr/local/bin/python");
-  private static final PythonVersion PYTHON_VERSION = PythonVersion.of("CPython", "2.6.9");
+  private static final PythonVersion PYTHON_VERSION = PythonVersion.of("CPython", "2.6");
   private static final ImmutableMap<String, String> PEX_ENVIRONMENT = ImmutableMap.of();
   private static final ImmutableList<String> PEX_COMMAND = ImmutableList.of();
   private static final Path TEMP_PATH = Paths.get("/tmp/");

--- a/test/com/facebook/buck/python/PexStepTest.java
+++ b/test/com/facebook/buck/python/PexStepTest.java
@@ -44,6 +44,7 @@ import java.util.Map;
 public class PexStepTest {
 
   private static final Path PYTHON_PATH = Paths.get("/usr/local/bin/python");
+  private static final PythonVersion PYTHON_VERSION = PythonVersion.of("CPython", "2.6.9");
   private static final ImmutableMap<String, String> PEX_ENVIRONMENT = ImmutableMap.of();
   private static final ImmutableList<String> PEX_COMMAND = ImmutableList.of();
   private static final Path TEMP_PATH = Paths.get("/tmp/");
@@ -68,6 +69,7 @@ public class PexStepTest {
             PEX_ENVIRONMENT,
             PEX_COMMAND,
             PYTHON_PATH,
+            PYTHON_VERSION,
             TEMP_PATH,
             DEST_PATH,
             ENTRY_POINT,
@@ -82,6 +84,7 @@ public class PexStepTest {
 
     assertThat(command, startsWith(Joiner.on(" ").join(PEX_COMMAND)));
     assertThat(command, containsString("--python " + PYTHON_PATH));
+    assertThat(command, containsString("--python-version " + PYTHON_VERSION));
     assertThat(command, containsString("--entry-point " + ENTRY_POINT));
     assertThat(command, endsWith(" " + DEST_PATH));
   }
@@ -94,6 +97,7 @@ public class PexStepTest {
             PEX_ENVIRONMENT,
             PEX_COMMAND,
             PYTHON_PATH,
+            PYTHON_VERSION,
             TEMP_PATH,
             DEST_PATH,
             ENTRY_POINT,
@@ -118,6 +122,7 @@ public class PexStepTest {
             PEX_ENVIRONMENT,
             PEX_COMMAND,
             PYTHON_PATH,
+            PYTHON_VERSION,
             TEMP_PATH,
             DEST_PATH,
             ENTRY_POINT,
@@ -156,6 +161,7 @@ public class PexStepTest {
                 .add("--some", "--args")
                 .build(),
             PYTHON_PATH,
+            PYTHON_VERSION,
             TEMP_PATH,
             DEST_PATH,
             ENTRY_POINT,

--- a/test/com/facebook/buck/python/PrebuiltPythonLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/python/PrebuiltPythonLibraryIntegrationTest.java
@@ -37,7 +37,7 @@ import java.io.IOException;
 public class PrebuiltPythonLibraryIntegrationTest {
 
   @Rule
-  public DebuggableTemporaryFolder tmp = new DebuggableTemporaryFolder().doNotDeleteOnExit();
+  public DebuggableTemporaryFolder tmp = new DebuggableTemporaryFolder();
   public ProjectWorkspace workspace;
 
   @Before
@@ -58,10 +58,11 @@ public class PrebuiltPythonLibraryIntegrationTest {
                     new CapturingPrintStream(),
                     Ansi.withoutTty())))
         .getPythonVersion()
-        .getVersionString()
-        .substring("Python ".length());
-    if (!version.equals("2.6")) {
-      workspace.move("dist/package-0.1-py2.6.egg", "dist/package-0.1-py" + version + ".egg");
+        .getVersionString();
+    if (!version.startsWith("2.6")) {
+      workspace.move(
+          "dist/package-0.1-py2.6.egg",
+          "dist/package-0.1-py" + version.substring(0, 3) + ".egg");
     }
   }
 

--- a/test/com/facebook/buck/python/PythonBinaryDescriptionTest.java
+++ b/test/com/facebook/buck/python/PythonBinaryDescriptionTest.java
@@ -76,7 +76,7 @@ public class PythonBinaryDescriptionTest {
   private static final PythonPlatform PY2 =
       PythonPlatform.of(
           ImmutableFlavor.of("py2"),
-          new PythonEnvironment(Paths.get("python2"), PythonVersion.of("CPython", "2.6.9")),
+          new PythonEnvironment(Paths.get("python2"), PythonVersion.of("CPython", "2.6")),
           Optional.of(PYTHON2_DEP_TARGET));
 
   @Test

--- a/test/com/facebook/buck/python/PythonBinaryDescriptionTest.java
+++ b/test/com/facebook/buck/python/PythonBinaryDescriptionTest.java
@@ -76,7 +76,7 @@ public class PythonBinaryDescriptionTest {
   private static final PythonPlatform PY2 =
       PythonPlatform.of(
           ImmutableFlavor.of("py2"),
-          new PythonEnvironment(Paths.get("python2"), PythonVersion.of("2.6")),
+          new PythonEnvironment(Paths.get("python2"), PythonVersion.of("CPython", "2.6.9")),
           Optional.of(PYTHON2_DEP_TARGET));
 
   @Test
@@ -218,12 +218,12 @@ public class PythonBinaryDescriptionTest {
     PythonPlatform platform1 =
         PythonPlatform.of(
             ImmutableFlavor.of("pyPlat1"),
-            new PythonEnvironment(Paths.get("python2.6"), PythonVersion.of("2.6")),
+            new PythonEnvironment(Paths.get("python2.6"), PythonVersion.of("CPython", "2.6.9")),
             Optional.<BuildTarget>absent());
     PythonPlatform platform2 =
         PythonPlatform.of(
             ImmutableFlavor.of("pyPlat2"),
-            new PythonEnvironment(Paths.get("python2.7"), PythonVersion.of("2.7")),
+            new PythonEnvironment(Paths.get("python2.7"), PythonVersion.of("CPython", "2.7.11")),
             Optional.<BuildTarget>absent());
     PythonBinaryBuilder builder =
         PythonBinaryBuilder.create(

--- a/test/com/facebook/buck/python/PythonBinaryIntegrationTest.java
+++ b/test/com/facebook/buck/python/PythonBinaryIntegrationTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeThat;
 
 import com.facebook.buck.cli.BuckConfig;
@@ -32,11 +33,8 @@ import com.facebook.buck.cli.FakeBuckConfig;
 import com.facebook.buck.cxx.CxxBuckConfig;
 import com.facebook.buck.cxx.DefaultCxxPlatforms;
 import com.facebook.buck.event.BuckEventListener;
-import com.facebook.buck.io.FakeExecutableFinder;
+import com.facebook.buck.io.ExecutableFinder;
 import com.facebook.buck.io.ProjectFilesystem;
-import com.facebook.buck.rules.BuildRuleResolver;
-import com.facebook.buck.rules.TargetGraph;
-import com.facebook.buck.testutil.ParameterizedTests;
 import com.facebook.buck.testutil.integration.DebuggableTemporaryFolder;
 import com.facebook.buck.testutil.integration.ProjectWorkspace;
 import com.facebook.buck.testutil.integration.TestDataHelper;
@@ -57,27 +55,40 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
 @RunWith(Parameterized.class)
 public class PythonBinaryIntegrationTest {
 
-  @Parameterized.Parameters(name = "{0},{1}")
+  @Parameterized.Parameters(name = "{0}(dir={1}),{2}")
   public static Collection<Object[]> data() {
-    return ParameterizedTests.getPermutations(
-        Arrays.asList(PythonBuckConfig.PackageStyle.values()),
-        Arrays.asList(NativeLinkStrategy.values()));
+    ImmutableList.Builder<Object[]> validPermutations = ImmutableList.builder();
+    for (PythonBuckConfig.PackageStyle packageStyle : PythonBuckConfig.PackageStyle.values()) {
+      for (boolean pexDirectory : new boolean[]{true, false}) {
+        if (packageStyle == PythonBuckConfig.PackageStyle.INPLACE && pexDirectory) {
+          continue;
+        }
+
+        for (NativeLinkStrategy linkStrategy : NativeLinkStrategy.values()) {
+          validPermutations.add(new Object[]{packageStyle, pexDirectory, linkStrategy});
+        }
+      }
+    }
+    return validPermutations.build();
   }
 
   @Parameterized.Parameter
   public PythonBuckConfig.PackageStyle packageStyle;
 
   @Parameterized.Parameter(value = 1)
+  public boolean pexDirectory;
+
+  @Parameterized.Parameter(value = 2)
   public NativeLinkStrategy nativeLinkStrategy;
 
   @Rule
@@ -89,10 +100,12 @@ public class PythonBinaryIntegrationTest {
   public void setUp() throws IOException {
     workspace = TestDataHelper.createProjectWorkspaceForScenario(this, "python_binary", tmp);
     workspace.setUp();
+    String pexFlags = pexDirectory ? "--directory" : "";
     workspace.writeContentsToPath(
         "[python]\n" +
             "  package_style = " + packageStyle.toString().toLowerCase() + "\n" +
-            "  native_link_strategy = " + nativeLinkStrategy.toString().toLowerCase() + "\n",
+            "  native_link_strategy = " + nativeLinkStrategy.toString().toLowerCase() + "\n" +
+            "  pex_flags = " + pexFlags + "\n",
         ".buckconfig");
     PythonBuckConfig config = getPythonBuckConfig();
     assertThat(config.getPackageStyle(), equalTo(packageStyle));
@@ -117,7 +130,8 @@ public class PythonBinaryIntegrationTest {
     Files.createSymbolicLink(
         link,
         workspace.getPath(Splitter.on(" ").splitToList(output).get(1)).toAbsolutePath());
-    ProcessExecutor.Result result = workspace.runCommand(link.toString());
+    ProcessExecutor.Result result = workspace.runCommand(
+        getPythonBuckConfig().getPythonInterpreter(), link.toString());
     assertThat(
         result.getStdout().or("") + result.getStderr().or(""),
         result.getExitCode(),
@@ -131,6 +145,18 @@ public class PythonBinaryIntegrationTest {
     assertThat(
         result.getStdout(),
         containsString("HELLO WORLD"));
+  }
+
+  @Test
+  public void testOutput() throws IOException {
+    workspace.runBuckBuild("//:bin").assertSuccess();
+
+    File output = workspace.getPath("buck-out/gen/bin.pex").toFile();
+    if (pexDirectory) {
+      assertTrue(output.isDirectory());
+    } else {
+      assertTrue(output.isFile());
+    }
   }
 
   @Test
@@ -299,10 +325,10 @@ public class PythonBinaryIntegrationTest {
             new ProjectFilesystem(tmp.getRootPath()),
             Architecture.detect(),
             Platform.detect(),
-            ImmutableMap.<String, String>of());
+            ImmutableMap.copyOf(System.getenv()));
     return new PythonBuckConfig(
         buckConfig,
-        new FakeExecutableFinder(ImmutableList.<Path>of()));
+        new ExecutableFinder());
   }
 
 }

--- a/test/com/facebook/buck/python/PythonBinaryIntegrationTest.java
+++ b/test/com/facebook/buck/python/PythonBinaryIntegrationTest.java
@@ -35,6 +35,8 @@ import com.facebook.buck.cxx.DefaultCxxPlatforms;
 import com.facebook.buck.event.BuckEventListener;
 import com.facebook.buck.io.ExecutableFinder;
 import com.facebook.buck.io.ProjectFilesystem;
+import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.TargetGraph;
 import com.facebook.buck.testutil.integration.DebuggableTemporaryFolder;
 import com.facebook.buck.testutil.integration.ProjectWorkspace;
 import com.facebook.buck.testutil.integration.TestDataHelper;

--- a/test/com/facebook/buck/python/PythonBuckConfigTest.java
+++ b/test/com/facebook/buck/python/PythonBuckConfigTest.java
@@ -16,6 +16,7 @@
 
 package com.facebook.buck.python;
 
+import static com.facebook.buck.testutil.HasConsecutiveItemsMatcher.hasConsecutiveItems;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -69,8 +70,8 @@ public class PythonBuckConfigTest {
     PythonVersion version =
         PythonBuckConfig.extractPythonVersion(
             Paths.get("usr", "bin", "python"),
-            new ProcessExecutor.Result(0, "", "Python 2.7.5\n"));
-    assertEquals("Python 2.7", version.toString());
+            new ProcessExecutor.Result(0, "", "CPython 2 7 5\n"));
+    assertEquals("CPython 2.7.5", version.toString());
   }
 
   @Test
@@ -264,34 +265,18 @@ public class PythonBuckConfigTest {
     PythonVersion version =
         PythonBuckConfig.extractPythonVersion(
             Paths.get("non", "important", "path"),
-            new ProcessExecutor.Result(0, "", "pyrun 2.7.6 (release 2.0.0)\n"));
-    assertEquals("pyrun 2.7", version.toString());
+            new ProcessExecutor.Result(0, "", "CPython 2 7 6\n"));
+    assertEquals("CPython 2.7.6", version.toString());
   }
 
   @Test
-  public void testGetPypyVersion() throws Exception {
-    String pypyOutput =
-        "Python 2.7.10 (850edf14b2c75573720f59e95767335fb1affe55, Oct 30 2015, 00:18:28)\n" +
-        "[PyPy 4.0.0 with GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.1.76)]\n";
-
+  public void testGetWindowsVersion() throws Exception {
+    String output = "CPython 2 7 10\r\n";
     PythonVersion version =
         PythonBuckConfig.extractPythonVersion(
             Paths.get("non", "important", "path"),
-            new ProcessExecutor.Result(0, "", pypyOutput));
-    assertThat(version.toString(), Matchers.equalTo("Python 2.7"));
-  }
-
-  @Test
-  public void testGetPypyWindowsVersion() throws Exception {
-    String pypyOutput =
-        "Python 2.7.10 (850edf14b2c75573720f59e95767335fb1affe55, Oct 30 2015, 00:18:28)\r\n" +
-        "[PyPy 4.0.0 with GCC 4.2.1 Compatible Apple LLVM 7.0.0 (ok that was a lie)]\r\n";
-
-    PythonVersion version =
-        PythonBuckConfig.extractPythonVersion(
-            Paths.get("non", "important", "path"),
-            new ProcessExecutor.Result(0, "", pypyOutput));
-    assertThat(version.toString(), Matchers.equalTo("Python 2.7"));
+            new ProcessExecutor.Result(0, "", output));
+    assertThat(version.toString(), Matchers.equalTo("CPython 2.7.10"));
   }
 
   @Test
@@ -305,10 +290,23 @@ public class PythonBuckConfigTest {
     assertThat(
         config.getDefaultPythonPlatform(
             new FakeProcessExecutor(
-                Functions.constant(new FakeProcess(0, "Python 2.7.5", "")),
+                Functions.constant(new FakeProcess(0, "CPython 2 7 5", "")),
                 new TestConsole()))
             .getCxxLibrary(),
         Matchers.equalTo(Optional.of(library)));
   }
 
+  @Test
+  public void testPexArgs() throws Exception {
+    PythonBuckConfig config =
+        new PythonBuckConfig(
+            FakeBuckConfig.builder().setSections(
+                ImmutableMap.of("python", ImmutableMap.of("pex_flags", "--hello --world"))).build(),
+            new AlwaysFoundExecutableFinder());
+    BuildRuleResolver resolver = new BuildRuleResolver(
+        TargetGraph.EMPTY, new BuildTargetNodeToBuildRuleTransformer());
+    assertThat(
+        config.getPexTool(resolver).getCommandPrefix(new SourcePathResolver(resolver)),
+        hasConsecutiveItems("--hello", "--world"));
+  }
 }

--- a/test/com/facebook/buck/python/PythonBuckConfigTest.java
+++ b/test/com/facebook/buck/python/PythonBuckConfigTest.java
@@ -70,8 +70,8 @@ public class PythonBuckConfigTest {
     PythonVersion version =
         PythonBuckConfig.extractPythonVersion(
             Paths.get("usr", "bin", "python"),
-            new ProcessExecutor.Result(0, "", "CPython 2 7 5\n"));
-    assertEquals("CPython 2.7.5", version.toString());
+            new ProcessExecutor.Result(0, "", "CPython 2 7\n"));
+    assertEquals("CPython 2.7", version.toString());
   }
 
   @Test
@@ -265,18 +265,18 @@ public class PythonBuckConfigTest {
     PythonVersion version =
         PythonBuckConfig.extractPythonVersion(
             Paths.get("non", "important", "path"),
-            new ProcessExecutor.Result(0, "", "CPython 2 7 6\n"));
-    assertEquals("CPython 2.7.6", version.toString());
+            new ProcessExecutor.Result(0, "", "CPython 2 7\n"));
+    assertEquals("CPython 2.7", version.toString());
   }
 
   @Test
   public void testGetWindowsVersion() throws Exception {
-    String output = "CPython 2 7 10\r\n";
+    String output = "CPython 2 7\r\n";
     PythonVersion version =
         PythonBuckConfig.extractPythonVersion(
             Paths.get("non", "important", "path"),
             new ProcessExecutor.Result(0, "", output));
-    assertThat(version.toString(), Matchers.equalTo("CPython 2.7.10"));
+    assertThat(version.toString(), Matchers.equalTo("CPython 2.7"));
   }
 
   @Test
@@ -290,7 +290,7 @@ public class PythonBuckConfigTest {
     assertThat(
         config.getDefaultPythonPlatform(
             new FakeProcessExecutor(
-                Functions.constant(new FakeProcess(0, "CPython 2 7 5", "")),
+                Functions.constant(new FakeProcess(0, "CPython 2 7", "")),
                 new TestConsole()))
             .getCxxLibrary(),
         Matchers.equalTo(Optional.of(library)));
@@ -304,7 +304,7 @@ public class PythonBuckConfigTest {
                 ImmutableMap.of("python", ImmutableMap.of("pex_flags", "--hello --world"))).build(),
             new AlwaysFoundExecutableFinder());
     BuildRuleResolver resolver = new BuildRuleResolver(
-        TargetGraph.EMPTY, new BuildTargetNodeToBuildRuleTransformer());
+        TargetGraph.EMPTY, new DefaultTargetNodeToBuildRuleTransformer());
     assertThat(
         config.getPexTool(resolver).getCommandPrefix(new SourcePathResolver(resolver)),
         hasConsecutiveItems("--hello", "--world"));

--- a/test/com/facebook/buck/python/PythonPackagedBinaryTest.java
+++ b/test/com/facebook/buck/python/PythonPackagedBinaryTest.java
@@ -78,7 +78,7 @@ public class PythonPackagedBinaryTest {
         ImmutableList.<String>of(),
         new HashedFileTool(Paths.get("dummy_path_to_pex_runner")),
         ".pex",
-        new PythonEnvironment(Paths.get("fake_python"), PythonVersion.of("Python 2.7")),
+        new PythonEnvironment(Paths.get("fake_python"), PythonVersion.of("CPython", "2.7.11")),
         "main",
         PythonPackageComponents.of(
             ImmutableMap.<Path, SourcePath>of(

--- a/test/com/facebook/buck/python/PythonPackagedBinaryTest.java
+++ b/test/com/facebook/buck/python/PythonPackagedBinaryTest.java
@@ -78,7 +78,7 @@ public class PythonPackagedBinaryTest {
         ImmutableList.<String>of(),
         new HashedFileTool(Paths.get("dummy_path_to_pex_runner")),
         ".pex",
-        new PythonEnvironment(Paths.get("fake_python"), PythonVersion.of("CPython", "2.7.11")),
+        new PythonEnvironment(Paths.get("fake_python"), PythonVersion.of("CPython", "2.7")),
         "main",
         PythonPackageComponents.of(
             ImmutableMap.<Path, SourcePath>of(

--- a/test/com/facebook/buck/python/PythonTestDescriptionTest.java
+++ b/test/com/facebook/buck/python/PythonTestDescriptionTest.java
@@ -195,12 +195,12 @@ public class PythonTestDescriptionTest {
     PythonPlatform platform1 =
         PythonPlatform.of(
             ImmutableFlavor.of("pyPlat1"),
-            new PythonEnvironment(Paths.get("python2.6"), PythonVersion.of("2.6")),
+            new PythonEnvironment(Paths.get("python2.6"), PythonVersion.of("CPython", "2.6")),
             Optional.<BuildTarget>absent());
     PythonPlatform platform2 =
         PythonPlatform.of(
             ImmutableFlavor.of("pyPlat2"),
-            new PythonEnvironment(Paths.get("python2.7"), PythonVersion.of("2.7")),
+            new PythonEnvironment(Paths.get("python2.7"), PythonVersion.of("CPython", "2.7")),
             Optional.<BuildTarget>absent());
     PythonTestBuilder builder =
         PythonTestBuilder.create(

--- a/test/com/facebook/buck/python/PythonTestIntegrationTest.java
+++ b/test/com/facebook/buck/python/PythonTestIntegrationTest.java
@@ -33,7 +33,6 @@ import com.facebook.buck.testutil.integration.ProjectWorkspace.ProcessResult;
 import com.facebook.buck.testutil.integration.TestDataHelper;
 import com.facebook.buck.util.ProcessExecutor;
 import com.facebook.buck.util.VersionStringComparator;
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 
 import org.hamcrest.Matchers;
@@ -105,10 +104,10 @@ public class PythonTestIntegrationTest {
 
   @Test
   public void testPythonTestTimeout() throws IOException {
-      ProcessResult result = workspace.runBuckCommand("test", "//:test-spinning");
-      String stderr = result.getStderr();
-      result.assertSpecialExitCode("test should fail", 42);
-      assertTrue(stderr, stderr.contains("Following test case timed out: //:test-spinning"));
+    ProcessResult result = workspace.runBuckCommand("test", "//:test-spinning");
+    String stderr = result.getStderr();
+    result.assertSpecialExitCode("test should fail", 42);
+    assertTrue(stderr, stderr.contains("Following test case timed out: //:test-spinning"));
   }
 
   @Test
@@ -146,18 +145,18 @@ public class PythonTestIntegrationTest {
 
   private void assumePythonVersionIsAtLeast(String expectedVersion, String message)
       throws InterruptedException {
-    PythonVersion pythonVersion =
+    PythonVersion actualVersion =
         new PythonBuckConfig(FakeBuckConfig.builder().build(), new ExecutableFinder())
             .getPythonEnvironment(new ProcessExecutor(new TestConsole()))
             .getPythonVersion();
-    String actualVersion = Splitter.on(' ').splitToList(pythonVersion.getVersionString()).get(1);
     assumeTrue(
         String.format(
             "Needs at least Python-%s, but found Python-%s: %s",
             expectedVersion,
             actualVersion,
             message),
-        new VersionStringComparator().compare(actualVersion, expectedVersion) >= 0);
+        new VersionStringComparator().compare(
+            actualVersion.getVersionString(), expectedVersion) >= 0);
   }
 
   private static <T> T getOnlyValue(Iterable<T> iterable) {

--- a/test/com/facebook/buck/python/PythonTestUtils.java
+++ b/test/com/facebook/buck/python/PythonTestUtils.java
@@ -32,7 +32,7 @@ public class PythonTestUtils {
           ImmutableFlavor.of("default"),
           new PythonEnvironment(
               Paths.get("python"),
-              PythonVersion.of("2.6")),
+              PythonVersion.of("CPython", "2.6")),
           Optional.<BuildTarget>absent());
 
   public static final FlavorDomain<PythonPlatform> PYTHON_PLATFORMS =

--- a/test/com/facebook/buck/rules/DefaultKnownBuildRuleTypes.java
+++ b/test/com/facebook/buck/rules/DefaultKnownBuildRuleTypes.java
@@ -52,9 +52,9 @@ public class DefaultKnownBuildRuleTypes {
 
   private static final ImmutableMap<String, String> PYTHONS =
       ImmutableMap.of(
-          "python", "2.6.5",
-          "python2", "2.6.5",
-          "python3", "3.5.0");
+          "python", "2.6",
+          "python2", "2.6",
+          "python3", "3.5");
 
   protected static ImmutableMap<ProcessExecutorParams, FakeProcess> getPythonProcessMap(
       List<String> paths) {

--- a/test/com/facebook/buck/rules/DefaultKnownBuildRuleTypes.java
+++ b/test/com/facebook/buck/rules/DefaultKnownBuildRuleTypes.java
@@ -65,10 +65,11 @@ public class DefaultKnownBuildRuleTypes {
         for (String extension : new String[]{"", ".exe", ".EXE"}) {
           processMap.put(
               ProcessExecutorParams.builder()
-                  .setCommand(
-                      ImmutableList.of(path + File.separator + python.getKey() + extension, "-V"))
+                  .setCommand(ImmutableList.of(
+                      path + File.separator + python.getKey() + extension,
+                      "-"))
                   .build(),
-              new FakeProcess(0, "Python " + python.getValue(), ""));
+              new FakeProcess(0, "CPython " + python.getValue().replace('.', ' '), ""));
         }
       }
     }

--- a/third-party/py/pex/README.facebook
+++ b/third-party/py/pex/README.facebook
@@ -8,3 +8,4 @@ Local modifications:
    system, as this got more problematic to fake in our own `pkg_resources` module.
  - Fixed usage of os.link (does not exist on windows).
  - Fixed prebuilt package resolution when pexs have '#' in the name.
+ - Added the ability to not hash the contents of the pex (used for in-place builds).

--- a/third-party/py/pex/pex/pex_builder.py
+++ b/third-party/py/pex/pex/pex_builder.py
@@ -370,7 +370,7 @@ class PEXBuilder(object):
           self._chroot.write(provider.get_resource_string(source_name, fn),
             os.path.join(self.BOOTSTRAP_DIR, target_location, fn), 'bootstrap')
 
-  def freeze(self, bytecode_compile=True):
+  def freeze(self, bytecode_compile=True, code_hash=True):
     """Freeze the PEX.
 
     :param bytecode_compile: If True, precompile .py files into .pyc files when freezing code.
@@ -380,7 +380,8 @@ class PEXBuilder(object):
     """
     self._ensure_unfrozen('Freezing the environment')
     self._prepare_inits()
-    self._prepare_code_hash()
+    if code_hash:
+      self._prepare_code_hash()
     self._prepare_manifest()
     self._prepare_bootstrap()
     self._prepare_main()


### PR DESCRIPTION
This time without the micro version (since CPython at least promises not to break ABI compat on micro upgrades). Is there any code you guys have that depends on the system python vs pyrun distinction? The ABI should be the same there, but that's the only change now.