### PR TITLE
Support for manifest placeholders

### DIFF
--- a/src/com/facebook/buck/android/ReplaceManifestPlaceholdersStep.java
+++ b/src/com/facebook/buck/android/ReplaceManifestPlaceholdersStep.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2012-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.android;
+
+import com.facebook.buck.io.ProjectFilesystem;
+import com.facebook.buck.step.ExecutionContext;
+import com.facebook.buck.step.Step;
+import com.facebook.buck.step.StepExecutionResult;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Replaces placeholders in the android manifest.
+ */
+public class ReplaceManifestPlaceholdersStep implements Step {
+
+  private final ProjectFilesystem projectFilesystem;
+  private final Path androidManifest;
+  private final Path replacedManifest;
+  private final ImmutableMap<String, String> manifestEntries;
+
+  public ReplaceManifestPlaceholdersStep(
+      ProjectFilesystem projectFilesystem,
+      Path androidManifest,
+      Path replacedManifest,
+      ImmutableMap<String, String> manifestEntries) {
+    this.projectFilesystem = projectFilesystem;
+    this.androidManifest = androidManifest;
+    this.replacedManifest = replacedManifest;
+    this.manifestEntries = manifestEntries;
+  }
+
+  @Override
+  public StepExecutionResult execute(ExecutionContext context) throws InterruptedException {
+    try {
+      String content = new String(
+          Files.readAllBytes(projectFilesystem.resolve(androidManifest)), StandardCharsets.UTF_8);
+      String replaced = replacePlaceholders(content, manifestEntries);
+      projectFilesystem.writeContentsToPath(replaced, replacedManifest);
+    } catch (IOException e) {
+      context.logError(e, "Could not replace manifest placeholders.");
+      return StepExecutionResult.ERROR;
+    }
+    return StepExecutionResult.SUCCESS;
+  }
+
+  @Override
+  public String getShortName() {
+    return "replace_manifest_placeholders";
+  }
+
+  @Override
+  public String getDescription(ExecutionContext context) {
+    return String.format("%s: %s -> %s", getShortName(), androidManifest, replacedManifest);
+  }
+
+  @VisibleForTesting
+  static String replacePlaceholders(String content, ImmutableMap<String, String> placeholders) {
+    Iterable<String> escaped = Iterables.transform(
+        placeholders.keySet(), new Function<String, String>() {
+          @Override
+          public String apply(String input) {
+            return Pattern.quote(input);
+          }
+        });
+
+    Joiner joiner = Joiner.on("|");
+    String patternString = Pattern.quote("${") + "(" + joiner.join(escaped) + ")" +
+        Pattern.quote("}");
+    Pattern pattern = Pattern.compile(patternString);
+    Matcher matcher = pattern.matcher(content);
+
+    StringBuffer sb = new StringBuffer();
+    while (matcher.find()) {
+      matcher.appendReplacement(sb, placeholders.get(matcher.group(1)));
+    }
+    matcher.appendTail(sb);
+    return sb.toString();
+  }
+}

--- a/src/com/facebook/buck/rules/coercer/AbstractManifestEntries.java
+++ b/src/com/facebook/buck/rules/coercer/AbstractManifestEntries.java
@@ -20,6 +20,7 @@ import com.facebook.buck.rules.RuleKeyObjectSink;
 import com.facebook.buck.util.immutables.BuckStyleImmutable;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 
 import org.immutables.value.Value;
 
