### PR TITLE
Prevent the fact that we're using antiquated APIs poking through.

### DIFF
--- a/src/com/facebook/buck/apple/CodeSignStep.java
+++ b/src/com/facebook/buck/apple/CodeSignStep.java
@@ -78,7 +78,7 @@ class CodeSignStep implements Step {
     ProcessExecutorParams processExecutorParams =
         paramsBuilder
             .setCommand(commandBuilder.build())
-            .setDirectory(workingDirectory.toFile())
+            .setDirectory(workingDirectory)
             .build();
     // Must specify that stdout is expected or else output may be wrapped in Ansi escape chars.
     Set<ProcessExecutor.Option> options = EnumSet.of(ProcessExecutor.Option.EXPECTING_STD_OUT);

--- a/src/com/facebook/buck/apple/SwiftStdlibStep.java
+++ b/src/com/facebook/buck/apple/SwiftStdlibStep.java
@@ -66,7 +66,7 @@ class SwiftStdlibStep implements Step {
 
   private ProcessExecutorParams makeProcessExecutorParams() {
     ProcessExecutorParams.Builder builder = ProcessExecutorParams.builder();
-    builder.setDirectory(workingDirectory.toAbsolutePath().toFile());
+    builder.setDirectory(workingDirectory.toAbsolutePath());
     builder.setCommand(command);
     builder.addCommand("--destination", temp.toString());
     if (codeSignIdentitySupplier.isPresent()) {

--- a/src/com/facebook/buck/apple/XctestRunTestsStep.java
+++ b/src/com/facebook/buck/apple/XctestRunTestsStep.java
@@ -113,7 +113,7 @@ class XctestRunTestsStep implements Step {
   public StepExecutionResult execute(ExecutionContext context) throws InterruptedException {
     ProcessExecutorParams.Builder builder = ProcessExecutorParams.builder()
         .addAllCommand(getCommand())
-        .setDirectory(filesystem.getRootPath().toAbsolutePath().toFile())
+        .setDirectory(filesystem.getRootPath().toAbsolutePath())
         .setRedirectErrorStream(true)
         .setEnvironment(getEnv(context));
 

--- a/src/com/facebook/buck/apple/XctoolRunTestsStep.java
+++ b/src/com/facebook/buck/apple/XctoolRunTestsStep.java
@@ -239,7 +239,7 @@ class XctoolRunTestsStep implements Step {
 
     ProcessExecutorParams.Builder processExecutorParamsBuilder = ProcessExecutorParams.builder()
         .addAllCommand(command)
-        .setDirectory(filesystem.getRootPath().toAbsolutePath().toFile())
+        .setDirectory(filesystem.getRootPath().toAbsolutePath())
         .setRedirectOutput(ProcessBuilder.Redirect.PIPE)
         .setEnvironment(env);
 

--- a/src/com/facebook/buck/cli/RunCommand.java
+++ b/src/com/facebook/buck/cli/RunCommand.java
@@ -159,7 +159,7 @@ public class RunCommand extends AbstractCommand {
                     .putAll(params.getEnvironment())
                     .putAll(executable.getEnvironment(resolver))
                     .build())
-            .setDirectory(params.getCell().getFilesystem().getRootPath().toFile())
+            .setDirectory(params.getCell().getFilesystem().getRootPath())
             .build();
     ForwardingProcessListener processListener =
         new ForwardingProcessListener(

--- a/src/com/facebook/buck/cli/TestCommand.java
+++ b/src/com/facebook/buck/cli/TestCommand.java
@@ -335,7 +335,7 @@ public class TestCommand extends BuildCommand {
             .addCommand(
                 "--jobs",
                 String.valueOf(getConcurrencyLimit(params.getBuckConfig()).threadLimit))
-            .setDirectory(params.getCell().getFilesystem().getRootPath().toFile())
+            .setDirectory(params.getCell().getFilesystem().getRootPath())
             .build();
     ForwardingProcessListener processListener =
         new ForwardingProcessListener(

--- a/src/com/facebook/buck/python/PythonRunTestsStep.java
+++ b/src/com/facebook/buck/python/PythonRunTestsStep.java
@@ -104,7 +104,7 @@ public class PythonRunTestsStep implements Step {
                 .addAll(commandPrefix)
                 .add("-l", "-L", "buck")
                 .build())
-        .setDirectory(workingDirectory.toFile())
+        .setDirectory(workingDirectory)
         .setEnvironment(environment.get())
         .build();
     ProcessExecutor.Result result = context.getProcessExecutor().launchAndExecute(

--- a/src/com/facebook/buck/rage/DefaultExtraInfoCollector.java
+++ b/src/com/facebook/buck/rage/DefaultExtraInfoCollector.java
@@ -70,7 +70,7 @@ public class DefaultExtraInfoCollector implements ExtraInfoCollector {
               .addCommand(
                   "--output-dir",
                   projectFilesystem.resolve(rageExtraFilesDir).toString())
-              .setDirectory(projectFilesystem.getRootPath().toFile())
+              .setDirectory(projectFilesystem.getRootPath())
               .build(),
           ImmutableSet.of(
               ProcessExecutor.Option.EXPECTING_STD_OUT,

--- a/src/com/facebook/buck/shell/ShellStep.java
+++ b/src/com/facebook/buck/shell/ShellStep.java
@@ -95,7 +95,7 @@ public abstract class ShellStep implements Step {
     Map<String, String> environment = Maps.newHashMap();
     setProcessEnvironment(context, environment, workingDirectory.toFile());
     builder.setEnvironment(environment);
-    builder.setDirectory(workingDirectory.toFile());
+    builder.setDirectory(workingDirectory);
 
     Optional<String> stdin = getStdin(context);
     if (stdin.isPresent()) {

--- a/src/com/facebook/buck/shell/WorkerShellStep.java
+++ b/src/com/facebook/buck/shell/WorkerShellStep.java
@@ -98,7 +98,7 @@ public class WorkerShellStep implements Step {
     ProcessExecutorParams processParams = ProcessExecutorParams.builder()
         .setCommand(getCommand(context.getPlatform()))
         .setEnvironment(getEnvironmentForProcess(context))
-        .setDirectory(filesystem.getRootPath().toFile())
+        .setDirectory(filesystem.getRootPath())
         .build();
     WorkerProcess newProcess = new WorkerProcess(
         context.getProcessExecutor(),

--- a/src/com/facebook/buck/swift/SwiftCompileStep.java
+++ b/src/com/facebook/buck/swift/SwiftCompileStep.java
@@ -58,7 +58,7 @@ class SwiftCompileStep implements Step {
 
   private ProcessExecutorParams makeProcessExecutorParams() {
     ProcessExecutorParams.Builder builder = ProcessExecutorParams.builder();
-    builder.setDirectory(compilerCwd.toAbsolutePath().toFile());
+    builder.setDirectory(compilerCwd.toAbsolutePath());
     builder.setEnvironment(compilerEnvironment);
     builder.setCommand(compilerCommand);
     return builder.build();

--- a/src/com/facebook/buck/util/AbstractProcessExecutorParams.java
+++ b/src/com/facebook/buck/util/AbstractProcessExecutorParams.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableList;
 
 import org.immutables.value.Value;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.Map;
 
 /**
@@ -46,7 +46,7 @@ abstract class AbstractProcessExecutorParams {
    * If present, the current working directory for the launched process.
    */
   @Value.Parameter
-  public abstract Optional<File> getDirectory();
+  public abstract Optional<Path> getDirectory();
 
   /**
    * If present, the map of environment variables used for the launched

--- a/src/com/facebook/buck/util/ListeningProcessExecutor.java
+++ b/src/com/facebook/buck/util/ListeningProcessExecutor.java
@@ -259,7 +259,7 @@ public class ListeningProcessExecutor {
       processBuilder.environment().putAll(params.getEnvironment().get());
     }
     if (params.getDirectory().isPresent()) {
-      processBuilder.setCwd(params.getDirectory().get().toPath());
+      processBuilder.setCwd(params.getDirectory().get());
     }
 
     NuProcess process = BgProcessKiller.startProcess(processBuilder);

--- a/src/com/facebook/buck/util/ProcessExecutor.java
+++ b/src/com/facebook/buck/util/ProcessExecutor.java
@@ -16,6 +16,7 @@
 
 package com.facebook.buck.util;
 
+import com.facebook.buck.io.MorePaths;
 import com.facebook.buck.log.Logger;
 import com.facebook.buck.util.environment.Platform;
 import com.google.common.annotations.VisibleForTesting;
@@ -176,7 +177,7 @@ public class ProcessExecutor {
     }
     ProcessBuilder pb = new ProcessBuilder(command);
     if (params.getDirectory().isPresent()) {
-      pb.directory(params.getDirectory().get());
+      pb.directory(params.getDirectory().get().toFile());
     }
     if (params.getEnvironment().isPresent()) {
       pb.environment().clear();

--- a/src/com/facebook/buck/util/ProcessExecutor.java
+++ b/src/com/facebook/buck/util/ProcessExecutor.java
@@ -16,7 +16,6 @@
 
 package com.facebook.buck.util;
 
-import com.facebook.buck.io.MorePaths;
 import com.facebook.buck.log.Logger;
 import com.facebook.buck.util.environment.Platform;
 import com.google.common.annotations.VisibleForTesting;

--- a/src/com/facebook/buck/util/versioncontrol/DefaultVersionControlCmdLineInterfaceFactory.java
+++ b/src/com/facebook/buck/util/versioncontrol/DefaultVersionControlCmdLineInterfaceFactory.java
@@ -45,7 +45,7 @@ public class DefaultVersionControlCmdLineInterfaceFactory
   @Override
   public VersionControlCmdLineInterface createCmdLineInterface() throws InterruptedException {
       HgCmdLineInterface hgCmdLineInterface =
-          new HgCmdLineInterface(processExecutorFactory, projectRoot.toFile(), hgCmd, environment);
+          new HgCmdLineInterface(processExecutorFactory, projectRoot, hgCmd, environment);
 
       try {
         hgCmdLineInterface.currentRevisionId();

--- a/src/com/facebook/buck/util/versioncontrol/HgCmdLineInterface.java
+++ b/src/com/facebook/buck/util/versioncontrol/HgCmdLineInterface.java
@@ -32,9 +32,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -89,13 +89,13 @@ public class HgCmdLineInterface implements VersionControlCmdLineInterface {
           "'{date|hgdate}'");
 
   private ProcessExecutorFactory processExecutorFactory;
-  private final File projectRoot;
+  private final Path projectRoot;
   private final String hgCmd;
   private final ImmutableMap<String, String> environment;
 
   public HgCmdLineInterface(
       ProcessExecutorFactory processExecutorFactory,
-      File projectRoot,
+      Path projectRoot,
       String hgCmd,
       ImmutableMap<String, String> environment) {
     this.processExecutorFactory = processExecutorFactory;

--- a/test/com/facebook/buck/apple/XctoolRunTestsStepTest.java
+++ b/test/com/facebook/buck/apple/XctoolRunTestsStepTest.java
@@ -90,7 +90,7 @@ public class XctoolRunTestsStepTest {
                     "-logicTest",
                     "/path/to/Foo.xctest"))
             .setEnvironment(ImmutableMap.of("DEVELOPER_DIR", "/path/to/developer/dir"))
-            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath().toFile())
+            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath())
             .setRedirectOutput(ProcessBuilder.Redirect.PIPE)
             .build();
     FakeProcess fakeXctoolSuccess = new FakeProcess(0, "", "");
@@ -139,7 +139,7 @@ public class XctoolRunTestsStepTest {
                     "-logicTest",
                     "/path/to/Foo.xctest"))
             .setEnvironment(ImmutableMap.of("DEVELOPER_DIR", "/path/to/developer/dir"))
-            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath().toFile())
+            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath())
             .setRedirectOutput(ProcessBuilder.Redirect.PIPE)
             .build();
     FakeProcess fakeXctoolFailure = new FakeProcess(42, "", "Something went terribly wrong\n");
@@ -198,7 +198,7 @@ public class XctoolRunTestsStepTest {
                     "-appTest",
                     "/path/to/FooAppTest.xctest:/path/to/Foo.app"))
             .setEnvironment(ImmutableMap.of("DEVELOPER_DIR", "/path/to/developer/dir"))
-            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath().toFile())
+            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath())
             .setRedirectOutput(ProcessBuilder.Redirect.PIPE)
             .build();
     FakeProcess fakeXctoolSuccess = new FakeProcess(0, "", "");
@@ -255,7 +255,7 @@ public class XctoolRunTestsStepTest {
                     "-appTest",
                     "/path/to/FooAppTest.xctest:/path/to/Foo.app"))
             .setEnvironment(ImmutableMap.of("DEVELOPER_DIR", "/path/to/developer/dir"))
-            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath().toFile())
+            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath())
             .setRedirectOutput(ProcessBuilder.Redirect.PIPE)
             .build();
     FakeProcess fakeXctoolSuccess = new FakeProcess(0, "", "");
@@ -305,7 +305,7 @@ public class XctoolRunTestsStepTest {
                     "-logicTest",
                     "/path/to/Foo.xctest"))
             .setEnvironment(ImmutableMap.of("DEVELOPER_DIR", "/path/to/developer/dir"))
-            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath().toFile())
+            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath())
             .setRedirectOutput(ProcessBuilder.Redirect.PIPE)
             .build();
     // Test failure is indicated by xctool exiting with exit code 1, so it shouldn't
@@ -357,7 +357,7 @@ public class XctoolRunTestsStepTest {
                     "-logicTest",
                     "/path/to/Foo.xctest"))
             .setEnvironment(ImmutableMap.of("DEVELOPER_DIR", "/path/to/developer/dir"))
-            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath().toFile())
+            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath())
             .setRedirectOutput(ProcessBuilder.Redirect.PIPE)
             .build();
     FakeProcess fakeXctoolFailure = new FakeProcess(400, "", "");
@@ -412,7 +412,7 @@ public class XctoolRunTestsStepTest {
                     "/path/to/BarTest.xctest",
                     "-listTestsOnly"))
             .setEnvironment(ImmutableMap.of("DEVELOPER_DIR", "/path/to/developer/dir"))
-            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath().toFile())
+            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath())
             .setRedirectOutput(ProcessBuilder.Redirect.PIPE)
             .build();
     try (InputStream stdout =
@@ -442,7 +442,7 @@ public class XctoolRunTestsStepTest {
                 "-only",
                 "/path/to/BarTest.xctest:BarTest/testYetAnotherMagicValue")
             .setEnvironment(ImmutableMap.of("DEVELOPER_DIR", "/path/to/developer/dir"))
-            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath().toFile())
+            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath())
             .setRedirectOutput(ProcessBuilder.Redirect.PIPE)
             .build();
       FakeProcess fakeXctoolSuccess = new FakeProcess(0, "", "");
@@ -503,7 +503,7 @@ public class XctoolRunTestsStepTest {
                     "/path/to/BarTest.xctest",
                     "-listTestsOnly"))
             .setEnvironment(ImmutableMap.of("DEVELOPER_DIR", "/path/to/developer/dir"))
-            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath().toFile())
+            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath())
             .setRedirectOutput(ProcessBuilder.Redirect.PIPE)
             .build();
     FakeProcess fakeXctoolListTestsFailureProcess =
@@ -566,7 +566,7 @@ public class XctoolRunTestsStepTest {
                     "/path/to/BarTest.xctest",
                     "-listTestsOnly"))
             .setEnvironment(ImmutableMap.of("DEVELOPER_DIR", "/path/to/developer/dir"))
-            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath().toFile())
+            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath())
             .setRedirectOutput(ProcessBuilder.Redirect.PIPE)
             .build();
     try (InputStream stdout =
@@ -631,7 +631,7 @@ public class XctoolRunTestsStepTest {
                     "DEVELOPER_DIR", "/path/to/developer/dir",
                     "XCTOOL_TEST_ENV_TEST_LOG_PATH", "/path/to/test-logs",
                     "XCTOOL_TEST_ENV_TEST_LOG_LEVEL", "verbose"))
-            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath().toFile())
+            .setDirectory(projectFilesystem.getRootPath().toAbsolutePath())
             .setRedirectOutput(ProcessBuilder.Redirect.PIPE)
             .build();
     FakeProcess fakeXctoolSuccess = new FakeProcess(0, "", "");

--- a/test/com/facebook/buck/util/ListeningProcessExecutorTest.java
+++ b/test/com/facebook/buck/util/ListeningProcessExecutorTest.java
@@ -77,7 +77,7 @@ public class ListeningProcessExecutorTest {
       paramsBuilder.addCommand("cat");
     }
     paramsBuilder.addCommand("hello-world.txt");
-    paramsBuilder.setDirectory(tmp.getRoot().toFile());
+    paramsBuilder.setDirectory(tmp.getRoot());
     Path helloWorldPath = tmp.getRoot().resolve("hello-world.txt");
     String fileContents = "Hello, world!";
     Files.write(helloWorldPath, fileContents.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
The ProcessBuilder is from the Dawn of Computing, and uses `File`
instead of `Path`. Clean up the abstraction leakage.