### PR TITLE
Use package and resource name when computing referenced resource names in dex

### DIFF
--- a/test/com/facebook/buck/android/AndroidBinaryIntegrationTest.java
+++ b/test/com/facebook/buck/android/AndroidBinaryIntegrationTest.java
@@ -243,7 +243,7 @@ public class AndroidBinaryIntegrationTest {
         buildInfo.getValues(DexProducedFromJavaLibrary.REFERENCED_RESOURCES);
     assertTrue(resourcesFromMetadata.isPresent());
     assertEquals(
-        ImmutableSet.of("title", "top_layout"),
+        ImmutableSet.of("com.sample.top_layout", "com.sample2.title"),
         ImmutableSet.copyOf(resourcesFromMetadata.get()));
   }
 

--- a/test/com/facebook/buck/android/TrimUberRDotJavaTest.java
+++ b/test/com/facebook/buck/android/TrimUberRDotJavaTest.java
@@ -99,7 +99,7 @@ public class TrimUberRDotJavaTest {
             .putMetadata(DexProducedFromJavaLibrary.CLASSNAMES_TO_HASHES, "{}")
             .putMetadata(
                 DexProducedFromJavaLibrary.REFERENCED_RESOURCES,
-                ImmutableList.of("my_first_resource"))));
+                ImmutableList.of("com.test.my_first_resource"))));
 
     TrimUberRDotJava trimUberRDotJava = new TrimUberRDotJava(
         new FakeBuildRuleParamsBuilder(BuildTargetFactory.newInstance("//:trim"))

--- a/third-party/java/dx/src/com/android/dx/command/dexer/Main.java
+++ b/third-party/java/dx/src/com/android/dx/command/dexer/Main.java
@@ -1654,8 +1654,8 @@ public class Main {
             CstType fieldClass = item.getDefiningClass();
             CstString fieldName = item.getRef().getNat().getName();
             if (fieldClass.getClassType().getDescriptor().contains("/R$")) {
-                // We ignore the name of the containing class for simplicity.
-                resourceNames.add(fieldName.getString());
+                // Add the packageName of the class for better accuracy.
+                resourceNames.add(fieldClass.getPackageName() + "." + fieldName.getString());
             }
         }
     }


### PR DESCRIPTION
Resolves #828