### PR TITLE
Decouple swift from apple platform

### DIFF
--- a/src/com/facebook/buck/apple/AbstractAppleCxxPlatform.java
+++ b/src/com/facebook/buck/apple/AbstractAppleCxxPlatform.java
@@ -20,13 +20,13 @@ import com.facebook.buck.cxx.CxxPlatform;
 import com.facebook.buck.model.Flavor;
 import com.facebook.buck.model.FlavorConvertible;
 import com.facebook.buck.rules.Tool;
+import com.facebook.buck.swift.SwiftPlatform;
 import com.facebook.buck.util.immutables.BuckStyleImmutable;
 import com.google.common.base.Optional;
 
 import org.immutables.value.Value;
 
 import java.nio.file.Path;
-import java.util.Set;
 
 /**
  * Adds Apple-specific tools to {@link CxxPlatform}.
@@ -36,6 +36,8 @@ import java.util.Set;
 abstract class AbstractAppleCxxPlatform implements FlavorConvertible {
 
   public abstract CxxPlatform getCxxPlatform();
+
+  public abstract Optional<SwiftPlatform> getSwiftPlatform();
 
   public abstract AppleSdk getAppleSdk();
 
@@ -52,10 +54,6 @@ abstract class AbstractAppleCxxPlatform implements FlavorConvertible {
   public abstract Optional<Path> getStubBinary();
   public abstract Tool getLldb();
   public abstract Optional<Tool> getCodesignAllocate();
-  public abstract Optional<Tool> getSwift();
-  public abstract Optional<Tool> getSwiftStdlibTool();
-  public abstract Set<Path> getSwiftRuntimePaths();
-  public abstract Set<Path> getSwiftStaticRuntimePaths();
 
   // Short Xcode version code, e.g. 0721
   public abstract Optional<String> getXcodeVersion();

--- a/src/com/facebook/buck/apple/AppleBundle.java
+++ b/src/com/facebook/buck/apple/AppleBundle.java
@@ -54,6 +54,7 @@ import com.facebook.buck.step.fs.MkdirStep;
 import com.facebook.buck.step.fs.MoveStep;
 import com.facebook.buck.step.fs.RmStep;
 import com.facebook.buck.step.fs.WriteFileStep;
+import com.facebook.buck.swift.SwiftPlatform;
 import com.facebook.buck.util.HumanReadableException;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
@@ -141,7 +142,7 @@ public class AppleBundle
   private final Optional<Tool> codesignAllocatePath;
 
   @AddToRuleKey
-  private final Optional<Tool> swiftStdlibTool;
+  private final Optional<SwiftPlatform> swiftPlatform;
 
   // Need to use String here as RuleKeyBuilder requires that paths exist to compute hashes.
   @AddToRuleKey
@@ -224,7 +225,7 @@ public class AppleBundle
           CodeSignIdentityStore.fromIdentities(ImmutableList.<CodeSignIdentity>of());
     }
     this.codesignAllocatePath = appleCxxPlatform.getCodesignAllocate();
-    this.swiftStdlibTool = appleCxxPlatform.getSwiftStdlibTool();
+    this.swiftPlatform = appleCxxPlatform.getSwiftPlatform();
   }
 
   public static String getBinaryName(BuildTarget buildTarget, Optional<String> productName) {
@@ -674,9 +675,11 @@ public class AppleBundle
       ImmutableList.Builder<Step> stepsBuilder) {
     // It's apparently safe to run this even on a non-swift bundle (in that case, no libs
     // are copied over).
-    if (swiftStdlibTool.isPresent()) {
+    if (swiftPlatform.isPresent()) {
       ImmutableList.Builder<String> swiftStdlibCommand = ImmutableList.builder();
-      swiftStdlibCommand.addAll(swiftStdlibTool.get().getCommandPrefix(getResolver()));
+      swiftStdlibCommand.addAll(swiftPlatform.get()
+          .getSwiftStdlibTool()
+          .getCommandPrefix(getResolver()));
       swiftStdlibCommand.add(
           "--scan-executable",
           bundleBinaryPath.toString(),

--- a/src/com/facebook/buck/apple/AppleCxxPlatforms.java
+++ b/src/com/facebook/buck/apple/AppleCxxPlatforms.java
@@ -16,8 +16,6 @@
 
 package com.facebook.buck.apple;
 
-import static com.sun.imageio.plugins.jpeg.JPEG.version;
-
 import com.dd.plist.NSDictionary;
 import com.dd.plist.NSObject;
 import com.dd.plist.PropertyListFormatException;
@@ -403,6 +401,7 @@ public class AppleCxxPlatforms {
         applePlatform.getName(),
         targetArchitecture + "-apple-" +
             applePlatform.getSwiftName().or(applePlatform.getName()) + targetSdk.getVersion(),
+        version,
         sdkPaths,
         toolSearchPaths,
         executableFinder);
@@ -431,6 +430,7 @@ public class AppleCxxPlatforms {
   private static Optional<SwiftPlatform> getSwiftPlatform(
       String platformName,
       String targetArchitectureName,
+      String version,
       AbstractAppleSdkPaths sdkPaths,
       ImmutableList<Path> toolSearchPaths,
       ExecutableFinder executableFinder) {

--- a/src/com/facebook/buck/apple/BUCK.autodeps
+++ b/src/com/facebook/buck/apple/BUCK.autodeps
@@ -1,4 +1,4 @@
-#@# GENERATED FILE: DO NOT MODIFY d72c7ad98d585b8b22762045968ebfe93432e739 #@#
+#@# GENERATED FILE: DO NOT MODIFY d56ffb663a5ba41d3d1c880c804f6419ce071dea #@#
 {
   "platform" : {
     "deps" : [
@@ -10,6 +10,7 @@
       "//src/com/facebook/buck/cxx:platform",
       "//src/com/facebook/buck/model:model",
       "//src/com/facebook/buck/rules:build_rule",
+      "//src/com/facebook/buck/swift:platform",
       "//src/com/facebook/buck/util/immutables:immutables",
       "//third-party/java/guava:guava"
     ]
@@ -25,6 +26,7 @@
       "//src/com/facebook/buck/log:api",
       "//src/com/facebook/buck/model:macros",
       "//src/com/facebook/buck/step/fs:fs",
+      "//src/com/facebook/buck/swift:platform",
       "//src/com/facebook/buck/test/result/type:type",
       "//src/com/facebook/buck/util:escaper",
       "//src/com/facebook/buck/util:exceptions",

--- a/src/com/facebook/buck/io/ExecutableFinder.java
+++ b/src/com/facebook/buck/io/ExecutableFinder.java
@@ -28,6 +28,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
@@ -202,5 +203,14 @@ public class ExecutableFinder {
           .build();
     }
     return ImmutableSet.of("");
+  }
+
+  public Optional<Path> getOptionalToolPath(
+      String tool,
+      ImmutableList<Path> toolSearchPaths) {
+    return getOptionalExecutable(
+        Paths.get(tool),
+        toolSearchPaths,
+        ImmutableSet.<String>of());
   }
 }

--- a/src/com/facebook/buck/rules/BUCK.autodeps
+++ b/src/com/facebook/buck/rules/BUCK.autodeps
@@ -1,4 +1,4 @@
-#@# GENERATED FILE: DO NOT MODIFY 8e4f16f8c543a789c1af1661fa4f3f427d256714 #@#
+#@# GENERATED FILE: DO NOT MODIFY 4b65432866bd8470341a4d6fbe287bbfeeb32ccf #@#
 {
   "action_graph_cache" : {
     "deps" : [
@@ -208,6 +208,7 @@
       "//src/com/facebook/buck/rust:rust",
       "//src/com/facebook/buck/shell:rules",
       "//src/com/facebook/buck/shell:worker",
+      "//src/com/facebook/buck/swift:platform",
       "//src/com/facebook/buck/swift:swift",
       "//src/com/facebook/buck/thrift:thrift",
       "//src/com/facebook/buck/util:exceptions",

--- a/src/com/facebook/buck/swift/AbstractSwiftPlatform.java
+++ b/src/com/facebook/buck/swift/AbstractSwiftPlatform.java
@@ -1,0 +1,23 @@
+package com.facebook.buck.swift;
+
+
+import com.facebook.buck.rules.Tool;
+import com.facebook.buck.util.immutables.BuckStyleImmutable;
+
+import org.immutables.value.Value;
+
+import java.nio.file.Path;
+import java.util.Set;
+
+/**
+ * Interface describing a Swift toolchain and platform to build for.
+ */
+@Value.Immutable
+@BuckStyleImmutable
+interface AbstractSwiftPlatform {
+
+  Tool getSwift();
+  Tool getSwiftStdlibTool();
+  Set<Path> getSwiftRuntimePaths();
+  Set<Path> getSwiftStaticRuntimePaths();
+}

