### PR TITLE
support for groovy rules in intellij project generation

### DIFF
--- a/src/com/facebook/buck/jvm/java/intellij/IjModuleFactory.java
+++ b/src/com/facebook/buck/jvm/java/intellij/IjModuleFactory.java
@@ -21,6 +21,8 @@ import com.facebook.buck.android.AndroidLibraryDescription;
 import com.facebook.buck.android.AndroidResourceDescription;
 import com.facebook.buck.android.RobolectricTestDescription;
 import com.facebook.buck.cxx.CxxLibraryDescription;
+import com.facebook.buck.jvm.groovy.GroovyLibraryDescription;
+import com.facebook.buck.jvm.groovy.GroovyTestDescription;
 import com.facebook.buck.jvm.java.JavaLibraryDescription;
 import com.facebook.buck.jvm.java.JavaTestDescription;
 import com.facebook.buck.jvm.java.JvmLibraryArg;
@@ -64,7 +66,9 @@ public class IjModuleFactory {
       CxxLibraryDescription.TYPE,
       JavaLibraryDescription.TYPE,
       JavaTestDescription.TYPE,
-      RobolectricTestDescription.TYPE);
+      RobolectricTestDescription.TYPE,
+      GroovyLibraryDescription.TYPE,
+      GroovyTestDescription.TYPE);
 
   public static final Predicate<TargetNode<?>> SUPPORTED_MODULE_TYPES_PREDICATE =
       new Predicate<TargetNode<?>>() {
@@ -309,6 +313,8 @@ public class IjModuleFactory {
     addToIndex(new JavaLibraryModuleRule());
     addToIndex(new JavaTestModuleRule());
     addToIndex(new RobolectricTestModuleRule());
+    addToIndex(new GroovyLibraryModuleRule());
+    addToIndex(new GroovyTestModuleRule());
 
     this.moduleFactoryResolver = moduleFactoryResolver;
 
@@ -653,6 +659,38 @@ public class IjModuleFactory {
           true /* wantsPackagePrefix */,
           context);
       addCompiledShadowIfNeeded(target, context);
+    }
+  }
+
+  private class GroovyLibraryModuleRule implements IjModuleRule<GroovyLibraryDescription.Arg> {
+
+    @Override
+    public BuildRuleType getType() {
+      return GroovyLibraryDescription.TYPE;
+    }
+
+    @Override
+    public void apply(TargetNode<GroovyLibraryDescription.Arg> target, ModuleBuildContext context) {
+      addDepsAndSources(
+          target,
+          true /* wantsPackagePrefix */,
+          context);
+    }
+  }
+
+  private class GroovyTestModuleRule implements IjModuleRule<GroovyTestDescription.Arg> {
+
+    @Override
+    public BuildRuleType getType() {
+      return GroovyTestDescription.TYPE;
+    }
+
+    @Override
+    public void apply(TargetNode<GroovyTestDescription.Arg> target, ModuleBuildContext context) {
+      addDepsAndTestSources(
+          target,
+          true /* wantsPackagePrefix */,
+          context);
     }
   }
 

--- a/src/com/facebook/buck/jvm/java/intellij/IjModuleFactory.java
+++ b/src/com/facebook/buck/jvm/java/intellij/IjModuleFactory.java
@@ -673,7 +673,7 @@ public class IjModuleFactory {
     public void apply(TargetNode<GroovyLibraryDescription.Arg> target, ModuleBuildContext context) {
       addDepsAndSources(
           target,
-          true /* wantsPackagePrefix */,
+          false /* wantsPackagePrefix */,
           context);
     }
   }
@@ -689,7 +689,7 @@ public class IjModuleFactory {
     public void apply(TargetNode<GroovyTestDescription.Arg> target, ModuleBuildContext context) {
       addDepsAndTestSources(
           target,
-          true /* wantsPackagePrefix */,
+          false /* wantsPackagePrefix */,
           context);
     }
   }

