### PR TITLE
Add preferred_linkage for swift_library to support static linking

### DIFF
--- a/src/com/facebook/buck/swift/SwiftDescriptions.java
+++ b/src/com/facebook/buck/swift/SwiftDescriptions.java
@@ -68,6 +68,7 @@ class SwiftDescriptions {
     output.moduleName = Optional.of(buildTarget.getShortName());
     output.enableObjcInterop = Optional.of(true);
     output.bridgingHeader = args.bridgingHeader;
+    output.preferredLinkage = args.preferredLinkage;
   }
 
 }

--- a/src/com/facebook/buck/swift/SwiftLibrary.java
+++ b/src/com/facebook/buck/swift/SwiftLibrary.java
@@ -138,7 +138,21 @@ class SwiftLibrary
         .addAllArgs(rule.getLinkArgs())
         .addAllFrameworks(frameworks)
         .addAllLibraries(libraries);
-    if (type == Linker.LinkableDepType.SHARED) {
+    boolean isDynamic;
+    switch (linkage) {
+      case STATIC:
+        isDynamic = false;
+        break;
+      case SHARED:
+        isDynamic = true;
+        break;
+      case ANY:
+        isDynamic = type == Linker.LinkableDepType.SHARED;
+        break;
+      default:
+        throw new IllegalStateException("unhandled linkage type: " + linkage);
+    }
+    if (isDynamic) {
       inputBuilder.addArgs(new SourcePathArg(getResolver(),
           new BuildTargetSourcePath(requireSwiftLinkRule(cxxPlatform.getFlavor())
               .getBuildTarget())));

--- a/src/com/facebook/buck/swift/SwiftLibrary.java
+++ b/src/com/facebook/buck/swift/SwiftLibrary.java
@@ -78,6 +78,7 @@ class SwiftLibrary
   private final ImmutableSet<FrameworkPath> libraries;
   private final FlavorDomain<AppleCxxPlatform> appleCxxPlatformFlavorDomain;
   private final Optional<Pattern> supportedPlatformsRegex;
+  private final Linkage linkage;
 
   SwiftLibrary(
       BuildRuleParams params,
@@ -87,7 +88,8 @@ class SwiftLibrary
       ImmutableSet<FrameworkPath> frameworks,
       ImmutableSet<FrameworkPath> libraries,
       FlavorDomain<AppleCxxPlatform> appleCxxPlatformFlavorDomain,
-      Optional<Pattern> supportedPlatformsRegex) {
+      Optional<Pattern> supportedPlatformsRegex,
+      Linkage linkage) {
     super(params, pathResolver);
     this.ruleResolver = ruleResolver;
     this.exportedDeps = exportedDeps;
@@ -95,6 +97,7 @@ class SwiftLibrary
     this.libraries = libraries;
     this.appleCxxPlatformFlavorDomain = appleCxxPlatformFlavorDomain;
     this.supportedPlatformsRegex = supportedPlatformsRegex;
+    this.linkage = linkage;
   }
 
   private boolean isPlatformSupported(CxxPlatform cxxPlatform) {
@@ -196,7 +199,7 @@ class SwiftLibrary
     if (getBuildTarget().getFlavors().contains(SWIFT_COMPANION_FLAVOR)) {
       return Linkage.STATIC;
     } else {
-      return Linkage.ANY;
+      return linkage;
     }
   }
 

--- a/src/com/facebook/buck/swift/SwiftLibraryDescription.java
+++ b/src/com/facebook/buck/swift/SwiftLibraryDescription.java
@@ -241,7 +241,8 @@ public class SwiftLibraryDescription implements
         args.frameworks.get(),
         args.libraries.get(),
         appleCxxPlatformFlavorDomain,
-        args.supportedPlatformsRegex);
+        args.supportedPlatformsRegex,
+        args.preferredLinkage.or(NativeLinkable.Linkage.ANY));
   }
 
   private BuildRule createSharedLibraryBuildRule(
@@ -339,6 +340,7 @@ public class SwiftLibraryDescription implements
     public Optional<String> soname;
     public Optional<SourcePath> bridgingHeader;
     public Optional<ImmutableSortedSet<BuildTarget>> deps;
+    public Optional<NativeLinkable.Linkage> preferredLinkage;
   }
 
 }

