### PR TITLE
Allow java_library to have a manifest file

### DIFF
--- a/src/com/facebook/buck/android/AndroidBinaryGraphEnhancer.java
+++ b/src/com/facebook/buck/android/AndroidBinaryGraphEnhancer.java
@@ -273,6 +273,7 @@ public class AndroidBinaryGraphEnhancer {
               javacOptions.withSourceLevel("7").withTargetLevel("7"),
               JavacOptionsAmender.IDENTITY),
           /* resourcesRoot */ Optional.<Path>absent(),
+          /* manifest file */ Optional.<SourcePath>absent(),
           /* mavenCoords */ Optional.<String>absent(),
           ImmutableSortedSet.<BuildTarget>of(),
           /* classesToRemoveFromJar */ ImmutableSet.<Pattern>of());
@@ -447,6 +448,7 @@ public class AndroidBinaryGraphEnhancer {
         /* additionalClasspathEntries */ ImmutableSet.<Path>of(),
         new JavacToJarStepFactory(javacOptions, JavacOptionsAmender.IDENTITY),
         /* resourcesRoot */ Optional.<Path>absent(),
+        /* manifest file */ Optional.<SourcePath>absent(),
         /* mavenCoords */ Optional.<String>absent(),
         ImmutableSortedSet.<BuildTarget>of(),
         /* classesToRemoveFromJar */ ImmutableSet.<Pattern>of());

--- a/src/com/facebook/buck/android/AndroidBuildConfigJavaLibrary.java
+++ b/src/com/facebook/buck/android/AndroidBuildConfigJavaLibrary.java
@@ -69,6 +69,7 @@ class AndroidBuildConfigJavaLibrary extends DefaultJavaLibrary implements Androi
         /* additionalClasspathEntries */ ImmutableSet.<Path>of(),
         new JavacToJarStepFactory(javacOptions, JavacOptionsAmender.IDENTITY),
         /* resourcesRoot */ Optional.<Path>absent(),
+        /* manifest file */ Optional.<SourcePath>absent(),
         /* mavenCoords */ Optional.<String>absent(),
         /* tests */ ImmutableSortedSet.<BuildTarget>of(),
         /* classesToRemoveFromJar */ ImmutableSet.<Pattern>of());

--- a/src/com/facebook/buck/android/AndroidLibrary.java
+++ b/src/com/facebook/buck/android/AndroidLibrary.java
@@ -81,6 +81,7 @@ public class AndroidLibrary extends DefaultJavaLibrary implements AndroidPackage
         additionalClasspathEntries,
         new JavacToJarStepFactory(javacOptions, new BootClasspathAppender()),
         resourcesRoot,
+        manifestFile,
         mavenCoords,
         tests,
         javacOptions.getClassesToRemoveFromJar());

--- a/src/com/facebook/buck/android/AndroidLibrary.java
+++ b/src/com/facebook/buck/android/AndroidLibrary.java
@@ -81,7 +81,7 @@ public class AndroidLibrary extends DefaultJavaLibrary implements AndroidPackage
         additionalClasspathEntries,
         new JavacToJarStepFactory(javacOptions, new BootClasspathAppender()),
         resourcesRoot,
-        manifestFile,
+        Optional.<SourcePath>absent(),
         mavenCoords,
         tests,
         javacOptions.getClassesToRemoveFromJar());

--- a/src/com/facebook/buck/android/RobolectricTestDescription.java
+++ b/src/com/facebook/buck/android/RobolectricTestDescription.java
@@ -186,6 +186,7 @@ public class RobolectricTestDescription implements Description<RobolectricTestDe
                 additionalClasspathEntries,
                 new JavacToJarStepFactory(javacOptions, new BootClasspathAppender()),
                 args.resourcesRoot,
+                args.manifestFile,
                 args.mavenCoords,
                 /* tests */ ImmutableSortedSet.<BuildTarget>of(),
                 /* classesToRemoveFromJar */ ImmutableSet.<Pattern>of()));

--- a/src/com/facebook/buck/jvm/groovy/GroovyLibraryDescription.java
+++ b/src/com/facebook/buck/jvm/groovy/GroovyLibraryDescription.java
@@ -113,6 +113,7 @@ public class GroovyLibraryDescription implements Description<GroovyLibraryDescri
                         pathResolver,
                         args)),
                 Optional.<Path>absent(),
+                /* manifest file */ Optional.<SourcePath>absent(),
                 Optional.<String>absent(),
                 ImmutableSortedSet.<BuildTarget>of(),
                 /* classesToRemoveFromJar */ ImmutableSet.<Pattern>of()));

