### PR TITLE
Fix swift linking when swift version is specified

### DIFF
--- a/src/com/facebook/buck/apple/AppleCxxPlatforms.java
+++ b/src/com/facebook/buck/apple/AppleCxxPlatforms.java
@@ -401,15 +401,17 @@ public class AppleCxxPlatforms {
 
     ApplePlatform applePlatform = targetSdk.getApplePlatform();
     ImmutableList.Builder<Path> swiftOverrideSearchPathBuilder = ImmutableList.builder();
+    AppleSdkPaths.Builder swiftSdkPathsBuilder = AppleSdkPaths.builder().from(sdkPaths);
     if (swiftToolChain.isPresent()) {
       swiftOverrideSearchPathBuilder.add(swiftToolChain.get().getPath().resolve(USR_BIN));
+      swiftSdkPathsBuilder.setToolchainPaths(ImmutableList.of(swiftToolChain.get().getPath()));
     }
     Optional<SwiftPlatform> swiftPlatform = getSwiftPlatform(
         applePlatform.getName(),
         targetArchitecture + "-apple-" +
             applePlatform.getSwiftName().or(applePlatform.getName()) + targetSdk.getVersion(),
         version,
-        sdkPaths,
+        swiftSdkPathsBuilder.build(),
         swiftOverrideSearchPathBuilder
             .addAll(toolSearchPaths)
             .build(),

--- a/test/com/facebook/buck/apple/AppleCxxPlatformsTest.java
+++ b/test/com/facebook/buck/apple/AppleCxxPlatformsTest.java
@@ -987,6 +987,8 @@ public class AppleCxxPlatformsTest {
     assertTrue(swiftTool instanceof VersionedTool);
     assertThat(((VersionedTool) swiftTool).getPath(),
         equalTo(Paths.get("Toolchains/XcodeDefault.xctoolchain/usr/bin/swift")));
+
+    assertThat(swiftPlatformOptional.get().getSwiftRuntimePaths(), Matchers.<Path>empty());
   }
 
   @Test
@@ -997,6 +999,9 @@ public class AppleCxxPlatformsTest {
     Tool swiftTool = swiftPlatformOptional.get().getSwift();
     assertThat(((VersionedTool) swiftTool).getPath(),
         not(equalTo(Paths.get("Toolchains/Swift_2.3.xctoolchain/usr/bin/swift"))));
+
+    assertThat(swiftPlatformOptional.get().getSwiftRuntimePaths(),
+        equalTo(ImmutableSet.of(temp.getRoot().resolve("usr/lib/swift/iphoneos"))));
   }
 
   private AppleCxxPlatform buildAppleCxxPlatformWithSwiftToolchain(boolean useDefaultSwift)
@@ -1008,6 +1013,8 @@ public class AppleCxxPlatformsTest {
         .setVersion("1")
         .build();
     temp.newFolder("usr", "bin");
+    temp.newFolder("usr", "lib", "swift", "iphoneos");
+    temp.newFolder("usr", "lib", "swift_static", "iphoneos");
     MoreFiles.makeExecutable(temp.newFile("usr/bin/swift"));
     MoreFiles.makeExecutable(temp.newFile("usr/bin/swift-stdlib-tool"));
     Optional<AppleToolchain> selectedSwiftToolChain = useDefaultSwift ?


### PR DESCRIPTION
Given swift version is specified in .buckconfig, which is different to the default swift, https://github.com/facebook/buck/pull/899 works for standalone swift target, but doesn't cover the case when there are multiple swift targets depend on each other, which will fail at linking time.

This PR will fix that problem.