### PR TITLE
iOS: setAppIncludesFrameworks to true

### DIFF
--- a/src/com/facebook/buck/apple/AbstractApplePlatform.java
+++ b/src/com/facebook/buck/apple/AbstractApplePlatform.java
@@ -35,6 +35,7 @@ abstract class AbstractApplePlatform implements Comparable<AbstractApplePlatform
           .setSwiftName("ios")
           .setArchitectures(ImmutableList.of("armv7", "arm64"))
           .setMinVersionFlagPrefix("-mios-version-min=")
+          .setAppIncludesFrameworks(true)
           // only used for legacy watch apps
           .setStubBinaryPath(Optional.of(Paths.get("Library/Application Support/WatchKit/WK")))
           .build();
@@ -44,6 +45,7 @@ abstract class AbstractApplePlatform implements Comparable<AbstractApplePlatform
           .setSwiftName("ios")
           .setArchitectures(ImmutableList.of("i386", "x86_64"))
           .setMinVersionFlagPrefix("-mios-simulator-version-min=")
+          .setAppIncludesFrameworks(true)
           // only used for legacy watch apps
           .setStubBinaryPath(Optional.of(Paths.get("Library/Application Support/WatchKit/WK")))
           .build();


### PR DESCRIPTION
I want to include dynamic frameworks in my build buck app. The work is coming along and I hope to open a PR soon. On iOS these frameworks are available from iOS8+, is there a way to set the `setAppIncludesFrameworks` value conditionally based on specified  [target_sdk_version](https://buckbuild.com/concept/buckconfig.html#apple.target_sdk_version)?