### PR TITLE
Add support to compile Go gc assembly

### DIFF
--- a/docs/__go_common.soy
+++ b/docs/__go_common.soy
@@ -22,7 +22,9 @@ Note: Buck is currently tested with (and therefore supports) version 1.5 of Go.
   {param name : 'srcs' /}
   {param desc}
   <p>
-    The set of Go source files to be compiled by this rule.
+    The set of source files to be compiled by this rule. .go files will be compiled with the Go
+    compiler, .s files will be compiled with the assembler, and everything else is assumed to be
+    files that may be <code>#include</code>d by the assembler.
   </p>
   {/param}
 {/call}
@@ -47,6 +49,17 @@ Note: Buck is currently tested with (and therefore supports) version 1.5 of Go.
   {param default : '[]' /}
   {param desc}
   The set of additional compiler flags to pass to <code>go tool compile</code>.
+  {/param}
+{/call}
+{/template}
+
+/***/
+{template .assembler_flags_arg}
+{call buck.arg}
+  {param name : 'assembler_flags' /}
+  {param default : '[]' /}
+  {param desc}
+  The set of additional assembler flags to pass to <code>go tool asm</code>.
   {/param}
 {/call}
 {/template}

--- a/docs/concept/buckconfig.soy
+++ b/docs/concept/buckconfig.soy
@@ -1130,6 +1130,24 @@ $ buck targets --resolve-alias app#src_jar
 
 {call buckconfig.entry}
   {param section: 'go' /}
+  {param name: 'assembler' /}
+  {param example_value: '/usr/local/libexec/go/pkg/tool/darwin_amd64/asm' /}
+  {param description}
+    The full path to the Go assembler.  This is normally automatically discovered.
+  {/param}
+{/call}
+
+{call buckconfig.entry}
+  {param section: 'go' /}
+  {param name: 'packer' /}
+  {param example_value: '/usr/local/libexec/go/pkg/tool/darwin_amd64/pack' /}
+  {param description}
+    The full path to the Go packer.  This is normally automatically discovered.
+  {/param}
+{/call}
+
+{call buckconfig.entry}
+  {param section: 'go' /}
   {param name: 'linker' /}
   {param example_value: '/usr/local/libexec/go/pkg/tool/darwin_amd64/link' /}
   {param description}

--- a/docs/rule/go_binary.soy
+++ b/docs/rule/go_binary.soy
@@ -37,6 +37,8 @@
 
 {call go_common.compiler_flags_arg /}
 
+{call go_common.assembler_flags_arg /}
+
 {call go_common.linker_flags_arg /}
 
 {/param} // close args

--- a/docs/rule/go_library.soy
+++ b/docs/rule/go_library.soy
@@ -39,6 +39,8 @@
 
 {call go_common.compiler_flags_arg /}
 
+{call go_common.assembler_flags_arg /}
+
 {call buck.tests_arg /}
 
 {/param} // close args

--- a/docs/rule/go_test.soy
+++ b/docs/rule/go_test.soy
@@ -60,6 +60,8 @@
 
 {call go_common.compiler_flags_arg /}
 
+{call go_common.assembler_flags_arg /}
+
 {call go_common.linker_flags_arg /}
 
 {call buck.test_label_arg /}

--- a/src/com/facebook/buck/go/GoBinaryDescription.java
+++ b/src/com/facebook/buck/go/GoBinaryDescription.java
@@ -75,6 +75,7 @@ public class GoBinaryDescription implements Description<GoBinaryDescription.Arg>
         goBuckConfig,
         args.srcs,
         args.compilerFlags.get(),
+        args.assemblerFlags.get(),
         args.linkerFlags.get(),
         platform);
   }
@@ -83,6 +84,7 @@ public class GoBinaryDescription implements Description<GoBinaryDescription.Arg>
   public static class Arg extends AbstractDescriptionArg {
     public ImmutableSet<SourcePath> srcs;
     public Optional<List<String>> compilerFlags;
+    public Optional<List<String>> assemblerFlags;
     public Optional<List<String>> linkerFlags;
     public Optional<ImmutableSortedSet<BuildTarget>> deps;
   }

--- a/src/com/facebook/buck/go/GoDescriptors.java
+++ b/src/com/facebook/buck/go/GoDescriptors.java
@@ -105,6 +105,7 @@ abstract class GoDescriptors {
       Path packageName,
       ImmutableSet<SourcePath> srcs,
       List<String> compilerFlags,
+      List<String> assemblerFlags,
       GoPlatform platform) throws NoSuchBuildTargetException {
     SourcePathResolver pathResolver = new SourcePathResolver(resolver);
 
@@ -134,6 +135,10 @@ abstract class GoDescriptors {
         ImmutableSet.copyOf(srcs),
         ImmutableList.copyOf(compilerFlags),
         goBuckConfig.getCompiler(),
+        ImmutableList.copyOf(assemblerFlags),
+        goBuckConfig.getAssemblerIncludeDirs(),
+        goBuckConfig.getAssembler(),
+        goBuckConfig.getPacker(),
         platform);
   }
 
