### PR TITLE
Fix the way environment is handled for worker_tool processes.

### DIFF
--- a/docs/rule/worker_tool.soy
+++ b/docs/rule/worker_tool.soy
@@ -57,6 +57,15 @@
   {/param}
 {/call}
 
+{call buck.arg}
+  {param name: 'env' /}
+  {param default: 'None' /}
+  {param desc}
+    A map of environment variables that will be passed to the executable represented
+    by <code>exe</code> on initial startup.
+  {/param}
+{/call}
+
 {/param}
 
 {param examples}

--- a/src/com/facebook/buck/js/ReactNativeBundleWorkerStep.java
+++ b/src/com/facebook/buck/js/ReactNativeBundleWorkerStep.java
@@ -21,6 +21,7 @@ import com.facebook.buck.shell.WorkerJobParams;
 import com.facebook.buck.shell.WorkerShellStep;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import java.nio.file.Path;
 
@@ -40,15 +41,15 @@ public class ReactNativeBundleWorkerStep extends WorkerShellStep {
       Path sourceMapFile) {
     super(
         filesystem,
-        filesystem.resolve(tmpDir),
-        filesystem.getRootPath(),
         Optional.of(
             WorkerJobParams.of(
+                filesystem.resolve(tmpDir),
                 jsPackagerCommand,
                 String.format(
                     "--platform %s%s",
                     platform.toString(),
                     additionalPackagerFlags.isPresent() ? " " + additionalPackagerFlags.get() : ""),
+                ImmutableMap.<String, String>of(),
                 String.format(
                     "--command %s --entry-file %s --platform %s --dev %s --bundle-output %s " +
                         "--assets-dest %s --sourcemap-output %s",

--- a/src/com/facebook/buck/js/ReactNativeDepsWorkerStep.java
+++ b/src/com/facebook/buck/js/ReactNativeDepsWorkerStep.java
@@ -21,6 +21,7 @@ import com.facebook.buck.shell.WorkerJobParams;
 import com.facebook.buck.shell.WorkerShellStep;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import java.nio.file.Path;
 
@@ -36,15 +37,15 @@ public class ReactNativeDepsWorkerStep extends WorkerShellStep {
       Path outputFile) {
     super(
         filesystem,
-        filesystem.resolve(tmpDir),
-        filesystem.getRootPath(),
         Optional.of(
             WorkerJobParams.of(
+                filesystem.resolve(tmpDir),
                 jsPackagerCommand,
                 String.format(
                     "--platform %s%s",
                     platform.toString(),
                     additionalPackagerFlags.isPresent() ? " " + additionalPackagerFlags.get() : ""),
+                ImmutableMap.<String, String>of(),
                 String.format(
                     "--command dependencies --platform %s --entry-file %s --output %s",
                     platform.toString(),

--- a/src/com/facebook/buck/rules/args/WorkerMacroArg.java
+++ b/src/com/facebook/buck/rules/args/WorkerMacroArg.java
@@ -23,15 +23,20 @@ import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.CellPathResolver;
 import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.buck.rules.Tool;
 import com.facebook.buck.rules.macros.MacroHandler;
 import com.facebook.buck.rules.macros.WorkerMacroExpander;
 import com.facebook.buck.shell.WorkerTool;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.nio.file.Path;
 
 public class WorkerMacroArg extends MacroArg {
 
   private final WorkerTool workerTool;
   private final ImmutableList<String> startupCommand;
+  private final ImmutableMap<String, String> startupEnvironment;
   private final String jobArgs;
 
   public WorkerMacroArg(
@@ -71,14 +76,23 @@ public class WorkerMacroArg extends MacroArg {
           target));
     }
     this.workerTool = (WorkerTool) workerTool;
-    startupCommand = this.workerTool
-        .getTool()
-        .getCommandPrefix(new SourcePathResolver(resolver));
+    SourcePathResolver pathResolver = new SourcePathResolver(resolver);
+    Tool exe = this.workerTool.getTool();
+    startupCommand = exe.getCommandPrefix(pathResolver);
+    startupEnvironment = exe.getEnvironment(pathResolver);
     jobArgs = macroHandler.expand(target, cellNames, resolver, unexpanded).trim();
   }
 
   public ImmutableList<String> getStartupCommand() {
     return startupCommand;
+  }
+
+  public ImmutableMap<String, String> getEnvironment() {
+    return startupEnvironment;
+  }
+
+  public Path getTempDir() {
+    return workerTool.getTempDir();
   }
 
   public String getStartupArgs() {

--- a/src/com/facebook/buck/shell/AbstractWorkerJobParams.java
+++ b/src/com/facebook/buck/shell/AbstractWorkerJobParams.java
@@ -18,13 +18,18 @@ package com.facebook.buck.shell;
 
 import com.facebook.buck.util.immutables.BuckStyleTuple;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import org.immutables.value.Value;
+
+import java.nio.file.Path;
 
 @Value.Immutable
 @BuckStyleTuple
 interface AbstractWorkerJobParams {
+  Path getTempDir();
   ImmutableList<String> getStartupCommand();
   String getStartupArgs();
+  ImmutableMap<String, String> getStartupEnvironment();
   String getJobArgs();
 }

--- a/src/com/facebook/buck/shell/Genrule.java
+++ b/src/com/facebook/buck/shell/Genrule.java
@@ -326,8 +326,6 @@ public class Genrule extends AbstractBuildRule
   public WorkerShellStep createWorkerShellStep() {
     return new WorkerShellStep(
         getProjectFilesystem(),
-        absolutePathToTmpDirectory,
-        absolutePathToSrcDirectory,
         convertToWorkerJobParams(cmd),
         convertToWorkerJobParams(bash),
         convertToWorkerJobParams(cmdExe)) {
@@ -348,8 +346,10 @@ public class Genrule extends AbstractBuildRule
               public WorkerJobParams apply(Arg arg) {
                 WorkerMacroArg workerMacroArg = (WorkerMacroArg) arg;
                 return WorkerJobParams.of(
+                    workerMacroArg.getTempDir(),
                     workerMacroArg.getStartupCommand(),
                     workerMacroArg.getStartupArgs(),
+                    workerMacroArg.getEnvironment(),
                     workerMacroArg.getJobArgs());
               }
             });

--- a/src/com/facebook/buck/shell/WorkerProcess.java
+++ b/src/com/facebook/buck/shell/WorkerProcess.java
@@ -24,6 +24,7 @@ import com.facebook.buck.util.ProcessExecutorParams;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
@@ -91,8 +92,9 @@ public class WorkerProcess {
   }
 
   public synchronized WorkerJobResult submitAndWaitForJob(String jobArgs) throws IOException {
-    assert protocol != null :
-        "Tried to submit a job to the worker process before the handshake was performed.";
+    Preconditions.checkState(
+        protocol != null,
+        "Tried to submit a job to the worker process before the handshake was performed.");
 
     int messageID = currentMessageID.getAndAdd(1);
     Path argsPath = Paths.get(
@@ -132,11 +134,11 @@ public class WorkerProcess {
   }
 
   public void close() {
-    assert protocol != null :
-        "Tried to close the worker process before the handshake was performed.";
     LOG.debug("Closing process %d", this.hashCode());
     try {
-      protocol.close();
+      if (protocol != null) {
+        protocol.close();
+      }
     } catch (IOException e) {
       LOG.debug(e, "Error closing worker process %s.", this.hashCode());
       throw new HumanReadableException(e,

--- a/src/com/facebook/buck/shell/WorkerTool.java
+++ b/src/com/facebook/buck/shell/WorkerTool.java
@@ -18,7 +18,10 @@ package com.facebook.buck.shell;
 
 import com.facebook.buck.rules.Tool;
 
+import java.nio.file.Path;
+
 public interface WorkerTool {
   Tool getTool();
   String getArgs();
+  Path getTempDir();
 }

--- a/src/com/facebook/buck/util/ProcessExecutor.java
+++ b/src/com/facebook/buck/util/ProcessExecutor.java
@@ -155,8 +155,13 @@ public class ProcessExecutor {
    * Launches a {@link java.lang.Process} given {@link ProcessExecutorParams}.
    */
   public LaunchedProcess launchProcess(ProcessExecutorParams params) throws IOException {
-    Process process = launchProcessInternal(params);
-    return new LaunchedProcessImpl(process);
+    try {
+      Process process = launchProcessInternal(params);
+      return new LaunchedProcessImpl(process);
+    } catch (IOException ex) {
+      stdErrStream.println("Failed to launch " + params);
+      throw ex;
+    }
   }
 
   @VisibleForTesting


### PR DESCRIPTION
Previously the worker process was started with environment variables from whatever first rule happened to start it.

This changes the behavior to:
 - allow specifying environment variables via `env` in worker_tool
 - remove step-specific environment variables from the worker launch environment.
 - moves `$CWD` to project root
 - moves `$TMP` to `buck-out/bin/<worker_tool target>_worker`

This way the worker is started the same way every time. It also avoids including the
(potentially huge) environment from the genrule in an actual call to exec.

In terms of code organization, I followed the existing pattern, but I think perhaps
it might make sense to move `WorkerProcess` startup into `WorkerTool` itself so we
don't have to pass so many arguments around.
