### PR TITLE
Change OSX framework bundle paths

### DIFF
--- a/src/com/facebook/buck/apple/AbstractAppleBundleDestinations.java
+++ b/src/com/facebook/buck/apple/AbstractAppleBundleDestinations.java
@@ -46,6 +46,12 @@ abstract class AbstractAppleBundleDestinations implements RuleKeyAppendable {
   @Value.Parameter
   public abstract Path getWatchAppPath();
 
+  @Value.Parameter
+  public abstract Path getHeadersPath();
+
+  @Value.Parameter
+  public abstract Path getModulesPath();
+
   @Override
   public void appendToRuleKey(RuleKeyObjectSink sink) {
     sink
@@ -54,7 +60,9 @@ abstract class AbstractAppleBundleDestinations implements RuleKeyAppendable {
         .setReflectively("executables_path", getExecutablesPath().toString())
         .setReflectively("frameworks_path", getFrameworksPath().toString())
         .setReflectively("plugins_path", getPlugInsPath().toString())
-        .setReflectively("watch_app_path", getWatchAppPath().toString());
+        .setReflectively("watch_app_path", getWatchAppPath().toString())
+        .setReflectively("headers_path", getHeadersPath().toString())
+        .setReflectively("modules_path", getModulesPath().toString());
   }
 
   private static final Path OSX_CONTENTS_PATH = Paths.get("Contents");
@@ -66,6 +74,21 @@ abstract class AbstractAppleBundleDestinations implements RuleKeyAppendable {
           .setFrameworksPath(OSX_CONTENTS_PATH.resolve("Frameworks"))
           .setPlugInsPath(OSX_CONTENTS_PATH.resolve("PlugIns"))
           .setWatchAppPath(OSX_CONTENTS_PATH)
+          .setHeadersPath(OSX_CONTENTS_PATH)
+          .setModulesPath(OSX_CONTENTS_PATH)
+          .build();
+
+  private static final Path OSX_FRAMEWORK_CONTENTS_PATH = Paths.get("");
+  public static final AppleBundleDestinations OSX_FRAMEWORK_DESTINATIONS =
+      AppleBundleDestinations.builder()
+          .setMetadataPath(OSX_FRAMEWORK_CONTENTS_PATH.resolve("Resources"))
+          .setResourcesPath(OSX_FRAMEWORK_CONTENTS_PATH.resolve("Resources"))
+          .setExecutablesPath(OSX_FRAMEWORK_CONTENTS_PATH)
+          .setFrameworksPath(OSX_FRAMEWORK_CONTENTS_PATH.resolve("Frameworks"))
+          .setPlugInsPath(OSX_FRAMEWORK_CONTENTS_PATH)
+          .setWatchAppPath(OSX_FRAMEWORK_CONTENTS_PATH)
+          .setHeadersPath(OSX_FRAMEWORK_CONTENTS_PATH.resolve("Headers"))
+          .setModulesPath(OSX_FRAMEWORK_CONTENTS_PATH.resolve("Modules"))
           .build();
 
   private static final Path IOS_CONTENTS_PATH = Paths.get("");
@@ -77,13 +100,37 @@ abstract class AbstractAppleBundleDestinations implements RuleKeyAppendable {
           .setFrameworksPath(IOS_CONTENTS_PATH.resolve("Frameworks"))
           .setPlugInsPath(IOS_CONTENTS_PATH.resolve("PlugIns"))
           .setWatchAppPath(IOS_CONTENTS_PATH.resolve("Watch"))
+          .setHeadersPath(IOS_CONTENTS_PATH)
+          .setModulesPath(IOS_CONTENTS_PATH)
           .build();
+
+  private static final Path IOS_FRAMEWORK_CONTENTS_PATH = Paths.get("");
+  public static final AppleBundleDestinations IOS_FRAMEWORK_DESTINATIONS =
+      AppleBundleDestinations.builder()
+          .setMetadataPath(IOS_FRAMEWORK_CONTENTS_PATH)
+          .setResourcesPath(IOS_FRAMEWORK_CONTENTS_PATH)
+          .setExecutablesPath(IOS_FRAMEWORK_CONTENTS_PATH)
+          .setFrameworksPath(IOS_FRAMEWORK_CONTENTS_PATH.resolve("Frameworks"))
+          .setPlugInsPath(IOS_FRAMEWORK_CONTENTS_PATH)
+          .setWatchAppPath(IOS_FRAMEWORK_CONTENTS_PATH)
+          .setHeadersPath(IOS_FRAMEWORK_CONTENTS_PATH.resolve("Headers"))
+          .setModulesPath(IOS_FRAMEWORK_CONTENTS_PATH.resolve("Modules"))
+          .build();
+
 
   public static AppleBundleDestinations platformDestinations(ApplePlatform platform) {
     if (platform.getName().contains("osx")) {
       return AppleBundleDestinations.OSX_DESTINATIONS;
     } else {
       return AppleBundleDestinations.IOS_DESTINATIONS;
+    }
+  }
+
+  public static AppleBundleDestinations platformFrameworkDestinations(ApplePlatform platform) {
+    if (platform.getName().contains("osx")) {
+      return AppleBundleDestinations.OSX_FRAMEWORK_DESTINATIONS;
+    } else {
+      return AppleBundleDestinations.IOS_FRAMEWORK_DESTINATIONS;
     }
   }
 }

--- a/src/com/facebook/buck/apple/AppleDescriptions.java
+++ b/src/com/facebook/buck/apple/AppleDescriptions.java
@@ -488,9 +488,15 @@ public class AppleDescriptions {
         params.getBuildTarget(),
         MultiarchFileInfos.create(appleCxxPlatforms, params.getBuildTarget()));
 
-    AppleBundleDestinations destinations =
-        AppleBundleDestinations.platformDestinations(
-            appleCxxPlatform.getAppleSdk().getApplePlatform());
+    AppleBundleDestinations destinations = null;
+
+    if (extension.isLeft() && extension.getLeft().equals(AppleBundleExtension.FRAMEWORK)) {
+      destinations = AppleBundleDestinations.platformFrameworkDestinations(
+          appleCxxPlatform.getAppleSdk().getApplePlatform());
+    } else {
+      destinations = AppleBundleDestinations.platformDestinations(
+                        appleCxxPlatform.getAppleSdk().getApplePlatform());
+    }
 
     AppleBundleResources collectedResources = AppleResources.collectResourceDirsAndFiles(
         targetGraph,

--- a/test/com/facebook/buck/apple/AppleBinaryIntegrationTest.java
+++ b/test/com/facebook/buck/apple/AppleBinaryIntegrationTest.java
@@ -268,7 +268,7 @@ public class AppleBinaryIntegrationTest {
         containsString("executable"));
     Path frameworkBundlePath = bundlePath.resolve("Contents/Frameworks/TestLibrary.framework");
     assertThat(Files.exists(frameworkBundlePath), is(true));
-    Path frameworkBinaryPath = frameworkBundlePath.resolve("Contents/MacOS/TestLibrary");
+    Path frameworkBinaryPath = frameworkBundlePath.resolve("TestLibrary");
     assertThat(Files.exists(frameworkBinaryPath), is(true));
     assertThat(
         workspace.runCommand("file", frameworkBinaryPath.toString()).getStdout().get(),

--- a/test/com/facebook/buck/apple/AppleLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/apple/AppleLibraryIntegrationTest.java
@@ -270,8 +270,43 @@ public class AppleLibraryIntegrationTest {
                 "%s")
             .resolve("TestLibrary.framework"));
     assertThat(Files.exists(frameworkPath), is(true));
-    assertThat(Files.exists(frameworkPath.resolve("Contents/Info.plist")), is(true));
-    Path libraryPath = frameworkPath.resolve("Contents/MacOS/TestLibrary");
+    assertThat(Files.exists(frameworkPath.resolve("Resources/Info.plist")), is(true));
+    Path libraryPath = frameworkPath.resolve("TestLibrary");
+    assertThat(Files.exists(libraryPath), is(true));
+    assertThat(
+        workspace.runCommand("file", libraryPath.toString()).getStdout().get(),
+        containsString("dynamically linked shared library"));
+  }
+
+  @Test
+  public void testAppleLibraryBuildsFrameworkIOS() throws Exception {
+    assumeTrue(Platform.detect() == Platform.MACOS);
+    assumeTrue(AppleNativeIntegrationTestUtils.isApplePlatformAvailable(ApplePlatform.IPHONESIMULATOR));
+
+    ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(
+        this, "apple_library_builds_something", tmp);
+    workspace.setUp();
+    ProjectFilesystem filesystem = new ProjectFilesystem(workspace.getDestPath());
+
+    BuildTarget target = BuildTargetFactory.newInstance(
+        "//Libraries/TestLibrary:TestLibrary#framework,iphonesimulator-x86_64,no-debug");
+    ProjectWorkspace.ProcessResult result = workspace.runBuckCommand(
+        "build",
+        target.getFullyQualifiedName());
+    result.assertSuccess();
+
+    Path frameworkPath = workspace.getPath(
+        BuildTargets
+            .getGenPath(
+                filesystem,
+                BuildTarget.builder(target)
+                    .addFlavors(AppleDescriptions.INCLUDE_FRAMEWORKS_FLAVOR)
+                    .build(),
+                "%s")
+            .resolve("TestLibrary.framework"));
+    assertThat(Files.exists(frameworkPath), is(true));
+    assertThat(Files.exists(frameworkPath.resolve("Info.plist")), is(true));
+    Path libraryPath = frameworkPath.resolve("TestLibrary");
     assertThat(Files.exists(libraryPath), is(true));
     assertThat(
         workspace.runCommand("file", libraryPath.toString()).getStdout().get(),
@@ -304,7 +339,7 @@ public class AppleLibraryIntegrationTest {
                     .build(),
                 "%s")
             .resolve("TestLibrary.framework"));
-    Path libraryPath = frameworkPath.resolve("Contents/MacOS/TestLibrary");
+    Path libraryPath = frameworkPath.resolve("TestLibrary");
     assertThat(Files.exists(libraryPath), is(true));
     ProcessExecutor.Result lipoVerifyResult =
         workspace.runCommand("lipo", libraryPath.toString(), "-verify_arch", "i386", "x86_64");
@@ -426,17 +461,17 @@ public class AppleLibraryIntegrationTest {
                 "%s")
             .resolve("TestLibrary.framework"));
     assertThat(Files.exists(frameworkPath), is(true));
-    Path frameworksPath = frameworkPath.resolve("Contents/Frameworks");
+    Path frameworksPath = frameworkPath.resolve("Frameworks");
     assertThat(Files.exists(frameworksPath), is(true));
     Path depPath =
-        frameworksPath.resolve("TestLibraryDep.framework/Contents/MacOS/TestLibraryDep");
+        frameworksPath.resolve("TestLibraryDep.framework/TestLibraryDep");
     assertThat(Files.exists(depPath), is(true));
     assertThat(
         workspace.runCommand("file", depPath.toString()).getStdout().get(),
         containsString("dynamically linked shared library"));
     Path transitiveDepPath =
         frameworksPath.resolve(
-            "TestLibraryTransitiveDep.framework/Contents/MacOS/TestLibraryTransitiveDep");
+            "TestLibraryTransitiveDep.framework/TestLibraryTransitiveDep");
     assertThat(Files.exists(transitiveDepPath), is(true));
     assertThat(
         workspace.runCommand("file", transitiveDepPath.toString()).getStdout().get(),
@@ -471,10 +506,10 @@ public class AppleLibraryIntegrationTest {
                 "%s")
             .resolve("TestLibrary.framework"));
     assertThat(Files.exists(frameworkPath), is(true));
-    Path frameworksPath = frameworkPath.resolve("Contents/Frameworks");
+    Path frameworksPath = frameworkPath.resolve("Frameworks");
     assertThat(Files.exists(frameworksPath), is(true));
     Path depFrameworksPath =
-        frameworksPath.resolve("TestLibraryDep.framework/Contents/Frameworks");
+        frameworksPath.resolve("TestLibraryDep.framework/Frameworks");
     assertThat(Files.exists(depFrameworksPath), is(false));
   }
 
@@ -499,8 +534,8 @@ public class AppleLibraryIntegrationTest {
     Path frameworkPath = workspace.getPath(BuildTargets.getGenPath(filesystem, target, "%s")
         .resolve("TestLibrary.framework"));
     assertThat(Files.exists(frameworkPath), is(true));
-    assertThat(Files.exists(frameworkPath.resolve("Contents/Info.plist")), is(true));
-    Path libraryPath = frameworkPath.resolve("Contents/MacOS/TestLibrary");
+    assertThat(Files.exists(frameworkPath.resolve("Resources/Info.plist")), is(true));
+    Path libraryPath = frameworkPath.resolve("TestLibrary");
     assertThat(Files.exists(libraryPath), is(true));
     assertThat(
         workspace.runCommand("file", libraryPath.toString()).getStdout().get(),


### PR DESCRIPTION
I don't know where the `Contents` and `MacOs` folders originally came from, that commit (d44f10e6258859badb0d5ce9ee3ff99d65e1aaf6) doesn't contain a lot of background. I think those folders are wrong for the following reasons:

- They do not conform to the [apple docs](https://developer.apple.com/library/mac/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/FrameworkAnatomy.html)
- Checking a random library on my mac also doesn't show them.
```
$ tree -L 3 /Library/Frameworks/iTunesLibrary.framework
/Library/Frameworks/iTunesLibrary.framework
├── Headers -> Versions/Current/Headers
├── Modules -> Versions/Current/Modules
├── Resources -> Versions/Current/Resources
├── Versions
│   ├── A
│   │   ├── Headers
│   │   └── iTunesLibrary
│   └── Current -> A
└── iTunesLibrary -> Versions/Current/iTunesLibrary
```
- When using a framework generated from an `apple_library` (I know this doesn't fully work but I'm working on a PR to fix that), clang complains during linking/preprocessing (with `-F` and `-framework`) that it cannot find the framework. When I changed the binaries and headers to not be in the contents and MacOS paths everything works.
