### PR TITLE
Fix the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,15 @@ addons:
       # Travis is on 64bit and there will be a cryptic aapt error w/o these libs.
       # For native code tests, we need some additional libraries if we are in a 64-bit environment.
       - libgd2-xpm
-      - ia32-libs
-      - ia32-libs-multiarch
-      - gcc-multilib
+      - libc6:i386
+      - libstdc++6:i386
+      - zlib1g:i386
       - groovy
 
 before_install:
+  # Limit Ant's and Buck's memory usage to avoid the OOM killer.
+  - export ANT_OPTS='-Xmx500m'
+  - export BUCK_EXTRA_JAVA_ARGS='-Xmx500m'
   # Set up the Android environment.
   - export NDK_HOME=${HOME}/android-ndk-linux
   - ./scripts/travisci_install_android_ndk.sh


### PR DESCRIPTION
Summary:
`ia32-libs` cannot be installed on Travis machines because of a
broken dependency. Instead explicitly use the libraries we need.
Also limit Ant's and Buck's memory usage to avoid the OOM killer.

Test Plan:
Send a pull request, check the Travis build.