### PR TITLE
Adding base_module_strip to Python targets

### DIFF
--- a/docs/__python_common.soy
+++ b/docs/__python_common.soy
@@ -65,6 +65,21 @@
 {/template}
 
 /***/
+{template .base_module_strip_arg}
+{call buck.arg}
+  {param name: 'base_module_strip' /}
+  {param default : 'None' /}
+  {param desc}
+  An integer consisting of the number of path elements to strip from the beginning of the
+  `base_module`.  Often times you want to store your source under a directory named `src` or
+  something similar, but you want the Python namespace to be `import my.module` and not `import
+  src.my.module`.  Setting this to `1` would achieve this.  You can also set this globally in a
+  `python` section of `.buckconfig`.
+  {/param}
+{/call}
+{/template}
+
+/***/
 {template .platform_arg}
 {call buck.arg}
   {param name : 'platform' /}

--- a/docs/concept/buckconfig.soy
+++ b/docs/concept/buckconfig.soy
@@ -2044,6 +2044,15 @@ your <code>.buckjavaargs</code> file</a>:
   {/param}
 {/call}
 
+{call buckconfig.entry}
+  {param section: 'python' /}
+  {param name: 'base_module_strip' /}
+  {param example_value: '1' /}
+  {param description}
+    If specified this value will be applied to the `base_module_strip` for all Python targets.
+  {/param}
+{/call}
+
 {call buckconfig.section}
   {param name: 'rust' /}
   {param description}

--- a/src/com/facebook/buck/python/CxxPythonExtensionDescription.java
+++ b/src/com/facebook/buck/python/CxxPythonExtensionDescription.java
@@ -87,14 +87,17 @@ public class CxxPythonExtensionDescription implements
   public static final BuildRuleType TYPE = BuildRuleType.of("cxx_python_extension");
 
   private final FlavorDomain<PythonPlatform> pythonPlatforms;
+  private final PythonBuckConfig pythonBuckConfig;
   private final CxxBuckConfig cxxBuckConfig;
   private final FlavorDomain<CxxPlatform> cxxPlatforms;
 
   public CxxPythonExtensionDescription(
       FlavorDomain<PythonPlatform> pythonPlatforms,
+      PythonBuckConfig pythonBuckConfig,
       CxxBuckConfig cxxBuckConfig,
       FlavorDomain<CxxPlatform> cxxPlatforms) {
     this.pythonPlatforms = pythonPlatforms;
+    this.pythonBuckConfig = pythonBuckConfig;
     this.cxxBuckConfig = cxxBuckConfig;
     this.cxxPlatforms = cxxPlatforms;
   }
@@ -319,7 +322,12 @@ public class CxxPythonExtensionDescription implements
     // Otherwise, we return the generic placeholder of this library, that dependents can use
     // get the real build rules via querying the action graph.
     final SourcePathResolver pathResolver = new SourcePathResolver(ruleResolver);
-    Path baseModule = PythonUtil.getBasePath(params.getBuildTarget(), args.baseModule);
+    Path baseModule = PythonUtil.getBasePath(
+        params.getBuildTarget(),
+        args.baseModule,
+        args.baseModuleStrip.isPresent()
+            ? args.baseModuleStrip
+            : pythonBuckConfig.getBaseModuleStrip());
     final Path module = baseModule.resolve(getExtensionName(params.getBuildTarget()));
     return new CxxPythonExtension(params, pathResolver) {
 
@@ -435,6 +443,7 @@ public class CxxPythonExtensionDescription implements
   public static class Arg extends CxxConstructorArg {
     public Optional<PatternMatchedCollection<ImmutableSortedSet<BuildTarget>>> platformDeps;
     public Optional<String> baseModule;
+    public Optional<Integer> baseModuleStrip;
   }
 
 }

--- a/src/com/facebook/buck/python/PythonBinaryDescription.java
+++ b/src/com/facebook/buck/python/PythonBinaryDescription.java
@@ -264,7 +264,12 @@ public class PythonBinaryDescription implements
           "%s: must set exactly one of `main_module` and `main`",
           params.getBuildTarget());
     }
