### PR TITLE
Only merge valid entitlements keys from provisioning profiles

### DIFF
--- a/src/com/facebook/buck/apple/AbstractProvisioningProfileMetadata.java
+++ b/src/com/facebook/buck/apple/AbstractProvisioningProfileMetadata.java
@@ -180,4 +180,34 @@ abstract class AbstractProvisioningProfileMetadata implements RuleKeyAppendable 
   public void appendToRuleKey(RuleKeyObjectSink sink) {
     sink.setReflectively("provisioning-profile-uuid", getUUID());
   }
+
+  public ImmutableMap<String, NSObject> getMergeableEntitlements() {
+    final ImmutableSet<String> excludedKeys = ImmutableSet.of(
+        "com.apple.developer.icloud-container-development-container-identifiers",
+        "com.apple.developer.icloud-container-environment",
+        "com.apple.developer.icloud-container-identifiers",
+        "com.apple.developer.icloud-services",
+        "com.apple.developer.restricted-resource-mode",
+        "com.apple.developer.ubiquity-container-identifiers",
+        "com.apple.developer.ubiquity-kvstore-identifier",
+        "inter-app-audio",
+        "com.apple.developer.homekit",
+        "com.apple.developer.healthkit",
+        "com.apple.developer.in-app-payments",
+        "com.apple.developer.associated-domains",
+        "com.apple.security.application-groups",
+        "com.apple.developer.maps",
+        "com.apple.developer.networking.vpn.api",
+        "com.apple.external-accessory.wireless-configuration"
+    );
+
+    ImmutableMap<String, NSObject> allEntitlements = getEntitlements();
+    ImmutableMap.Builder<String, NSObject> filteredEntitlementsBuilder = ImmutableMap.builder();
+    for (String key : allEntitlements.keySet()) {
+      if (!excludedKeys.contains(key)) {
+        filteredEntitlementsBuilder.put(key, allEntitlements.get(key));
+      }
+    }
+    return filteredEntitlementsBuilder.build();
+  }
 }

--- a/src/com/facebook/buck/apple/ProvisioningProfileCopyStep.java
+++ b/src/com/facebook/buck/apple/ProvisioningProfileCopyStep.java
@@ -156,21 +156,21 @@ class ProvisioningProfileCopyStep implements Step {
       return StepExecutionResult.ERROR;
     }
 
