### PR TITLE
Set Robolectric runtime dependency directory and manifest file.

### DIFF
--- a/src/com/facebook/buck/android/RobolectricTest.java
+++ b/src/com/facebook/buck/android/RobolectricTest.java
@@ -65,8 +65,8 @@ public class RobolectricTest extends JavaTest {
       ANDROID, LIBRARY, TEST);
 
   private final Optional<DummyRDotJava> optionalDummyRDotJava;
-  private final Optional<SourcePath> manifest;
-  private final Optional<String> runtimeDependency;
+  private final Optional<SourcePath> robolectricManifest;
+  private final Optional<String> robolectricRuntimeDependency;
 
   /**
    * Used by robolectric test runner to get list of resource directories that
@@ -122,8 +122,8 @@ public class RobolectricTest extends JavaTest {
       ForkMode forkMode,
       Optional<Level> stdOutLogLevel,
       Optional<Level> stdErrLogLevel,
-      Optional<String> runtimeDependency,
-      Optional<SourcePath> manifest) {
+      Optional<String> robolectricRuntimeDependency,
+      Optional<SourcePath> robolectricManifest) {
     super(
         buildRuleParams,
         resolver,
@@ -142,8 +142,8 @@ public class RobolectricTest extends JavaTest {
         stdOutLogLevel,
         stdErrLogLevel);
     this.optionalDummyRDotJava = optionalDummyRDotJava;
-    this.runtimeDependency = runtimeDependency;
-    this.manifest = manifest;
+    this.robolectricRuntimeDependency = robolectricRuntimeDependency;
+    this.robolectricManifest = robolectricManifest;
   }
 
   @Override
@@ -168,11 +168,11 @@ public class RobolectricTest extends JavaTest {
 
     // Force robolectric to only use local dependency resolution.
     vmArgsBuilder.add("-Drobolectric.offline=true");
-    if (this.manifest.isPresent()) {
-      vmArgsBuilder.add(String.format("-D%s=%s", ROBOLECTRIC_MANIFEST, this.manifest.get()));
+    if (robolectricManifest.isPresent()) {
+      vmArgsBuilder.add(String.format("-D%s=%s", ROBOLECTRIC_MANIFEST, robolectricManifest.get()));
     }
-    if (runtimeDependency.isPresent()) {
-      vmArgsBuilder.add("-Drobolectric.dependency.dir=" + runtimeDependency.get());
+    if (robolectricRuntimeDependency.isPresent()) {
+      vmArgsBuilder.add("-Drobolectric.dependency.dir=" + robolectricRuntimeDependency.get());
     }
   }
 

--- a/src/com/facebook/buck/android/RobolectricTest.java
+++ b/src/com/facebook/buck/android/RobolectricTest.java
@@ -65,12 +65,18 @@ public class RobolectricTest extends JavaTest {
       ANDROID, LIBRARY, TEST);
 
   private final Optional<DummyRDotJava> optionalDummyRDotJava;
+  private final Optional<SourcePath> manifest;
+  private final Optional<String> runtimeDependency;
+
   /**
    * Used by robolectric test runner to get list of resource directories that
    * can be used for tests.
    */
   static final String LIST_OF_RESOURCE_DIRECTORIES_PROPERTY_NAME =
       "buck.robolectric_res_directories";
+
+  static final String ROBOLECTRIC_MANIFEST =
+      "buck.robolectric_manifest";
 
   private final Function<HasAndroidResourceDeps, Path> resourceDirectoryFunction =
       new Function<HasAndroidResourceDeps, Path>() {
@@ -115,7 +121,9 @@ public class RobolectricTest extends JavaTest {
       boolean runTestSeparately,
       ForkMode forkMode,
       Optional<Level> stdOutLogLevel,
-      Optional<Level> stdErrLogLevel) {
+      Optional<Level> stdErrLogLevel,
+      Optional<String> runtimeDependency,
+      Optional<SourcePath> manifest) {
     super(
         buildRuleParams,
         resolver,
@@ -134,6 +142,8 @@ public class RobolectricTest extends JavaTest {
         stdOutLogLevel,
         stdErrLogLevel);
     this.optionalDummyRDotJava = optionalDummyRDotJava;
+    this.runtimeDependency = runtimeDependency;
+    this.manifest = manifest;
   }
 
   @Override
@@ -158,6 +168,12 @@ public class RobolectricTest extends JavaTest {
 
     // Force robolectric to only use local dependency resolution.
     vmArgsBuilder.add("-Drobolectric.offline=true");
+    if (this.manifest.isPresent()) {
+      vmArgsBuilder.add(String.format("-D%s=%s", ROBOLECTRIC_MANIFEST, this.manifest.get()));
+    }
+    if (runtimeDependency.isPresent()) {
+      vmArgsBuilder.add("-Drobolectric.dependency.dir=" + runtimeDependency.get());
+    }
   }
 
   @VisibleForTesting

--- a/src/com/facebook/buck/android/RobolectricTestDescription.java
+++ b/src/com/facebook/buck/android/RobolectricTestDescription.java
@@ -38,6 +38,7 @@ import com.facebook.buck.rules.BuildRuleType;
 import com.facebook.buck.rules.BuildRules;
 import com.facebook.buck.rules.BuildTargetSourcePath;
 import com.facebook.buck.rules.Description;
+import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.SourcePaths;
 import com.facebook.buck.rules.TargetGraph;
@@ -201,7 +202,9 @@ public class RobolectricTestDescription implements Description<RobolectricTestDe
                 args.getRunTestSeparately(),
                 args.getForkMode(),
                 args.stdOutLogLevel,
-                args.stdErrLogLevel));
+                args.stdErrLogLevel,
+                args.runtimeDependency,
+                args.manifest));
 
     resolver.addToIndex(
         CalculateAbi.of(
@@ -215,5 +218,7 @@ public class RobolectricTestDescription implements Description<RobolectricTestDe
 
   @SuppressFieldNotInitialized
   public class Arg extends JavaTestDescription.Arg {
+    public Optional<String> runtimeDependency;
+    public Optional<SourcePath> manifest;
   }
 }


### PR DESCRIPTION
 - Specify the folder which contains the runtime dependencies for robolectric as it runs in offline mode with buck.
 - Specify the path to the android manifest file to be used by robolectric.

Resolves: https://github.com/facebook/buck/issues/807