-    Path baseModule = PythonUtil.getBasePath(params.getBuildTarget(), args.baseModule);
+    Path baseModule = PythonUtil.getBasePath(
+        params.getBuildTarget(),
+        args.baseModule,
+        args.baseModuleStrip.isPresent()
+            ? args.baseModuleStrip
+            : pythonBuckConfig.getBaseModuleStrip());
 
     String mainModule;
     ImmutableMap.Builder<Path, SourcePath> modules = ImmutableMap.builder();
@@ -359,6 +364,7 @@ public class PythonBinaryDescription implements
     public Optional<String> mainModule;
     public Optional<ImmutableSortedSet<BuildTarget>> deps;
     public Optional<String> baseModule;
+    public Optional<Integer> baseModuleStrip;
     public Optional<Boolean> zipSafe;
     public Optional<ImmutableList<String>> buildArgs;
     public Optional<String> platform;

--- a/src/com/facebook/buck/python/PythonBuckConfig.java
+++ b/src/com/facebook/buck/python/PythonBuckConfig.java
@@ -241,6 +241,10 @@ public class PythonBuckConfig {
     return delegate.getValue(SECTION, "pex_extension").or(".pex");
   }
 
+  public Optional<Integer> getBaseModuleStrip() {
+      return delegate.getInteger(SECTION, "base_module_strip");
+  }
+
   private static PythonVersion getPythonVersion(ProcessExecutor processExecutor, Path pythonPath)
       throws InterruptedException {
     try {

--- a/src/com/facebook/buck/python/PythonLibraryDescription.java
+++ b/src/com/facebook/buck/python/PythonLibraryDescription.java
@@ -40,6 +40,12 @@ public class PythonLibraryDescription implements Description<Arg> {
 
   public static final BuildRuleType TYPE = BuildRuleType.of("python_library");
 
+  private final PythonBuckConfig pythonBuckConfig;
+
+  public PythonLibraryDescription(PythonBuckConfig pythonBuckConfig) {
+      this.pythonBuckConfig = pythonBuckConfig;
+  }
+
   @SuppressFieldNotInitialized
   public static class Arg extends AbstractDescriptionArg {
     public Optional<SourceList> srcs;
@@ -48,6 +54,7 @@ public class PythonLibraryDescription implements Description<Arg> {
     public Optional<PatternMatchedCollection<SourceList>> platformResources;
     public Optional<ImmutableSortedSet<BuildTarget>> deps;
     public Optional<String> baseModule;
+    public Optional<Integer> baseModuleStrip;
     public Optional<Boolean> zipSafe;
   }
 
@@ -68,7 +75,12 @@ public class PythonLibraryDescription implements Description<Arg> {
       BuildRuleResolver resolver,
       final A args) {
     final SourcePathResolver pathResolver = new SourcePathResolver(resolver);
-    final Path baseModule = PythonUtil.getBasePath(params.getBuildTarget(), args.baseModule);
+    final Path baseModule = PythonUtil.getBasePath(
+        params.getBuildTarget(),
+        args.baseModule,
+        args.baseModuleStrip.isPresent()
+            ? args.baseModuleStrip
+            : pythonBuckConfig.getBaseModuleStrip());
     return new PythonLibrary(
         params,
         pathResolver,

--- a/src/com/facebook/buck/python/PythonTestDescription.java
+++ b/src/com/facebook/buck/python/PythonTestDescription.java
@@ -186,7 +186,12 @@ public class PythonTestDescription implements
                 .or(pythonPlatforms.getFlavors().iterator().next())));
     CxxPlatform cxxPlatform = cxxPlatforms.getValue(params.getBuildTarget()).or(defaultCxxPlatform);
     SourcePathResolver pathResolver = new SourcePathResolver(resolver);
-    Path baseModule = PythonUtil.getBasePath(params.getBuildTarget(), args.baseModule);
+    Path baseModule = PythonUtil.getBasePath(
+        params.getBuildTarget(),
+        args.baseModule,
+        args.baseModuleStrip.isPresent()
+            ? args.baseModuleStrip
+            : pythonBuckConfig.getBaseModuleStrip());
 
     ImmutableMap<Path, SourcePath> srcs =
         ImmutableMap.<Path, SourcePath>builder()

--- a/src/com/facebook/buck/python/PythonUtil.java
+++ b/src/com/facebook/buck/python/PythonUtil.java
@@ -291,10 +291,22 @@ public class PythonUtil {
     return allComponents.build();
   }
 
-  public static Path getBasePath(BuildTarget target, Optional<String> override) {
-    return override.isPresent()
+  public static Path getBasePath(
+      BuildTarget target,
+      Optional<String> override,
+      Optional<Integer> strip) {
+
+    Path basePath = override.isPresent()
         ? Paths.get(override.get().replace('.', '/'))
         : target.getBasePath();
+
+    if (strip.isPresent()) {
+        if (strip.get() == basePath.getNameCount()) {
+            return Paths.get("");
+        }
+        return basePath.subpath(strip.get(), basePath.getNameCount());
+    }
+    return basePath;
   }
 
   public static ImmutableSet<String> getPreloadNames(

--- a/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
+++ b/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
@@ -588,7 +588,7 @@ public class KnownBuildRuleTypes {
     builder.register(cxxLibraryDescription);
     builder.register(new CxxLuaExtensionDescription(luaConfig, cxxBuckConfig, cxxPlatforms));
     builder.register(
-        new CxxPythonExtensionDescription(pythonPlatforms, cxxBuckConfig, cxxPlatforms));
+        new CxxPythonExtensionDescription(pythonPlatforms, pyConfig, cxxBuckConfig, cxxPlatforms));
     builder.register(
         new CxxTestDescription(
             cxxBuckConfig,
@@ -662,7 +662,7 @@ public class KnownBuildRuleTypes {
     builder.register(new PrebuiltPythonLibraryDescription());
     builder.register(new ProjectConfigDescription());
     builder.register(pythonBinaryDescription);
-    builder.register(new PythonLibraryDescription());
+    builder.register(new PythonLibraryDescription(pyConfig));
     builder.register(
         new PythonTestDescription(
             pythonBinaryDescription,
@@ -704,9 +704,18 @@ public class KnownBuildRuleTypes {
                     thriftBuckConfig,
                     cxxLibraryDescription,
                     /* cpp2 */ true),
-                new ThriftPythonEnhancer(thriftBuckConfig, ThriftPythonEnhancer.Type.NORMAL),
-                new ThriftPythonEnhancer(thriftBuckConfig, ThriftPythonEnhancer.Type.TWISTED),
-                new ThriftPythonEnhancer(thriftBuckConfig, ThriftPythonEnhancer.Type.ASYNCIO))));
+                new ThriftPythonEnhancer(
+                    thriftBuckConfig,
+                    pyConfig,
+                    ThriftPythonEnhancer.Type.NORMAL),
+                new ThriftPythonEnhancer(
+                    thriftBuckConfig,
+                    pyConfig,
+                    ThriftPythonEnhancer.Type.TWISTED),
+                new ThriftPythonEnhancer(
+                    thriftBuckConfig,
+                    pyConfig,
+                    ThriftPythonEnhancer.Type.ASYNCIO))));
     builder.register(new WorkerToolDescription());
     builder.register(new XcodePostbuildScriptDescription());
     builder.register(new XcodePrebuildScriptDescription());

--- a/src/com/facebook/buck/thrift/ThriftPythonEnhancer.java
+++ b/src/com/facebook/buck/thrift/ThriftPythonEnhancer.java
@@ -19,6 +19,7 @@ package com.facebook.buck.thrift;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.Flavor;
 import com.facebook.buck.model.ImmutableFlavor;
+import com.facebook.buck.python.PythonBuckConfig;
 import com.facebook.buck.python.PythonLibrary;
 import com.facebook.buck.python.PythonPlatform;
 import com.facebook.buck.python.PythonUtil;
@@ -56,10 +57,15 @@ public class ThriftPythonEnhancer implements ThriftLanguageSpecificEnhancer {
   }
 
   private final ThriftBuckConfig thriftBuckConfig;
+  private final PythonBuckConfig pythonBuckConfig;
   private final Type type;
 
-  public ThriftPythonEnhancer(ThriftBuckConfig thriftBuckConfig, Type type) {
+  public ThriftPythonEnhancer(
+      ThriftBuckConfig thriftBuckConfig,
+      PythonBuckConfig pythonBuckConfig,
+      Type type) {
     this.thriftBuckConfig = thriftBuckConfig;
+    this.pythonBuckConfig = pythonBuckConfig;
     this.type = type;
   }
 
@@ -89,7 +95,7 @@ public class ThriftPythonEnhancer implements ThriftLanguageSpecificEnhancer {
       ImmutableList<String> services) {
 
     Path prefix =
-        PythonUtil.getBasePath(target, getBaseModule(args))
+        PythonUtil.getBasePath(target, getBaseModule(args), pythonBuckConfig.getBaseModuleStrip())
             .resolve(Files.getNameWithoutExtension(thriftName));
 
     ImmutableSortedSet.Builder<String> sources = ImmutableSortedSet.naturalOrder();

--- a/test/com/facebook/buck/jvm/java/MavenUberJarTest.java
+++ b/test/com/facebook/buck/jvm/java/MavenUberJarTest.java
@@ -18,15 +18,18 @@ package com.facebook.buck.jvm.java;
 
 import static org.junit.Assert.assertThat;
 
-import com.facebook.buck.rules.DefaultTargetNodeToBuildRuleTransformer;
+import com.facebook.buck.cli.FakeBuckConfig;
 import com.facebook.buck.io.ProjectFilesystem;
+import com.facebook.buck.io.ExecutableFinder;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.parser.NoSuchBuildTargetException;
 import com.facebook.buck.python.PythonLibraryBuilder;
+import com.facebook.buck.python.PythonBuckConfig;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildTargetSourcePath;
+import com.facebook.buck.rules.DefaultTargetNodeToBuildRuleTransformer;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.TargetGraph;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
@@ -57,7 +60,9 @@ public class MavenUberJarTest {
     BuildTarget javaTarget = BuildTargetFactory.newInstance("//:java");
 
     BuildRule pythonLibrary = PythonLibraryBuilder
-        .createBuilder(pythonTarget)
+        .createBuilder(
+                pythonTarget,
+                new PythonBuckConfig(FakeBuckConfig.builder().build(), new ExecutableFinder()))
         .build(ruleResolver);
 
     JavaLibraryBuilder javaLibraryBuilder = JavaLibraryBuilder

--- a/test/com/facebook/buck/python/CxxPythonExtensionBuilder.java
+++ b/test/com/facebook/buck/python/CxxPythonExtensionBuilder.java
@@ -21,6 +21,7 @@ import com.facebook.buck.cxx.CxxBuckConfig;
 import com.facebook.buck.cxx.CxxPlatform;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.FlavorDomain;
+import com.facebook.buck.python.PythonBuckConfig;
 import com.facebook.buck.rules.coercer.PatternMatchedCollection;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSortedSet;
@@ -31,9 +32,10 @@ public class CxxPythonExtensionBuilder extends
   public CxxPythonExtensionBuilder(
       BuildTarget target,
       FlavorDomain<PythonPlatform> pythonPlatforms,
+      PythonBuckConfig pythonBuckConfig,
       CxxBuckConfig cxxBuckConfig,
       FlavorDomain<CxxPlatform> cxxPlatforms) {
-    super(new CxxPythonExtensionDescription(pythonPlatforms, cxxBuckConfig, cxxPlatforms), target);
+    super(new CxxPythonExtensionDescription(pythonPlatforms, pythonBuckConfig, cxxBuckConfig, cxxPlatforms), target);
   }
 
   public CxxPythonExtensionBuilder setBaseModule(String baseModule) {

--- a/test/com/facebook/buck/python/CxxPythonExtensionDescriptionTest.java
+++ b/test/com/facebook/buck/python/CxxPythonExtensionDescriptionTest.java
@@ -100,6 +100,7 @@ public class CxxPythonExtensionDescriptionTest {
     CxxPythonExtensionBuilder builder = new CxxPythonExtensionBuilder(
         target,
         FlavorDomain.of("Python Platform", PY2, PY3),
+        new PythonBuckConfig(FakeBuckConfig.builder().build(), new ExecutableFinder()),
         new CxxBuckConfig(FakeBuckConfig.builder().build()),
         CxxTestBuilder.createDefaultPlatforms());
 
@@ -133,6 +134,7 @@ public class CxxPythonExtensionDescriptionTest {
     CxxPythonExtensionBuilder baseModuleBuilder = new CxxPythonExtensionBuilder(
         target2,
         FlavorDomain.of("Python Platform", PY2, PY3),
+        new PythonBuckConfig(FakeBuckConfig.builder().build(), new ExecutableFinder()),
         new CxxBuckConfig(FakeBuckConfig.builder().build()),
         CxxTestBuilder.createDefaultPlatforms())
         .setBaseModule(name);
@@ -181,6 +183,7 @@ public class CxxPythonExtensionDescriptionTest {
     CxxPythonExtensionBuilder builder = new CxxPythonExtensionBuilder(
         target,
         FlavorDomain.of("Python Platform", PY2, PY3),
+        new PythonBuckConfig(FakeBuckConfig.builder().build(), new ExecutableFinder()),
         new CxxBuckConfig(FakeBuckConfig.builder().build()),
         CxxTestBuilder.createDefaultPlatforms())
         .setDeps(ImmutableSortedSet.of(cxxLibraryTarget));
@@ -239,6 +242,7 @@ public class CxxPythonExtensionDescriptionTest {
     CxxPythonExtensionBuilder builder = new CxxPythonExtensionBuilder(
         target,
         FlavorDomain.of("Python Platform", PY2, PY3),
+        new PythonBuckConfig(FakeBuckConfig.builder().build(), new ExecutableFinder()),
         new CxxBuckConfig(FakeBuckConfig.builder().build()),
         CxxTestBuilder.createDefaultPlatforms());
 
@@ -298,6 +302,7 @@ public class CxxPythonExtensionDescriptionTest {
         (CxxPythonExtensionDescription) new CxxPythonExtensionBuilder(
             target,
             FlavorDomain.of("Python Platform", PY2, PY3),
+            new PythonBuckConfig(FakeBuckConfig.builder().build(), new ExecutableFinder()),
             new CxxBuckConfig(FakeBuckConfig.builder().build()),
             CxxTestBuilder.createDefaultPlatforms())
             .build()
@@ -326,6 +331,7 @@ public class CxxPythonExtensionDescriptionTest {
     CxxPythonExtensionBuilder builder = new CxxPythonExtensionBuilder(
         target,
         FlavorDomain.of("Python Platform", PY2, PY3),
+        new PythonBuckConfig(FakeBuckConfig.builder().build(), new ExecutableFinder()),
         new CxxBuckConfig(FakeBuckConfig.builder().build()),
         CxxTestBuilder.createDefaultPlatforms());
 
@@ -373,6 +379,7 @@ public class CxxPythonExtensionDescriptionTest {
         new CxxPythonExtensionBuilder(
             BuildTargetFactory.newInstance("//:rule"),
             FlavorDomain.of("Python Platform", PY2, PY3),
+            new PythonBuckConfig(FakeBuckConfig.builder().build(), new ExecutableFinder()),
             new CxxBuckConfig(FakeBuckConfig.builder().build()),
             CxxTestBuilder.createDefaultPlatforms());
     CxxPythonExtension rule =
@@ -397,6 +404,7 @@ public class CxxPythonExtensionDescriptionTest {
         new CxxPythonExtensionBuilder(
             BuildTargetFactory.newInstance("//:rule"),
             FlavorDomain.of("Python Platform", PY2, PY3),
+            new PythonBuckConfig(FakeBuckConfig.builder().build(), new ExecutableFinder()),
             new CxxBuckConfig(FakeBuckConfig.builder().build()),
             CxxTestBuilder.createDefaultPlatforms());
     CxxPythonExtension rule =
@@ -424,6 +432,7 @@ public class CxxPythonExtensionDescriptionTest {
         new CxxPythonExtensionBuilder(
             BuildTargetFactory.newInstance("//:rule"),
             FlavorDomain.of("Python Platform", PY2, PY3),
+            new PythonBuckConfig(FakeBuckConfig.builder().build(), new ExecutableFinder()),
             new CxxBuckConfig(FakeBuckConfig.builder().build()),
             CxxTestBuilder.createDefaultPlatforms());
     builder.setLinkerFlags(ImmutableList.of("--flag"));
@@ -458,6 +467,7 @@ public class CxxPythonExtensionDescriptionTest {
         new CxxPythonExtensionBuilder(
             BuildTargetFactory.newInstance("//:rule"),
             FlavorDomain.of("Python Platform", PY2, PY3),
+            new PythonBuckConfig(FakeBuckConfig.builder().build(), new ExecutableFinder()),
             new CxxBuckConfig(FakeBuckConfig.builder().build()),
             CxxTestBuilder.createDefaultPlatforms());
     CxxPythonExtension rule =
@@ -499,6 +509,7 @@ public class CxxPythonExtensionDescriptionTest {
         new CxxPythonExtensionBuilder(
             BuildTargetFactory.newInstance("//:rule"),
             pythonPlatforms,
+            new PythonBuckConfig(FakeBuckConfig.builder().build(), new ExecutableFinder()),
             new CxxBuckConfig(FakeBuckConfig.builder().build()),
             CxxTestBuilder.createDefaultPlatforms())
         .setPlatformDeps(
@@ -565,6 +576,7 @@ public class CxxPythonExtensionDescriptionTest {
         (CxxPythonExtension) new CxxPythonExtensionBuilder(
             BuildTargetFactory.newInstance("//:ext"),
             FlavorDomain.of("Python Platform", PY2, PY3),
+            new PythonBuckConfig(FakeBuckConfig.builder().build(), new ExecutableFinder()),
             new CxxBuckConfig(FakeBuckConfig.builder().build()),
             CxxTestBuilder.createDefaultPlatforms())
             .setDeps(ImmutableSortedSet.of(cxxBinary.getBuildTarget()))

--- a/test/com/facebook/buck/python/PythonBinaryDescriptionTest.java
+++ b/test/com/facebook/buck/python/PythonBinaryDescriptionTest.java
@@ -27,6 +27,7 @@ import com.facebook.buck.cxx.CxxLink;
 import com.facebook.buck.cxx.CxxPlatformUtils;
 import com.facebook.buck.cxx.PrebuiltCxxLibraryBuilder;
 import com.facebook.buck.io.AlwaysFoundExecutableFinder;
+import com.facebook.buck.io.ExecutableFinder;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.model.FlavorDomain;
@@ -88,7 +89,9 @@ public class PythonBinaryDescriptionTest {
             .setOut("blah.py")
             .build(resolver);
     PythonLibrary lib =
-        (PythonLibrary) new PythonLibraryBuilder(BuildTargetFactory.newInstance("//:lib"))
+        (PythonLibrary) new PythonLibraryBuilder(
+                BuildTargetFactory.newInstance("//:lib"),
+                new PythonBuckConfig(FakeBuckConfig.builder().build(), new ExecutableFinder()))
             .setSrcs(
                 SourceList.ofUnnamedSources(
                     ImmutableSortedSet.<SourcePath>of(
@@ -256,7 +259,9 @@ public class PythonBinaryDescriptionTest {
         new CxxBinaryBuilder(BuildTargetFactory.newInstance("//:dep"))
             .build(resolver);
     BuildRule pythonLibrary =
-        new PythonLibraryBuilder(BuildTargetFactory.newInstance("//:lib"))
+        new PythonLibraryBuilder(
+              BuildTargetFactory.newInstance("//:lib"),
+              new PythonBuckConfig(FakeBuckConfig.builder().build(), new ExecutableFinder()))
             .setDeps(ImmutableSortedSet.of(cxxBinary.getBuildTarget()))
             .build(resolver);
     PythonBinary pythonBinary =
@@ -474,6 +479,7 @@ public class PythonBinaryDescriptionTest {
         new CxxPythonExtensionBuilder(
             BuildTargetFactory.newInstance("//:extension"),
             pythonPlatforms,
+            new PythonBuckConfig(FakeBuckConfig.builder().build(), new ExecutableFinder()),
             new CxxBuckConfig(FakeBuckConfig.builder().build()),
             CxxPlatformUtils.DEFAULT_PLATFORMS);
     extensionBuilder.setBaseModule("hello");
@@ -527,7 +533,9 @@ public class PythonBinaryDescriptionTest {
             .setSrcs(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("cxx.c"))))
             .setDeps(ImmutableSortedSet.of(transitiveCxxLibraryBuilder.getTarget()));
     PythonLibraryBuilder pythonLibraryBuilder =
-        new PythonLibraryBuilder(BuildTargetFactory.newInstance("//:lib"))
+        new PythonLibraryBuilder(
+                BuildTargetFactory.newInstance("//:lib"),
+                new PythonBuckConfig(FakeBuckConfig.builder().build(), new ExecutableFinder()))
             .setSrcs(
                 SourceList.ofUnnamedSources(
                     ImmutableSortedSet.<SourcePath>of(new FakeSourcePath("prebuilt.so"))))

--- a/test/com/facebook/buck/python/PythonLibraryBuilder.java
+++ b/test/com/facebook/buck/python/PythonLibraryBuilder.java
@@ -25,12 +25,14 @@ import com.google.common.collect.ImmutableSortedSet;
 
 public class PythonLibraryBuilder extends AbstractNodeBuilder<PythonLibraryDescription.Arg> {
 
-  public PythonLibraryBuilder(BuildTarget target) {
-    super(new PythonLibraryDescription(), target);
+  public PythonLibraryBuilder(BuildTarget target, PythonBuckConfig pythonBuckConfig) {
+    super(new PythonLibraryDescription(pythonBuckConfig), target);
   }
 
-  public static PythonLibraryBuilder createBuilder(BuildTarget target) {
-    return new PythonLibraryBuilder(target);
+  public static PythonLibraryBuilder createBuilder(
+      BuildTarget target,
+      PythonBuckConfig pythonBuckConfig) {
+    return new PythonLibraryBuilder(target, pythonBuckConfig);
   }
 
   public PythonLibraryBuilder setSrcs(SourceList srcs) {
@@ -56,6 +58,11 @@ public class PythonLibraryBuilder extends AbstractNodeBuilder<PythonLibraryDescr
 
   public PythonLibraryBuilder setBaseModule(String baseModule) {
     arg.baseModule = Optional.of(baseModule);
+    return this;
+  }
+
+  public PythonLibraryBuilder setBaseModuleStrip(Integer baseModuleStrip) {
+    arg.baseModuleStrip = Optional.of(baseModuleStrip);
     return this;
   }
 

--- a/test/com/facebook/buck/python/PythonTestDescriptionTest.java
+++ b/test/com/facebook/buck/python/PythonTestDescriptionTest.java
@@ -23,6 +23,7 @@ import com.facebook.buck.cli.FakeBuckConfig;
 import com.facebook.buck.cxx.CxxBinaryBuilder;
 import com.facebook.buck.cxx.CxxPlatformUtils;
 import com.facebook.buck.io.AlwaysFoundExecutableFinder;
+import com.facebook.buck.io.ExecutableFinder;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.model.FlavorDomain;
@@ -232,7 +233,9 @@ public class PythonTestDescriptionTest {
         new CxxBinaryBuilder(BuildTargetFactory.newInstance("//:dep"))
             .build(resolver);
     BuildRule pythonLibrary =
-        new PythonLibraryBuilder(BuildTargetFactory.newInstance("//:lib"))
+        new PythonLibraryBuilder(
+                BuildTargetFactory.newInstance("//:lib"),
+                new PythonBuckConfig(FakeBuckConfig.builder().build(), new ExecutableFinder()))
             .setDeps(ImmutableSortedSet.of(cxxBinary.getBuildTarget()))
             .build(resolver);
     PythonTest pythonTest =

--- a/test/com/facebook/buck/thrift/ThriftPythonEnhancerTest.java
+++ b/test/com/facebook/buck/thrift/ThriftPythonEnhancerTest.java
@@ -20,17 +20,19 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.facebook.buck.cli.BuckConfig;
-import com.facebook.buck.rules.DefaultTargetNodeToBuildRuleTransformer;
 import com.facebook.buck.cli.FakeBuckConfig;
+import com.facebook.buck.io.ExecutableFinder;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.model.ImmutableFlavor;
+import com.facebook.buck.python.PythonBuckConfig;
 import com.facebook.buck.python.PythonLibrary;
 import com.facebook.buck.python.PythonTestUtils;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.CommandTool;
+import com.facebook.buck.rules.DefaultTargetNodeToBuildRuleTransformer;
 import com.facebook.buck.rules.FakeBuildRule;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
 import com.facebook.buck.rules.FakeSourcePath;
@@ -54,17 +56,23 @@ public class ThriftPythonEnhancerTest {
   private static final BuildTarget TARGET = BuildTargetFactory.newInstance("//:test#python");
   private static final BuckConfig BUCK_CONFIG = FakeBuckConfig.builder().build();
   private static final ThriftBuckConfig THRIFT_BUCK_CONFIG = new ThriftBuckConfig(BUCK_CONFIG);
+  private static final PythonBuckConfig PYTHON_BUCK_CONFIG = new PythonBuckConfig(
+          BUCK_CONFIG,
+          new ExecutableFinder());
   private static final ThriftPythonEnhancer ENHANCER =
       new ThriftPythonEnhancer(
           THRIFT_BUCK_CONFIG,
+          PYTHON_BUCK_CONFIG,
           ThriftPythonEnhancer.Type.NORMAL);
   private static final ThriftPythonEnhancer TWISTED_ENHANCER =
       new ThriftPythonEnhancer(
           THRIFT_BUCK_CONFIG,
+          PYTHON_BUCK_CONFIG,
           ThriftPythonEnhancer.Type.TWISTED);
   private static final ThriftPythonEnhancer ASYNCIO_ENHANCER =
       new ThriftPythonEnhancer(
           THRIFT_BUCK_CONFIG,
+          PYTHON_BUCK_CONFIG,
           ThriftPythonEnhancer.Type.ASYNCIO);
 
   private static FakeBuildRule createFakeBuildRule(
@@ -194,17 +202,21 @@ public class ThriftPythonEnhancerTest {
     BuckConfig buckConfig = FakeBuckConfig.builder().setSections(
         ImmutableMap.of("thrift", strConfig.build())).build();
     ThriftBuckConfig thriftBuckConfig = new ThriftBuckConfig(buckConfig);
+    PythonBuckConfig pythonBuckConfig = new PythonBuckConfig(buckConfig, new ExecutableFinder());
     ThriftPythonEnhancer enhancer =
         new ThriftPythonEnhancer(
             thriftBuckConfig,
+            pythonBuckConfig,
             ThriftPythonEnhancer.Type.NORMAL);
     ThriftPythonEnhancer twistedEnhancer =
         new ThriftPythonEnhancer(
             thriftBuckConfig,
+            pythonBuckConfig,
             ThriftPythonEnhancer.Type.TWISTED);
     ThriftPythonEnhancer asyncioEnhancer =
         new ThriftPythonEnhancer(
             thriftBuckConfig,
+            pythonBuckConfig,
             ThriftPythonEnhancer.Type.ASYNCIO);
 
     // With no options we just need to find the python thrift library.


### PR DESCRIPTION
Often times I want to organize my source tree so that my Python sources
start one or two directories down from the project root.  With a
.buckconfig at the top level these two directories must exist in the
module namespace unless you go and manually specify base_module for each
of the targets.  When moving sources into Buck this meant I would need
to refactor a large number of files just for imports.

This adds a new base_module_strip argument to Python targets, which if
specified strips that many elements when PythonUtil.getBasePath is
called using the subpath method on the path.  You can also specify the
value as a config value and have it apply to all targets.