### PR TITLE
Make apple_library build without objc source

### DIFF
--- a/src/com/facebook/buck/cxx/CxxLibraryDescription.java
+++ b/src/com/facebook/buck/cxx/CxxLibraryDescription.java
@@ -276,17 +276,6 @@ public class CxxLibraryDescription implements
             cxxPlatform.getFlavor(),
             linkType);
 
-    if (objects.isEmpty()) {
-      return new NoopBuildRule(
-          new BuildRuleParams(
-              sharedTarget,
-              Suppliers.ofInstance(ImmutableSortedSet.<BuildRule>of()),
-              Suppliers.ofInstance(ImmutableSortedSet.<BuildRule>of()),
-              params.getProjectFilesystem(),
-              params.getCellRoots()),
-          pathResolver);
-    }
-
     String sharedLibrarySoname = CxxDescriptionEnhancer.getSharedLibrarySoname(
         soname,
         params.getBuildTarget(),

--- a/test/com/facebook/buck/apple/AppleBinaryIntegrationTest.java
+++ b/test/com/facebook/buck/apple/AppleBinaryIntegrationTest.java
@@ -19,7 +19,6 @@ package com.facebook.buck.apple;
 import static com.facebook.buck.cxx.CxxFlavorSanitizer.sanitize;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/test/com/facebook/buck/apple/AppleBinaryIntegrationTest.java
+++ b/test/com/facebook/buck/apple/AppleBinaryIntegrationTest.java
@@ -19,6 +19,7 @@ package com.facebook.buck.apple;
 import static com.facebook.buck.cxx.CxxFlavorSanitizer.sanitize;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -43,6 +44,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 
 import org.hamcrest.Matchers;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -882,6 +884,25 @@ public class AppleBinaryIntegrationTest {
             workspace.getPath(
                 BuildTargets.getGenPath(filesystem, target, "%s-LinkMap").resolve(
                     singleArchX8664Target.getShortNameAndFlavorPostfix() + "-LinkMap.txt"))));
+  }
+
+  @Test
+  public void testBuildEmptySourceAppleBinaryDependsOnNonEmptyAppleLibrary() throws Exception {
+    assumeTrue(Platform.detect() == Platform.MACOS);
+
+    ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(
+        this,
+        "empty_source_targets",
+        tmp);
+    workspace.setUp();
+    BuildTarget target = workspace.newBuildTarget("//:real-none2#iphonesimulator-x86_64");
+    ProjectWorkspace.ProcessResult result = workspace.runBuckCommand(
+        "run",
+        target.getFullyQualifiedName());
+    result.assertSuccess();
+    Assert.assertThat(
+        result.getStdout(),
+        equalTo("Hello"));
   }
 
   private static void assertIsSymbolicLink(

--- a/test/com/facebook/buck/apple/AppleBinaryIntegrationTest.java
+++ b/test/com/facebook/buck/apple/AppleBinaryIntegrationTest.java
@@ -19,6 +19,7 @@ package com.facebook.buck.apple;
 import static com.facebook.buck.cxx.CxxFlavorSanitizer.sanitize;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -554,14 +555,14 @@ public class AppleBinaryIntegrationTest {
             .resolve(target.getShortName() + ".app.dSYM")
             .resolve("Contents/Resources/DWARF")
             .resolve(target.getShortName()));
-    assertThat(Files.exists(output), Matchers.equalTo(true));
+    assertThat(Files.exists(output), equalTo(true));
     AppleDsymTestUtil.checkDsymFileHasDebugSymbolForMain(workspace, output);
 
     Path binaryOutput = workspace.getPath(
         BuildTargets.getGenPath(filesystem, appTarget, "%s")
             .resolve(target.getShortName() + ".app")
             .resolve(target.getShortName()));
-    assertThat(Files.exists(binaryOutput), Matchers.equalTo(true));
+    assertThat(Files.exists(binaryOutput), equalTo(true));
 
     ProcessExecutor.Result hasSymbol = workspace.runCommand("nm", binaryOutput.toString());
     String stdout = hasSymbol.getStdout().or("");
@@ -585,7 +586,7 @@ public class AppleBinaryIntegrationTest {
         BuildTargets.getGenPath(filesystem, appTarget, "%s")
             .resolve(target.getShortName() + ".app")
             .resolve(target.getShortName()));
-    assertThat(Files.exists(output), Matchers.equalTo(true));
+    assertThat(Files.exists(output), equalTo(true));
     ProcessExecutor.Result hasSymbol = workspace.runCommand("nm", output.toString());
     String stdout = hasSymbol.getStdout().or("");
     assertThat(stdout, containsString("t -[AppDelegate window]"));
@@ -639,9 +640,9 @@ public class AppleBinaryIntegrationTest {
                 "%s")
             .resolve("main.m.o"));
 
