### PR TITLE
Use manifest path set for andorid_library rules for project generation

### DIFF
--- a/src/com/facebook/buck/jvm/java/intellij/IjModuleFactory.java
+++ b/src/com/facebook/buck/jvm/java/intellij/IjModuleFactory.java
@@ -94,6 +94,12 @@ public class IjModuleFactory {
     Path getAndroidManifestPath(TargetNode<AndroidBinaryDescription.Arg> targetNode);
 
     /**
+     * @param targetNode node describing the Android library to get the manifest of.
+     * @return path on disk to the AndroidManifest.
+     */
+    Optional<Path> getLibraryAndroidManifestPath(TargetNode<AndroidLibraryDescription.Arg> targetNode);
+
+    /**
      * @param targetNode node describing the Android binary to get the Proguard config of.
      * @return path on disk to the proguard config.
      */
@@ -637,9 +643,14 @@ public class IjModuleFactory {
       if (dummyRDotJavaClassPath.isPresent()) {
         context.addExtraClassPathDependency(dummyRDotJavaClassPath.get());
       }
-      context.getOrCreateAndroidFacetBuilder()
-          .setAutogenerateSources(autogenerateAndroidFacetSources)
-          .setAndroidLibrary(true);
+
+      IjModuleAndroidFacet.Builder builder = context.getOrCreateAndroidFacetBuilder();
+      Optional<Path> manifestPath = moduleFactoryResolver.getLibraryAndroidManifestPath(target);
+      if (manifestPath.isPresent()) {
+        builder.setManifestPath(manifestPath.get());
+      }
+      builder.setAutogenerateSources(autogenerateAndroidFacetSources);
+      builder.setAndroidLibrary(true);
     }
   }
 

--- a/src/com/facebook/buck/jvm/java/intellij/IjProject.java
+++ b/src/com/facebook/buck/jvm/java/intellij/IjProject.java
@@ -17,6 +17,7 @@
 package com.facebook.buck.jvm.java.intellij;
 
 import com.facebook.buck.android.AndroidBinaryDescription;
+import com.facebook.buck.android.AndroidLibraryDescription;
 import com.facebook.buck.android.AndroidLibraryGraphEnhancer;
 import com.facebook.buck.android.AndroidPrebuiltAar;
 import com.facebook.buck.android.AndroidResourceDescription;
@@ -56,6 +57,7 @@ public class IjProject {
   private final ProjectFilesystem projectFilesystem;
   private final IjModuleGraph.AggregationMode aggregationMode;
   private final IjProjectConfig projectConfig;
+  private final IntellijConfig intellijConfig;
 
   public IjProject(
       TargetGraphAndTargets targetGraphAndTargets,
@@ -74,6 +76,7 @@ public class IjProject {
     this.projectFilesystem = projectFilesystem;
     this.aggregationMode = aggregationMode;
     this.projectConfig = IjProjectBuckConfig.create(buckConfig);
+    this.intellijConfig = new IntellijConfig(buckConfig);
   }
 
   /**
@@ -143,6 +146,12 @@ public class IjProject {
           @Override
           public Path getAndroidManifestPath(TargetNode<AndroidBinaryDescription.Arg> targetNode) {
             return sourcePathResolver.getAbsolutePath(targetNode.getConstructorArg().manifest);
+          }
+
+          @Override
+          public Optional<Path> getLibraryAndroidManifestPath(TargetNode<AndroidLibraryDescription.Arg> targetNode) {
+            Optional<SourcePath> manifestPath = targetNode.getConstructorArg().manifest;
+            return manifestPath.transform(sourcePathResolver.getAbsolutePathFunction()).or(intellijConfig.getAndroidManifest());
           }
 
           @Override

--- a/src/com/facebook/buck/jvm/java/intellij/IjProjectTemplateDataPreparer.java
+++ b/src/com/facebook/buck/jvm/java/intellij/IjProjectTemplateDataPreparer.java
@@ -464,9 +464,7 @@ public class IjProjectTemplateDataPreparer {
     Optional<Path> androidManifestPath = androidFacet.getManifestPath();
     Path manifestPath;
     if (androidManifestPath.isPresent()) {
-      manifestPath = androidManifestPath.get()
-          .relativize(moduleBasePath.toAbsolutePath())
-          .resolve(androidManifestPath.get().getFileName());
+      manifestPath = moduleBasePath.toAbsolutePath().relativize(androidManifestPath.get());
     } else {
       manifestPath = moduleBasePath
                       .relativize(

--- a/test/com/facebook/buck/jvm/java/intellij/IjModuleFactoryTest.java
+++ b/test/com/facebook/buck/jvm/java/intellij/IjModuleFactoryTest.java
@@ -26,6 +26,7 @@ import com.facebook.buck.android.AndroidBinaryBuilder;
 import com.facebook.buck.android.AndroidBinaryDescription;
 import com.facebook.buck.android.AndroidLibraryBuilder;
 import com.facebook.buck.android.AndroidPrebuiltAarBuilder;
+import com.facebook.buck.android.AndroidLibraryDescription;
 import com.facebook.buck.android.AndroidResourceDescription;
 import com.facebook.buck.cli.BuckConfig;
 import com.facebook.buck.cli.FakeBuckConfig;
@@ -566,6 +567,11 @@ public class IjModuleFactoryTest {
           public Path getAndroidManifestPath(
               TargetNode<AndroidBinaryDescription.Arg> targetNode) {
             return ((FakeSourcePath) targetNode.getConstructorArg().manifest).getRelativePath();
+          }
+
+          @Override
+          public Optional<Path> getLibraryAndroidManifestPath(TargetNode<AndroidLibraryDescription.Arg> targetNode) {
+            return Optional.absent();
           }
 
           @Override

--- a/test/com/facebook/buck/jvm/java/intellij/IjModuleGraphTest.java
+++ b/test/com/facebook/buck/jvm/java/intellij/IjModuleGraphTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.fail;
 
 import com.facebook.buck.android.AndroidBinaryDescription;
 import com.facebook.buck.android.AndroidLibraryBuilder;
+import com.facebook.buck.android.AndroidLibraryDescription;
 import com.facebook.buck.android.AndroidResourceBuilder;
 import com.facebook.buck.android.AndroidResourceDescription;
 import com.facebook.buck.cli.BuckConfig;
@@ -818,6 +819,11 @@ public class IjModuleGraphTest {
           @Override
           public Path getAndroidManifestPath(TargetNode<AndroidBinaryDescription.Arg> targetNode) {
             return Paths.get("TestAndroidManifest.xml");
+          }
+
+          @Override
+          public Optional<Path> getLibraryAndroidManifestPath(TargetNode<AndroidLibraryDescription.Arg> targetNode) {
+            return Optional.absent();
           }
 
           @Override

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/android_project_with_gradle_conventions/libB/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/android_project_with_gradle_conventions/libB/BUCK.fixture
@@ -10,7 +10,6 @@ android_library(
 
 android_resource(
     name='manifest',
-    manifest='src/main/AndroidManifest.xml',
     deps=['//libA:manifest'],
     visibility=['PUBLIC'],
 )


### PR DESCRIPTION
Also fallback to the default manifest path set in the `intellij` buckconfig section