### PR TITLE
Fix function docs always containing `visibility` and `licenses`

### DIFF
--- a/docs/__common.soy
+++ b/docs/__common.soy
@@ -487,7 +487,6 @@ src="https://www.facebook.com/tr?id=1637165926500152&ev=PageView&noscript=1"
 {/if}
 {/template}
 
-
 /**
  * Used to format an argument to a build rule.
  *
@@ -559,15 +558,40 @@ src="https://www.facebook.com/tr?id=1637165926500152&ev=PageView&noscript=1"
 
 /**
  * @param overview HTML description of the function.
+ * @param status one of FROZEN, UNFROZEN, or DEPRECATED to indicate the
+       current level of support for the rule.
  * @param args HTML documentation for each arg for the function.
  *     Should be created using multiple applications of the {buck.functionArg}
  *     template.
  * @param? examples HTML documentation that shows examples of the function
  *     in action.
+ * @param? furtherexp Further explanation; HTML shown after arguments and
+        examples.
  */
 {template .function}
-  // For now, functions and build rules should be documented the same way.
-  {call .rule data="all" /}
+{switch $status}
+  {case 'FROZEN'}
+    // Nothing to show here.
+  {case 'UNFROZEN'}
+    <p><small>This is liable to change in the future.</small></p>
+  {case 'DEPRECATED'}
+    <p><small>This will be removed in the future.</small></p>
+{/switch}
+{$overview|noAutoescape}
+
+<h2>Arguments</h2>
+<ul class="{css arglist}">
+  {$args|noAutoescape}
+</ul>
+
+{if $examples}
+  <h2>Examples</h2>
+  {$examples|noAutoescape}
+{/if}
+
+{if $furtherexp}
+  {$furtherexp|noAutoescape}
+{/if}
 {/template}
 
 

--- a/docs/function/flatten_dicts.soy
+++ b/docs/function/flatten_dicts.soy
@@ -10,7 +10,7 @@
     {/param}
     {param content}
 
-{call buck.rule}
+{call buck.function}
 {param status: 'FROZEN' /}
 {param overview}
 The <code>flatten_dicts()</code> function is used to merge a list of dicts together. It is
@@ -53,7 +53,7 @@ Values in dictionaries which appear later in the list have priority over values 
 earlier.
 {/param}
 
-{/call} // buck.rule
+{/call} // buck.function
     {/param} // content
   {/call}
 {/template}

--- a/docs/function/glob.soy
+++ b/docs/function/glob.soy
@@ -10,7 +10,7 @@
     {/param}
     {param content}
 
-{call buck.rule}
+{call buck.function}
 {param status: 'FROZEN' /}
 {param overview}
 The <code>glob()</code> function is used to specify a set of files
@@ -99,7 +99,7 @@ that end in <code>Test.java</code>:
 
 {/param}
 
-{/call} // buck.rule
+{/call} // buck.function
     {/param} // content
   {/call}
 {/template}

--- a/docs/function/include_defs.soy
+++ b/docs/function/include_defs.soy
@@ -11,7 +11,7 @@
     {/param}
     {param content}
 
-{call buck.rule}
+{call buck.function}
 {param status: 'FROZEN' /}
 {param overview}
 The <code>include_defs()</code> function is used to include
@@ -35,7 +35,7 @@ macros for creating more complex build rules.
 {call buck.functionArg}
   {param desc}
   The first and only argument is a path, of sorts, to a file containing
-  {sp}<a href="{ROOT}extending/macros.html"><code>macros</code></a> and 
+  {sp}<a href="{ROOT}extending/macros.html"><code>macros</code></a> and
   constants. It looks similar to a build target because it starts with
   {sp}<code>//</code> (indicating the root of the project), but is not a
   proper build target because it identifies a file relative to the root of
@@ -72,7 +72,7 @@ android_binary(
 
 {/param}
 
-{/call} // buck.rule
+{/call} // buck.function
     {/param} // content
   {/call}
 {/template}

--- a/docs/function/read_config.soy
+++ b/docs/function/read_config.soy
@@ -10,7 +10,7 @@
     {/param}
     {param content}
 
-{call buck.rule}
+{call buck.function}
 {param status: 'UNFROZEN' /}
 {param overview}
 The <code>read_config()</code> function is used to read <code>.buckconfig</code>
@@ -66,7 +66,7 @@ cxx_binary(
 
 {/param}
 
-{/call} // buck.rule
+{/call} // buck.function
     {/param} // content
   {/call}
 {/template}

--- a/docs/function/string_parameter_macros.soy
+++ b/docs/function/string_parameter_macros.soy
@@ -10,7 +10,7 @@
     {/param}
     {param content}
 
-{call buck.rule}
+{call buck.function}
 {param status: 'UNFROZEN' /}
 {param overview}
 Some rules allow the use of specialized macros embedded within the strings
@@ -60,7 +60,7 @@ genrule(
 
 {/param}
 
-{/call} // buck.rule
+{/call} // buck.function
     {/param} // content
   {/call}
 {/template}

--- a/docs/function/subdir_glob.soy
+++ b/docs/function/subdir_glob.soy
@@ -6,17 +6,17 @@
     {param title: 'subdir_glob()' /}
     {param prettify: true /}
     {param description}
-      The subdir_glob() function is useful for defining header maps for C/C++ libraries which 
+      The subdir_glob() function is useful for defining header maps for C/C++ libraries which
       should be relative the given sub-directory.
     {/param}
     {param content}
 
-{call buck.rule}
+{call buck.function}
 {param status: 'UNFROZEN' /}
 {param overview}
-	<p>The <code>subdir_glob()</code> function is useful for defining header maps for C/C++ libraries 
-	which should be relative the given sub-directory. Given a list of tuples, the form of 
-	(relative-sub-directory, glob-pattern), return a dict of sub-directory relative paths to full 
+	<p>The <code>subdir_glob()</code> function is useful for defining header maps for C/C++ libraries
+	which should be relative the given sub-directory. Given a list of tuples, the form of
+	(relative-sub-directory, glob-pattern), return a dict of sub-directory relative paths to full
 	paths.</p>
 	<p>Please refer to <code>{call buck.fn_glob /}</code> for explanations and examples of the pattern. </p>
 {/param}
@@ -57,10 +57,10 @@ Given this <code>exported_headers</code> description:
 exported_headers = subdir_glob([
     ("lib/source", "video/**/*.h"),
     ("lib/source", "audio/**/*.h"),
-  ], 
+  ],
   excludes = [
     "lib/source/video/codecs/*.h",
-  ], 
+  ],
   prefix = "MediaLib/")
 </pre>{/literal}
 
@@ -89,7 +89,7 @@ lib/
 
 {/param}
 
-{/call} // buck.rule
+{/call} // buck.function
     {/param} // content
   {/call}
 {/template}


### PR DESCRIPTION
Before:

<img width="800" alt="screen shot 2016-03-31 at 5 10 58 pm" src="https://cloud.githubusercontent.com/assets/368904/14194475/c7b8ddf0-f763-11e5-94b4-3cb20f8652eb.png">

After:

<img width="767" alt="screen shot 2016-03-31 at 5 11 07 pm" src="https://cloud.githubusercontent.com/assets/368904/14194477/d02f4c6c-f763-11e5-8314-dbd45796c553.png">

