### PR TITLE
Add option to specify swift version

### DIFF
--- a/src/com/facebook/buck/apple/AbstractAppleCxxPlatform.java
+++ b/src/com/facebook/buck/apple/AbstractAppleCxxPlatform.java
@@ -22,6 +22,7 @@ import com.facebook.buck.model.FlavorConvertible;
 import com.facebook.buck.rules.Tool;
 import com.facebook.buck.swift.SwiftPlatform;
 import com.facebook.buck.util.immutables.BuckStyleImmutable;
+import com.google.common.base.Function;
 import com.google.common.base.Optional;
 
 import org.immutables.value.Value;
@@ -34,6 +35,14 @@ import java.nio.file.Path;
 @Value.Immutable
 @BuckStyleImmutable
 abstract class AbstractAppleCxxPlatform implements FlavorConvertible {
+
+  public static final Function<String, String> SWIFT_VERSION_TO_TOOLCHAIN_IDENTIFIER =
+      new Function<String, String>() {
+        @Override
+        public String apply(String version) {
+          return "com.apple.dt.toolchain.Swift_" + version.replaceAll("\\D", "_");
+        }
+      };
 
   public abstract CxxPlatform getCxxPlatform();
 

--- a/src/com/facebook/buck/swift/SwiftBuckConfig.java
+++ b/src/com/facebook/buck/swift/SwiftBuckConfig.java
@@ -43,4 +43,8 @@ public class SwiftBuckConfig {
       }
     });
   }
+
+  public Optional<String> getVersion() {
+    return delegate.getValue(SECTION_NAME, "version");
+  }
 }

--- a/src/com/facebook/buck/swift/SwiftLibraryDescription.java
+++ b/src/com/facebook/buck/swift/SwiftLibraryDescription.java
@@ -229,7 +229,8 @@ public class SwiftLibraryDescription implements
         resolver,
         new SourcePathResolver(resolver),
         ImmutableSet.<BuildRule>of(),
-        swiftPlatformFlavorDomain, args.frameworks.get(),
+        swiftPlatformFlavorDomain,
+        args.frameworks.get(),
         args.libraries.get(),
         args.supportedPlatformsRegex,
         args.preferredLinkage.or(NativeLinkable.Linkage.ANY));

--- a/test/com/facebook/buck/apple/AppleNativeIntegrationTestUtils.java
+++ b/test/com/facebook/buck/apple/AppleNativeIntegrationTestUtils.java
@@ -70,9 +70,9 @@ public class AppleNativeIntegrationTestUtils {
         sdkPaths.get(anySdk),
         buckConfig,
         new AppleConfig(buckConfig),
-        Optional.of(new ProcessExecutor(Console.createNullConsole())));
-    return
-        appleCxxPlatform.getSwiftPlatform().isPresent();
+        Optional.of(new ProcessExecutor(Console.createNullConsole())),
+        Optional.<AppleToolchain>absent());
+    return appleCxxPlatform.getSwiftPlatform().isPresent();
   }
 
 }

--- a/test/com/facebook/buck/apple/FakeAppleRuleDescriptions.java
+++ b/test/com/facebook/buck/apple/FakeAppleRuleDescriptions.java
@@ -99,7 +99,6 @@ public class FakeAppleRuleDescriptions {
           Paths.get("Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib"),
           Paths.get("Toolchains/XcodeDefault.xctoolchain/usr/bin/strip"),
           Paths.get("Toolchains/XcodeDefault.xctoolchain/usr/bin/swift"),
-          Paths.get("Toolchains/XcodeDefault.xctoolchain/usr/bin/swift"),
           Paths.get("Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-stdlib-tool"),
           Paths.get("Toolchains/XcodeDefault.xctoolchain/usr/bin/nm"),
           Paths.get("Platforms/iPhoneOS.platform/Developer/usr/bin/libtool"),

--- a/test/com/facebook/buck/apple/FakeAppleRuleDescriptions.java
+++ b/test/com/facebook/buck/apple/FakeAppleRuleDescriptions.java
@@ -110,7 +110,7 @@ public class FakeAppleRuleDescriptions {
           Paths.get("Tools/otest"),
           Paths.get("usr/bin/xctest")));
 
-  private static final ProcessExecutor PROCESS_EXECUTOR = new FakeProcessExecutor(
+  public static final ProcessExecutor PROCESS_EXECUTOR = new FakeProcessExecutor(
       new Function<ProcessExecutorParams, FakeProcess>() {
         @Override
         public FakeProcess apply(ProcessExecutorParams input) {
@@ -128,7 +128,8 @@ public class FakeAppleRuleDescriptions {
           FakeBuckConfig.builder().build(),
           new FakeAppleConfig(),
           EXECUTABLE_FINDER,
-          Optional.of(PROCESS_EXECUTOR));
+          Optional.of(PROCESS_EXECUTOR),
+          Optional.<AppleToolchain>absent());
 
   public static final AppleCxxPlatform DEFAULT_IPHONEOS_X86_64_PLATFORM =
       AppleCxxPlatforms.buildWithExecutableChecker(
@@ -139,7 +140,8 @@ public class FakeAppleRuleDescriptions {
           FakeBuckConfig.builder().build(),
           new FakeAppleConfig(),
           EXECUTABLE_FINDER,
-          Optional.of(PROCESS_EXECUTOR));
+          Optional.of(PROCESS_EXECUTOR),
+          Optional.<AppleToolchain>absent());
 
 
   public static final AppleCxxPlatform DEFAULT_MACOSX_X86_64_PLATFORM =
@@ -151,7 +153,8 @@ public class FakeAppleRuleDescriptions {
           FakeBuckConfig.builder().build(),
           new FakeAppleConfig(),
           EXECUTABLE_FINDER,
-          Optional.of(PROCESS_EXECUTOR));
+          Optional.of(PROCESS_EXECUTOR),
+          Optional.<AppleToolchain>absent());
 
   public static final BuckConfig DEFAULT_BUCK_CONFIG = FakeBuckConfig.builder().build();
 


### PR DESCRIPTION
After upgrading to Xcode8, the default swift compiler will be 3.0. This PR will allow buck to specify swift version to be used by adding following setting to the buck config file:

```
[swift]
  version = 2.3
```

Extracted from https://github.com/facebook/buck/pull/893