### PR TITLE
Add a test targets test_host_app as a target dependency in projects

### DIFF
--- a/src/com/facebook/buck/apple/project_generator/NewNativeTargetProjectMutator.java
+++ b/src/com/facebook/buck/apple/project_generator/NewNativeTargetProjectMutator.java
@@ -29,6 +29,7 @@ import com.facebook.buck.apple.XcodePrebuildScriptDescription;
 import com.facebook.buck.apple.XcodeScriptDescriptionArg;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXBuildFile;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXBuildPhase;
+import com.facebook.buck.apple.xcode.xcodeproj.PBXContainerItemProxy;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXFileReference;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXFrameworksBuildPhase;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXGroup;
@@ -39,6 +40,8 @@ import com.facebook.buck.apple.xcode.xcodeproj.PBXReference;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXResourcesBuildPhase;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXShellScriptBuildPhase;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXSourcesBuildPhase;
+import com.facebook.buck.apple.xcode.xcodeproj.PBXTarget;
+import com.facebook.buck.apple.xcode.xcodeproj.PBXTargetDependency;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXVariantGroup;
 import com.facebook.buck.apple.xcode.xcodeproj.ProductType;
 import com.facebook.buck.apple.xcode.xcodeproj.SourceTreePath;
@@ -124,6 +127,8 @@ class NewNativeTargetProjectMutator {
   private Iterable<PBXShellScriptBuildPhase> preBuildRunScriptPhases = ImmutableList.of();
   private Iterable<PBXBuildPhase> copyFilesPhases = ImmutableList.of();
   private Iterable<PBXShellScriptBuildPhase> postBuildRunScriptPhases = ImmutableList.of();
+  private Iterable<PBXTargetDependency> targetDependencies = ImmutableList.of();
+
 
   public NewNativeTargetProjectMutator(
       PathRelativizer pathRelativizer,
@@ -244,6 +249,12 @@ class NewNativeTargetProjectMutator {
     return this;
   }
 
+  public NewNativeTargetProjectMutator setTargetDependenciesFromTargets(
+      Iterable<PBXTarget> targets, PBXProject project) {
+    targetDependencies = createTargetDependenciesForTargets(targets, project);
+    return this;
+  }
+
   /**
    * @param recursiveAssetCatalogs List of asset catalog targets of targetNode and dependencies of
    *                               targetNode.
@@ -278,6 +289,7 @@ class NewNativeTargetProjectMutator {
     addResourcesBuildPhase(target, targetGroup);
     target.getBuildPhases().addAll((Collection<? extends PBXBuildPhase>) copyFilesPhases);
     addRunScriptBuildPhases(target, postBuildRunScriptPhases);
+    addTargetDependencies(target, targetDependencies);
 
     // Product
 
@@ -621,6 +633,16 @@ class NewNativeTargetProjectMutator {
     }
   }
 
+  private ImmutableList<PBXTargetDependency> createTargetDependenciesForTargets(
+      Iterable<PBXTarget> targets, PBXProject project) {
+    ImmutableList.Builder<PBXTargetDependency> builder = ImmutableList.builder();
+    for (PBXTarget target : targets) {
+      PBXContainerItemProxy proxy = new PBXContainerItemProxy(project, target);
+      builder.add(new PBXTargetDependency(proxy));
+    }
+    return builder.build();
+  }
+
   private ImmutableList<PBXShellScriptBuildPhase> createScriptsForTargetNodes(
       Iterable<TargetNode<?>> nodes) throws IllegalStateException {
     ImmutableList.Builder<PBXShellScriptBuildPhase> builder =
@@ -656,6 +678,14 @@ class NewNativeTargetProjectMutator {
       Iterable<PBXShellScriptBuildPhase> phases) {
     for (PBXShellScriptBuildPhase phase : phases) {
       target.getBuildPhases().add(phase);
+    }
+  }
+
+  private void addTargetDependencies(
+      PBXNativeTarget target,
+      Iterable<PBXTargetDependency> targetDependencies) {
+    for (PBXTargetDependency dependency : targetDependencies) {
+      target.getDependencies().add(dependency);
     }
   }
 

--- a/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
+++ b/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
@@ -1202,6 +1202,18 @@ public class ProjectGenerator {
       mutator.setPostBuildRunScriptPhasesFromTargetNodes(postScriptPhases.build());
     }
 
+    if (bundleLoaderNode.isPresent()) {
+      // Add the bundle loader as a target dependency of the target
+      TargetNode<AppleBundleDescription.Arg> bundleLoader = bundleLoaderNode.get();
+      Optional<PBXTarget> bundleTarget = targetNodeToProjectTarget.getUnchecked(bundleLoader);
+      if (bundleTarget.isPresent()) {
+        LOG.debug("Adding target dependency %s to target %s",
+            getProductNameForBuildTarget(bundleLoader.getBuildTarget()),
+            buildTargetName);
+        mutator.setTargetDependenciesFromTargets(ImmutableList.of(bundleTarget.get()), project);
+      }
+    }
+
     NewNativeTargetProjectMutator.Result targetBuilderResult;
     try {
       targetBuilderResult = mutator.buildTargetAndAddToProject(project);

--- a/src/com/facebook/buck/apple/xcode/xcodeproj/PBXContainerItemProxy.java
+++ b/src/com/facebook/buck/apple/xcode/xcodeproj/PBXContainerItemProxy.java
@@ -76,9 +76,8 @@ public class PBXContainerItemProxy extends PBXContainerItem {
     super.serializeInto(s);
 
     Preconditions.checkNotNull(containerPortal.getGlobalID());
-    Preconditions.checkNotNull(target.getGlobalID());
     s.addField("containerPortal", containerPortal.getGlobalID());
-    s.addField("remoteGlobalIDString", target.getGlobalID());
+    s.addField("remoteGlobalIDString", target);
     s.addField("remoteInfo", target.getName());
     s.addField("proxyType", proxyType.getIntValue());
   }

--- a/src/com/facebook/buck/apple/xcode/xcodeproj/PBXContainerItemProxy.java
+++ b/src/com/facebook/buck/apple/xcode/xcodeproj/PBXContainerItemProxy.java
@@ -17,11 +17,11 @@
 package com.facebook.buck.apple.xcode.xcodeproj;
 
 import com.facebook.buck.apple.xcode.XcodeprojSerializer;
+import com.google.common.base.Preconditions;
 
 /**
- * Reference to another object used by {@link PBXTargetDependency}. Can reference a remote file
- * by specifying the {@link PBXFileReference} to the remote project file, and the GID of the object
- * within that file.
+ * Reference to another target used by {@link PBXTargetDependency}. Can reference a target
+ * in a remote project file.
  */
 public class PBXContainerItemProxy extends PBXContainerItem {
   public enum ProxyType {
@@ -37,25 +37,24 @@ public class PBXContainerItemProxy extends PBXContainerItem {
     }
   }
 
-  private final PBXFileReference containerPortal;
-  private final String remoteGlobalIDString;
+  private final PBXProject containerPortal;
+  private final PBXTarget target;
   private final ProxyType proxyType;
 
   public PBXContainerItemProxy(
-      PBXFileReference containerPortal,
-      String remoteGlobalIDString,
-      ProxyType proxyType) {
+      PBXProject containerPortal,
+      PBXTarget target) {
     this.containerPortal = containerPortal;
-    this.remoteGlobalIDString = remoteGlobalIDString;
-    this.proxyType = proxyType;
+    this.target = target;
+    this.proxyType = ProxyType.TARGET_REFERENCE;
   }
 
-  public PBXFileReference getContainerPortal() {
+  public PBXProject getContainerPortal() {
     return containerPortal;
   }
 
-  public String getRemoteGlobalIDString() {
-    return remoteGlobalIDString;
+  public PBXTarget getTarget() {
+    return target;
   }
 
   public ProxyType getProxyType() {
@@ -69,15 +68,18 @@ public class PBXContainerItemProxy extends PBXContainerItem {
 
   @Override
   public int stableHash() {
-    return remoteGlobalIDString.hashCode();
+    return containerPortal.hashCode() ^ target.hashCode();
   }
 
   @Override
   public void serializeInto(XcodeprojSerializer s) {
     super.serializeInto(s);
 
-    s.addField("containerPortal", containerPortal);
-    s.addField("remoteGlobalIDString", remoteGlobalIDString);
+    Preconditions.checkNotNull(containerPortal.getGlobalID());
+    Preconditions.checkNotNull(target.getGlobalID());
+    s.addField("containerPortal", containerPortal.getGlobalID());
+    s.addField("remoteGlobalIDString", target.getGlobalID());
+    s.addField("remoteInfo", target.getName());
     s.addField("proxyType", proxyType.getIntValue());
   }
 }

--- a/test/com/facebook/buck/apple/project_generator/NewNativeTargetProjectMutatorTest.java
+++ b/test/com/facebook/buck/apple/project_generator/NewNativeTargetProjectMutatorTest.java
@@ -47,6 +47,8 @@ import com.facebook.buck.apple.xcode.xcodeproj.PBXProject;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXReference;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXResourcesBuildPhase;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXShellScriptBuildPhase;
+import com.facebook.buck.apple.xcode.xcodeproj.PBXTarget;
+import com.facebook.buck.apple.xcode.xcodeproj.PBXTargetDependency;
 import com.facebook.buck.apple.xcode.xcodeproj.ProductType;
 import com.facebook.buck.apple.xcode.xcodeproj.SourceTreePath;
 import com.facebook.buck.rules.DefaultTargetNodeToBuildRuleTransformer;
@@ -400,6 +402,25 @@ public class NewNativeTargetProjectMutatorTest {
         startsWith("BASE_DIR=${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\n" +
             "JS_OUT=${BASE_DIR}/Apps/Foo/FooBundle.js\n" +
             "SOURCE_MAP=${TEMP_DIR}/rn_source_map/Apps/Foo/FooBundle.js.map\n"));
+  }
+
+  @Test
+  public void testTargetDepencies() throws NoSuchBuildTargetException {
+    NewNativeTargetProjectMutator mutator = mutatorWithCommonDefaults();
+    PBXNativeTarget target1 = new PBXNativeTarget("Target1");
+    PBXNativeTarget target2 = new PBXNativeTarget("Target2");
+    ImmutableSet<PBXTarget> dependentTargets = ImmutableSet.<PBXTarget>of(target1, target2);
+    mutator.setTargetDependenciesFromTargets(dependentTargets, generatedProject);
+
+    NewNativeTargetProjectMutator.Result result =
+        mutator.buildTargetAndAddToProject(generatedProject);
+
+    ImmutableSet.Builder<PBXTarget> targetBuilder = ImmutableSet.builder();
+    for (PBXTargetDependency dependency : result.target.getDependencies()) {
+      targetBuilder.add(dependency.getTargetProxy().getTarget());
+    }
+
+    assertEquals(targetBuilder.build(), dependentTargets);
   }
 
   private NewNativeTargetProjectMutator mutatorWithCommonDefaults() {


### PR DESCRIPTION
Currently a generated Xcode project with a test target with configured test host will correctly set up the bundle loader for the test target, but will not set a target dependency (strangely this is not implicitly added by Xcode). This PR adds the target dependency to the generated project.