### PR TITLE
Fixing FileClassPathRunner to handle directories that contain "@"

### DIFF
--- a/test/com/facebook/buck/jvm/java/runner/FileClassPathRunnerTest.java
+++ b/test/com/facebook/buck/jvm/java/runner/FileClassPathRunnerTest.java
@@ -78,6 +78,25 @@ public class FileClassPathRunnerTest {
   }
 
   @Test
+  public void shouldHandleDirectoriesThatContainAtSign() throws IOException {
+    Path subdir = tmp.newFolder("carrots@3").toPath();
+    Path classfile = subdir.resolve("classfile");
+    Files.write(classfile, "peppers.jar".getBytes());
+
+    URL[] toLoad = {
+        new URL("file:" + subdir.toAbsolutePath() +
+                File.separator + "@" + classfile.toAbsolutePath())
+    };
+
+    List<Path> classpathFiles = FileClassPathRunner.getClasspathFiles(toLoad);
+    assertEquals(1, classpathFiles.size());
+    assertEquals(classfile, classpathFiles.get(0));
+
+    List<URL> readUrls = FileClassPathRunner.readUrls(classpathFiles, false);
+    assertEquals(ImmutableList.of(urlify("peppers.jar")), readUrls);
+  }
+
+  @Test
   public void shouldAddReadUrlsToGivenUrlClassLoader()
       throws IOException, ReflectiveOperationException {
     Path urlsAreHere = tmp.newFile().toPath();


### PR DESCRIPTION
Summary:
Updated FileClassPathRunner.getClasspathFiles() to scan for "@" only at the
beginning of each section in the path (instead of anywhere in the path). This
allows the project's path include directories that contain "@".

Test Plan: Added new unit test

fixes #734