### PR TITLE
Always use relative paths for Android manifest entries in IML files.

### DIFF
--- a/src/com/facebook/buck/jvm/java/intellij/IjProjectTemplateDataPreparer.java
+++ b/src/com/facebook/buck/jvm/java/intellij/IjProjectTemplateDataPreparer.java
@@ -462,7 +462,9 @@ public class IjProjectTemplateDataPreparer {
     Optional<Path> androidManifestPath = androidFacet.getManifestPath();
     Path manifestPath;
     if (androidManifestPath.isPresent()) {
-      manifestPath = androidManifestPath.get();
+      manifestPath = androidManifestPath.get()
+          .relativize(moduleBasePath.toAbsolutePath())
+          .resolve(androidManifestPath.get().getFileName());
     } else {
       manifestPath = moduleBasePath
                       .relativize(


### PR DESCRIPTION
These paths always need to be relative, otherwise the IDE will duplicate it like this:
 <img width="1020" alt="screen shot 2016-07-27 at 4 32 26 pm" src="https://cloud.githubusercontent.com/assets/23467/17196244/16938414-5418-11e6-85b9-fc51634e9753.png">
