### PR TITLE
add `rt.jar` into javac classpath

### DIFF
--- a/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
+++ b/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
@@ -430,6 +430,7 @@ public class DefaultJavaLibrary extends AbstractBuildRule
         ImmutableSetMultimap.<JavaLibrary, Path>builder()
             .putAll(getDeclaredClasspathEntries())
             .putAll(this, additionalClasspathEntries)
+            .put(this, Paths.get(System.getProperty("java.home")).resolve("lib").resolve("rt.jar"))
             .build();
 
 


### PR DESCRIPTION
Summary:
To let BUCK build java 8 sources correctly, we need add `rt.jar` into javac classpath, otherwise, `android_library` rule will fail to compile (but `java_library` compiles successfully).

Test Plan:
Build updated code, and tested in demo this repo: https://github.com/Piasy/BuckJava8RetroLambdaDemo, unit test code need to be updated.