### PR TITLE
Add support for generating alternate dummy R dot java file with final values

### DIFF
--- a/docs/rule/android_library.soy
+++ b/docs/rule/android_library.soy
@@ -65,6 +65,16 @@ compiled class files and resources.
 {/call}
 
 {call buck.arg}
+  {param name: 'final_r_name' /}
+  {param default : 'None' /}
+  {param desc}
+  An optional name for a class like R.java with final values that is generated to be used
+  for annotation processors. The values will be wrong i.e they will not match the real values
+  in the final android binary, so they should only be used by carefully crafted annotation processors.
+  {/param}
+{/call}
+
+{call buck.arg}
   {param name: 'deps' /}
   {param default : '[]' /}
   {param desc}

--- a/src/com/facebook/buck/android/AndroidLibraryDescription.java
+++ b/src/com/facebook/buck/android/AndroidLibraryDescription.java
@@ -97,7 +97,8 @@ public class AndroidLibraryDescription
         javacOptions,
         DependencyMode.FIRST_ORDER,
         /* forceFinalResourceIds */ false,
-        args.resourceUnionPackage);
+        args.resourceUnionPackage,
+        args.finalRName);
 
     boolean hasDummyRDotJavaFlavor =
         params.getBuildTarget().getFlavors().contains(DUMMY_R_DOT_JAVA_FLAVOR);
@@ -175,5 +176,6 @@ public class AndroidLibraryDescription
   public static class Arg extends JavaLibraryDescription.Arg {
     public Optional<SourcePath> manifest;
     public Optional<String> resourceUnionPackage;
+    public Optional<String> finalRName;
   }
 }

--- a/src/com/facebook/buck/android/AndroidLibraryGraphEnhancer.java
+++ b/src/com/facebook/buck/android/AndroidLibraryGraphEnhancer.java
@@ -46,6 +46,7 @@ public class AndroidLibraryGraphEnhancer {
   private final DependencyMode resourceDependencyMode;
   private final boolean forceFinalResourceIds;
   private final Optional<String> resourceUnionPackage;
+  private final Optional<String> finalRName;
 
   public AndroidLibraryGraphEnhancer(
       BuildTarget buildTarget,
@@ -53,7 +54,8 @@ public class AndroidLibraryGraphEnhancer {
       JavacOptions javacOptions,
       DependencyMode resourceDependencyMode,
       boolean forceFinalResourceIds,
-      Optional<String> resourceUnionPackage) {
+      Optional<String> resourceUnionPackage,
+      Optional<String> finalRName) {
     this.dummyRDotJavaBuildTarget = getDummyRDotJavaTarget(buildTarget);
     this.originalBuildRuleParams = buildRuleParams;
     // Override javacoptions because DummyRDotJava doesn't require annotation processing.
@@ -63,6 +65,7 @@ public class AndroidLibraryGraphEnhancer {
     this.resourceDependencyMode = resourceDependencyMode;
     this.forceFinalResourceIds = forceFinalResourceIds;
     this.resourceUnionPackage = resourceUnionPackage;
+    this.finalRName = finalRName;
   }
 
   public static BuildTarget getDummyRDotJavaTarget(BuildTarget buildTarget) {
@@ -135,7 +138,8 @@ public class AndroidLibraryGraphEnhancer {
         new BuildTargetSourcePath(abiJarTarget),
         javacOptions,
         forceFinalResourceIds,
-        resourceUnionPackage);
+        resourceUnionPackage,
+        finalRName);
     ruleResolver.addToIndex(dummyRDotJava);
 
     ruleResolver.addToIndex(

--- a/src/com/facebook/buck/android/RobolectricTestDescription.java
+++ b/src/com/facebook/buck/android/RobolectricTestDescription.java
@@ -105,7 +105,8 @@ public class RobolectricTestDescription implements Description<RobolectricTestDe
         javacOptions,
         DependencyMode.TRANSITIVE,
         /* forceFinalResourceIds */ true,
-        Optional.<String>absent());
+        /* resourceUnionPackage */ Optional.<String>absent(),
+        /* rName */ Optional.<String>absent());
     Optional<DummyRDotJava> dummyRDotJava = graphEnhancer.getBuildableForAndroidResources(
         resolver,
         /* createBuildableIfEmpty */ true);

--- a/test/com/facebook/buck/android/AndroidLibraryGraphEnhancerTest.java
+++ b/test/com/facebook/buck/android/AndroidLibraryGraphEnhancerTest.java
@@ -58,7 +58,8 @@ public class AndroidLibraryGraphEnhancerTest {
         DEFAULT_JAVAC_OPTIONS,
         DependencyMode.FIRST_ORDER,
         /* forceFinalResourceIds */ false,
-        Optional.<String>absent());
+        /* unionPackage */ Optional.<String>absent(),
+        /* rName */ Optional.<String>absent());
     Optional<DummyRDotJava> result = graphEnhancer.getBuildableForAndroidResources(
         new BuildRuleResolver(TargetGraph.EMPTY, new DefaultTargetNodeToBuildRuleTransformer()),
         /* createdBuildableIfEmptyDeps */ false);
@@ -74,7 +75,8 @@ public class AndroidLibraryGraphEnhancerTest {
         DEFAULT_JAVAC_OPTIONS,
         DependencyMode.FIRST_ORDER,
         /* forceFinalResourceIds */ false,
-        Optional.<String>absent());
+        /* unionPackage */ Optional.<String>absent(),
+        /* rName */ Optional.<String>absent());
     BuildRuleResolver buildRuleResolver =
         new BuildRuleResolver(TargetGraph.EMPTY, new DefaultTargetNodeToBuildRuleTransformer());
     Optional<DummyRDotJava> result = graphEnhancer.getBuildableForAndroidResources(
@@ -117,7 +119,8 @@ public class AndroidLibraryGraphEnhancerTest {
         DEFAULT_JAVAC_OPTIONS,
         DependencyMode.FIRST_ORDER,
         /* forceFinalResourceIds */ false,
-        Optional.<String>absent());
+        /* unionPackage */ Optional.<String>absent(),
+        /* rName */ Optional.<String>absent());
     Optional<DummyRDotJava> dummyRDotJava = graphEnhancer.getBuildableForAndroidResources(
         ruleResolver,
         /* createBuildableIfEmptyDeps */ false);