-    // Merge tne entitlements with the profile, and write out.
+    // Merge the entitlements with the profile, and write out.
     if (entitlementsPlist.isPresent()) {
       return (new PlistProcessStep(
           filesystem,
           entitlementsPlist.get(),
           Optional.<Path>absent(),
           signingEntitlementsTempPath,
-          bestProfile.get().getEntitlements(),
+          bestProfile.get().getMergeableEntitlements(),
           ImmutableMap.<String, NSObject>of(),
           PlistProcessStep.OutputFormat.XML)).execute(context);
     } else {
       // No entitlements.plist explicitly specified; write out the minimal entitlements needed.
       String appID = bestProfile.get().getAppID().getFirst() + "." + bundleID;
       NSDictionary entitlementsPlist = new NSDictionary();
-      entitlementsPlist.putAll(bestProfile.get().getEntitlements());
+      entitlementsPlist.putAll(bestProfile.get().getMergeableEntitlements());
       entitlementsPlist.put(APPLICATION_IDENTIFIER, appID);
       entitlementsPlist.put(KEYCHAIN_ACCESS_GROUPS, new String[]{appID});
       return (new WriteFileStep(

--- a/test/com/facebook/buck/apple/ProvisioningProfileCopyStepTest.java
+++ b/test/com/facebook/buck/apple/ProvisioningProfileCopyStepTest.java
@@ -17,10 +17,15 @@
 package com.facebook.buck.apple;
 
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
+import com.dd.plist.NSDictionary;
+import com.dd.plist.NSObject;
+import com.dd.plist.PropertyListParser;
 import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.step.ExecutionContext;
 import com.facebook.buck.step.TestExecutionContext;
@@ -31,6 +36,7 @@ import com.facebook.buck.util.HumanReadableException;
 import com.facebook.buck.util.environment.Platform;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -51,6 +57,7 @@ public class ProvisioningProfileCopyStepTest {
   private Path tempOutputDir;
   private Path outputFile;
   private Path xcentFile;
+  private Path entitlementsFile;
   private ProjectFilesystem projectFilesystem;
   private ExecutionContext executionContext;
   private CodeSignIdentityStore codeSignIdentityStore;
@@ -82,7 +89,7 @@ public class ProvisioningProfileCopyStepTest {
     executionContext = TestExecutionContext.newInstance();
     codeSignIdentityStore =
         CodeSignIdentityStore.fromIdentities(ImmutableList.<CodeSignIdentity>of());
-
+    entitlementsFile = testdataDir.resolve("Entitlements.plist");
   }
 
   @Test
@@ -167,5 +174,59 @@ public class ProvisioningProfileCopyStepTest {
     step.execute(executionContext);
     assertTrue(profileFuture.isDone());
     assertNotNull(profileFuture.get());
+  }
+
+  @Test
+  public void testNoEntitlementsDoesNotMergeInvalidProfileKeys() throws Exception {
+    assumeTrue(Platform.detect() == Platform.MACOS);
+    ProvisioningProfileCopyStep step = new ProvisioningProfileCopyStep(
+        projectFilesystem,
+        testdataDir.resolve("Info.plist"),
+        Optional.of("00000000-0000-0000-0000-000000000000"),
+        Optional.<Path>absent(),
+        ProvisioningProfileStore.fromSearchPath(testdataDir),
+        outputFile,
+        xcentFile,
+        codeSignIdentityStore
+    );
+    step.execute(executionContext);
+
+    ProvisioningProfileMetadata selectedProfile = step.getSelectedProvisioningProfileFuture().get();
+    ImmutableMap<String, NSObject> profileEntitlements = selectedProfile.getEntitlements();
+    assertTrue(profileEntitlements.containsKey( "com.apple.security.application-groups"));
+
+    Optional<String> xcentContents = projectFilesystem.readFileIfItExists(xcentFile);
+    assertTrue(xcentContents.isPresent());
+    NSDictionary xcentPlist = (NSDictionary)PropertyListParser.parse(xcentContents.get().getBytes());
+    assertFalse(xcentPlist.containsKey("com.apple.security.application-groups"));
+    assertEquals(xcentPlist.get("com.apple.developer.team-identifier"),
+        profileEntitlements.get("com.apple.developer.team-identifier"));
+  }
+
+  @Test
+  public void testEntitlementsDoesNotMergeInvalidProfileKeys() throws Exception {
+    assumeTrue(Platform.detect() == Platform.MACOS);
+    ProvisioningProfileCopyStep step = new ProvisioningProfileCopyStep(
+        projectFilesystem,
+        testdataDir.resolve("Info.plist"),
+        Optional.of("00000000-0000-0000-0000-000000000000"),
+        Optional.of(entitlementsFile),
+        ProvisioningProfileStore.fromSearchPath(testdataDir),
+        outputFile,
+        xcentFile,
+        codeSignIdentityStore
+    );
+    step.execute(executionContext);
+
+    ProvisioningProfileMetadata selectedProfile = step.getSelectedProvisioningProfileFuture().get();
+    ImmutableMap<String, NSObject> profileEntitlements = selectedProfile.getEntitlements();
+    assertTrue(profileEntitlements.containsKey( "com.apple.security.application-groups"));
+
+    Optional<String> xcentContents = projectFilesystem.readFileIfItExists(xcentFile);
+    assertTrue(xcentContents.isPresent());
+    NSDictionary xcentPlist = (NSDictionary)PropertyListParser.parse(xcentContents.get().getBytes());
+    assertFalse(xcentPlist.containsKey("com.apple.security.application-groups"));
+    assertEquals(xcentPlist.get("com.apple.developer.team-identifier"),
+        profileEntitlements.get("com.apple.developer.team-identifier"));
   }
 }

--- a/test/com/facebook/buck/apple/ProvisioningProfileCopyStepTest.java
+++ b/test/com/facebook/buck/apple/ProvisioningProfileCopyStepTest.java
@@ -193,11 +193,12 @@ public class ProvisioningProfileCopyStepTest {
 
     ProvisioningProfileMetadata selectedProfile = step.getSelectedProvisioningProfileFuture().get();
     ImmutableMap<String, NSObject> profileEntitlements = selectedProfile.getEntitlements();
-    assertTrue(profileEntitlements.containsKey( "com.apple.security.application-groups"));
+    assertTrue(profileEntitlements.containsKey("com.apple.security.application-groups"));
 
     Optional<String> xcentContents = projectFilesystem.readFileIfItExists(xcentFile);
     assertTrue(xcentContents.isPresent());
-    NSDictionary xcentPlist = (NSDictionary)PropertyListParser.parse(xcentContents.get().getBytes());
+    NSDictionary xcentPlist = (NSDictionary)
+        PropertyListParser.parse(xcentContents.get().getBytes());
     assertFalse(xcentPlist.containsKey("com.apple.security.application-groups"));
     assertEquals(xcentPlist.get("com.apple.developer.team-identifier"),
         profileEntitlements.get("com.apple.developer.team-identifier"));
@@ -220,11 +221,12 @@ public class ProvisioningProfileCopyStepTest {
 
     ProvisioningProfileMetadata selectedProfile = step.getSelectedProvisioningProfileFuture().get();
     ImmutableMap<String, NSObject> profileEntitlements = selectedProfile.getEntitlements();
-    assertTrue(profileEntitlements.containsKey( "com.apple.security.application-groups"));
+    assertTrue(profileEntitlements.containsKey("com.apple.security.application-groups"));
 
     Optional<String> xcentContents = projectFilesystem.readFileIfItExists(xcentFile);
     assertTrue(xcentContents.isPresent());
-    NSDictionary xcentPlist = (NSDictionary)PropertyListParser.parse(xcentContents.get().getBytes());
+    NSDictionary xcentPlist = (NSDictionary)
+        PropertyListParser.parse(xcentContents.get().getBytes());
     assertFalse(xcentPlist.containsKey("com.apple.security.application-groups"));
     assertEquals(xcentPlist.get("com.apple.developer.team-identifier"),
         profileEntitlements.get("com.apple.developer.team-identifier"));

--- a/test/com/facebook/buck/apple/ProvisioningProfileMetadataTest.java
+++ b/test/com/facebook/buck/apple/ProvisioningProfileMetadataTest.java
@@ -18,7 +18,9 @@ package com.facebook.buck.apple;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import com.dd.plist.NSDate;
@@ -98,4 +100,18 @@ public class ProvisioningProfileMetadataTest {
     thrown.expectMessage("Malformed app ID: invalid.");
     ProvisioningProfileMetadata.splitAppID("invalid.");
   }
+
+  @Test
+  public void testFilteredEntitlementsStripOut() throws Exception {
+    assumeTrue(Platform.detect() == Platform.MACOS);
+    Path testdataDir = TestDataHelper.getTestDataDirectory(this).resolve("provisioning_profiles");
+    Path testFile = testdataDir.resolve("sample.mobileprovision");
+
+    ProvisioningProfileMetadata data =
+        ProvisioningProfileMetadata.fromProvisioningProfilePath(testFile);
+
+    assertTrue(data.getEntitlements().containsKey("com.apple.security.application-groups"));
+    assertFalse(data.getMergeableEntitlements().containsKey("com.apple.security.application-groups"));
+  }
+
 }

--- a/test/com/facebook/buck/apple/ProvisioningProfileMetadataTest.java
+++ b/test/com/facebook/buck/apple/ProvisioningProfileMetadataTest.java
@@ -111,7 +111,8 @@ public class ProvisioningProfileMetadataTest {
         ProvisioningProfileMetadata.fromProvisioningProfilePath(testFile);
 
     assertTrue(data.getEntitlements().containsKey("com.apple.security.application-groups"));
-    assertFalse(data.getMergeableEntitlements().containsKey("com.apple.security.application-groups"));
+    assertFalse(data.getMergeableEntitlements().containsKey(
+        "com.apple.security.application-groups"));
   }
 
 }

--- a/test/com/facebook/buck/apple/testdata/provisioning_profiles/Entitlements.plist
+++ b/test/com/facebook/buck/apple/testdata/provisioning_profiles/Entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>application-identifier</key>
+	<string>ABCDE12345.com.example.TestApp</string>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>ABCDE12345.com.example.TestApp</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Fixes #798. Use a blacklist of keys that should not be merged from provisioning profile entitlements into xcent files.