### PR TITLE
Support XCUITest project generation

### DIFF
--- a/src/com/facebook/buck/apple/AppleTest.java
+++ b/src/com/facebook/buck/apple/AppleTest.java
@@ -102,6 +102,9 @@ public class AppleTest
   @AddToRuleKey
   private final boolean runTestSeparately;
 
+  @AddToRuleKey
+  private final boolean isUiTest;
+
   private final Path testOutputPath;
   private final Path testLogsPath;
 
@@ -189,7 +192,8 @@ public class AppleTest
       String testLogDirectoryEnvironmentVariable,
       String testLogLevelEnvironmentVariable,
       String testLogLevel,
-      Optional<Long> testRuleTimeoutMs) {
+      Optional<Long> testRuleTimeoutMs,
+      boolean isUiTest) {
     super(params, resolver);
     this.xctool = xctool;
     this.xctoolStutterTimeout = xctoolStutterTimeout;
@@ -212,6 +216,7 @@ public class AppleTest
     this.testLogDirectoryEnvironmentVariable = testLogDirectoryEnvironmentVariable;
     this.testLogLevelEnvironmentVariable = testLogLevelEnvironmentVariable;
     this.testLogLevel = testLogLevel;
+    this.isUiTest = isUiTest;
   }
 
   @Override
@@ -474,4 +479,7 @@ public class AppleTest
     return testBundle.getPathToOutput();
   }
 
+  public boolean isUiTest() {
+    return isUiTest;
+  }
 }

--- a/src/com/facebook/buck/apple/AppleTestDescription.java
+++ b/src/com/facebook/buck/apple/AppleTestDescription.java
@@ -294,7 +294,8 @@ public class AppleTestDescription implements
         appleConfig.getTestLogDirectoryEnvironmentVariable(),
         appleConfig.getTestLogLevelEnvironmentVariable(),
         appleConfig.getTestLogLevel(),
-        args.testRuleTimeoutMs.or(defaultTestRuleTimeoutMs));
+        args.testRuleTimeoutMs.or(defaultTestRuleTimeoutMs),
+        args.isUiTest());
   }
 
   private Optional<SourcePath> getXctool(
@@ -482,6 +483,7 @@ public class AppleTestDescription implements
     public Optional<ImmutableSortedSet<Label>> labels;
     public Optional<Boolean> canGroup;
     public Optional<Boolean> runTestSeparately;
+    public Optional<Boolean> isUiTest;
     public Optional<BuildTarget> testHostApp;
 
     // Bundle related fields.
@@ -514,6 +516,10 @@ public class AppleTestDescription implements
 
     public boolean getRunTestSeparately() {
       return runTestSeparately.or(false);
+    }
+
+    public boolean isUiTest() {
+      return isUiTest.or(false);
     }
   }
 }

