### PR TITLE
Add support for go 1.6-style vendoring.

### DIFF
--- a/src/com/facebook/buck/go/GoCompile.java
+++ b/src/com/facebook/buck/go/GoCompile.java
@@ -35,6 +35,7 @@ import com.facebook.buck.step.fs.SymlinkFileStep;
 import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import java.nio.file.Path;
@@ -56,8 +57,9 @@ public class GoCompile extends AbstractBuildRule {
   private final ImmutableList<String> assemblerFlags;
   @AddToRuleKey
   private final GoPlatform platform;
-  // TODO(mikekap): Make this part of the rule key.
+  // TODO(mikekap): Make these part of the rule key.
   private final ImmutableList<Path> assemblerIncludeDirs;
+  private final ImmutableMap<Path, Path> importPathMap;
 
   private final SymlinkTree symlinkTree;
   private final Path output;
@@ -67,6 +69,7 @@ public class GoCompile extends AbstractBuildRule {
       SourcePathResolver resolver,
       SymlinkTree symlinkTree,
       Path packageName,
+      ImmutableMap<Path, Path> importPathMap,
       ImmutableSet<SourcePath> srcs,
       ImmutableList<String> compilerFlags,
       Tool compiler,
@@ -76,6 +79,7 @@ public class GoCompile extends AbstractBuildRule {
       Tool packer,
       GoPlatform platform) {
     super(params, resolver);
+    this.importPathMap = importPathMap;
     this.srcs = srcs;
     this.symlinkTree = symlinkTree;
     this.packageName = packageName;
@@ -137,6 +141,7 @@ public class GoCompile extends AbstractBuildRule {
         compilerFlags,
         packageName,
         compileSrcs,
+        importPathMap,
         ImmutableList.of(symlinkTree.getRoot()),
         asmHeaderPath,
         allowExternalReferences,

--- a/src/com/facebook/buck/go/GoCompileStep.java
+++ b/src/com/facebook/buck/go/GoCompileStep.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import java.nio.file.Path;
+import java.util.Map;
 
 public class GoCompileStep extends ShellStep {
 
@@ -33,6 +34,7 @@ public class GoCompileStep extends ShellStep {
   private final Path packageName;
   private final ImmutableList<String> flags;
   private final ImmutableList<Path> srcs;
+  private final ImmutableMap<Path, Path> importPathMap;
   private final ImmutableList<Path> includeDirectories;
   private final Optional<Path> asmHeaderPath;
   private final boolean allowExternalReferences;
@@ -46,6 +48,7 @@ public class GoCompileStep extends ShellStep {
       ImmutableList<String> flags,
       Path packageName,
       ImmutableList<Path> srcs,
+      ImmutableMap<Path, Path> importPathMap,
       ImmutableList<Path> includeDirectories,
       Optional<Path> asmHeaderPath,
       boolean allowExternalReferences,
@@ -57,6 +60,7 @@ public class GoCompileStep extends ShellStep {
     this.flags = flags;
     this.packageName = packageName;
     this.srcs = srcs;
+    this.importPathMap = importPathMap;
     this.includeDirectories = includeDirectories;
     this.asmHeaderPath = asmHeaderPath;
     this.allowExternalReferences = allowExternalReferences;
@@ -77,6 +81,10 @@ public class GoCompileStep extends ShellStep {
 
     for (Path dir : includeDirectories) {
       commandBuilder.add("-I", dir.toString());
+    }
+
+    for (Map.Entry<Path, Path> importMap : importPathMap.entrySet()) {
+      commandBuilder.add("-importmap", importMap.getKey() + "=" + importMap.getValue());
     }
 
     if (asmHeaderPath.isPresent()) {

--- a/test/com/facebook/buck/go/BUCK
+++ b/test/com/facebook/buck/go/BUCK
@@ -29,6 +29,7 @@ java_test(
     '//test/com/facebook/buck/model:BuildTargetFactory',
     '//test/com/facebook/buck/rules:testutil',
     '//src/com/facebook/buck/go:go',
+    '//src/com/facebook/buck/io:io',
     '//third-party/java/guava:guava',
     '//third-party/java/hamcrest:hamcrest',
     '//third-party/java/junit:junit',

--- a/test/com/facebook/buck/go/GoBinaryIntegrationTest.java
+++ b/test/com/facebook/buck/go/GoBinaryIntegrationTest.java
@@ -99,6 +99,17 @@ public class GoBinaryIntegrationTest {
   }
 
   @Test
+  public void vendoredLibrary() throws IOException, InterruptedException {
+    ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(
+        this, "vendored_library", tmp);
+    workspace.setUp();
+
+    assertThat(
+        workspace.runBuckCommand("run", "//:hello").assertSuccess().getStdout(),
+        Matchers.containsString("Hello, world!"));
+  }
+
+  @Test
   public void libraryWithPrefix() throws IOException, InterruptedException {
     ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(
         this, "library_with_prefix", tmp);

--- a/test/com/facebook/buck/go/GoDescriptorsTest.java
+++ b/test/com/facebook/buck/go/GoDescriptorsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.go;
+
+import com.facebook.buck.io.MorePaths;
+import com.google.common.base.Function;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import static org.junit.Assert.assertThat;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+public class GoDescriptorsTest {
+  private ImmutableMap<String, String> getPackageImportMap(
+      String basePackage, Iterable<String> packages) {
+    return ImmutableMap.copyOf(FluentIterable.from(
+        GoDescriptors.getPackageImportMap(
+            Paths.get(basePackage),
+            FluentIterable.from(packages).transform(MorePaths.TO_PATH)).entrySet())
+        .transform(new Function<Map.Entry<Path, Path>, Map.Entry<String, String>>() {
+          @Override
+          public Map.Entry<String, String> apply(Map.Entry<Path, Path> input) {
+            return Maps.immutableEntry(input.getKey().toString(), input.getValue().toString());
+          }
+        }));
+  }
+
+  @Test
+  public void testImportMapEmpty() {
+    assertThat(
+        getPackageImportMap(
+            "foo/bar/baz",
+            ImmutableList.of(
+                "foo/bar",
+                "bar",
+                "foo/bar/baz/waffle"
+            )),
+        Matchers.anEmptyMap());
+  }
+
+  @Test
+  public void testImportMapRoot() {
+    assertThat(
+        getPackageImportMap(
+            "foo/bar/baz",
+            ImmutableList.of(
+                "foo/bar",
+                "bar",
+                "foo/bar/baz/waffle",
+                "foo/vendor/hello/world"
+            )),
+        Matchers.equalTo(ImmutableMap.of(
+            "hello/world", "foo/vendor/hello/world")));
+  }
+
+  @Test
+  public void testImportMapNonRoot() {
+    assertThat(
+        getPackageImportMap(
+            "foo/bar/baz",
+            ImmutableList.of(
+                "foo/bar",
+                "bar",
+                "foo/bar/baz/waffle",
+                "foo/bar/vendor/hello/world"
+            )),
+        Matchers.equalTo(ImmutableMap.of(
+            "hello/world", "foo/bar/vendor/hello/world")));
+  }
+
+  @Test
+  public void testImportMapLongestWins() {
+    assertThat(
+        getPackageImportMap(
+            "foo/bar/baz",
+            ImmutableList.of(
+                "foo/bar",
+                "bar",
+                "foo/bar/baz/waffle",
+                "vendor/hello/world",
+                "foo/bar/vendor/hello/world"
+            )),
+        Matchers.equalTo(ImmutableMap.of(
+            "hello/world", "foo/bar/vendor/hello/world")));
+  }
+}

--- a/test/com/facebook/buck/go/testdata/vendored_library/BUCK.fixture
+++ b/test/com/facebook/buck/go/testdata/vendored_library/BUCK.fixture
@@ -1,0 +1,9 @@
+go_binary(
+  name = "hello",
+  srcs = [
+    "main.go",
+  ],
+  deps = [
+    "//messenger:messenger",
+  ],
+)

--- a/test/com/facebook/buck/go/testdata/vendored_library/main.go
+++ b/test/com/facebook/buck/go/testdata/vendored_library/main.go
@@ -1,0 +1,8 @@
+package main
+
+import "messenger"
+
+func main() {
+	messenger := messenger.NewMessenger("Hello, world!")
+	messenger.Deliver()
+}

--- a/test/com/facebook/buck/go/testdata/vendored_library/messenger/BUCK.fixture
+++ b/test/com/facebook/buck/go/testdata/vendored_library/messenger/BUCK.fixture
@@ -1,0 +1,12 @@
+go_library(
+  name = 'messenger',
+  srcs = [
+    'messenger.go',
+  ],
+  deps = [
+    '//vendor/printer:printer',
+  ],
+  visibility = [
+    'PUBLIC',
+  ],
+)

--- a/test/com/facebook/buck/go/testdata/vendored_library/messenger/messenger.go
+++ b/test/com/facebook/buck/go/testdata/vendored_library/messenger/messenger.go
@@ -1,0 +1,15 @@
+package messenger
+
+import "printer"
+
+type Messenger struct {
+	message string
+}
+
+func NewMessenger(message string) *Messenger {
+	return &Messenger{message: message}
+}
+
+func (m *Messenger) Deliver() {
+	printer.Print(m.message)
+}

--- a/test/com/facebook/buck/go/testdata/vendored_library/vendor/printer/BUCK
+++ b/test/com/facebook/buck/go/testdata/vendored_library/vendor/printer/BUCK
@@ -1,0 +1,7 @@
+go_library(
+  name = 'printer',
+  srcs = [
+    'printer.go',
+  ],
+  visibility = [ 'PUBLIC' ],
+)

--- a/test/com/facebook/buck/go/testdata/vendored_library/vendor/printer/printer.go
+++ b/test/com/facebook/buck/go/testdata/vendored_library/vendor/printer/printer.go
@@ -1,0 +1,7 @@
+package printer
+
+import "fmt"
+
+func Print(m string) {
+	fmt.Println(m)
+}


### PR DESCRIPTION
I think longer-term it might be nice to remove the use of Path for go package names. It's definitely convenient but they're not really real paths and it confuses the rule key builder pretty badly.