### PR TITLE
Add bridging header support for project generation

### DIFF
--- a/src/com/facebook/buck/apple/project_generator/NewNativeTargetProjectMutator.java
+++ b/src/com/facebook/buck/apple/project_generator/NewNativeTargetProjectMutator.java
@@ -115,6 +115,7 @@ class NewNativeTargetProjectMutator {
   private ImmutableSet<SourcePath> privateHeaders = ImmutableSet.of();
   private Optional<SourcePath> prefixHeader = Optional.absent();
   private Optional<SourcePath> infoPlist = Optional.absent();
+  private Optional<SourcePath> bridgingHeader = Optional.absent();
   private ImmutableSet<FrameworkPath> frameworks = ImmutableSet.of();
   private ImmutableSet<PBXFileReference> archives = ImmutableSet.of();
   private ImmutableSet<AppleResourceDescription.Arg> recursiveResources = ImmutableSet.of();
@@ -196,6 +197,11 @@ class NewNativeTargetProjectMutator {
 
   public NewNativeTargetProjectMutator setInfoPlist(Optional<SourcePath> infoPlist) {
     this.infoPlist = infoPlist;
+    return this;
+  }
+
+  public NewNativeTargetProjectMutator setBridgingHeader(Optional<SourcePath> bridgingHeader) {
+    this.bridgingHeader = bridgingHeader;
     return this;
   }
 
@@ -331,6 +337,14 @@ class NewNativeTargetProjectMutator {
           pathRelativizer.outputPathToSourcePath(infoPlist.get()),
           Optional.<String>absent());
       sourcesGroup.getOrCreateFileReferenceBySourceTreePath(infoPlistSourceTreePath);
+    }
+
+    if (bridgingHeader.isPresent()) {
+      SourceTreePath bridgingHeaderSourceTreePath = new SourceTreePath(
+          PBXReference.SourceTree.GROUP,
+          pathRelativizer.outputPathToSourcePath(bridgingHeader.get()),
+          Optional.<String>absent());
+      sourcesGroup.getOrCreateFileReferenceBySourceTreePath(bridgingHeaderSourceTreePath);
     }
 
     if (!sourcesBuildPhase.getFiles().isEmpty()) {

--- a/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
+++ b/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
@@ -939,7 +939,7 @@ public class ProjectGenerator {
     }
   }
 
-  PBXNativeTarget generateAppleBundleTarget(
+  private PBXNativeTarget generateAppleBundleTarget(
       PBXProject project,
       TargetNode<? extends HasAppleBundleFields> targetNode,
       TargetNode<? extends AppleNativeTargetDescriptionArg> binaryNode,
@@ -1173,6 +1173,8 @@ public class ProjectGenerator {
       mutator.setInfoPlist(Optional.of(bundleArg.getInfoPlist()));
     }
 
+    mutator.setBridgingHeader(arg.bridgingHeader);
+
     Optional<TargetNode<AppleNativeTargetDescriptionArg>> appleTargetNode =
         targetNode.castArg(AppleNativeTargetDescriptionArg.class);
     if (appleTargetNode.isPresent() && isFocusedOnTarget) {
@@ -1317,6 +1319,13 @@ public class ProjectGenerator {
     if (infoPlistOptional.isPresent()) {
       Path infoPlistPath = pathRelativizer.outputDirToRootRelative(infoPlistOptional.get());
       extraSettingsBuilder.put("INFOPLIST_FILE", infoPlistPath.toString());
+    }
+    if (arg.bridgingHeader.isPresent()) {
+      Path bridgingHeaderPath = pathRelativizer.outputDirToRootRelative(
+          sourcePathResolver.apply(arg.bridgingHeader.get()));
+      extraSettingsBuilder.put(
+          "SWIFT_OBJC_BRIDGING_HEADER",
+          Joiner.on('/').join("$(SRCROOT)", bridgingHeaderPath.toString()));
     }
     Optional<SourcePath> prefixHeaderOptional = targetNode.getConstructorArg().prefixHeader;
     if (prefixHeaderOptional.isPresent()) {

--- a/test/com/facebook/buck/apple/AbstractAppleNativeTargetBuilder.java
+++ b/test/com/facebook/buck/apple/AbstractAppleNativeTargetBuilder.java
@@ -171,5 +171,10 @@ public abstract class AbstractAppleNativeTargetBuilder<
     return getThis();
   }
 
+  public BUILDER setBridgingHeader(Optional<SourcePath> bridgingHeader) {
+    arg.bridgingHeader = bridgingHeader;
+    return getThis();
+  }
+
   protected abstract BUILDER getThis();
 }


### PR DESCRIPTION
Generated project should include bridging header file & settings. This currently doesn't not support swift target. I'll do it after https://github.com/facebook/buck/pull/870 to avoid conflict.