--- a/src/com/facebook/buck/swift/AbstractSwiftPlatform.java
+++ b/src/com/facebook/buck/swift/AbstractSwiftPlatform.java
@@ -1,5 +1,20 @@
-package com.facebook.buck.swift;
+/*
+ * Copyright 2016-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 
+package com.facebook.buck.swift;
 
 import com.facebook.buck.rules.Tool;
 import com.facebook.buck.util.immutables.BuckStyleImmutable;

--- a/src/com/facebook/buck/swift/BUCK
+++ b/src/com/facebook/buck/swift/BUCK
@@ -1,4 +1,19 @@
+PLATFORM_SRCS = [
+  'AbstractSwiftPlatform.java',
+  'SwiftPlatforms.java',
+]
+java_immutables_library(
+  name = 'platform',
+  srcs = PLATFORM_SRCS,
+  immutable_types = [
+    'SwiftPlatform',
+  ],
+  autodeps = True,
+  visibility = ['PUBLIC'],
+)
+
 standard_java_library(
+  srcs = glob(['*.java',], excludes=PLATFORM_SRCS),
   tests = [
     '//test/com/facebook/buck/swift:swift',
   ],

--- a/src/com/facebook/buck/swift/BUCK.autodeps
+++ b/src/com/facebook/buck/swift/BUCK.autodeps
@@ -1,4 +1,4 @@
-#@# GENERATED FILE: DO NOT MODIFY 888a4d368aaa9a9fab2d6f7278f62be85023fdb4 #@#
+#@# GENERATED FILE: DO NOT MODIFY 5d6eaa2b2b7dc8b09061c6a49714ad07d78ce803 #@#
 {
   "platform" : {
     "deps" : [
@@ -20,7 +20,6 @@
       "//src/com/facebook/buck/util:util"
     ],
     "exported_deps" : [
-      "//src/com/facebook/buck/apple:platform",
       "//src/com/facebook/buck/cli:config",
       "//src/com/facebook/buck/cxx:platform",
       "//src/com/facebook/buck/cxx:rules",

--- a/src/com/facebook/buck/swift/BUCK.autodeps
+++ b/src/com/facebook/buck/swift/BUCK.autodeps
@@ -1,5 +1,14 @@
-#@# GENERATED FILE: DO NOT MODIFY e489bf81f2d1d73666773d21b7844d23b2b33470 #@#
+#@# GENERATED FILE: DO NOT MODIFY 888a4d368aaa9a9fab2d6f7278f62be85023fdb4 #@#
 {
+  "platform" : {
+    "deps" : [
+      "//third-party/java/immutables:processor"
+    ],
+    "exported_deps" : [
+      "//src/com/facebook/buck/rules:build_rule",
+      "//src/com/facebook/buck/util/immutables:immutables"
+    ]
+  },
   "swift" : {
     "deps" : [
       "//src/com/facebook/buck/io:MorePaths.java",
@@ -22,6 +31,7 @@
       "//src/com/facebook/buck/rules/args:args",
       "//src/com/facebook/buck/rules/coercer:coercer",
       "//src/com/facebook/buck/step:step",
+      "//src/com/facebook/buck/swift:platform",
       "//third-party/java/guava:guava",
       "//third-party/java/infer-annotations:infer-annotations"
     ]

--- a/src/com/facebook/buck/swift/SwiftLibrary.java
+++ b/src/com/facebook/buck/swift/SwiftLibrary.java
@@ -34,6 +34,7 @@ import com.facebook.buck.cxx.NativeLinkable;
 import com.facebook.buck.cxx.NativeLinkableInput;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.Flavor;
+import com.facebook.buck.model.FlavorDomain;
 import com.facebook.buck.parser.NoSuchBuildTargetException;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleParams;
@@ -74,7 +75,7 @@ class SwiftLibrary
   private final Iterable<? extends BuildRule> exportedDeps;
   private final ImmutableSet<FrameworkPath> frameworks;
   private final ImmutableSet<FrameworkPath> libraries;
-  private final SwiftPlatform swiftPlatform;
+  private final FlavorDomain<SwiftPlatform> swiftPlatformFlavorDomain;
   private final Optional<Pattern> supportedPlatformsRegex;
   private final Linkage linkage;
 
@@ -83,9 +84,9 @@ class SwiftLibrary
       BuildRuleResolver ruleResolver,
       final SourcePathResolver pathResolver,
       Iterable<? extends BuildRule> exportedDeps,
+      FlavorDomain<SwiftPlatform> swiftPlatformFlavorDomain,
       ImmutableSet<FrameworkPath> frameworks,
       ImmutableSet<FrameworkPath> libraries,
-      SwiftPlatform swiftPlatform,
       Optional<Pattern> supportedPlatformsRegex,
       Linkage linkage) {
     super(params, pathResolver);
@@ -93,7 +94,7 @@ class SwiftLibrary
     this.exportedDeps = exportedDeps;
     this.frameworks = frameworks;
     this.libraries = libraries;
-    this.swiftPlatform = swiftPlatform;
+    this.swiftPlatformFlavorDomain = swiftPlatformFlavorDomain;
     this.supportedPlatformsRegex = supportedPlatformsRegex;
     this.linkage = linkage;
   }
@@ -122,7 +123,10 @@ class SwiftLibrary
     }
     return FluentIterable.from(exportedDeps)
         .filter(NativeLinkable.class)
-        .append(new SwiftRuntimeNativeLinkable(swiftPlatform));
+        .append(
+            new SwiftRuntimeNativeLinkable(
+                swiftPlatformFlavorDomain.getValue(
+                    cxxPlatform.getFlavor())));
   }
 
   @Override

--- a/src/com/facebook/buck/swift/SwiftLibrary.java
+++ b/src/com/facebook/buck/swift/SwiftLibrary.java
@@ -19,7 +19,6 @@ package com.facebook.buck.swift;
 import static com.facebook.buck.swift.SwiftLibraryDescription.SWIFT_COMPANION_FLAVOR;
 import static com.facebook.buck.swift.SwiftLibraryDescription.SWIFT_COMPILE_FLAVOR;
 
-import com.facebook.buck.apple.AppleCxxPlatform;
 import com.facebook.buck.cxx.CxxDescriptionEnhancer;
 import com.facebook.buck.cxx.CxxHeadersDir;
 import com.facebook.buck.cxx.CxxLink;
@@ -35,7 +34,6 @@ import com.facebook.buck.cxx.NativeLinkable;
 import com.facebook.buck.cxx.NativeLinkableInput;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.Flavor;
-import com.facebook.buck.model.FlavorDomain;
 import com.facebook.buck.parser.NoSuchBuildTargetException;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleParams;
@@ -76,7 +74,7 @@ class SwiftLibrary
   private final Iterable<? extends BuildRule> exportedDeps;
   private final ImmutableSet<FrameworkPath> frameworks;
   private final ImmutableSet<FrameworkPath> libraries;
-  private final FlavorDomain<AppleCxxPlatform> appleCxxPlatformFlavorDomain;
+  private final SwiftPlatform swiftPlatform;
   private final Optional<Pattern> supportedPlatformsRegex;
   private final Linkage linkage;
 
@@ -87,7 +85,7 @@ class SwiftLibrary
       Iterable<? extends BuildRule> exportedDeps,
       ImmutableSet<FrameworkPath> frameworks,
       ImmutableSet<FrameworkPath> libraries,
-      FlavorDomain<AppleCxxPlatform> appleCxxPlatformFlavorDomain,
+      SwiftPlatform swiftPlatform,
       Optional<Pattern> supportedPlatformsRegex,
       Linkage linkage) {
     super(params, pathResolver);
@@ -95,7 +93,7 @@ class SwiftLibrary
     this.exportedDeps = exportedDeps;
     this.frameworks = frameworks;
     this.libraries = libraries;
-    this.appleCxxPlatformFlavorDomain = appleCxxPlatformFlavorDomain;
+    this.swiftPlatform = swiftPlatform;
     this.supportedPlatformsRegex = supportedPlatformsRegex;
     this.linkage = linkage;
   }
@@ -124,8 +122,7 @@ class SwiftLibrary
     }
     return FluentIterable.from(exportedDeps)
         .filter(NativeLinkable.class)
-        .append(new SwiftRuntimeNativeLinkable(
-            appleCxxPlatformFlavorDomain.getValue(cxxPlatform.getFlavor())));
+        .append(new SwiftRuntimeNativeLinkable(swiftPlatform));
   }
 
   @Override

--- a/src/com/facebook/buck/swift/SwiftPlatforms.java
+++ b/src/com/facebook/buck/swift/SwiftPlatforms.java
@@ -1,0 +1,39 @@
+package com.facebook.buck.swift;
+
+import com.facebook.buck.rules.Tool;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+public class SwiftPlatforms {
+
+  // Utility class, do not instantiate.
+  private SwiftPlatforms() { }
+
+  public static SwiftPlatform build(
+      String platformName,
+      Set<Path> toolchainPaths,
+      Tool swift,
+      Tool swiftStdLibTool) {
+    SwiftPlatform.Builder builder = SwiftPlatform.builder()
+        .setSwift(swift)
+        .setSwiftStdlibTool(swiftStdLibTool);
+
+    for (Path toolchainPath : toolchainPaths) {
+      Path swiftRuntimePath = toolchainPath
+          .resolve("usr/lib/swift")
+          .resolve(platformName);
+      if (Files.isDirectory(swiftRuntimePath)) {
+        builder.addSwiftRuntimePaths(swiftRuntimePath);
+      }
+      Path swiftStaticRuntimePath = toolchainPath
+          .resolve("usr/lib/swift_static")
+          .resolve(platformName);
+      if (Files.isDirectory(swiftStaticRuntimePath)) {
+        builder.addSwiftStaticRuntimePaths(swiftStaticRuntimePath);
+      }
+    }
+    return builder.build();
+  }
+}

--- a/src/com/facebook/buck/swift/SwiftPlatforms.java
+++ b/src/com/facebook/buck/swift/SwiftPlatforms.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.facebook.buck.swift;
 
 import com.facebook.buck.rules.Tool;

--- a/src/com/facebook/buck/swift/SwiftRuntimeNativeLinkable.java
+++ b/src/com/facebook/buck/swift/SwiftRuntimeNativeLinkable.java
@@ -18,7 +18,6 @@ package com.facebook.buck.swift;
 
 import static com.facebook.buck.model.UnflavoredBuildTarget.BUILD_TARGET_PREFIX;
 
-import com.facebook.buck.apple.AppleCxxPlatform;
 import com.facebook.buck.cxx.CxxPlatform;
 import com.facebook.buck.cxx.Linker;
 import com.facebook.buck.cxx.NativeLinkable;
@@ -43,10 +42,10 @@ final class SwiftRuntimeNativeLinkable implements NativeLinkable {
   private static final BuildTarget PSEUDO_BUILD_TARGET = BuildTarget
       .builder(Paths.get(SWIFT_RUNTIME), BUILD_TARGET_PREFIX + SWIFT_RUNTIME, SWIFT_RUNTIME)
       .build();
-  private final AppleCxxPlatform appleCxxPlatform;
+  private final SwiftPlatform swiftPlatform;
 
-  SwiftRuntimeNativeLinkable(AppleCxxPlatform appleCxxPlatform) {
-    this.appleCxxPlatform = appleCxxPlatform;
+  SwiftRuntimeNativeLinkable(SwiftPlatform swiftPlatform) {
+    this.swiftPlatform = swiftPlatform;
   }
 
   @Override
@@ -71,7 +70,7 @@ final class SwiftRuntimeNativeLinkable implements NativeLinkable {
 
     ImmutableSet<Path> swiftRuntimePaths = type == Linker.LinkableDepType.SHARED ?
         ImmutableSet.<Path>of() :
-        appleCxxPlatform.getSwiftStaticRuntimePaths();
+        swiftPlatform.getSwiftStaticRuntimePaths();
 
     // Fall back to shared if static isn't supported on this platform.
     if (type == Linker.LinkableDepType.SHARED || swiftRuntimePaths.isEmpty()) {
@@ -85,7 +84,7 @@ final class SwiftRuntimeNativeLinkable implements NativeLinkable {
               "-rpath",
               "-Xlinker",
               "@loader_path/Frameworks"));
-      swiftRuntimePaths = appleCxxPlatform.getSwiftRuntimePaths();
+      swiftRuntimePaths = swiftPlatform.getSwiftRuntimePaths();
     } else {
       // Static linking requires force-loading Swift libs, since the dependency
       // discovery mechanism is disabled otherwise.

--- a/test/com/facebook/buck/apple/AppleNativeIntegrationTestUtils.java
+++ b/test/com/facebook/buck/apple/AppleNativeIntegrationTestUtils.java
@@ -72,8 +72,7 @@ public class AppleNativeIntegrationTestUtils {
         new AppleConfig(buckConfig),
         Optional.of(new ProcessExecutor(Console.createNullConsole())));
     return
-        appleCxxPlatform.getSwift().isPresent() &&
-        appleCxxPlatform.getSwiftStdlibTool().isPresent();
+        appleCxxPlatform.getSwiftPlatform().isPresent();
   }
 
 }

--- a/test/com/facebook/buck/apple/BUCK.autodeps
+++ b/test/com/facebook/buck/apple/BUCK.autodeps
@@ -1,4 +1,4 @@
-#@# GENERATED FILE: DO NOT MODIFY 352af2212183e4803ddd6c1bf2d9dfcf686ce025 #@#
+#@# GENERATED FILE: DO NOT MODIFY 1362edabe614b5b482dde0878d09f1cd85e17dad #@#
 {
   "apple" : {
     "deps" : [
@@ -89,6 +89,7 @@
       "//src/com/facebook/buck/model:model",
       "//src/com/facebook/buck/rules:build_rule",
       "//src/com/facebook/buck/rules/coercer:coercer",
+      "//src/com/facebook/buck/swift:platform",
       "//src/com/facebook/buck/swift:swift",
       "//src/com/facebook/buck/util:io",
       "//test/com/facebook/buck/rules:testutil",

--- a/test/com/facebook/buck/apple/FakeAppleRuleDescriptions.java
+++ b/test/com/facebook/buck/apple/FakeAppleRuleDescriptions.java
@@ -30,6 +30,7 @@ import com.facebook.buck.io.FakeExecutableFinder;
 import com.facebook.buck.model.FlavorDomain;
 import com.facebook.buck.swift.SwiftBuckConfig;
 import com.facebook.buck.swift.SwiftLibraryDescription;
+import com.facebook.buck.swift.SwiftPlatform;
 import com.facebook.buck.testutil.TestConsole;
 import com.facebook.buck.util.FakeProcess;
 import com.facebook.buck.util.FakeProcessExecutor;
@@ -40,6 +41,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import java.nio.file.Path;
@@ -170,14 +172,23 @@ public class FakeAppleRuleDescriptions {
           DEFAULT_IPHONEOS_I386_PLATFORM,
           DEFAULT_IPHONEOS_X86_64_PLATFORM,
           DEFAULT_MACOSX_X86_64_PLATFORM);
+  public static final FlavorDomain<SwiftPlatform> DEFAULT_SWIFT_PLATFORM_FLAVOR_DOMAIN =
+      new FlavorDomain<>("Fake Swift Platform",
+          ImmutableMap.of(
+              DEFAULT_IPHONEOS_I386_PLATFORM.getFlavor(),
+              DEFAULT_IPHONEOS_I386_PLATFORM.getSwiftPlatform().get(),
+              DEFAULT_IPHONEOS_X86_64_PLATFORM.getFlavor(),
+              DEFAULT_IPHONEOS_X86_64_PLATFORM.getSwiftPlatform().get(),
+              DEFAULT_MACOSX_X86_64_PLATFORM.getFlavor(),
+              DEFAULT_MACOSX_X86_64_PLATFORM.getSwiftPlatform().get()
+          ));
 
   public static final SwiftLibraryDescription SWIFT_LIBRARY_DESCRIPTION =
       new SwiftLibraryDescription(
           CxxPlatformUtils.DEFAULT_CONFIG,
           new SwiftBuckConfig(DEFAULT_BUCK_CONFIG),
           DEFAULT_APPLE_FLAVOR_DOMAIN,
-          DEFAULT_APPLE_CXX_PLATFORM_FLAVOR_DOMAIN,
-          DEFAULT_IPHONEOS_X86_64_PLATFORM.getCxxPlatform());
+          DEFAULT_SWIFT_PLATFORM_FLAVOR_DOMAIN);
   /**
    * A fake apple_library description with an iOS platform for use in tests.
    */

