### PR TITLE
Add SWIFT_VERSION for project generation

### DIFF
--- a/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
+++ b/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
@@ -101,6 +101,7 @@ import com.facebook.buck.rules.TargetNode;
 import com.facebook.buck.rules.coercer.FrameworkPath;
 import com.facebook.buck.rules.coercer.SourceList;
 import com.facebook.buck.shell.ExportFileDescription;
+import com.facebook.buck.swift.SwiftBuckConfig;
 import com.facebook.buck.util.Escaper;
 import com.facebook.buck.util.HumanReadableException;
 import com.facebook.buck.util.MoreIterables;
@@ -318,6 +319,7 @@ public class ProjectGenerator {
   private final HalideBuckConfig halideBuckConfig;
   private final CxxBuckConfig cxxBuckConfig;
   private final AppleConfig appleConfig;
+  private final SwiftBuckConfig swiftBuckConfig;
   private final ImmutableList<BuildTarget> focusModules;
 
   public ProjectGenerator(
@@ -339,7 +341,8 @@ public class ProjectGenerator {
       BuckEventBus buckEventBus,
       HalideBuckConfig halideBuckConfig,
       CxxBuckConfig cxxBuckConfig,
-      AppleConfig appleConfig) {
+      AppleConfig appleConfig,
+      SwiftBuckConfig swiftBuckConfig) {
     this.sourcePathResolver = new Function<SourcePath, Path>() {
       @Override
       public Path apply(SourcePath input) {
@@ -392,6 +395,7 @@ public class ProjectGenerator {
     this.halideBuckConfig = halideBuckConfig;
     this.cxxBuckConfig = cxxBuckConfig;
     this.appleConfig = appleConfig;
+    this.swiftBuckConfig = swiftBuckConfig;
     this.focusModules = focusModules;
 
     for (BuildTarget focusedTarget : focusModules) {
@@ -1330,6 +1334,10 @@ public class ProjectGenerator {
       extraSettingsBuilder.put(
           "SWIFT_OBJC_BRIDGING_HEADER",
           Joiner.on('/').join("$(SRCROOT)", bridgingHeaderPath.toString()));
+    }
+    Optional<String> swiftVersion = swiftBuckConfig.getVersion();
+    if (swiftVersion.isPresent()) {
+      extraSettingsBuilder.put("SWIFT_VERSION", swiftVersion.get());
     }
     Optional<SourcePath> prefixHeaderOptional = targetNode.getConstructorArg().prefixHeader;
     if (prefixHeaderOptional.isPresent()) {

--- a/src/com/facebook/buck/apple/project_generator/WorkspaceAndProjectGenerator.java
+++ b/src/com/facebook/buck/apple/project_generator/WorkspaceAndProjectGenerator.java
@@ -43,6 +43,7 @@ import com.facebook.buck.rules.Cell;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.TargetGraph;
 import com.facebook.buck.rules.TargetNode;
+import com.facebook.buck.swift.SwiftBuckConfig;
 import com.facebook.buck.util.HumanReadableException;
 import com.facebook.buck.util.Optionals;
 import com.google.common.annotations.VisibleForTesting;
@@ -112,6 +113,7 @@ public class WorkspaceAndProjectGenerator {
   private final HalideBuckConfig halideBuckConfig;
   private final CxxBuckConfig cxxBuckConfig;
   private final AppleConfig appleConfig;
+  private final SwiftBuckConfig swiftBuckConfig;
 
   public WorkspaceAndProjectGenerator(
       Cell cell,
@@ -133,7 +135,8 @@ public class WorkspaceAndProjectGenerator {
       BuckEventBus buckEventBus,
       HalideBuckConfig halideBuckConfig,
       CxxBuckConfig cxxBuckConfig,
-      AppleConfig appleConfig) {
+      AppleConfig appleConfig,
+      SwiftBuckConfig swiftBuckConfig) {
     this.rootCell = cell;
     this.projectGraph = projectGraph;
     this.workspaceArguments = workspaceArguments;
@@ -151,6 +154,7 @@ public class WorkspaceAndProjectGenerator {
     this.buildFileName = buildFileName;
     this.sourcePathResolverForNode = sourcePathResolverForNode;
     this.buckEventBus = buckEventBus;
+    this.swiftBuckConfig = swiftBuckConfig;
     this.combinedProjectGenerator = Optional.absent();
     this.halideBuckConfig = halideBuckConfig;
     this.cxxBuckConfig = cxxBuckConfig;
@@ -507,7 +511,8 @@ public class WorkspaceAndProjectGenerator {
         buckEventBus,
         halideBuckConfig,
         cxxBuckConfig,
-        appleConfig);
+        appleConfig,
+        swiftBuckConfig);
     combinedTestsProjectGenerator
         .setAdditionalCombinedTestTargets(groupedTests)
         .createXcodeProjects();
@@ -573,7 +578,8 @@ public class WorkspaceAndProjectGenerator {
             buckEventBus,
             halideBuckConfig,
             cxxBuckConfig,
-            appleConfig)
+            appleConfig,
+            swiftBuckConfig)
             .setTestsToGenerateAsStaticLibraries(groupableTests);
         projectGenerators.put(projectDirectory, generator);
         shouldGenerateProjects = true;
@@ -623,7 +629,8 @@ public class WorkspaceAndProjectGenerator {
         buckEventBus,
         halideBuckConfig,
         cxxBuckConfig,
-        appleConfig)
+        appleConfig,
+        swiftBuckConfig)
         .setAdditionalCombinedTestTargets(groupedTests)
         .setTestsToGenerateAsStaticLibraries(groupableTests);
     combinedProjectGenerator = Optional.of(generator);

--- a/src/com/facebook/buck/cli/ProjectCommand.java
+++ b/src/com/facebook/buck/cli/ProjectCommand.java
@@ -66,6 +66,7 @@ import com.facebook.buck.rules.TargetGraphAndTargets;
 import com.facebook.buck.rules.TargetNode;
 import com.facebook.buck.step.ExecutionContext;
 import com.facebook.buck.step.ExecutorPool;
+import com.facebook.buck.swift.SwiftBuckConfig;
 import com.facebook.buck.util.HumanReadableException;
 import com.facebook.buck.util.MoreExceptions;
 import com.facebook.buck.util.ProcessManager;
@@ -972,9 +973,11 @@ public class ProjectCommand extends BuildCommand {
             inputNode);
       }
 
-      AppleConfig appleConfig = new AppleConfig(params.getBuckConfig());
-      HalideBuckConfig halideBuckConfig = new HalideBuckConfig(params.getBuckConfig());
-      CxxBuckConfig cxxBuckConfig = new CxxBuckConfig(params.getBuckConfig());
+      BuckConfig buckConfig = params.getBuckConfig();
+      AppleConfig appleConfig = new AppleConfig(buckConfig);
+      HalideBuckConfig halideBuckConfig = new HalideBuckConfig(buckConfig);
+      CxxBuckConfig cxxBuckConfig = new CxxBuckConfig(buckConfig);
+      SwiftBuckConfig swiftBuckConfig = new SwiftBuckConfig(buckConfig);
 
       CxxPlatform defaultCxxPlatform = params.getCell().getKnownBuildRuleTypes().
           getDefaultCxxPlatforms();
@@ -1006,7 +1009,8 @@ public class ProjectCommand extends BuildCommand {
           params.getBuckEventBus(),
           halideBuckConfig,
           cxxBuckConfig,
-          appleConfig);
+          appleConfig,
+          swiftBuckConfig);
       generator.setGroupableTests(groupableTests);
       ListeningExecutorService executorService = params.getExecutors().get(
           ExecutorPool.PROJECT);

--- a/test/com/facebook/buck/apple/project_generator/WorkspaceAndProjectGeneratorTest.java
+++ b/test/com/facebook/buck/apple/project_generator/WorkspaceAndProjectGeneratorTest.java
@@ -48,6 +48,7 @@ import com.facebook.buck.apple.xcode.XCScheme;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXAggregateTarget;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXTarget;
 import com.facebook.buck.apple.xcode.xcodeproj.ProductType;
+import com.facebook.buck.cli.BuckConfig;
 import com.facebook.buck.cli.FakeBuckConfig;
 import com.facebook.buck.cxx.CxxBuckConfig;
 import com.facebook.buck.cxx.CxxLibraryBuilder;
@@ -75,6 +76,7 @@ import com.facebook.buck.rules.TargetNode;
 import com.facebook.buck.rules.TestCellBuilder;
 import com.facebook.buck.shell.GenruleBuilder;
 import com.facebook.buck.shell.GenruleDescription;
+import com.facebook.buck.swift.SwiftBuckConfig;
 import com.facebook.buck.testutil.TargetGraphFactory;
 import com.facebook.buck.timing.IncrementingFakeClock;
 import com.google.common.base.Function;
@@ -116,6 +118,7 @@ public class WorkspaceAndProjectGeneratorTest {
   private HalideBuckConfig halideBuckConfig;
   private CxxBuckConfig cxxBuckConfig;
   private AppleConfig appleConfig;
+  private SwiftBuckConfig swiftBuckConfig;
 
   private TargetGraph targetGraph;
   private TargetNode<XcodeWorkspaceConfigDescription.Arg> workspaceNode;
@@ -130,7 +133,9 @@ public class WorkspaceAndProjectGeneratorTest {
     ProjectFilesystem projectFilesystem = rootCell.getFilesystem();
     halideBuckConfig = HalideLibraryBuilder.createDefaultHalideConfig(projectFilesystem);
     cxxBuckConfig = CxxLibraryBuilder.createDefaultConfig();
-    appleConfig = new AppleConfig(FakeBuckConfig.builder().build());
+    BuckConfig fakeBuckConfig = FakeBuckConfig.builder().build();
+    appleConfig = new AppleConfig(fakeBuckConfig);
+    swiftBuckConfig = new SwiftBuckConfig(fakeBuckConfig);
     setUpWorkspaceAndProjects();
   }
 
@@ -265,7 +270,8 @@ public class WorkspaceAndProjectGeneratorTest {
         getFakeBuckEventBus(),
         halideBuckConfig,
         cxxBuckConfig,
-        appleConfig);
+        appleConfig,
+        swiftBuckConfig);
     Map<Path, ProjectGenerator> projectGenerators = new HashMap<>();
     generator.generateWorkspaceAndDependentProjects(
         projectGenerators,
@@ -340,7 +346,8 @@ public class WorkspaceAndProjectGeneratorTest {
         getFakeBuckEventBus(),
         halideBuckConfig,
         cxxBuckConfig,
-        appleConfig);
+        appleConfig,
+        swiftBuckConfig);
     Map<Path, ProjectGenerator> projectGenerators = new HashMap<>();
     generator.generateWorkspaceAndDependentProjects(
         projectGenerators,
@@ -399,7 +406,8 @@ public class WorkspaceAndProjectGeneratorTest {
         getFakeBuckEventBus(),
         halideBuckConfig,
         cxxBuckConfig,
-        appleConfig);
+        appleConfig,
+        swiftBuckConfig);
     Map<Path, ProjectGenerator> projectGenerators = new HashMap<>();
     generator.generateWorkspaceAndDependentProjects(
         projectGenerators,
@@ -464,7 +472,8 @@ public class WorkspaceAndProjectGeneratorTest {
         getFakeBuckEventBus(),
         halideBuckConfig,
         cxxBuckConfig,
-        appleConfig);
+        appleConfig,
+        swiftBuckConfig);
 
     Map<Path, ProjectGenerator> projectGenerators = new HashMap<>();
     generator.generateWorkspaceAndDependentProjects(
@@ -539,7 +548,8 @@ public class WorkspaceAndProjectGeneratorTest {
         getFakeBuckEventBus(),
         halideBuckConfig,
         cxxBuckConfig,
-        appleConfig);
+        appleConfig,
+        swiftBuckConfig);
     Map<Path, ProjectGenerator> projectGenerators = new HashMap<>();
     generator.generateWorkspaceAndDependentProjects(
         projectGenerators,
@@ -596,7 +606,8 @@ public class WorkspaceAndProjectGeneratorTest {
         getFakeBuckEventBus(),
         halideBuckConfig,
         cxxBuckConfig,
-        appleConfig);
+        appleConfig,
+        swiftBuckConfig);
     Map<Path, ProjectGenerator> projectGenerators = new HashMap<>();
     generator.generateWorkspaceAndDependentProjects(
         projectGenerators,
@@ -634,7 +645,8 @@ public class WorkspaceAndProjectGeneratorTest {
         getFakeBuckEventBus(),
         halideBuckConfig,
         cxxBuckConfig,
-        appleConfig);
+        appleConfig,
+        swiftBuckConfig);
     Map<Path, ProjectGenerator> projectGenerators = new HashMap<>();
     generator.generateWorkspaceAndDependentProjects(
         projectGenerators,
@@ -702,7 +714,8 @@ public class WorkspaceAndProjectGeneratorTest {
         getFakeBuckEventBus(),
         halideBuckConfig,
         cxxBuckConfig,
-        appleConfig);
+        appleConfig,
+        swiftBuckConfig);
     Map<Path, ProjectGenerator> projectGenerators = new HashMap<>();
     generator.generateWorkspaceAndDependentProjects(
         projectGenerators,
@@ -751,7 +764,8 @@ public class WorkspaceAndProjectGeneratorTest {
         getFakeBuckEventBus(),
         halideBuckConfig,
         cxxBuckConfig,
-        appleConfig);
+        appleConfig,
+        swiftBuckConfig);
     Map<Path, ProjectGenerator> projectGenerators = new HashMap<>();
 
     try {
@@ -836,7 +850,8 @@ public class WorkspaceAndProjectGeneratorTest {
         getFakeBuckEventBus(),
         halideBuckConfig,
         cxxBuckConfig,
-        appleConfig);
+        appleConfig,
+        swiftBuckConfig);
     generator.setGroupableTests(AppleBuildRules.filterGroupableTests(targetGraph.getNodes()));
     Map<Path, ProjectGenerator> projectGenerators = Maps.newHashMap();
     generator.generateWorkspaceAndDependentProjects(
@@ -1200,7 +1215,8 @@ public class WorkspaceAndProjectGeneratorTest {
         getFakeBuckEventBus(),
         halideBuckConfig,
         cxxBuckConfig,
-        appleConfig);
+        appleConfig,
+        swiftBuckConfig);
     Map<Path, ProjectGenerator> projectGenerators = new HashMap<>();
     generator.generateWorkspaceAndDependentProjects(
         projectGenerators,
@@ -1358,7 +1374,8 @@ public class WorkspaceAndProjectGeneratorTest {
         getFakeBuckEventBus(),
         halideBuckConfig,
         cxxBuckConfig,
-        appleConfig);
+        appleConfig,
+        swiftBuckConfig);
     Map<Path, ProjectGenerator> projectGenerators = new HashMap<>();
     generator.generateWorkspaceAndDependentProjects(
         projectGenerators,
@@ -1454,7 +1471,8 @@ public class WorkspaceAndProjectGeneratorTest {
         getFakeBuckEventBus(),
         halideBuckConfig,
         cxxBuckConfig,
-        appleConfig);
+        appleConfig,
+        swiftBuckConfig);
     Map<Path, ProjectGenerator> projectGenerators = new HashMap<>();
     generator.generateWorkspaceAndDependentProjects(
         projectGenerators,
@@ -1516,7 +1534,8 @@ public class WorkspaceAndProjectGeneratorTest {
         getFakeBuckEventBus(),
         halideBuckConfig,
         cxxBuckConfig,
-        appleConfig);
+        appleConfig,
+        swiftBuckConfig);
     Map<Path, ProjectGenerator> projectGenerators = new HashMap<>();
     generator.generateWorkspaceAndDependentProjects(
         projectGenerators,


### PR DESCRIPTION
Use swift version specified in the .buckconfig file for project generation, if not specified, xcode will ask to convert the generated swift project every regeneration time.