--- a/test/com/facebook/buck/jvm/groovy/GroovyLibraryBuilder.java
+++ b/test/com/facebook/buck/jvm/groovy/GroovyLibraryBuilder.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2014-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.jvm.groovy;
+
+import static com.facebook.buck.jvm.java.JavaCompilationConstants.DEFAULT_JAVAC_OPTIONS;
+
+import com.facebook.buck.io.ProjectFilesystem;
+import com.facebook.buck.model.BuildTarget;
+import com.facebook.buck.rules.AbstractNodeBuilder;
+import com.facebook.buck.rules.BuildTargetSourcePath;
+import com.facebook.buck.rules.PathSourcePath;
+import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.testutil.FakeProjectFilesystem;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.hash.HashCode;
+
+import java.nio.file.Path;
+
+public class GroovyLibraryBuilder extends AbstractNodeBuilder<GroovyLibraryDescription.Arg> {
+
+  private final ProjectFilesystem projectFilesystem;
+
+  protected GroovyLibraryBuilder(
+      BuildTarget target,
+      ProjectFilesystem projectFilesystem,
+      HashCode hashCode) {
+    super(
+        new GroovyLibraryDescription(null, DEFAULT_JAVAC_OPTIONS),
+        target,
+        projectFilesystem,
+        hashCode);
+    this.projectFilesystem = projectFilesystem;
+  }
+
+  public static GroovyLibraryBuilder createBuilder(BuildTarget target) {
+    return new GroovyLibraryBuilder(target, new FakeProjectFilesystem(), null);
+  }
+
+  public static GroovyLibraryBuilder createBuilder(
+      BuildTarget target,
+      ProjectFilesystem projectFilesystem) {
+    return new GroovyLibraryBuilder(target, projectFilesystem, null);
+  }
+
+  public static GroovyLibraryBuilder createBuilder(BuildTarget target, HashCode hashCode) {
+    return new GroovyLibraryBuilder(target, new FakeProjectFilesystem(), hashCode);
+  }
+
+  public GroovyLibraryBuilder addDep(BuildTarget rule) {
+    arg.deps = amend(arg.deps, rule);
+    return this;
+  }
+
+  public GroovyLibraryBuilder addExportedDep(BuildTarget rule) {
+    arg.exportedDeps = amend(arg.exportedDeps, rule);
+    return this;
+  }
+
+  public GroovyLibraryBuilder addProvidedDep(BuildTarget rule) {
+    arg.providedDeps = amend(arg.providedDeps, rule);
+    return this;
+  }
+
+  public GroovyLibraryBuilder addResource(SourcePath sourcePath) {
+    arg.resources = amend(arg.resources, sourcePath);
+    return this;
+  }
+
+  public GroovyLibraryBuilder addSrc(SourcePath path) {
+    arg.srcs = amend(arg.srcs, path);
+    return this;
+  }
+
+  public GroovyLibraryBuilder addSrc(Path path) {
+    return addSrc(new PathSourcePath(projectFilesystem, path));
+  }
+
+  public GroovyLibraryBuilder addSrcTarget(BuildTarget target) {
+    return addSrc(new BuildTargetSourcePath(target));
+  }
+
+  public GroovyLibraryBuilder setAnnotationProcessors(ImmutableSet<String> annotationProcessors) {
+    arg.annotationProcessors = Optional.of(annotationProcessors);
+    return this;
+  }
+}

--- a/test/com/facebook/buck/jvm/java/intellij/IjModuleFactoryTest.java
+++ b/test/com/facebook/buck/jvm/java/intellij/IjModuleFactoryTest.java
@@ -26,6 +26,7 @@ import com.facebook.buck.android.AndroidBinaryDescription;
 import com.facebook.buck.android.AndroidLibraryBuilder;
 import com.facebook.buck.android.AndroidResourceDescription;
 import com.facebook.buck.cxx.CxxLibraryBuilder;
+import com.facebook.buck.jvm.groovy.GroovyLibraryBuilder;
 import com.facebook.buck.jvm.java.JavaLibraryBuilder;
 import com.facebook.buck.jvm.java.JavaTestBuilder;
 import com.facebook.buck.jvm.java.JvmLibraryArg;
@@ -297,6 +298,31 @@ public class IjModuleFactoryTest {
 
     IjFolder folder = module.getFolders().iterator().next();
     assertEquals(Paths.get("java/com/example/base"), folder.getPath());
+    assertFalse(folder instanceof TestFolder);
+    assertTrue(folder.getWantsPackagePrefix());
+  }
+
+  @Test
+  public void testGroovyLibrary() {
+    IjModuleFactory factory = createIjModuleFactory();
+
+    TargetNode<?> groovyLib = GroovyLibraryBuilder
+        .createBuilder(BuildTargetFactory.newInstance("//groovy/com/example/base:base"))
+        .addSrc(Paths.get("groovy/com/example/base/File.groovy"))
+        .build();
+
+    Path moduleBasePath = Paths.get("groovy/com/example/base");
+    IjModule module = factory.createModule(
+        moduleBasePath,
+        ImmutableSet.<TargetNode<?>>of(groovyLib));
+
+    assertEquals(moduleBasePath, module.getModuleBasePath());
+    assertFalse(module.getAndroidFacet().isPresent());
+    assertEquals(1, module.getFolders().size());
+    assertEquals(ImmutableSet.of(groovyLib), module.getTargets());
+
+    IjFolder folder = module.getFolders().iterator().next();
+    assertEquals(Paths.get("groovy/com/example/base"), folder.getPath());
     assertFalse(folder instanceof TestFolder);
     assertTrue(folder.getWantsPackagePrefix());
   }


### PR DESCRIPTION
Not quite right yet but for your consideration.

This pull request supports `groovy_library` and `groovy_test` rules as intellij source folders.

Outstanding issues:
1. what additional unit or integration tests do you want to see?
2. I'm not sure what `addCompiledShadowIfNeeded()` does but I'm not calling it, should I?
3. there's an unnecessary `<exclude>` and a `packagePrefix` being created in the .iml, any suggestions on the best place to look for a fix?
