### PR TITLE
Fix storyboard linking for watchOS1 apps

### DIFF
--- a/src/com/facebook/buck/apple/AppleBundle.java
+++ b/src/com/facebook/buck/apple/AppleBundle.java
@@ -695,7 +695,7 @@ public class AppleBundle
       Path sourcePath,
       Path destinationPath,
       ImmutableList.Builder<Step> stepsBuilder) {
-    if (platformName.contains("watch")) {
+    if (platformName.contains("watch") || isLegacyWatchApp()) {
       LOG.debug("Compiling storyboard %s to storyboardc %s and linking",
           sourcePath,
           destinationPath);

--- a/test/com/facebook/buck/apple/AppleBundleIntegrationTest.java
+++ b/test/com/facebook/buck/apple/AppleBundleIntegrationTest.java
@@ -743,6 +743,7 @@ public class AppleBundleIntegrationTest {
     assertTrue(
         Files.exists(
             watchAppPath.resolve("PlugIns/DemoWatchAppExtension.appex/DemoWatchAppExtension")));
+    assertTrue(Files.exists(watchAppPath.resolve("Interface.plist")));
   }
 
   @Test
@@ -784,6 +785,7 @@ public class AppleBundleIntegrationTest {
     assertTrue(Files.exists(watchExtensionPath.resolve("DemoWatchAppExtension")));
     assertTrue(Files.exists(watchExtensionPath.resolve("DemoWatchApp.app/DemoWatchApp")));
     assertTrue(Files.exists(watchExtensionPath.resolve("DemoWatchApp.app/_WatchKitStub/WK")));
+    assertTrue(Files.exists(watchExtensionPath.resolve("DemoWatchApp.app/Interface.plist")));
   }
 
   @Test


### PR DESCRIPTION
watchOS1 apps also need to have linked storyboards in plist format. Fixes #772 