@@ -172,7 +175,8 @@ public class AndroidLibraryGraphEnhancerTest {
                     .build(),
                 DependencyMode.FIRST_ORDER,
         /* forceFinalResourceIds */ false,
-        Optional.<String>absent());
+        /* unionPackage */ Optional.<String>absent(),
+        /* rName */ Optional.<String>absent());
     Optional<DummyRDotJava> dummyRDotJava = graphEnhancer.getBuildableForAndroidResources(
         ruleResolver,
         /* createBuildableIfEmptyDeps */ false);
@@ -203,7 +207,8 @@ public class AndroidLibraryGraphEnhancerTest {
             options,
             DependencyMode.FIRST_ORDER,
             /* forceFinalResourceIds */ false,
-            Optional.<String>absent());
+            /* unionPackage */ Optional.<String>absent(),
+            /* rName */ Optional.<String>absent());
     Optional<DummyRDotJava> result =
         graphEnhancer.getBuildableForAndroidResources(
             resolver,
@@ -211,5 +216,4 @@ public class AndroidLibraryGraphEnhancerTest {
     assertTrue(result.isPresent());
     assertThat(result.get().getDeps(), Matchers.<BuildRule>hasItem(dep));
   }
-
 }

--- a/test/com/facebook/buck/android/DummyRDotJavaTest.java
+++ b/test/com/facebook/buck/android/DummyRDotJavaTest.java
@@ -101,12 +101,13 @@ public class DummyRDotJavaTest {
         new FakeSourcePath("abi.jar"),
         ANDROID_JAVAC_OPTIONS,
         /* forceFinalResourceIds */ false,
-        Optional.<String>absent());
+        Optional.<String>absent(),
+        Optional.of("R2"));
 
     FakeBuildableContext buildableContext = new FakeBuildableContext();
     List<Step> steps = dummyRDotJava.getBuildSteps(EasyMock.createMock(BuildContext.class),
         buildableContext);
-    assertEquals("DummyRDotJava returns an incorrect number of Steps.", 9, steps.size());
+    assertEquals("DummyRDotJava returns an incorrect number of Steps.", 10, steps.size());
 
     String rDotJavaSrcFolder =
         BuildTargets
@@ -140,6 +141,7 @@ public class DummyRDotJavaTest {
         Paths.get(rDotJavaSrcFolder).resolve("com/facebook/R.java"));
     List<String> expectedStepDescriptions = Lists.newArrayList(
         makeCleanDirDescription(filesystem.resolve(rDotJavaSrcFolder)),
+        "android-res-merge " + Joiner.on(' ').join(sortedSymbolsFiles),
         "android-res-merge " + Joiner.on(' ').join(sortedSymbolsFiles),
         makeCleanDirDescription(filesystem.resolve(rDotJavaBinFolder)),
         makeCleanDirDescription(filesystem.resolve(rDotJavaAbiFolder)),
@@ -187,6 +189,7 @@ public class DummyRDotJavaTest {
         new FakeSourcePath("abi.jar"),
         ANDROID_JAVAC_OPTIONS,
         /* forceFinalResourceIds */ false,
+        Optional.<String>absent(),
         Optional.<String>absent());
     assertEquals(
         BuildTargets.getScratchPath(


### PR DESCRIPTION
- The generated `finalR` class can be used in butterknife annotations to make buck compatible with butterknife