### PR TITLE
Expose option to force final resource ids

### DIFF
--- a/src/com/facebook/buck/android/AndroidLibraryDescription.java
+++ b/src/com/facebook/buck/android/AndroidLibraryDescription.java
@@ -96,7 +96,7 @@ public class AndroidLibraryDescription
             Suppliers.ofInstance(resolver.getAllRules(args.exportedDeps.get()))),
         javacOptions,
         DependencyMode.FIRST_ORDER,
-        /* forceFinalResourceIds */ false,
+        args.forceFinalResourceIds.or(false),
         args.resourceUnionPackage);
 
     boolean hasDummyRDotJavaFlavor =
@@ -175,5 +175,6 @@ public class AndroidLibraryDescription
   public static class Arg extends JavaLibraryDescription.Arg {
     public Optional<SourcePath> manifest;
     public Optional<String> resourceUnionPackage;
+    public Optional<String> forceFinalResourceIds;
   }
 }

--- a/src/com/facebook/buck/android/AndroidLibraryDescription.java
+++ b/src/com/facebook/buck/android/AndroidLibraryDescription.java
@@ -175,6 +175,6 @@ public class AndroidLibraryDescription
   public static class Arg extends JavaLibraryDescription.Arg {
     public Optional<SourcePath> manifest;
     public Optional<String> resourceUnionPackage;
-    public Optional<String> forceFinalResourceIds;
+    public Optional<Boolean> forceFinalResourceIds;
   }
 }


### PR DESCRIPTION
Expose a `force_final_resource_ids` option on the `android_library` rule.

This is useful to set on library rules that are only depended on by `android_binary` rules. This enables libraries like Butterknife and android-annotations to work properly with buck when used in apps.

Partially resolves #223