### PR TITLE
Correct example to match the docs

### DIFF
--- a/docs/rule/project_config.soy
+++ b/docs/rule/project_config.soy
@@ -104,7 +104,7 @@ project_config(
   src_target = ':lib-base',
   src_roots = [ 'src' ],
   test_target = ':tests',
-  test_root = 'tests',
+  test_roots = ['tests'],
 )
 </pre>{/literal}
 {/param}


### PR DESCRIPTION
Happened to notice the example was slightly off from the docs and wouldn't work. 