### PR TITLE
Execute worker tools via `bash -e -c` - same way as genrules.

### DIFF
--- a/src/com/facebook/buck/shell/BUCK.autodeps
+++ b/src/com/facebook/buck/shell/BUCK.autodeps
@@ -1,4 +1,4 @@
-#@# GENERATED FILE: DO NOT MODIFY bdd33aef2262e335e601f478d2cb91b87e5d6387 #@#
+#@# GENERATED FILE: DO NOT MODIFY 2f7ab94a26eb282e2f14e1e9843443a5c96c2c6c #@#
 {
   "rules" : {
     "deps" : [
@@ -52,6 +52,7 @@
     "deps" : [
       "//src/com/facebook/buck/event:event",
       "//src/com/facebook/buck/shell:worker_process",
+      "//src/com/facebook/buck/util:escaper",
       "//src/com/facebook/buck/util:exceptions",
       "//src/com/facebook/buck/util:io",
       "//third-party/java/immutables:processor"

--- a/test/com/facebook/buck/shell/WorkerShellStepTest.java
+++ b/test/com/facebook/buck/shell/WorkerShellStepTest.java
@@ -159,18 +159,15 @@ public class WorkerShellStepTest {
             ImmutableList.of(
                 "/bin/bash",
                 "-e",
-                "command",
-                "--platform",
-                "unix-like")));
+                "-c",
+                "command --platform unix-like")));
     assertThat(
         step.getCommand(Platform.WINDOWS),
         Matchers.equalTo(
             ImmutableList.of(
                 "cmd.exe",
                 "/c",
-                "command",
-                "--platform",
-                "windows")));
+                "command --platform windows")));
   }
 
   @Test
@@ -201,7 +198,7 @@ public class WorkerShellStepTest {
     WorkerProcess workerProcess = new FakeWorkerProcess(ImmutableMap.of("myJobArgs", jobResult));
 
     ConcurrentHashMap<String, WorkerProcess> workerProcessMap = new ConcurrentHashMap<>();
-    workerProcessMap.put("/bin/bash -e startupCommand startupArgs", workerProcess);
+    workerProcessMap.put("/bin/bash -e -c startupCommand startupArgs", workerProcess);
 
     BuckEventBus eventBus = BuckEventBusFactory.newInstance();
     FakeBuckEventListener listener = new FakeBuckEventListener();


### PR DESCRIPTION
Otherwise tools with multiple arguments don't work correctly (e.g. `java_binary`)