-    assertThat(Files.exists(binaryOutput), Matchers.equalTo(true));
-    assertThat(Files.exists(delegateFileOutput), Matchers.equalTo(true));
-    assertThat(Files.exists(mainFileOutput), Matchers.equalTo(true));
+    assertThat(Files.exists(binaryOutput), equalTo(true));
+    assertThat(Files.exists(delegateFileOutput), equalTo(true));
+    assertThat(Files.exists(mainFileOutput), equalTo(true));
   }
 
   @Test
@@ -693,9 +694,9 @@ public class AppleBinaryIntegrationTest {
                 "%s")
             .resolve("main.m.o"));
 
-    assertThat(Files.exists(binaryOutput), Matchers.equalTo(true));
-    assertThat(Files.exists(delegateFileOutput), Matchers.equalTo(false));
-    assertThat(Files.exists(mainFileOutput), Matchers.equalTo(false));
+    assertThat(Files.exists(binaryOutput), equalTo(true));
+    assertThat(Files.exists(delegateFileOutput), equalTo(false));
+    assertThat(Files.exists(mainFileOutput), equalTo(false));
   }
 
   @Test
@@ -747,9 +748,9 @@ public class AppleBinaryIntegrationTest {
                 "%s")
             .resolve("main.m.o"));
 
-    assertThat(Files.exists(binaryOutput), Matchers.equalTo(true));
-    assertThat(Files.exists(delegateFileOutput), Matchers.equalTo(false));
-    assertThat(Files.exists(mainFileOutput), Matchers.equalTo(false));
+    assertThat(Files.exists(binaryOutput), equalTo(true));
+    assertThat(Files.exists(delegateFileOutput), equalTo(false));
+    assertThat(Files.exists(mainFileOutput), equalTo(false));
   }
 
   @Test
@@ -772,7 +773,7 @@ public class AppleBinaryIntegrationTest {
                     .resolve(target.getShortName() + ".app.dSYM")
                     .resolve("Contents/Resources/DWARF")
                     .resolve(target.getShortName()))),
-        Matchers.equalTo(false));
+        equalTo(false));
     assertThat(
         Files.exists(
             workspace.getPath(
@@ -784,7 +785,7 @@ public class AppleBinaryIntegrationTest {
                     .resolve(target.getShortName() + ".app.dSYM")
                     .resolve("Contents/Resources/DWARF")
                     .resolve(target.getShortName()))),
-        Matchers.equalTo(false));
+        equalTo(false));
     assertThat(
         Files.exists(
             workspace.getPath(
@@ -792,7 +793,7 @@ public class AppleBinaryIntegrationTest {
                     .resolve(target.getShortName() + ".app.dSYM")
                     .resolve("Contents/Resources/DWARF")
                     .resolve(target.getShortName()))),
-        Matchers.equalTo(false));
+        equalTo(false));
 
     BuildTarget appTarget = target.withFlavors(
         AppleDebugFormat.NONE.getFlavor(),
@@ -801,7 +802,7 @@ public class AppleBinaryIntegrationTest {
         BuildTargets.getGenPath(filesystem, appTarget, "%s")
             .resolve(target.getShortName() + ".app")
             .resolve(target.getShortName()));
-    assertThat(Files.exists(binaryOutput), Matchers.equalTo(true));
+    assertThat(Files.exists(binaryOutput), equalTo(true));
 
     ProcessExecutor.Result hasSymbol = workspace.runCommand("nm", binaryOutput.toString());
     String stdout = hasSymbol.getStdout().or("");
@@ -829,7 +830,7 @@ public class AppleBinaryIntegrationTest {
             .resolve(appTarget.getShortName() + ".app.dSYM")
             .resolve("Contents/Resources/DWARF")
             .resolve(appTarget.getShortName()));
-    assertThat(Files.exists(dwarfPath), Matchers.equalTo(true));
+    assertThat(Files.exists(dwarfPath), equalTo(true));
     AppleDsymTestUtil.checkDsymFileHasDebugSymbolForMain(workspace, dwarfPath);
   }
 
@@ -853,7 +854,7 @@ public class AppleBinaryIntegrationTest {
                     .resolve(appTarget.getShortName() + ".app.dSYM")
                     .resolve("Contents/Resources/DWARF")
                     .resolve(appTarget.getShortName()))),
-        Matchers.equalTo(false));
+        equalTo(false));
   }
 
   @Test

--- a/test/com/facebook/buck/apple/AppleLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/apple/AppleLibraryIntegrationTest.java
@@ -37,7 +37,6 @@ import com.facebook.buck.testutil.integration.TestDataHelper;
 import com.facebook.buck.util.ProcessExecutor;
 import com.facebook.buck.util.environment.Platform;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -633,7 +632,7 @@ public class AppleLibraryIntegrationTest {
             filesystem,
             target,
             "%s/libreal-none.dylib"));