@@ -41,6 +42,8 @@ abstract class AbstractManifestEntries implements RuleKeyAppendable {
   protected abstract Optional<String> getVersionName();
   @Value.Parameter
   protected abstract Optional<Boolean> getDebugMode();
+  @Value.Parameter
+  protected abstract Optional<ImmutableMap<String, String>> getPlaceholders();
 
   @Override
   public void appendToRuleKey(RuleKeyObjectSink sink) {
@@ -49,7 +52,8 @@ abstract class AbstractManifestEntries implements RuleKeyAppendable {
         .setReflectively("targetSdkVersion", getTargetSdkVersion())
         .setReflectively("versionCode", getVersionCode())
         .setReflectively("versionName", getVersionName())
-        .setReflectively("debugMode", getDebugMode());
+        .setReflectively("debugMode", getDebugMode())
+        .setReflectively("placeholders", getPlaceholders());
   }
 
   /**
@@ -60,7 +64,8 @@ abstract class AbstractManifestEntries implements RuleKeyAppendable {
         getTargetSdkVersion().isPresent() ||
         getVersionName().isPresent() ||
         getVersionCode().isPresent() ||
-        getDebugMode().isPresent();
+        getDebugMode().isPresent() ||
+        getPlaceholders().isPresent();
   }
 
   /**

--- a/test/com/facebook/buck/android/ReplaceManifestPlaceholdersStepTest.java
+++ b/test/com/facebook/buck/android/ReplaceManifestPlaceholdersStepTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.buck.android;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.junit.Test;
+
+/**
+ * Test manifest placeholder replacement
+ */
+public class ReplaceManifestPlaceholdersStepTest {
+
+  @Test
+  public void shouldReplaceManifestPlaceholders() {
+    String placeholderText = "<manifest>\n" +
+        "    <permission\n" +
+        "        android:name=\"${applicationId}.permission.C2D_MESSAGE\"\n" +
+        "        android:protectionLevel=\"${custom$}\" />\n" +
+        "</manifest>";
+    ImmutableMap<String, String> placeholders = ImmutableMap.of(
+        "applicationId",
+        "com.example",
+        "custom$",
+        "0x2");
+    String replaced = ReplaceManifestPlaceholdersStep.replacePlaceholders(
+        placeholderText,
+        placeholders);
+    String expected = "<manifest>\n" +
+        "    <permission\n" +
+        "        android:name=\"com.example.permission.C2D_MESSAGE\"\n" +
+        "        android:protectionLevel=\"0x2\" />\n" +
+        "</manifest>";
+
+    assertEquals(expected, replaced);
+  }
+}

--- a/test/com/facebook/buck/rules/coercer/ManifestEntriesTest.java
+++ b/test/com/facebook/buck/rules/coercer/ManifestEntriesTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 import com.facebook.buck.rules.RuleKey;
 import com.facebook.buck.rules.RuleKeyBuilder;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 
 import org.junit.Test;
 
@@ -40,6 +41,8 @@ public class ManifestEntriesTest {
     assertTrue(ManifestEntries.builder().setVersionCode(1).build().hasAny());
     assertTrue(ManifestEntries.builder().setVersionName("").build().hasAny());
     assertTrue(ManifestEntries.builder().setDebugMode(false).build().hasAny());
+    assertTrue(ManifestEntries.builder().setPlaceholders(
+        ImmutableMap.of("key1", "val1")).build().hasAny());
   }
 
 
@@ -58,6 +61,8 @@ public class ManifestEntriesTest {
     expect(ruleKeyBuilder.setReflectively("versionName", Optional.of("thirteen")))
         .andReturn(ruleKeyBuilder);
     expect(ruleKeyBuilder.setReflectively("debugMode", Optional.absent()))
+        .andReturn(ruleKeyBuilder);
+    expect(ruleKeyBuilder.setReflectively("placeholders", Optional.absent()))
         .andReturn(ruleKeyBuilder);
 
     replay(ruleKeyBuilder);


### PR DESCRIPTION
This adds support for manifest placeholders:
 http://tools.android.com/tech-docs/new-build-system/user-guide/manifest-merger#TOC-Placeholder-support

Resolves #743 

Many components of libraries like Google Play Services etc. have an implicit `${applicationId}` placeholder which gets replaced correctly by the `android_binary`'s application id when building with gradle.

This PR enables buck to do the same and also support custom placeholders at the same time by adding an optional `placeholders` entry to the `manifest_entries` configuration.