@@ -143,6 +148,7 @@ abstract class GoDescriptors {
       GoBuckConfig goBuckConfig,
       ImmutableSet<SourcePath> srcs,
       List<String> compilerFlags,
+      List<String> assemblerFlags,
       List<String> linkerFlags,
       GoPlatform platform) throws NoSuchBuildTargetException {
     BuildTarget libraryTarget =
@@ -156,6 +162,7 @@ abstract class GoDescriptors {
         Paths.get("main"),
         srcs,
         compilerFlags,
+        assemblerFlags,
         platform);
     resolver.addToIndex(library);
 
@@ -224,6 +231,7 @@ abstract class GoDescriptors {
         ImmutableSet.<SourcePath>of(new PathSourcePath(
                 projectFilesystem,
                 MorePaths.relativize(projectFilesystem.getRootPath(), extractTestMainGenerator()))),
+        ImmutableList.<String>of(),
         ImmutableList.<String>of(),
         ImmutableList.<String>of(),
         goBuckConfig.getDefaultPlatform());

--- a/src/com/facebook/buck/go/GoLibraryDescription.java
+++ b/src/com/facebook/buck/go/GoLibraryDescription.java
@@ -82,9 +82,7 @@ public class GoLibraryDescription implements
     Optional<GoPlatform> platform =
         goBuckConfig.getPlatformFlavorDomain().getValue(buildTarget);
 
-    if (metadataClass.isAssignableFrom(Arg.class)) {
-      return Optional.of(metadataClass.cast(args));
-    } else if (metadataClass.isAssignableFrom(GoLinkable.class)) {
+    if (metadataClass.isAssignableFrom(GoLinkable.class)) {
       Preconditions.checkState(platform.isPresent());
 
       SourcePath output = new BuildTargetSourcePath(
@@ -127,6 +125,7 @@ public class GoLibraryDescription implements
               .or(goBuckConfig.getDefaultPackageName(params.getBuildTarget())),
           args.srcs,
           args.compilerFlags.or(ImmutableList.<String>of()),
+          args.assemblerFlags.get(),
           platform.get());
     }
 
@@ -137,6 +136,7 @@ public class GoLibraryDescription implements
   public static class Arg extends AbstractDescriptionArg implements HasTests {
     public ImmutableSet<SourcePath> srcs;
     public Optional<List<String>> compilerFlags;
+    public Optional<List<String>> assemblerFlags;
     public Optional<String> packageName;
     public Optional<ImmutableSortedSet<BuildTarget>> deps;
 

--- a/src/com/facebook/buck/go/GoPackStep.java
+++ b/src/com/facebook/buck/go/GoPackStep.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2016-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.go;
+
+import com.facebook.buck.shell.ShellStep;
+import com.facebook.buck.step.ExecutionContext;
+import com.google.common.base.Functions;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.nio.file.Path;
+
+public class GoPackStep extends ShellStep {
+  public enum Operation {
+    CREATE("c"),
+    APPEND("r"),
+    EXTRACT("x");
+
+    String opCode;
+    Operation(String opCode) {
+      this.opCode = opCode;
+    }
+
+    public String getOpCode(boolean verbose) {
+      return verbose ? opCode + "v" : opCode;
+    }
+  }
+
+  private final ImmutableMap<String, String> environment;
+  private final ImmutableList<String> packCommandPrefix;
+  private final Operation op;
+  private final ImmutableList<Path> srcs;
+  private final Path output;
+
+  public GoPackStep(
+      Path workingDirectory,
+      ImmutableMap<String, String> environment,
+      ImmutableList<String> packCommandPrefix,
+      Operation op,
+      ImmutableList<Path> srcs,
+      Path output) {
+    super(workingDirectory);
+    this.environment = environment;
+    this.packCommandPrefix = packCommandPrefix;
+    this.op = op;
+    this.output = output;
+    this.srcs = srcs;
+  }
+
+  @Override
+  protected ImmutableList<String> getShellCommandInternal(ExecutionContext context) {
+    return ImmutableList.<String>builder()
+        .addAll(packCommandPrefix)
+        .add(op.getOpCode(context.getVerbosity().shouldUseVerbosityFlagIfAvailable()))
+        .add(output.toString())
+        .addAll(FluentIterable.from(srcs).transform(Functions.toStringFunction()))
+        .build();
+  }
+
+  @Override
+  public ImmutableMap<String, String> getEnvironmentVariables(ExecutionContext context) {
+    return environment;
+  }
+
+  @Override
+  public String getShortName() {
+    return "go pack";
+  }
+}

--- a/src/com/facebook/buck/go/GoTestDescription.java
+++ b/src/com/facebook/buck/go/GoTestDescription.java
@@ -227,6 +227,7 @@ public class GoTestDescription implements
         goBuckConfig,
         ImmutableSet.<SourcePath>of(new BuildTargetSourcePath(generatedTestMain.getBuildTarget())),
         args.compilerFlags.get(),
+        args.assemblerFlags.get(),
         args.linkerFlags.get(),
         platform);
     resolver.addToIndex(testMain);
@@ -317,6 +318,10 @@ public class GoTestDescription implements
               .addAll(libraryArg.compilerFlags.get())
               .addAll(args.compilerFlags.get())
               .build(),
+          ImmutableList.<String>builder()
+              .addAll(libraryArg.assemblerFlags.get())
+              .addAll(args.assemblerFlags.get())
+              .build(),
           platform);
     } else {
       testLibrary = GoDescriptors.createGoCompileRule(
@@ -326,6 +331,7 @@ public class GoTestDescription implements
           packageName,
           args.srcs,
           args.compilerFlags.get(),
+          args.assemblerFlags.get(),
           platform);
     }
 
