### PR TITLE
handle multiple linker warnings in agent detection

### DIFF
--- a/src/com/facebook/buck/android/ExopackageInstaller.java
+++ b/src/com/facebook/buck/android/ExopackageInstaller.java
@@ -758,12 +758,13 @@ public class ExopackageInstaller {
     String pmPathPrefix = "package:";
 
     String pmPath = null;
-    if (lineIter.hasNext()) {
-      pmPath = lineIter.next();
-      if (pmPath.startsWith("WARNING: linker: ")) {
-        // Ignore silly linker warnings about non-PIC code on emulators
-        pmPath = lineIter.hasNext() ? lineIter.next() : null;
+    while (pmPath.startsWith("WARNING: linker: ")) {
+      // Ignore silly linker warnings about non-PIC code on emulators
+      if(!lineIter.hasNext()) {
+        pmPath = null;
+        break;
       }
+      pmPath = lineIter.next();
     }
 
     if (pmPath == null || !pmPath.startsWith(pmPathPrefix)) {

--- a/src/com/facebook/buck/android/ExopackageInstaller.java
+++ b/src/com/facebook/buck/android/ExopackageInstaller.java
@@ -760,7 +760,6 @@ public class ExopackageInstaller {
     String pmPath = null;
     if (lineIter.hasNext()) {
       pmPath = lineIter.next();
-      LOG.warn(pmPath);
       while (pmPath.startsWith("WARNING: linker: ")) {
         // Ignore silly linker warnings about non-PIC code on emulators
         if(!lineIter.hasNext()) {

--- a/src/com/facebook/buck/android/ExopackageInstaller.java
+++ b/src/com/facebook/buck/android/ExopackageInstaller.java
@@ -762,7 +762,7 @@ public class ExopackageInstaller {
       pmPath = lineIter.next();
       while (pmPath.startsWith("WARNING: linker: ")) {
         // Ignore silly linker warnings about non-PIC code on emulators
-        if(!lineIter.hasNext()) {
+        if (!lineIter.hasNext()) {
           pmPath = null;
           break;
         }

--- a/src/com/facebook/buck/android/ExopackageInstaller.java
+++ b/src/com/facebook/buck/android/ExopackageInstaller.java
@@ -758,13 +758,17 @@ public class ExopackageInstaller {
     String pmPathPrefix = "package:";
 
     String pmPath = null;
-    while (pmPath.startsWith("WARNING: linker: ")) {
-      // Ignore silly linker warnings about non-PIC code on emulators
-      if(!lineIter.hasNext()) {
-        pmPath = null;
-        break;
-      }
+    if (lineIter.hasNext()) {
       pmPath = lineIter.next();
+      LOG.warn(pmPath);
+      while (pmPath.startsWith("WARNING: linker: ")) {
+        // Ignore silly linker warnings about non-PIC code on emulators
+        if(!lineIter.hasNext()) {
+          pmPath = null;
+          break;
+        }
+        pmPath = lineIter.next();
+      }
     }
 
     if (pmPath == null || !pmPath.startsWith(pmPathPrefix)) {


### PR DESCRIPTION
Under certain conditions pm can output more than one linker warning line