### PR TITLE
Account for non-String ssid in MacWifiSsidFinder

### DIFF
--- a/src/com/facebook/buck/util/environment/MacWifiSsidFinder.java
+++ b/src/com/facebook/buck/util/environment/MacWifiSsidFinder.java
@@ -103,12 +103,15 @@ public class MacWifiSsidFinder {
       LOG.debug("No SSID found for interface %s.", defaultInterface.get());
       return Optional.absent();
     }
+    String ssidString;
     if (!(ssid instanceof String)) {
-      LOG.error("Fetched SSID, but got unexpected non-string type (got: %s).", ssid);
-      return Optional.absent();
+      LOG.warn("Fetched SSID, but got unexpected non-string type (got: %s).",
+          ssid.getClass().getName());
+      ssidString = ssid.toString();
+    } else {
+      ssidString = (String) ssid;
     }
 
-    String ssidString = (String) ssid;
     LOG.debug("Found SSID: %s", ssidString);
     return Optional.of(ssidString);
   }


### PR DESCRIPTION
When attempting to build on the our corporate wifi network, I get the following error:

```
[com.facebook.buck.util.environment.MacWifiSsidFinder] Fetched SSID, but got unexpected non-string type (got: Google).
```

`Google` in this case is the SSID name, not the type. After updating the code to return the class name and running again, I get the following:

```
[com.facebook.buck.util.environment.MacWifiSsidFinder] Fetched SSID, but got unexpected non-string type (got: ca.weblite.objc.Proxy).
```

So it appears that in some (I’m assuming rare) cases, the call to `ssid` is resulting in a `Proxy` object being returned instead of a `String`.

Calling `toString()` solves this issue, but I’m also curious to know why this would happen in the first place.

This is running on 10.11.6 (15G31)