@@ -338,6 +344,7 @@ public class GoTestDescription implements
     public Optional<BuildTarget> library;
     public Optional<String> packageName;
     public Optional<List<String>> compilerFlags;
+    public Optional<List<String>> assemblerFlags;
     public Optional<List<String>> linkerFlags;
     public Optional<ImmutableSortedSet<BuildTarget>> deps;
     public Optional<ImmutableSet<String>> contacts;

--- a/test/com/facebook/buck/go/GoBinaryIntegrationTest.java
+++ b/test/com/facebook/buck/go/GoBinaryIntegrationTest.java
@@ -64,6 +64,17 @@ public class GoBinaryIntegrationTest {
   }
 
   @Test
+  public void binaryWithAsm() throws IOException, InterruptedException {
+    ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(
+        this, "asm", tmp);
+    workspace.setUp();
+
+    ProjectWorkspace.ProcessResult result = workspace.runBuckCommand("run", "//src/asm_test:bin");
+    result.assertSuccess();
+    assertThat(result.getStdout(), Matchers.containsString("Sum is 6"));
+  }
+
+    @Test
   public void buildAfterChangeWorks() throws IOException, InterruptedException {
     ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(
         this, "simple_binary", tmp);

--- a/test/com/facebook/buck/go/testdata/asm/src/asm_test/BUCK.fixture
+++ b/test/com/facebook/buck/go/testdata/asm/src/asm_test/BUCK.fixture
@@ -1,0 +1,10 @@
+go_binary(
+    name = 'bin',
+    srcs = [
+        'main.go',
+        'sum_amd64.s',
+        'local.h',
+        # TODO(mikekap): Implement build tag filtering
+        # 'sum.go',
+    ]
+)

--- a/test/com/facebook/buck/go/testdata/asm/src/asm_test/local.h
+++ b/test/com/facebook/buck/go/testdata/asm/src/asm_test/local.h
@@ -1,0 +1,1 @@
+#define PLUS(a, b) a+b

--- a/test/com/facebook/buck/go/testdata/asm/src/asm_test/main.go
+++ b/test/com/facebook/buck/go/testdata/asm/src/asm_test/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "fmt"
+
+func Sum(xs []int64) int64
+
+func main() {
+    fmt.Printf("Sum is %d", Sum([]int64{1, 2, 3}))
+}

--- a/test/com/facebook/buck/go/testdata/asm/src/asm_test/sum.go
+++ b/test/com/facebook/buck/go/testdata/asm/src/asm_test/sum.go
@@ -1,0 +1,11 @@
+// +build !amd64
+
+package main
+
+func Sum(xs []int64) int64 {
+  var n int64
+  for _, v := range xs {
+    n += v
+  }
+  return n
+}

--- a/test/com/facebook/buck/go/testdata/asm/src/asm_test/sum_amd64.s
+++ b/test/com/facebook/buck/go/testdata/asm/src/asm_test/sum_amd64.s
@@ -1,0 +1,21 @@
+#include "go_asm.h"
+#include "textflag.h"
+#include "local.h"
+
+// func Sum(xs []int64) int64
+TEXT ·Sum(SB),7,$0
+    MOVQ    $0, SI       // n
+    MOVQ    PLUS(xs,0)(FP), BX // BX = &xs[0]
+    MOVQ    PLUS(xs_len,8)(FP), CX // len(xs)
+    INCQ    CX           // CX++
+
+start:
+    DECQ    CX           // CX--
+    JZ done              // jump if CX = 0
+    ADDQ    (BX), SI     // n += *BX
+    ADDQ    $8, BX       // BX += 8
+    JMP start
+
+done:
+    MOVQ    SI, ret+24(FP) // return n
+    RET


### PR DESCRIPTION
Gc being the standard go compiler; not to be confused with the garbage collector...

Pretty easy - run `go tool asm` for each .s file & use `go tool pack` to shove them into the same archive.