--- a/src/com/facebook/buck/jvm/groovy/GroovyTestDescription.java
+++ b/src/com/facebook/buck/jvm/groovy/GroovyTestDescription.java
@@ -131,6 +131,7 @@ public class GroovyTestDescription implements Description<GroovyTestDescription.
                 /* additionalClasspathEntries */ ImmutableSet.<Path>of(),
                 stepFactory,
                 /* resourcesRoot */ Optional.<Path>absent(),
+                /* manifest file */ Optional.<SourcePath>absent(),
                 /* mavenCoords */ Optional.<String>absent(),
                 /* tests */ ImmutableSortedSet.<BuildTarget>of(),
                 /* classesToRemoveFromJar */ ImmutableSet.<Pattern>of()

--- a/src/com/facebook/buck/jvm/java/JavaLibraryDescription.java
+++ b/src/com/facebook/buck/jvm/java/JavaLibraryDescription.java
@@ -164,6 +164,7 @@ public class JavaLibraryDescription implements Description<JavaLibraryDescriptio
                 /* additionalClasspathEntries */ ImmutableSet.<Path>of(),
                 new JavacToJarStepFactory(javacOptions, JavacOptionsAmender.IDENTITY),
                 args.resourcesRoot,
+                args.manifestFile,
                 args.mavenCoords,
                 args.tests.get(),
                 javacOptions.getClassesToRemoveFromJar()));
@@ -197,6 +198,7 @@ public class JavaLibraryDescription implements Description<JavaLibraryDescriptio
 
     @Hint(isInput = false)
     public Optional<Path> resourcesRoot;
+    public Optional<SourcePath> manifestFile;
     public Optional<String> mavenCoords;
     public Optional<SourcePath> mavenPomTemplate;
 

--- a/src/com/facebook/buck/jvm/java/JavaTestDescription.java
+++ b/src/com/facebook/buck/jvm/java/JavaTestDescription.java
@@ -161,6 +161,7 @@ public class JavaTestDescription implements
                 /* additionalClasspathEntries */ ImmutableSet.<Path>of(),
                 new JavacToJarStepFactory(javacOptions, JavacOptionsAmender.IDENTITY),
                 args.resourcesRoot,
+                args.manifestFile,
                 args.mavenCoords,
                 /* tests */ ImmutableSortedSet.<BuildTarget>of(),
                 /* classesToRemoveFromJar */ ImmutableSet.<Pattern>of()

--- a/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
@@ -102,6 +102,7 @@ public class KotlinLibraryDescription implements Description<KotlinLibraryDescri
                     kotlinBuckConfig.getKotlinCompiler().get(),
                     args.extraKotlincArguments.get()),
                 Optional.<Path>absent(),
+                /* manifest file */ Optional.<SourcePath>absent(),
                 Optional.<String>absent(),
                 ImmutableSortedSet.<BuildTarget>of(),
                 /* classesToRemoveFromJar */ ImmutableSet.<Pattern>of()));

--- a/src/com/facebook/buck/jvm/kotlin/KotlinTestDescription.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinTestDescription.java
@@ -126,6 +126,7 @@ public class KotlinTestDescription implements Description<KotlinTestDescription.
                 /* additionalClasspathEntries */ ImmutableSet.<Path>of(),
                 stepFactory,
                 /* resourcesRoot */ Optional.<Path>absent(),
+                /* manifest file */ Optional.<SourcePath>absent(),
                 /* mavenCoords */ Optional.<String>absent(),
                 /* tests */ ImmutableSortedSet.<BuildTarget>of(),
                 /* classesToRemoveFromJar */ ImmutableSet.<Pattern>of()

--- a/src/com/facebook/buck/jvm/scala/ScalaLibraryDescription.java
+++ b/src/com/facebook/buck/jvm/scala/ScalaLibraryDescription.java
@@ -135,6 +135,7 @@ public class ScalaLibraryDescription implements Description<ScalaLibraryDescript
                                 }))
                         .build()),
                 args.resourcesRoot,
+                args.manifestFile,
                 args.mavenCoords,
                 args.tests.get(),
                 /* classesToRemoveFromJar */ ImmutableSet.<Pattern>of()));
@@ -173,6 +174,7 @@ public class ScalaLibraryDescription implements Description<ScalaLibraryDescript
 
     @Hint(isInput = false)
     public Optional<Path> resourcesRoot;
+    public Optional<SourcePath> manifestFile;
     public Optional<String> mavenCoords;
 
     @Hint(isDep = false)

