### PR TITLE
Update xcodebuild version regex

### DIFF
--- a/src/com/facebook/buck/apple/AppleConfig.java
+++ b/src/com/facebook/buck/apple/AppleConfig.java
@@ -52,7 +52,7 @@ public class AppleConfig {
   private static final Logger LOG = Logger.get(AppleConfig.class);
 
   private static final Pattern XCODE_BUILD_NUMBER_PATTERN =
-      Pattern.compile("Build version ([A-Z0-9]+)");
+      Pattern.compile("Build version ([a-zA-Z0-9]+)");
 
   private final BuckConfig delegate;
 


### PR DESCRIPTION
Xcode8 GM has lower case characters in its version number:

```
Xcode 8.0
Build version 8A218a
```