### PR TITLE
Allow configuring Android SDK name and type for intellij project modules

### DIFF
--- a/docs/concept/buckconfig.soy
+++ b/docs/concept/buckconfig.soy
@@ -1585,6 +1585,24 @@ $ buck targets --resolve-alias app#src_jar
 
 {call buckconfig.entry}
   {param section: 'intellij' /}
+  {param name: 'android_module_sdk_type' /}
+  {param example_value: 'Android SDK' /}
+  {param description}
+    Default Android SDK type for android modules.
+  {/param}
+{/call}
+
+{call buckconfig.entry}
+  {param section: 'intellij' /}
+  {param name: 'android_module_sdk_name' /}
+  {param example_value: 'Android API 23 Platform' /}
+  {param description}
+    Default Android SDK name for android modules.
+  {/param}
+{/call}
+
+{call buckconfig.entry}
+  {param section: 'intellij' /}
   {param name: 'language_level' /}
   {param example_value: 'JDK_1_7' /}
   {param description}

--- a/src/com/facebook/buck/jvm/java/intellij/AbstractIjProjectConfig.java
+++ b/src/com/facebook/buck/jvm/java/intellij/AbstractIjProjectConfig.java
@@ -48,6 +48,10 @@ abstract class AbstractIjProjectConfig {
 
   public abstract Optional<String> getProjectJdkType();
 
+  public abstract Optional<String> getAndroidModuleSdkName();
+
+  public abstract Optional<String> getAndroidModuleSdkType();
+
   public abstract Optional<String> getProjectLanguageLevel();
 
   public abstract List<String> getExcludedResourcePaths();

--- a/src/com/facebook/buck/jvm/java/intellij/IjModuleFactory.java
+++ b/src/com/facebook/buck/jvm/java/intellij/IjModuleFactory.java
@@ -289,6 +289,7 @@ public class IjModuleFactory {
   }
 
   private static final String SDK_TYPE_JAVA = "JavaSDK";
+  private static final String SDK_TYPE_ANDROID = "Android SDK";
 
   private final Map<BuildRuleType, IjModuleRule<?>> moduleRuleIndex = new HashMap<>();
   private final IjModuleFactoryResolver moduleFactoryResolver;
@@ -357,13 +358,19 @@ public class IjModuleFactory {
     Optional<String> sourceLevel = getSourceLevel(targetNodes);
     // The only JDK type that is supported right now. If we ever add support for Android libraries
     // to have different language levels we need to add logic to detect correct JDK type.
-    String sdkType = SDK_TYPE_JAVA;
-
+    String sdkType;
     Optional<String> sdkName;
-    if (sourceLevel.isPresent()) {
-      sdkName = getSdkName(sourceLevel.get(), sdkType);
+
+    if (context.getAndroidFacet().isPresent()) {
+      sdkType = projectConfig.getAndroidModuleSdkType().orElse(SDK_TYPE_ANDROID);
+      sdkName = projectConfig.getAndroidModuleSdkName();
     } else {
-      sdkName = Optional.empty();
+      sdkType = projectConfig.getProjectJdkType().orElse(SDK_TYPE_JAVA);
+      if (sourceLevel.isPresent()) {
+        sdkName = getSdkName(sourceLevel.get(), sdkType);
+      } else {
+        sdkName = Optional.empty();
+      }
     }
 
     return IjModule.builder()

--- a/src/com/facebook/buck/jvm/java/intellij/IjProjectBuckConfig.java
+++ b/src/com/facebook/buck/jvm/java/intellij/IjProjectBuckConfig.java
@@ -76,6 +76,10 @@ public class IjProjectBuckConfig {
             buckConfig.getValue(INTELLIJ_BUCK_CONFIG_SECTION, "jdk_name"))
         .setProjectJdkType(
             buckConfig.getValue(INTELLIJ_BUCK_CONFIG_SECTION, "jdk_type"))
+        .setAndroidModuleSdkName(
+            buckConfig.getValue(INTELLIJ_BUCK_CONFIG_SECTION, "android_module_sdk_name"))
+        .setAndroidModuleSdkType(
+            buckConfig.getValue(INTELLIJ_BUCK_CONFIG_SECTION, "android_module_sdk_type"))
         .setProjectLanguageLevel(
             buckConfig.getValue(INTELLIJ_BUCK_CONFIG_SECTION, "language_level"))
         .setExcludedResourcePaths(excludedResourcePaths)

--- a/test/com/facebook/buck/jvm/java/intellij/ProjectIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/java/intellij/ProjectIntegrationTest.java
@@ -604,6 +604,11 @@ public class ProjectIntegrationTest {
   }
 
   @Test
+  public void testBuckProjectWithCustomAndroidSdks() throws IOException {
+    runBuckProjectAndVerify("project_with_custom_android_sdks");
+  }
+
+  @Test
   public void testVersion2BuckProjectWithProjectSettings() throws IOException {
     runBuckProjectAndVerify("experimental_project_with_project_settings");
   }

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/project_with_custom_android_sdks/.buckconfig
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/project_with_custom_android_sdks/.buckconfig
@@ -1,0 +1,11 @@
+[color]
+  ui = false
+[alias]
+  root=//:root_repo
+[project]
+  ignore = buck-out
+  ide = intellij
+  disable_r_java_idea_generator = true
+[intellij]
+  android_module_sdk_name = "Google Inc.:Google APIs:24"
+  android_module_sdk_type = "AndroidSDK"

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/project_with_custom_android_sdks/.idea/modules.xml.expected
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/project_with_custom_android_sdks/.idea/modules.xml.expected
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/modules/libA/modules_libA.iml" filepath="$PROJECT_DIR$/modules/libA/modules_libA.iml"  group="modules"  />
+      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml"  />
+
+   </modules>
+  </component>
+</project>

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/project_with_custom_android_sdks/modules/libA/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/project_with_custom_android_sdks/modules/libA/BUCK.fixture
@@ -1,0 +1,4 @@
+android_library(
+    name='src',
+    visibility=['PUBLIC'],
+)

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/project_with_custom_android_sdks/modules/libA/modules_libA.iml.expected
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/project_with_custom_android_sdks/modules/libA/modules_libA.iml.expected
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android" name="Android">
+      <configuration>
+        <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/libA/gen" />
+        <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/libA/gen" />
+        <option name="MANIFEST_FILE_RELATIVE_PATH" value="/../../android_res/AndroidManifest.xml" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="" />
+        <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/assets" />
+        <option name="LIBS_FOLDER_RELATIVE_PATH" value="/libs" />
+        <option name="APK_PATH" value="" />
+        <option name="LIBRARY_PROJECT" value="true" />
+        <option name="RUN_PROCESS_RESOURCES_MAVEN_TASK" value="true" />
+        <option name="GENERATE_UNSIGNED_APK" value="false" />
+        <option name="CUSTOM_DEBUG_KEYSTORE_PATH" value="" />
+        <option name="PACK_TEST_CODE" value="false" />
+        <option name="RUN_PROGUARD" value="false" />
+        <option name="PROGUARD_CFG_PATH" value="" />
+        <option name="ENABLE_SOURCES_AUTOGENERATION" value="false" />
+        <resOverlayFolders />
+        <includeSystemProguardFile>false</includeSystemProguardFile>
+        <includeAssetsFromLibraries>true</includeAssetsFromLibraries>
+        <additionalNativeLibs />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+
+    </content>
+    <content url="file://$MODULE_DIR$/../../buck-out/android/modules/libA/gen">
+      <sourceFolder url="file://$MODULE_DIR$/../../buck-out/android/modules/libA/gen" isTestSource="false" />
+    </content>
+    <orderEntry type="jdk" jdkName="Google Inc.:Google APIs:24" jdkType="AndroidSDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/project_with_custom_android_sdks/modules/libA/src/main/AndroidManifest.xml
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/project_with_custom_android_sdks/modules/libA/src/main/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.example"
+          android:versionCode="1"
+          android:versionName="1.0">
+
+    <application/>
+</manifest>

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/project_with_custom_android_sdks/project_root.iml.expected
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/project_with_custom_android_sdks/project_root.iml.expected
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/buck-out" isTestSource="false" />
+
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>


### PR DESCRIPTION
Ref #821

This adds support for setting the default android sdk name and type in generated intellij iml files.

```
[intellij]
  android_sdk_name = Android API 23 Platform
  android_sdk_type = AndroidSDK
```
