### PR TITLE
Disk IO timeout property

### DIFF
--- a/src/com/facebook/buck/artifact_cache/DirArtifactCache.java
+++ b/src/com/facebook/buck/artifact_cache/DirArtifactCache.java
@@ -335,6 +335,9 @@ public class DirArtifactCache implements ArtifactCache {
         maxTrimMark = Optional.of(i);
       }
       if (currentSizeBytes > maxSizeBytes) {
+        LOG.debug("Deleting %d files of %d bytes from the cache",
+            files.length - maxTrimMark.get(),
+            currentSizeBytes);
         return ArrayIterable.of(files, maxTrimMark.get(), files.length);
       }
     }

--- a/src/com/facebook/buck/cli/Main.java
+++ b/src/com/facebook/buck/cli/Main.java
@@ -136,6 +136,7 @@ import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
 
+import org.apache.commons.lang.math.NumberUtils;
 import org.kohsuke.args4j.CmdLineException;
 
 import java.io.Closeable;
@@ -201,7 +202,8 @@ public final class Main {
    */
   private static final String STATIC_CONTENT_DIRECTORY = System.getProperty(
       "buck.path_to_static_content", "webserver/static");
-  private static final int DISK_IO_STATS_TIMEOUT_SECONDS = 10;
+  private static final int DISK_IO_STATS_TIMEOUT_SECONDS = NumberUtils.toInt(System.getProperty(
+      "buck.disk_io_timeout"), 10);
   private static final int EXECUTOR_SERVICES_TIMEOUT_SECONDS = 60;
   private static final int COUNTER_AGGREGATOR_SERVICE_TIMEOUT_SECONDS = 20;
 


### PR DESCRIPTION
Ref #803. Make it possible to specify a custom disk IO executor timeout as a java property. This makes it possible to clean the cache on CI jobs while a better solution is found to fix the issue with the cache growing without bounds.