--- a/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
+++ b/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
@@ -2695,9 +2695,8 @@ public class ProjectGenerator {
             return ProductType.APPLICATION;
         }
       } else if (binaryNode.getType().equals(AppleTestDescription.TYPE)) {
-        @SuppressWarnings("unchecked")
         TargetNode<AppleTestDescription.Arg> testNode =
-              (TargetNode<AppleTestDescription.Arg>) binaryNode;
+            binaryNode.castArg(AppleTestDescription.Arg.class).get();
         if (testNode.getConstructorArg().isUiTest()) {
           return ProductType.UI_TEST;
         } else {

--- a/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
+++ b/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
@@ -1238,7 +1238,17 @@ public class ProjectGenerator {
     extraSettingsBuilder
         .put("TARGET_NAME", buildTargetName)
         .put("SRCROOT", pathRelativizer.outputPathToBuildTargetPath(buildTarget).toString());
-    if (bundleLoaderNode.isPresent() && isFocusedOnTarget) {
+    if (productType == ProductType.UI_TEST && isFocusedOnTarget) {
+      if (bundleLoaderNode.isPresent()) {
+        BuildTarget testTarget = bundleLoaderNode.get().getBuildTarget();
+        extraSettingsBuilder
+            .put("TEST_TARGET_NAME", getXcodeTargetName(testTarget));
+      } else {
+        throw new HumanReadableException(
+            "The test rule '%s' is configured with 'is_ui_test' but has no test_host_app",
+            buildTargetName);
+      }
+    } else if (bundleLoaderNode.isPresent() && isFocusedOnTarget) {
       TargetNode<AppleBundleDescription.Arg> bundleLoader = bundleLoaderNode.get();
       String bundleLoaderProductName = getProductNameForBuildTarget(bundleLoader.getBuildTarget());
       String bundleLoaderBundleName = bundleLoaderProductName + "." +
@@ -2685,7 +2695,14 @@ public class ProjectGenerator {
             return ProductType.APPLICATION;
         }
       } else if (binaryNode.getType().equals(AppleTestDescription.TYPE)) {
-        return ProductType.UNIT_TEST;
+        @SuppressWarnings("unchecked")
+        TargetNode<AppleTestDescription.Arg> testNode =
+              (TargetNode<AppleTestDescription.Arg>) binaryNode;
+        if (testNode.getConstructorArg().isUiTest()) {
+          return ProductType.UI_TEST;
+        } else {
+          return ProductType.UNIT_TEST;
+        }
       }
     }
 

--- a/src/com/facebook/buck/apple/xcode/xcodeproj/AbstractProductType.java
+++ b/src/com/facebook/buck/apple/xcode/xcodeproj/AbstractProductType.java
@@ -41,6 +41,8 @@ abstract class AbstractProductType {
       "com.apple.product-type.application.watchapp2");
   public static final ProductType UNIT_TEST = ProductType.of(
       "com.apple.product-type.bundle.unit-test");
+  public static final ProductType UI_TEST = ProductType.of(
+      "com.apple.product-type.bundle.ui-testing");
   public static final ProductType APP_EXTENSION = ProductType.of(
       "com.apple.product-type.app-extension");
 

--- a/test/com/facebook/buck/apple/AppleTestBuilder.java
+++ b/test/com/facebook/buck/apple/AppleTestBuilder.java
@@ -63,6 +63,11 @@ public final class AppleTestBuilder
     return this;
   }
 
+  public AppleTestBuilder isUiTest(Optional<Boolean> value) {
+    arg.isUiTest = value;
+    return this;
+  }
+
   public AppleTestBuilder setTestHostApp(Optional<BuildTarget> testHostApp) {
     arg.testHostApp = testHostApp;
     return this;

--- a/test/com/facebook/buck/apple/AppleTestIntegrationTest.java
+++ b/test/com/facebook/buck/apple/AppleTestIntegrationTest.java
@@ -331,6 +331,28 @@ public class AppleTestIntegrationTest {
   }
 
   @Test
+  public void skipsXCUITests() throws IOException {
+    assumeTrue(Platform.detect() == Platform.MACOS);
+    ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(
+        this, "apple_test_xcuitest", tmp);
+    workspace.setUp();
+    workspace.copyRecursively(
+        TestDataHelper.getTestDataDirectory(this).resolve("xctool"),
+        Paths.get("xctool"));
+    workspace.writeContentsToPath(
+        "[apple]\n  xctool_path = xctool/bin/xctool\n",
+        ".buckconfig.local");
+    ProjectWorkspace.ProcessResult result = workspace.runBuckCommand("test", "//:foo", "//:bar");
+    result.assertSuccess();
+    assertThat(
+        result.getStderr(),
+        containsString("NOTESTS <100ms  0 Passed   0 Skipped   0 Failed   XCUITest"));
+    assertThat(
+        result.getStderr(),
+        containsString("1 Passed   0 Skipped   0 Failed   FooXCTest"));
+  }
+
+  @Test
   public void slowTestShouldFailWithTimeout() throws IOException {
     assumeTrue(Platform.detect() == Platform.MACOS);
     ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(

--- a/test/com/facebook/buck/apple/AppleTestIntegrationTest.java
+++ b/test/com/facebook/buck/apple/AppleTestIntegrationTest.java
@@ -346,7 +346,9 @@ public class AppleTestIntegrationTest {
     result.assertSuccess();
     assertThat(
         result.getStderr(),
-        containsString("NOTESTS <100ms  0 Passed   0 Skipped   0 Failed   XCUITest"));
+        containsString(
+            "NOTESTS <100ms  0 Passed   0 Skipped   0 Failed   XCUITest runs not supported"
+        ));
     assertThat(
         result.getStderr(),
         containsString("1 Passed   0 Skipped   0 Failed   FooXCTest"));

--- a/test/com/facebook/buck/apple/project_generator/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/apple/project_generator/ProjectGeneratorTest.java
@@ -3655,6 +3655,50 @@ public class ProjectGeneratorTest {
   }
 
   @Test
+  public void uiTestUsesHostAppAsTarget() throws IOException {
+    BuildTarget hostAppBinaryTarget =
+        BuildTarget.builder(rootPath, "//foo", "HostAppBinary").build();
+    TargetNode<?> hostAppBinaryNode = AppleBinaryBuilder
+        .createBuilder(hostAppBinaryTarget)
+        .build();
+
+    BuildTarget hostAppTarget = BuildTarget.builder(rootPath, "//foo", "HostApp").build();
+    TargetNode<?> hostAppNode = AppleBundleBuilder
+        .createBuilder(hostAppTarget)
+        .setExtension(Either.<AppleBundleExtension, String>ofLeft(AppleBundleExtension.APP))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
+        .setBinary(hostAppBinaryTarget)
+        .build();
+
+    BuildTarget testTarget = BuildTarget.builder(rootPath, "//foo", "AppTest").build();
+    TargetNode<?> testNode = AppleTestBuilder.createBuilder(testTarget)
+        .setConfigs(
+            Optional.of(
+                ImmutableSortedMap.of(
+                    "Debug",
+                    ImmutableMap.<String, String>of())))
+        .setInfoPlist(new FakeSourcePath("Info.plist"))
+        .setTestHostApp(Optional.of(hostAppTarget))
+        .isUiTest(Optional.of(true))
+        .build();
+
+    ProjectGenerator projectGenerator = createProjectGeneratorForCombinedProject(
+        ImmutableSet.of(hostAppBinaryNode, hostAppNode, testNode),
+        ImmutableSet.<ProjectGenerator.Option>of());
+
+    projectGenerator.createXcodeProjects();
+
+    PBXTarget testPBXTarget = assertTargetExistsAndReturnTarget(
+        projectGenerator.getGeneratedProject(),
+        "//foo:AppTest");
+    assertEquals(testPBXTarget.getProductType(), ProductType.UI_TEST);
+
+    ImmutableMap<String, String> settings = getBuildSettings(testTarget, testPBXTarget, "Debug");
+    // Check starts with as the remainder depends on the bundle style at build time.
+    assertEquals(settings.get("TEST_TARGET_NAME"), "//foo:HostApp");
+  }
+
+  @Test
   public void applicationTestDoesNotCopyHostAppBundleIntoTestBundle() throws IOException {
     BuildTarget hostAppBinaryTarget =
         BuildTarget.builder(rootPath, "//foo", "HostAppBinary").build();

--- a/test/com/facebook/buck/apple/testdata/apple_test_xcuitest/.buckconfig
+++ b/test/com/facebook/buck/apple/testdata/apple_test_xcuitest/.buckconfig
@@ -1,0 +1,2 @@
+[cxx]
+  default_platform = iphonesimulator-x86_64

--- a/test/com/facebook/buck/apple/testdata/apple_test_xcuitest/BUCK.fixture
+++ b/test/com/facebook/buck/apple/testdata/apple_test_xcuitest/BUCK.fixture
@@ -1,0 +1,20 @@
+apple_test(
+    name = 'foo',
+    srcs = ['FooXCTest.m'],
+    info_plist = 'Test.plist',
+    frameworks = [
+        '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+        '$PLATFORM_DIR/Developer/Library/Frameworks/XCTest.framework'
+    ],
+)
+
+apple_test(
+    name = 'bar',
+    is_ui_test = True,
+    srcs = ['FooXCUITest.m'],
+    info_plist = 'Test.plist',
+    frameworks = [
+        '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+        '$PLATFORM_DIR/Developer/Library/Frameworks/XCTest.framework'
+    ],
+)

--- a/test/com/facebook/buck/apple/testdata/apple_test_xcuitest/FooXCTest.m
+++ b/test/com/facebook/buck/apple/testdata/apple_test_xcuitest/FooXCTest.m
@@ -1,0 +1,10 @@
+#import <XCTest/XCTest.h>
+
+@interface FooXCTest : XCTestCase
+@end
+
+@implementation FooXCTest
+- (void)testTwoPlusTwoEqualsFour {
+  XCTAssertEqual(2 + 2, 4, @"Two plus two equals four");
+}
+@end

--- a/test/com/facebook/buck/apple/testdata/apple_test_xcuitest/FooXCUITest.m
+++ b/test/com/facebook/buck/apple/testdata/apple_test_xcuitest/FooXCUITest.m
@@ -1,8 +1,13 @@
 #import <XCTest/XCTest.h>
 
-@interface FooXCTest : XCTestCase
+@interface FooXCUITest : XCTestCase
 @end
 
-@implementation FooXCTest
+@implementation FooXCUITest
+
+- (void)testThisWillBeSkipped
+{
+  XCTAssertTrue(false);
+}
 
 @end

--- a/test/com/facebook/buck/apple/testdata/apple_test_xcuitest/FooXCUITest.m
+++ b/test/com/facebook/buck/apple/testdata/apple_test_xcuitest/FooXCUITest.m
@@ -1,0 +1,8 @@
+#import <XCTest/XCTest.h>
+
+@interface FooXCTest : XCTestCase
+@end
+
+@implementation FooXCTest
+
+@end

--- a/test/com/facebook/buck/apple/testdata/apple_test_xcuitest/Test.plist
+++ b/test/com/facebook/buck/apple/testdata/apple_test_xcuitest/Test.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>CFBundleExecutable</key>
+        <string>${EXECUTABLE_NAME}</string>
+        <key>CFBundleIdentifier</key>
+        <string>com.facebook.${PRODUCT_NAME:rfc1034identifier}</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundlePackageType</key>
+        <string>BNDL</string>
+        <key>CFBundleShortVersionString</key>
+        <string>1.0</string>
+        <key>CFBundleSignature</key>
+        <string>????</string>
+        <key>CFBundleVersion</key>
+        <string>1</string>
+</dict>
+</plist>


### PR DESCRIPTION
This adds partial support for XCUITests, apple's uitesting framework. The `apple_test` rule will get a new optional parameter `is_ui_test`, which should be used in combination with `test_host_app`. An example:

```
apple_test(
  name = 'UITests',
  test_host_app = ':App',
  is_ui_test = True,
)
```

These test bundles will be skipped when with `buck test`, as xctool doesn't support running them (see [xctool#534](https://github.com/facebook/xctool/issues/534)). They will however be available when the project is generated with `buck project //foo:App`.