### PR TITLE
Allow ScalaStep to expand .src.zip sources

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -10,7 +10,7 @@
   <component name="ProjectResources">
     <default-html-doctype>http://www.w3.org/1999/xhtml</default-html-doctype>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="false" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="false" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build-ij/classes" />
   </component>
 </project>

--- a/src/com/facebook/buck/jvm/scala/ScalacStep.java
+++ b/src/com/facebook/buck/jvm/scala/ScalacStep.java
@@ -17,22 +17,28 @@
 package com.facebook.buck.jvm.scala;
 
 import com.facebook.buck.io.ProjectFilesystem;
+import com.facebook.buck.jvm.java.ExternalJavac;
+import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.Tool;
 import com.facebook.buck.shell.ShellStep;
 import com.facebook.buck.step.ExecutionContext;
+import com.facebook.buck.util.HumanReadableException;
 import com.facebook.buck.util.Verbosity;
 import com.google.common.base.Functions;
 import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 
 public class ScalacStep extends ShellStep {
+  private final BuildTarget invokingRule;
   private final Tool scalac;
   private final ImmutableList<String> extraArguments;
   private final SourcePathResolver resolver;
@@ -40,17 +46,21 @@ public class ScalacStep extends ShellStep {
   private final ImmutableSortedSet<Path> sourceFilePaths;
   private final ImmutableSortedSet<Path> classpathEntries;
   private final ProjectFilesystem filesystem;
+  private final Path pathToSrcsList;
 
   ScalacStep(
+      BuildTarget invokingRule,
       Tool scalac,
       ImmutableList<String> extraArguments,
       SourcePathResolver resolver,
       Path outputDirectory,
       ImmutableSortedSet<Path> sourceFilePaths,
       ImmutableSortedSet<Path> classpathEntries,
-      ProjectFilesystem filesystem) {
+      ProjectFilesystem filesystem,
+      Path pathToSrcsList) {
     super(filesystem.getRootPath());
 
+    this.invokingRule = invokingRule;
     this.scalac = scalac;
     this.extraArguments = extraArguments;
     this.resolver = resolver;
@@ -58,6 +68,7 @@ public class ScalacStep extends ShellStep {
     this.sourceFilePaths = sourceFilePaths;
     this.classpathEntries = classpathEntries;
     this.filesystem = filesystem;
+    this.pathToSrcsList = pathToSrcsList;
   }
 
   @Override
@@ -88,9 +99,35 @@ public class ScalacStep extends ShellStep {
     } else {
       commandBuilder.add("-classpath", classpath);
     }
-    commandBuilder.addAll(
-        FluentIterable.from(sourceFilePaths)
-            .transform(Functions.toStringFunction()));
+
+    ImmutableList<Path> expandedSources;
+    try {
+      expandedSources = ExternalJavac.getExpandedSourcePaths(
+          filesystem,
+          invokingRule,
+          sourceFilePaths,
+          Optional.of(workingDirectory),
+          ".scala");
+    } catch (IOException e) {
+      throw new HumanReadableException(
+          "Unable to expand sources for %s into %s",
+          invokingRule,
+          workingDirectory);
+    }
+
+    try {
+      filesystem.writeLinesToPath(
+          FluentIterable.from(expandedSources)
+              .transform(Functions.toStringFunction())
+              .transform(ExternalJavac.ARGFILES_ESCAPER),
+          pathToSrcsList);
+      commandBuilder.add("@" + pathToSrcsList);
+    } catch (IOException e) {
+      throw new HumanReadableException(
+          e,
+          "Cannot write list of .scala files to compile to %s file! Terminating compilation.",
+          pathToSrcsList);
+    }
 
     return commandBuilder.build();
   }

--- a/src/com/facebook/buck/jvm/scala/ScalacToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/scala/ScalacToJarStepFactory.java
@@ -61,13 +61,15 @@ class ScalacToJarStepFactory extends BaseCompileToJarStepFactory {
       BuildableContext buildableContext) {
     steps.add(
         new ScalacStep(
+            invokingRule,
             scalac,
             extraArguments,
             resolver,
             outputDirectory,
             sourceFilePaths,
             classpathEntries,
-            filesystem));
+            filesystem,
+            pathToSrcsList));
   }
 
   @Override


### PR DESCRIPTION
This is a bit exploratory. Basically, I'm trying to figure out how to get a `scala_library()` that comprises `.scala` files generated automatically by a `genrule()`.

My initial attempt was a genrule that generated a directory, but nothing really seemed to build when I passed off `:mygenrule` as a source to the `scala_library()` rule. I ended up slapping a `zip_file()` on top of the `genrule()` and then sending this PR. I reckon there's value in supporting zipped sources for Scala as well, but would like to know whether it's a reasonable thing to do for Buck.