--- a/src/com/facebook/buck/jvm/scala/ScalaTestDescription.java
+++ b/src/com/facebook/buck/jvm/scala/ScalaTestDescription.java
@@ -155,6 +155,7 @@ public class ScalaTestDescription implements Description<ScalaTestDescription.Ar
                         .build()
                 ),
                 args.resourcesRoot,
+                args.manifestFile,
                 args.mavenCoords,
                 /* tests */ ImmutableSortedSet.<BuildTarget>of(),
                 /* classesToRemoveFromJar */ ImmutableSet.<Pattern>of()));

--- a/src/com/facebook/buck/thrift/ThriftJavaEnhancer.java
+++ b/src/com/facebook/buck/thrift/ThriftJavaEnhancer.java
@@ -173,6 +173,7 @@ public class ThriftJavaEnhancer implements ThriftLanguageSpecificEnhancer {
                 /* additionalClasspathEntries */ ImmutableSet.<Path>of(),
                 new JavacToJarStepFactory(templateOptions, JavacOptionsAmender.IDENTITY),
                 /* resourcesRoot */ Optional.<Path>absent(),
+                /* manifest file */ Optional.<SourcePath>absent(),
                 /* mavenCoords */ Optional.<String>absent(),
                 /* tests */ ImmutableSortedSet.<BuildTarget>of(),
                 /* classesToRemoveFromJar */ ImmutableSet.<Pattern>of()));

--- a/test/com/facebook/buck/cli/testdata/target_command/TargetsCommandTestBuckJson1.js
+++ b/test/com/facebook/buck/cli/testdata/target_command/TargetsCommandTestBuckJson1.js
@@ -18,6 +18,7 @@
   "javac": null,
   "javacJar": null,
   "javaVersion": null,
+  "manifestFile": null,
   "mavenCoords":null,
   "mavenPomTemplate":null,
   "name" : "test-library",

--- a/test/com/facebook/buck/jvm/java/DefaultJavaLibraryTest.java
+++ b/test/com/facebook/buck/jvm/java/DefaultJavaLibraryTest.java
@@ -1101,6 +1101,7 @@ public class DefaultJavaLibraryTest {
         /* additionalClasspathEntries */ ImmutableSet.<Path>of(),
         new JavacToJarStepFactory(javacOptions, JavacOptionsAmender.IDENTITY),
         /* resourcesRoot */ Optional.<Path>absent(),
+        /* manifest file */ Optional.<SourcePath>absent(),
         /* mavenCoords */ Optional.<String>absent(),
         /* tests */ ImmutableSortedSet.<BuildTarget>of(),
         /* classesToRemoveFromJar */ ImmutableSet.<Pattern>of()) {

--- a/test/com/facebook/buck/jvm/java/testdata/manifest/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/java/testdata/manifest/BUCK.fixture
@@ -1,0 +1,5 @@
+java_library(
+  name = 'library',
+  resources = ['foo.txt'],
+  manifest_file = 'manifest.mf',
+)

--- a/test/com/facebook/buck/jvm/java/testdata/manifest/foo.txt
+++ b/test/com/facebook/buck/jvm/java/testdata/manifest/foo.txt
@@ -1,0 +1,1 @@
+hello world

--- a/test/com/facebook/buck/jvm/java/testdata/manifest/manifest.mf
+++ b/test/com/facebook/buck/jvm/java/testdata/manifest/manifest.mf
@@ -1,0 +1,4 @@
+
+Name: Example
+Data: cheese
+

--- a/test/com/facebook/buck/rules/KnownBuildRuleTypesTest.java
+++ b/test/com/facebook/buck/rules/KnownBuildRuleTypesTest.java
@@ -131,6 +131,7 @@ public class KnownBuildRuleTypesTest {
     arg.annotationProcessorOnly = Optional.absent();
     arg.postprocessClassesCommands = Optional.of(ImmutableList.<String>of());
     arg.resourcesRoot = Optional.absent();
+    arg.manifestFile = Optional.absent();
     arg.providedDeps = Optional.of(ImmutableSortedSet.<BuildTarget>of());
     arg.exportedDeps = Optional.of(ImmutableSortedSet.<BuildTarget>of());
     arg.deps = Optional.of(ImmutableSortedSet.<BuildTarget>of());


### PR DESCRIPTION
It is sometimes useful for a library to add entries to
manifest file (eg: include providers, or config data).

This diffs adds that capability to java_library and to
other rules I'm sure could use the manifest.