### PR TITLE
Remove dependencies tests when --without-dependencies-tests is used

### DIFF
--- a/src/com/facebook/buck/apple/project_generator/WorkspaceAndProjectGenerator.java
+++ b/src/com/facebook/buck/apple/project_generator/WorkspaceAndProjectGenerator.java
@@ -217,7 +217,6 @@ public class WorkspaceAndProjectGenerator {
         ungroupedTestsBuilder = ImmutableSetMultimap.builder();
 
     buildWorkspaceSchemes(
-        getTargetToBuildWithBuck(),
         projectGraph,
         projectGeneratorOptions.contains(ProjectGenerator.Option.INCLUDE_TESTS),
         projectGeneratorOptions.contains(ProjectGenerator.Option.INCLUDE_DEPENDENCIES_TESTS),
@@ -482,7 +481,6 @@ public class WorkspaceAndProjectGenerator {
   }
 
   private static void buildWorkspaceSchemes(
-      Optional<BuildTarget> mainTarget,
       TargetGraph projectGraph,
       boolean includeProjectTests,
       boolean includeDependenciesTests,
@@ -521,7 +519,7 @@ public class WorkspaceAndProjectGenerator {
     ImmutableSetMultimap.Builder<String, TargetNode<AppleTestDescription.Arg>>
         selectedTestsBuilder = ImmutableSetMultimap.builder();
     buildWorkspaceSchemeTests(
-        mainTarget,
+        workspaceArguments.srcTarget,
         projectGraph,
         includeProjectTests,
         includeDependenciesTests,


### PR DESCRIPTION
As @robbertvanginkel mentioned in https://github.com/facebook/buck/issues/710, this issue is pretty much a bug to be fixed.

This PR will fix that bug as following:

1. When `--without-dependencies-tests` flag is used, test scheme for the specified target should be generated, but not for its dependencies.
2. When `--without-dependencies-tests` flag is not used, test scheme for the specified target should contains all tests of its dependencies (old behavior).