### PR TITLE
Replace usages of static final fields on Guava's CharMatcher.

### DIFF
--- a/src/com/facebook/buck/go/GoBuckConfig.java
+++ b/src/com/facebook/buck/go/GoBuckConfig.java
@@ -215,7 +215,7 @@ public class GoBuckConfig {
                     /* timeOutMs */ Optional.<Long>absent(),
                     /* timeoutHandler */ Optional.<Function<Process, Void>>absent());
       if (goToolResult.getExitCode() == 0) {
-        return CharMatcher.WHITESPACE.trimFrom(goToolResult.getStdout().get());
+        return CharMatcher.whitespace().trimFrom(goToolResult.getStdout().get());
       } else {
         throw new HumanReadableException(goToolResult.getStderr().get());
       }

--- a/src/com/facebook/buck/jvm/java/JavaFileParser.java
+++ b/src/com/facebook/buck/jvm/java/JavaFileParser.java
@@ -548,7 +548,7 @@ public class JavaFileParser {
 
           // If it does not start with an uppercase letter, it is probably because it is a property
           // lookup.
-          if (CharMatcher.JAVA_UPPER_CASE.matches(symbol.charAt(0))) {
+          if (CharMatcher.javaUpperCase().matches(symbol.charAt(0))) {
             addTypeFromDotDelimitedSequence(symbol);
           }
         }
@@ -742,7 +742,7 @@ public class JavaFileParser {
       String component = fullyQualifiedName.substring(startIndex, dotIndex);
       // In practice, if there is an uppercase character in the component, it should be the first
       // character, but we have found some exceptions, in practice.
-      if (CharMatcher.JAVA_UPPER_CASE.matchesAnyOf(component)) {
+      if (CharMatcher.javaUpperCase().matchesAnyOf(component)) {
         return component;
       } else {
         startIndex = dotIndex + 1;
@@ -763,7 +763,7 @@ public class JavaFileParser {
   }
 
   private static boolean startsWithUppercaseChar(String str) {
-    return CharMatcher.JAVA_UPPER_CASE.matches(str.charAt(0));
+    return CharMatcher.javaUpperCase().matches(str.charAt(0));
   }
 
   private static boolean looksLikeAType(String str) {
@@ -778,10 +778,10 @@ public class JavaFileParser {
           str);
 
       // Don't let it start with a digit?
-      if (!CharMatcher.JAVA_LETTER_OR_DIGIT.matchesAllOf(part)) {
+      if (!CharMatcher.javaLetterOrDigit().matchesAllOf(part)) {
         return false;
       } else if (!hasPartThatStartsWithUppercaseLetter) {
-        hasPartThatStartsWithUppercaseLetter = CharMatcher.JAVA_UPPER_CASE.matches(part.charAt(0));
+        hasPartThatStartsWithUppercaseLetter = CharMatcher.javaUpperCase().matches(part.charAt(0));
       }
     }
     return hasPartThatStartsWithUppercaseLetter;

--- a/src/com/facebook/buck/jvm/java/Javac.java
+++ b/src/com/facebook/buck/jvm/java/Javac.java
@@ -39,7 +39,7 @@ public interface Javac extends RuleKeyAppendable, Tool {
   Function<String, String> ARGFILES_ESCAPER =
       Escaper.escaper(
           Escaper.Quoter.DOUBLE,
-          CharMatcher.anyOf("#\"'").or(CharMatcher.WHITESPACE));
+          CharMatcher.anyOf("#\"'").or(CharMatcher.whitespace()));
   String SRC_ZIP = ".src.zip";
   String SRC_JAR = "-sources.jar";
 

--- a/src/com/facebook/buck/jvm/java/autodeps/JavaDepsFinder.java
+++ b/src/com/facebook/buck/jvm/java/autodeps/JavaDepsFinder.java
@@ -115,7 +115,7 @@ public class JavaDepsFinder {
               // findProviderForSymbolFromBuckConfig(). Note that this heuristic could be a bit
               // tighter.
               boolean appearsToBeJavaPackage = !originalKey.endsWith(".") &&
-                  CharMatcher.JAVA_UPPER_CASE.matchesNoneOf(originalKey);
+                  CharMatcher.javaUpperCase().matchesNoneOf(originalKey);
               String key = appearsToBeJavaPackage ? originalKey + "." : originalKey;
               BuildTarget buildTarget = BuildTargetParser.INSTANCE.parse(
                   entry.getValue().trim(),

--- a/src/com/facebook/buck/python/PythonBuckConfig.java
+++ b/src/com/facebook/buck/python/PythonBuckConfig.java
@@ -265,9 +265,9 @@ public class PythonBuckConfig {
       Path pythonPath,
       ProcessExecutor.Result versionResult) {
     if (versionResult.getExitCode() == 0) {
-      String versionString = CharMatcher.WHITESPACE.trimFrom(
-          CharMatcher.WHITESPACE.trimFrom(versionResult.getStderr().get()) +
-          CharMatcher.WHITESPACE.trimFrom(versionResult.getStdout().get())
+      String versionString = CharMatcher.whitespace().trimFrom(
+          CharMatcher.whitespace().trimFrom(versionResult.getStderr().get()) +
+          CharMatcher.whitespace().trimFrom(versionResult.getStdout().get())
               .replaceAll("\u001B\\[[;\\d]*m", ""));
       Matcher matcher = PYTHON_VERSION_REGEX.matcher(versionString.split("\\r?\\n")[0]);
       if (!matcher.matches()) {

--- a/src/com/facebook/buck/python/PythonRunTestsStep.java
+++ b/src/com/facebook/buck/python/PythonRunTestsStep.java
@@ -96,8 +96,8 @@ public class PythonRunTestsStep implements Step {
   private String getTestsToRunRegexFromListOutput(String listOutput) {
     ImmutableList.Builder<String> testsToRunPatternComponents = ImmutableList.builder();
 
-    for (String strTestCase : CharMatcher.WHITESPACE.trimFrom(listOutput).split("\n")) {
-      String[] testCase = CharMatcher.WHITESPACE.trimFrom(strTestCase).split("#", 2);
+    for (String strTestCase : CharMatcher.whitespace().trimFrom(listOutput).split("\n")) {
+      String[] testCase = CharMatcher.whitespace().trimFrom(strTestCase).split("#", 2);
       if (testCase.length != 2) {
         throw new RuntimeException(String.format(
             "Bad test case name from python runner: '%s'", strTestCase));

--- a/src/com/facebook/buck/util/Escaper.java
+++ b/src/com/facebook/buck/util/Escaper.java
@@ -104,7 +104,7 @@ public final class Escaper {
   private static final CharMatcher BASH_SPECIAL_CHARS =
       CharMatcher
           .anyOf("<>|!?*[]$\\(){}\"'`&;=")
-          .or(CharMatcher.WHITESPACE);
+          .or(CharMatcher.whitespace());
 
   /**
    * Bash quoting {@link com.google.common.base.Function Function} which can be passed to

--- a/test/com/facebook/buck/cli/TargetsCommandIntegrationTest.java
+++ b/test/com/facebook/buck/cli/TargetsCommandIntegrationTest.java
@@ -134,7 +134,7 @@ public class TargetsCommandIntegrationTest {
 
   private String parseAndVerifyTargetAndHash(String target, String outputLine) {
     List<String> targetAndHash = Splitter.on(' ').splitToList(
-        CharMatcher.WHITESPACE.trimFrom(outputLine));
+        CharMatcher.whitespace().trimFrom(outputLine));
     assertEquals(2, targetAndHash.size());
     assertEquals(target, targetAndHash.get(0));
     assertFalse(targetAndHash.get(1).isEmpty());


### PR DESCRIPTION
This change replaces usages of static final fields on CharMatcher, eg. ChraMatcher.WHITESPAcE, with the equivalent static factory methods, eg. CharMatcher.whitespace().

Static final fields must be eagerly initialized, potentially causing many unnecessary implementation classes to be loaded. Using methods allow implementation classes to be loaded when actually needed.

These methods became available in Guava 19.0. Guava will eventually deprecate the static final fields.

See: https://github.com/google/guava/commit/d810fc4b42d80b64fd118c2cf1483fb7682d34a9.