### PR TITLE
Compiling swift files for appleTV

### DIFF
--- a/src/com/facebook/buck/apple/AbstractApplePlatform.java
+++ b/src/com/facebook/buck/apple/AbstractApplePlatform.java
@@ -72,6 +72,7 @@ abstract class AbstractApplePlatform implements Comparable<AbstractApplePlatform
           .setName("appletvsimulator")
           .setArchitectures(ImmutableList.of("x86_64"))
           .setMinVersionFlagPrefix("-mtvos-simulator-version-min=")
+          .setSwiftName("tvos")
           .build();
   public static final ApplePlatform MACOSX =
       ApplePlatform.builder()


### PR DESCRIPTION
When trying to compile swift files for appletvsimulator platform, the target parameter passed to the swift compiler is wrong.
It is x86_64-apple-appletvsimulator9.2 but should be x86_64-apple-tvos9.2
