### PR TITLE
Simplify the method for `getTransitiveClasspath`

### DIFF
--- a/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
+++ b/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
@@ -313,8 +313,7 @@ public class DefaultJavaLibrary extends AbstractBuildRule
               @Override
               public ImmutableSet<JavaLibrary> get() {
                 return JavaLibraryClasspathProvider.getTransitiveClasspathDeps(
-                    DefaultJavaLibrary.this,
-                    sourcePathForOutputJar());
+                    DefaultJavaLibrary.this);
               }
             });
 

--- a/src/com/facebook/buck/jvm/java/JavaLibraryClasspathProvider.java
+++ b/src/com/facebook/buck/jvm/java/JavaLibraryClasspathProvider.java
@@ -57,17 +57,15 @@ public class JavaLibraryClasspathProvider {
     return outputClasspathBuilder.build();
   }
 
-  public static ImmutableSet<JavaLibrary> getTransitiveClasspathDeps(
-      JavaLibrary javaLibrary,
-      Optional<SourcePath> outputJar) {
+  public static ImmutableSet<JavaLibrary> getTransitiveClasspathDeps(JavaLibrary javaLibrary) {
     ImmutableSet.Builder<JavaLibrary> classpathDeps = ImmutableSet.builder();
 
     classpathDeps.addAll(
         getClasspathDeps(
             javaLibrary.getDepsForTransitiveClasspathEntries()));
 
-    // Only add ourselves to the classpath if there's a jar to be built.
-    if (outputJar.isPresent()) {
+    // Only add ourselves to the classpath if there's a jar to be built or if we're a maven dep.
+    if (javaLibrary.getPathToOutput() != null || javaLibrary.getMavenCoords().isPresent()) {
       classpathDeps.add(javaLibrary);
     }
 

--- a/test/com/facebook/buck/jvm/java/FakeJavaLibrary.java
+++ b/test/com/facebook/buck/jvm/java/FakeJavaLibrary.java
@@ -90,10 +90,7 @@ public class FakeJavaLibrary extends FakeBuildRule implements JavaLibrary, Andro
 
   @Override
   public ImmutableSet<JavaLibrary> getTransitiveClasspathDeps() {
-    return JavaLibraryClasspathProvider.getTransitiveClasspathDeps(
-        this,
-        Optional.<SourcePath>of(new BuildTargetSourcePath(getBuildTarget(),
-            getPathToOutput())));
+    return JavaLibraryClasspathProvider.getTransitiveClasspathDeps(this);
   }
 
   @Override


### PR DESCRIPTION
Other than one test, we only ever passed in the first argument
as the second argument. *face palm*