-    assertThat(Files.exists(binaryOutput), CoreMatchers.is(true));
+    assertThat(Files.exists(binaryOutput), is(true));
   }
 
   @Test
@@ -657,7 +656,7 @@ public class AppleLibraryIntegrationTest {
             filesystem,
             target,
             "%s/libnone-swift.dylib"));
-    assertThat(Files.exists(binaryOutput), CoreMatchers.is(true));
+    assertThat(Files.exists(binaryOutput), is(true));
 
     assertThat(
         workspace.runCommand("otool", "-L", binaryOutput.toString()).getStdout().get(),

--- a/test/com/facebook/buck/apple/AppleLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/apple/AppleLibraryIntegrationTest.java
@@ -31,12 +31,13 @@ import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.model.BuildTargets;
 import com.facebook.buck.model.ImmutableFlavor;
 import com.facebook.buck.testutil.MoreAsserts;
-import com.facebook.buck.testutil.integration.TemporaryPaths;
 import com.facebook.buck.testutil.integration.ProjectWorkspace;
+import com.facebook.buck.testutil.integration.TemporaryPaths;
 import com.facebook.buck.testutil.integration.TestDataHelper;
 import com.facebook.buck.util.ProcessExecutor;
 import com.facebook.buck.util.environment.Platform;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -609,6 +610,58 @@ public class AppleLibraryIntegrationTest {
     MoreAsserts.assertContentsEqual(
         workspace.getPath(Paths.get("first").resolve(libraryPath)),
         workspace.getPath(Paths.get("second").resolve(libraryPath)));
+  }
+
+  @Test
+  public void testBuildEmptySourceAppleLibrary() throws Exception {
+    assumeTrue(Platform.detect() == Platform.MACOS);
+
+    ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(
+        this,
+        "empty_source_targets",
+        tmp);
+    workspace.setUp();
+    BuildTarget target = workspace.newBuildTarget("//:real-none#iphonesimulator-x86_64,shared");
+    ProjectWorkspace.ProcessResult result = workspace.runBuckCommand(
+        "build",
+        target.getFullyQualifiedName());
+    result.assertSuccess();
+
+    ProjectFilesystem filesystem = new ProjectFilesystem(workspace.getDestPath());
+    Path binaryOutput = workspace.getPath(
+        BuildTargets.getGenPath(
+            filesystem,
+            target,
+            "%s/libreal-none.dylib"));
+    assertThat(Files.exists(binaryOutput), CoreMatchers.is(true));
+  }
+
+  @Test
+  public void testBuildAppleLibraryThatHasSwift() throws Exception {
+    assumeTrue(Platform.detect() == Platform.MACOS);
+
+    ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(
+        this,
+        "empty_source_targets",
+        tmp);
+    workspace.setUp();
+    BuildTarget target = workspace.newBuildTarget("//:none-swift#iphonesimulator-x86_64,shared");
+    ProjectWorkspace.ProcessResult result = workspace.runBuckCommand(
+        "build",
+        target.getFullyQualifiedName());
+    result.assertSuccess();
+
+    ProjectFilesystem filesystem = new ProjectFilesystem(workspace.getDestPath());
+    Path binaryOutput = workspace.getPath(
+        BuildTargets.getGenPath(
+            filesystem,
+            target,
+            "%s/libnone-swift.dylib"));
+    assertThat(Files.exists(binaryOutput), CoreMatchers.is(true));
+
+    assertThat(
+        workspace.runCommand("otool", "-L", binaryOutput.toString()).getStdout().get(),
+        containsString("libswiftCore.dylib"));
   }
 
   private static void assertIsSymbolicLink(

--- a/test/com/facebook/buck/apple/testdata/empty_source_targets/BUCK.fixture
+++ b/test/com/facebook/buck/apple/testdata/empty_source_targets/BUCK.fixture
@@ -1,0 +1,23 @@
+apple_library(
+    name='none-swift',
+    srcs=['dummy.swift'],
+)
+
+apple_library(
+    name='real-none',
+    deps=[':second-real-none'],
+)
+
+apple_library(
+    name='second-real-none',
+)
+
+apple_binary(
+    name='real-none2',
+    deps=[':dummymain'],
+)
+
+apple_library(
+    name='dummymain',
+    srcs=['main.c'],
+)

--- a/test/com/facebook/buck/apple/testdata/empty_source_targets/dummy.swift
+++ b/test/com/facebook/buck/apple/testdata/empty_source_targets/dummy.swift
@@ -1,0 +1,2 @@
+class Dummy {
+}

--- a/test/com/facebook/buck/apple/testdata/empty_source_targets/main.c
+++ b/test/com/facebook/buck/apple/testdata/empty_source_targets/main.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+int main() {
+  printf("Hello");
+  return 0;
+}


### PR DESCRIPTION
Apparently, we can build `apple_library` share library even the target contains no objective-c source file.