### PR TITLE
Fix defect where a class that is abstract but has @Test annotations w…

### DIFF
--- a/src/com/facebook/buck/testrunner/JUnitRunner.java
+++ b/src/com/facebook/buck/testrunner/JUnitRunner.java
@@ -37,6 +37,7 @@ import org.junit.runners.model.RunnerBuilder;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -115,10 +116,12 @@ public final class JUnitRunner extends BaseRunner {
       final Class<?> testClass = Class.forName(className);
       Ignore ignore = testClass.getAnnotation(Ignore.class);
       boolean isTestClassIgnored = (ignore != null || !isTestClass(testClass));
+      boolean isTestClassAbstract = Modifier.isAbstract(testClass.getModifiers());
 
       List<TestResult> results;
-      if (isTestClassIgnored) {
-        // Test case has @Ignore annotation, so do nothing.
+      if (isTestClassIgnored || isTestClassAbstract) {
+        // Test case has @Ignore annotation, or is abstract and cannot be instantiated,
+        // so do nothing.
         results = Collections.emptyList();
       } else {
         results = new ArrayList<>();

--- a/test/com/facebook/buck/testrunner/BuildThenTestIntegrationTest.java
+++ b/test/com/facebook/buck/testrunner/BuildThenTestIntegrationTest.java
@@ -77,4 +77,19 @@ public class BuildThenTestIntegrationTest {
     testResult.assertSuccess("Passing test should exit with 0.");
   }
 
+  /**
+   * Test should not be run because the base class is abstract. If the test attempts to run,
+   * it will throw a java.lang.InstantiationException.
+   */
+  @Test
+  public void testRunningTestInAbstractClass() throws IOException {
+    ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(
+        this, "build_then_test", temporaryFolder);
+    workspace.setUp();
+
+    ProcessResult testResult = workspace.runBuckCommand("test", "//:abstractclass");
+    testResult.assertSuccess("Abstract class with test methods should exit with 0.");
+  }
+
+
 }

--- a/test/com/facebook/buck/testrunner/testdata/build_then_test/AbstractClassWithTests.java
+++ b/test/com/facebook/buck/testrunner/testdata/build_then_test/AbstractClassWithTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.junit.testdata.build_then_test;
+
+import org.junit.Test;
+
+public abstract class AbstractClassWithTests {
+
+  /**
+   * This test method should not be run since the class is abstract and
+   * cannot be instantiated.
+   */
+  @Test
+  public void test() {
+    throw new IllegalStateException("Attempt to call test declared in abstract class.");
+  }
+
+}

--- a/test/com/facebook/buck/testrunner/testdata/build_then_test/BUCK.fixture
+++ b/test/com/facebook/buck/testrunner/testdata/build_then_test/BUCK.fixture
@@ -14,6 +14,14 @@ java_test(
   ],
 )
 
+java_test(
+  name = 'abstractclass',
+  srcs = glob(['AbstractClassWithTests.java']),
+  deps = [
+    ':junit',
+  ],
+)
+
 prebuilt_jar(
   name = 'junit',
   binary_jar = 'junit-4.11.jar',


### PR DESCRIPTION
…as attempted to be instantiated and threw java.lang.InstantiationException

If you have an abstract Java class that defines methods with @Test annotations, buck attempts to instantiate an object with the class type and fails with a java.lang.InstantiationException.

This patch skips abstract classes when selecting tests to run. We hit this error trying to port ONOS from maven to buck.