--- a/test/com/facebook/buck/apple/FakeAppleRuleDescriptions.java
+++ b/test/com/facebook/buck/apple/FakeAppleRuleDescriptions.java
@@ -27,6 +27,7 @@ import com.facebook.buck.cxx.DefaultCxxPlatforms;
 import com.facebook.buck.cxx.InferBuckConfig;
 import com.facebook.buck.io.ExecutableFinder;
 import com.facebook.buck.io.FakeExecutableFinder;
+import com.facebook.buck.model.Flavor;
 import com.facebook.buck.model.FlavorDomain;
 import com.facebook.buck.swift.SwiftBuckConfig;
 import com.facebook.buck.swift.SwiftLibraryDescription;
@@ -172,16 +173,9 @@ public class FakeAppleRuleDescriptions {
           DEFAULT_IPHONEOS_I386_PLATFORM,
           DEFAULT_IPHONEOS_X86_64_PLATFORM,
           DEFAULT_MACOSX_X86_64_PLATFORM);
+
   public static final FlavorDomain<SwiftPlatform> DEFAULT_SWIFT_PLATFORM_FLAVOR_DOMAIN =
-      new FlavorDomain<>("Fake Swift Platform",
-          ImmutableMap.of(
-              DEFAULT_IPHONEOS_I386_PLATFORM.getFlavor(),
-              DEFAULT_IPHONEOS_I386_PLATFORM.getSwiftPlatform().get(),
-              DEFAULT_IPHONEOS_X86_64_PLATFORM.getFlavor(),
-              DEFAULT_IPHONEOS_X86_64_PLATFORM.getSwiftPlatform().get(),
-              DEFAULT_MACOSX_X86_64_PLATFORM.getFlavor(),
-              DEFAULT_MACOSX_X86_64_PLATFORM.getSwiftPlatform().get()
-          ));
+      new FlavorDomain<>("Fake Swift Platform", ImmutableMap.<Flavor, SwiftPlatform>of());
 
   public static final SwiftLibraryDescription SWIFT_LIBRARY_DESCRIPTION =
       new SwiftLibraryDescription(

--- a/test/com/facebook/buck/apple/FakeAppleRuleDescriptions.java
+++ b/test/com/facebook/buck/apple/FakeAppleRuleDescriptions.java
@@ -27,7 +27,6 @@ import com.facebook.buck.cxx.DefaultCxxPlatforms;
 import com.facebook.buck.cxx.InferBuckConfig;
 import com.facebook.buck.io.ExecutableFinder;
 import com.facebook.buck.io.FakeExecutableFinder;
-import com.facebook.buck.model.Flavor;
 import com.facebook.buck.model.FlavorDomain;
 import com.facebook.buck.swift.SwiftBuckConfig;
 import com.facebook.buck.swift.SwiftLibraryDescription;
@@ -100,6 +99,8 @@ public class FakeAppleRuleDescriptions {
           Paths.get("Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib"),
           Paths.get("Toolchains/XcodeDefault.xctoolchain/usr/bin/strip"),
           Paths.get("Toolchains/XcodeDefault.xctoolchain/usr/bin/swift"),
+          Paths.get("Toolchains/XcodeDefault.xctoolchain/usr/bin/swift"),
+          Paths.get("Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-stdlib-tool"),
           Paths.get("Toolchains/XcodeDefault.xctoolchain/usr/bin/nm"),
           Paths.get("Platforms/iPhoneOS.platform/Developer/usr/bin/libtool"),
           Paths.get("Platforms/iPhoneOS.platform/Developer/usr/bin/ar"),
@@ -175,7 +176,13 @@ public class FakeAppleRuleDescriptions {
           DEFAULT_MACOSX_X86_64_PLATFORM);
 
   public static final FlavorDomain<SwiftPlatform> DEFAULT_SWIFT_PLATFORM_FLAVOR_DOMAIN =
-      new FlavorDomain<>("Fake Swift Platform", ImmutableMap.<Flavor, SwiftPlatform>of());
+      new FlavorDomain<>("Fake Swift Platform", ImmutableMap.of(
+          DEFAULT_IPHONEOS_I386_PLATFORM.getFlavor(),
+          DEFAULT_IPHONEOS_I386_PLATFORM.getSwiftPlatform().get(),
+          DEFAULT_IPHONEOS_X86_64_PLATFORM.getFlavor(),
+          DEFAULT_IPHONEOS_X86_64_PLATFORM.getSwiftPlatform().get(),
+          DEFAULT_MACOSX_X86_64_PLATFORM.getFlavor(),
+          DEFAULT_MACOSX_X86_64_PLATFORM.getSwiftPlatform().get()));
 
   public static final SwiftLibraryDescription SWIFT_LIBRARY_DESCRIPTION =
       new SwiftLibraryDescription(

--- a/test/com/facebook/buck/io/ExecutableFinderTest.java
+++ b/test/com/facebook/buck/io/ExecutableFinderTest.java
@@ -223,6 +223,27 @@ public class ExecutableFinderTest {
             ImmutableMap.<String, String>of()));
   }
 
+  @Test
+  public void testThatDirectoryWithSwiftExecutableDoesHaveSwiftTool() throws IOException {
+    Path dir = tmp.newFolder("foo");
+    createExecutable("foo/swift");
+
+    assertEquals(
+        Optional.of(dir.resolve("swift")),
+        new ExecutableFinder().getOptionalToolPath(
+            "swift",
+            ImmutableList.of(dir)));
+  }
+
+  @Test
+  public void testThatEmptyDirectoryDoesNotHaveSwift() throws IOException {
+    assertEquals(
+        Optional.absent(),
+        new ExecutableFinder().getOptionalToolPath(
+            "swift",
+            ImmutableList.<Path>of()));
+  }
+
   private Path createExecutable(String executablePath) throws IOException {
     Path file = tmp.newFile(executablePath);
     MoreFiles.makeExecutable(file);

--- a/test/com/facebook/buck/swift/BUCK
+++ b/test/com/facebook/buck/swift/BUCK
@@ -1,3 +1,24 @@
 # These are separate from the rest of the tests so we can run
 # them separately, avoiding the 20 second timeout in the iOS simulator.
-standard_java_test(run_test_separately = True)
+STANDARD_TEST_SRCS = [
+    '*Test.java',
+]
+
+STANDARD_INTEGRATION_TEST_SRCS = [
+    '*IntegrationTest.java',
+]
+
+java_test(
+    name = 'unit',
+    srcs = glob(STANDARD_TEST_SRCS,
+                excludes=STANDARD_INTEGRATION_TEST_SRCS),
+    autodeps = True,
+)
+
+java_test(
+    name = 'swift_test_integration',
+    run_test_separately = True,
+    srcs = glob(STANDARD_INTEGRATION_TEST_SRCS),
+    autodeps = True,
+    resources = glob(['testdata/**'])
+)

--- a/test/com/facebook/buck/swift/BUCK.autodeps
+++ b/test/com/facebook/buck/swift/BUCK.autodeps
@@ -1,6 +1,24 @@
-#@# GENERATED FILE: DO NOT MODIFY 9e147fdd37701cefd9dabdf683e9a3b4d560c466 #@#
+#@# GENERATED FILE: DO NOT MODIFY bb1d8617c9ca0821d8384c5b34a9a4045c5949a5 #@#
 {
-  "swift" : {
+  "rules" : {
+    "deps" : [
+      "//src/com/facebook/buck/cxx:rules",
+      "//src/com/facebook/buck/model:model",
+      "//src/com/facebook/buck/rules:build_rule",
+      "//src/com/facebook/buck/swift:platform",
+      "//src/com/facebook/buck/swift:swift",
+      "//test/com/facebook/buck/apple:testutil",
+      "//test/com/facebook/buck/cli:FakeBuckConfig",
+      "//test/com/facebook/buck/model:testutil",
+      "//test/com/facebook/buck/rules:testutil",
+      "//test/com/facebook/buck/testutil/integration:integration",
+      "//third-party/java/guava:guava",
+      "//third-party/java/hamcrest:java-hamcrest",
+      "//third-party/java/junit:junit"
+    ],
+    "exported_deps" : [ ]
+  },
+  "swift_test_integration" : {
     "deps" : [
       "//src/com/facebook/buck/apple:platform",
       "//src/com/facebook/buck/apple:rules",
@@ -12,7 +30,6 @@
       "//src/com/facebook/buck/swift:swift",
       "//src/com/facebook/buck/util/environment:platform",
       "//test/com/facebook/buck/apple:testutil",
-      "//test/com/facebook/buck/cli:FakeBuckConfig",
       "//test/com/facebook/buck/cxx:testutil",
       "//test/com/facebook/buck/model:testutil",
       "//test/com/facebook/buck/rules:testutil",

--- a/test/com/facebook/buck/swift/BUCK.autodeps
+++ b/test/com/facebook/buck/swift/BUCK.autodeps
@@ -1,23 +1,5 @@
-#@# GENERATED FILE: DO NOT MODIFY bb1d8617c9ca0821d8384c5b34a9a4045c5949a5 #@#
+#@# GENERATED FILE: DO NOT MODIFY dc7638d63bceee50c55dcb727f78577eee716756 #@#
 {
-  "rules" : {
-    "deps" : [
-      "//src/com/facebook/buck/cxx:rules",
-      "//src/com/facebook/buck/model:model",
-      "//src/com/facebook/buck/rules:build_rule",
-      "//src/com/facebook/buck/swift:platform",
-      "//src/com/facebook/buck/swift:swift",
-      "//test/com/facebook/buck/apple:testutil",
-      "//test/com/facebook/buck/cli:FakeBuckConfig",
-      "//test/com/facebook/buck/model:testutil",
-      "//test/com/facebook/buck/rules:testutil",
-      "//test/com/facebook/buck/testutil/integration:integration",
-      "//third-party/java/guava:guava",
-      "//third-party/java/hamcrest:java-hamcrest",
-      "//third-party/java/junit:junit"
-    ],
-    "exported_deps" : [ ]
-  },
   "swift_test_integration" : {
     "deps" : [
       "//src/com/facebook/buck/apple:platform",
@@ -27,6 +9,7 @@
       "//src/com/facebook/buck/model:model",
       "//src/com/facebook/buck/rules:build_rule",
       "//src/com/facebook/buck/rules/coercer:coercer",
+      "//src/com/facebook/buck/swift:platform",
       "//src/com/facebook/buck/swift:swift",
       "//src/com/facebook/buck/util/environment:platform",
       "//test/com/facebook/buck/apple:testutil",
@@ -35,6 +18,22 @@
       "//test/com/facebook/buck/rules:testutil",
       "//test/com/facebook/buck/testutil:testutil",
       "//test/com/facebook/buck/testutil/integration:integration",
+      "//third-party/java/guava:guava",
+      "//third-party/java/hamcrest:java-hamcrest",
+      "//third-party/java/junit:junit"
+    ],
+    "exported_deps" : [ ]
+  },
+  "unit" : {
+    "deps" : [
+      "//src/com/facebook/buck/cxx:rules",
+      "//src/com/facebook/buck/model:model",
+      "//src/com/facebook/buck/rules:build_rule",
+      "//src/com/facebook/buck/swift:swift",
+      "//test/com/facebook/buck/apple:testutil",
+      "//test/com/facebook/buck/cli:FakeBuckConfig",
+      "//test/com/facebook/buck/model:testutil",
+      "//test/com/facebook/buck/rules:testutil",
       "//third-party/java/guava:guava",
       "//third-party/java/hamcrest:java-hamcrest",
       "//third-party/java/junit:junit"

--- a/test/com/facebook/buck/swift/SwiftDescriptionsTest.java
+++ b/test/com/facebook/buck/swift/SwiftDescriptionsTest.java
@@ -16,7 +16,7 @@
 
 package com.facebook.buck.swift;
 
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import com.facebook.buck.apple.FakeAppleRuleDescriptions;
 import com.facebook.buck.cxx.CxxLibraryDescription;
@@ -32,10 +32,10 @@ import com.facebook.buck.rules.TargetGraph;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSortedSet;
 
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 public class SwiftDescriptionsTest {
+
   @Test
   public void testPopulateSwiftLibraryDescriptionArg() throws Exception {
     BuildRuleResolver resolver =
@@ -57,13 +57,13 @@ public class SwiftDescriptionsTest {
     args.supportedPlatformsRegex = Optional.absent();
 
     SwiftDescriptions.populateSwiftLibraryDescriptionArg(pathResolver, output, args, buildTarget);
-    assertThat(output.moduleName.get(), Matchers.equalTo("bar"));
-    assertThat(output.srcs.get(), Matchers.equalTo(ImmutableSortedSet.<SourcePath>of(swiftSrc)));
+    assertEquals(output.moduleName.get(), "bar");
+    assertEquals(output.srcs.get(), ImmutableSortedSet.<SourcePath>of(swiftSrc));
 
     args.moduleName = Optional.of("baz");
 
     SwiftDescriptions.populateSwiftLibraryDescriptionArg(pathResolver, output, args, buildTarget);
-    assertThat(output.moduleName.get(), Matchers.equalTo("baz"));
+    assertEquals(output.moduleName.get(), "baz");
   }
 
 }

--- a/test/com/facebook/buck/swift/SwiftLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/swift/SwiftLibraryIntegrationTest.java
@@ -49,7 +49,7 @@ import org.junit.Test;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-public class SwiftLibraryTest {
+public class SwiftLibraryIntegrationTest {
   @Rule
   public final TemporaryPaths tmpDir = new TemporaryPaths();
 

--- a/test/com/facebook/buck/swift/SwiftPlatformsIntegrationTest.java
+++ b/test/com/facebook/buck/swift/SwiftPlatformsIntegrationTest.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-public class SwiftPlatformsTest {
+public class SwiftPlatformsIntegrationTest {
 
   @Rule
   public TemporaryPaths tmp = new TemporaryPaths();

--- a/test/com/facebook/buck/swift/SwiftPlatformsTest.java
+++ b/test/com/facebook/buck/swift/SwiftPlatformsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.swift;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.facebook.buck.rules.VersionedTool;
+import com.facebook.buck.testutil.integration.TemporaryPaths;
+import com.google.common.collect.ImmutableSet;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class SwiftPlatformsTest {
+
+  @Rule
+  public TemporaryPaths tmp = new TemporaryPaths();
+
+  private VersionedTool swiftTool;
+  private VersionedTool swiftStdTool;
+
+  @Before
+  public void setUp() {
+    swiftTool = VersionedTool.of(Paths.get("swift"), "foo", "1.0");
+    swiftStdTool = VersionedTool.of(Paths.get("swift-std"), "foo", "1.0");
+  }
+
+  @Test
+  public void testBuildSwiftPlatformWithEmptyToolchainPaths() {
+    SwiftPlatform swiftPlatform = SwiftPlatforms.build(
+        "iphoneos",
+        ImmutableSet.<Path>of(),
+        swiftTool, swiftStdTool);
+    assertEquals(swiftPlatform.getSwiftStdlibTool(), swiftStdTool);
+    assertEquals(swiftPlatform.getSwift(), swiftTool);
+    assertTrue(swiftPlatform.getSwiftRuntimePaths().isEmpty());
+    assertTrue(swiftPlatform.getSwiftStaticRuntimePaths().isEmpty());
+  }
+
+  @Test
+  public void testBuildSwiftPlatformWithNonEmptyLookupPathWithoutTools() throws IOException {
+    Path dir = tmp.newFolder("foo");
+    SwiftPlatform swiftPlatform = SwiftPlatforms.build(
+        "iphoneos",
+        ImmutableSet.of(dir),
+        swiftTool, swiftStdTool);
+    assertTrue(swiftPlatform.getSwiftRuntimePaths().isEmpty());
+    assertTrue(swiftPlatform.getSwiftStaticRuntimePaths().isEmpty());
+  }
+
+  @Test
+  public void testBuildSwiftPlatformWithNonEmptyLookupPathWithTools() throws IOException {
+    tmp.newFolder("foo/usr/lib/swift/iphoneos");
+    tmp.newFolder("foo2/usr/lib/swift_static/iphoneos");
+    tmp.newFolder("foo3/usr/lib/swift_static/iphoneos");
+    SwiftPlatform swiftPlatform = SwiftPlatforms.build(
+        "iphoneos",
+        ImmutableSet.of(
+            tmp.getRoot().resolve("foo"),
+            tmp.getRoot().resolve("foo2"),
+            tmp.getRoot().resolve("foo3")),
+        swiftTool, swiftStdTool);
+    assertEquals(swiftPlatform.getSwiftRuntimePaths().size(), 1);
+    assertEquals(swiftPlatform.getSwiftStaticRuntimePaths().size(), 2);
+  }
+
+}


### PR DESCRIPTION
Code base for supporting swift is getting larger, we should think about how to make buck to build swift platform-independently. This PR is a starting point for that, it is extracted from https://github.com/facebook/buck/pull/893, and should make it easier to specify swift version to be used with buck.