### PR TITLE
Updating the visibility of '//src/com/facebook/buck/log:log'

### DIFF
--- a/src/com/facebook/buck/log/BUCK
+++ b/src/com/facebook/buck/log/BUCK
@@ -45,6 +45,7 @@ java_immutables_library(
     '//src/com/facebook/buck/event:event',
     '//src/com/facebook/buck/rage:rage',
     '//src/com/facebook/buck/rules:types',
+    '//src/com/facebook/buck/log/memory:memory',
     '//test/com/facebook/buck/event/listener:listener',
     '//test/com/facebook/buck/httpserver/...',
     '//test/com/facebook/buck/log/...',

--- a/src/com/facebook/buck/log/memory/BUCK.autodeps
+++ b/src/com/facebook/buck/log/memory/BUCK.autodeps
@@ -1,12 +1,9 @@
-#@# GENERATED FILE: DO NOT MODIFY f1dd930abbfd69f4893447430ba8ab186d5a485d #@#
+#@# GENERATED FILE: DO NOT MODIFY 48a87f218f030217569e3da17eca5f75338f8d5e #@#
 {
   "memory" : {
     "deps" : [
-      "//src/com/facebook/buck/event/listener:listener",
       "//src/com/facebook/buck/log:api",
-      "//src/com/facebook/buck/util:object_mapper",
-      "//third-party/java/jackson:jackson-core",
-      "//third-party/java/jackson:jackson-databind"
+      "//src/com/facebook/buck/log:log"
     ],
     "exported_deps" : [
       "//third-party/java/guava:guava"


### PR DESCRIPTION
Summary:
Updating the visibility of '//src/com/facebook/buck/log:log'
and re-running 'buck autodeps'.

This addresses the broken Buck self build introduced
by: ff6b13710b85b0feb68f5d78bbbd942c3a867e37

fixes #860

Test Plan: Run 'buck build buck'