--- a/test/com/facebook/buck/swift/SwiftIOSBundleIntegrationTest.java
+++ b/test/com/facebook/buck/swift/SwiftIOSBundleIntegrationTest.java
@@ -30,8 +30,8 @@ import com.facebook.buck.apple.ApplePlatform;
 import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargets;
-import com.facebook.buck.testutil.integration.TemporaryPaths;
 import com.facebook.buck.testutil.integration.ProjectWorkspace;
+import com.facebook.buck.testutil.integration.TemporaryPaths;
 import com.facebook.buck.testutil.integration.TestDataHelper;
 import com.facebook.buck.util.environment.Platform;
 
@@ -236,5 +236,47 @@ public class SwiftIOSBundleIntegrationTest {
     assertThat(
         workspace.runCommand("otool", "-L", binaryOutput.toString()).getStdout().get(),
         not(containsString("@rpath/dep1-soname")));
+  }
+
+  @Test
+  public void testSwiftPreferredLinkage() throws Exception {
+    assumeTrue(Platform.detect() == Platform.MACOS);
+    assumeTrue(AppleNativeIntegrationTestUtils.isApplePlatformAvailable(ApplePlatform.MACOSX));
+
+    ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(
+        this, "swift_on_swift", tmp);
+    workspace.setUp();
+    ProjectFilesystem filesystem = new ProjectFilesystem(workspace.getDestPath());
+
+    workspace.replaceFileContents(
+        "BUCK",
+        "preferred_linkage = 'any', # iosdep1 preferred_linkage anchor",
+        "preferred_linkage = 'static'");
+
+    ProjectWorkspace.ProcessResult result = workspace.runBuckCommand(
+        "build",
+        ":ios-parent-dynamic#iphonesimulator-x86_64",
+        "--config",
+        "cxx.cflags=-g");
+    result.assertSuccess();
+
+    Path binaryOutput = tmp.getRoot()
+        .resolve(filesystem.getBuckPaths().getGenDir())
+        .resolve("ios-parent-dynamic#iphonesimulator-x86_64");
+    assertThat(Files.exists(binaryOutput), CoreMatchers.is(true));
+
+    Path dep1Output = tmp.getRoot()
+        .resolve(filesystem.getBuckPaths().getGenDir())
+        .resolve("iosdep1#iphonesimulator-x86_64")
+        .resolve("libiosdep1.dylib");
+    assertThat(Files.exists(dep1Output), CoreMatchers.is(false));
+
+    assertThat(
+        workspace.runCommand("otool", "-L", binaryOutput.toString()).getStdout().get(),
+        not(containsString("libiosdep1.dylib")));
+
+    assertThat(
+        workspace.runCommand("nm", binaryOutput.toString()).getStdout().or(""),
+        containsString("baz"));
   }
 }

--- a/test/com/facebook/buck/swift/testdata/swift_on_swift/BUCK.fixture
+++ b/test/com/facebook/buck/swift/testdata/swift_on_swift/BUCK.fixture
@@ -6,7 +6,7 @@ swift_library(
 apple_binary(
     name = 'parent',
     srcs = [ 'parent/main.swift' ],
-    deps = [ ':dep1' ]
+    deps = [ ':dep1' ],
 )
 
 swift_library(
@@ -27,7 +27,8 @@ apple_bundle(
 
 swift_library(
     name = 'iosdep1',
-    srcs = [ 'iosdep1/iosdep1.swift' ]
+    srcs = [ 'iosdep1/iosdep1.swift' ],
+    preferred_linkage = 'any', # iosdep1 preferred_linkage anchor
 )
 
 apple_binary(

--- a/test/com/facebook/buck/swift/testdata/swift_on_swift/ios-parent/AppDelegate.swift
+++ b/test/com/facebook/buck/swift/testdata/swift_on_swift/ios-parent/AppDelegate.swift
@@ -7,7 +7,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
-        IosFoo.bar()
+        IosFoo.baz()
         return true
     }
 

--- a/test/com/facebook/buck/swift/testdata/swift_on_swift/iosdep1/iosdep1.swift
+++ b/test/com/facebook/buck/swift/testdata/swift_on_swift/iosdep1/iosdep1.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 
 public class IosFoo {
-    public class func bar() {
+    public class func baz() {
         let alert = UIAlertView()
         alert.title = "From iosdep1.swift"
         alert.message = "Message from a dependency"


### PR DESCRIPTION
This PR haven't yet implemented creating static lib using `swift_library`, but if `preferred_linkage` is set to static for a swift target, it will be linked statically against any library that depends on it.