### PR TITLE
Add SwiftSupport directory and copy Swift stdlibs when creating .ipa packages

### DIFF
--- a/src/com/facebook/buck/apple/AppleBundle.java
+++ b/src/com/facebook/buck/apple/AppleBundle.java
@@ -489,7 +489,8 @@ public class AppleBundle
       addSwiftStdlibStepIfNeeded(
         bundleRoot.resolve(Paths.get("Frameworks")),
         Optional.of(codeSignIdentitySupplier),
-        stepsBuilder
+        stepsBuilder,
+        false /* is for packaging? */
       );
 
       stepsBuilder.add(
@@ -504,7 +505,8 @@ public class AppleBundle
       addSwiftStdlibStepIfNeeded(
         bundleRoot.resolve(Paths.get("Frameworks")),
         Optional.<Supplier<CodeSignIdentity>>absent(),
-        stepsBuilder
+        stepsBuilder,
+        false /* is for packaging? */
       );
     }
 
@@ -674,7 +676,8 @@ public class AppleBundle
   public void addSwiftStdlibStepIfNeeded(
       Path destinationPath,
       Optional<Supplier<CodeSignIdentity>> codeSignIdentitySupplier,
-      ImmutableList.Builder<Step> stepsBuilder) {
+      ImmutableList.Builder<Step> stepsBuilder,
+      boolean isForPackaging) {
     // It's apparently safe to run this even on a non-swift bundle (in that case, no libs
     // are copied over).
     if (swiftStdlibTool.isPresent()) {
@@ -688,13 +691,14 @@ public class AppleBundle
           "--scan-folder",
           bundleRoot.resolve(destinations.getPlugInsPath()).toString());
 
+      String tempDirPattern = isForPackaging ? "__swift_packaging_temp__%s" : "__swift_temp__%s";
       stepsBuilder.add(
           new SwiftStdlibStep(
               getProjectFilesystem().getRootPath(),
               BuildTargets.getScratchPath(
                   getProjectFilesystem(),
                   getBuildTarget(),
-                  "__swift_temp__%s"),
+                  tempDirPattern),
               destinationPath,
               swiftStdlibCommand.build(),
               codeSignIdentitySupplier)

--- a/src/com/facebook/buck/apple/AppleBundle.java
+++ b/src/com/facebook/buck/apple/AppleBundle.java
@@ -272,8 +272,20 @@ public class AppleBundle
     return platformName;
   }
 
+  public Path getFrameworksPath() {
+    return bundleRoot.resolve(this.destinations.getFrameworksPath());
+  }
+
+  public Path getPlugInsPath() {
+    return bundleRoot.resolve(destinations.getPlugInsPath());
+  }
+
   public Optional<BuildRule> getBinary() {
     return binary;
+  }
+
+  public Path getBundleBinaryPath() {
+    return bundleBinaryPath;
   }
 
   public boolean isLegacyWatchApp() {
@@ -403,7 +415,7 @@ public class AppleBundle
     }
 
     if (!frameworks.isEmpty()) {
-      Path frameworksDestinationPath = bundleRoot.resolve(this.destinations.getFrameworksPath());
+      Path frameworksDestinationPath = getFrameworksPath();
       stepsBuilder.add(new MkdirStep(getProjectFilesystem(), frameworksDestinationPath));
       for (SourcePath framework : frameworks) {
         stepsBuilder.add(
@@ -675,9 +687,9 @@ public class AppleBundle
           "--scan-executable",
           bundleBinaryPath.toString(),
           "--scan-folder",
-          bundleRoot.resolve(destinations.getFrameworksPath()).toString(),
+          getFrameworksPath().toString(),
           "--scan-folder",
-          bundleRoot.resolve(destinations.getPlugInsPath()).toString());
+          getPlugInsPath().toString());
 
       stepsBuilder.add(
           new SwiftStdlibStep(

--- a/src/com/facebook/buck/apple/AppleBundle.java
+++ b/src/com/facebook/buck/apple/AppleBundle.java
@@ -504,7 +504,7 @@ public class AppleBundle
     } else {
       addSwiftStdlibStepIfNeeded(
         bundleRoot.resolve(Paths.get("Frameworks")),
-        Optional.<Supplier<CodeSignIdentity>>absent(),
+        Optional.absent(),
         stepsBuilder,
         false /* is for packaging? */
       );
@@ -687,7 +687,7 @@ public class AppleBundle
           "--scan-executable",
           bundleBinaryPath.toString(),
           "--scan-folder",
-          bundleRoot.resolve(this.destinations.getFrameworksPath()).toString(),
+          bundleRoot.resolve(destinations.getFrameworksPath()).toString(),
           "--scan-folder",
           bundleRoot.resolve(destinations.getPlugInsPath()).toString());
 

--- a/src/com/facebook/buck/apple/ApplePackageDescription.java
+++ b/src/com/facebook/buck/apple/ApplePackageDescription.java
@@ -99,10 +99,19 @@ public class ApplePackageDescription implements
           applePackageConfigAndPlatformInfo.get(),
           new BuildTargetSourcePath(bundle.getBuildTarget()));
     } else {
+      Set<Flavor> platformFlavors = getPlatformFlavorsOrDefault(params.getBuildTarget());
+      AppleCxxPlatform platform = null;
+
+      for (Flavor flavor : platformFlavors) {
+        AppleCxxPlatform iPlatform = appleCxxPlatformFlavorDomain.getValue(flavor);
+        platform = iPlatform;
+        break;
+      }
       return new BuiltinApplePackage(
           params,
           sourcePathResolver,
-          bundle);
+          bundle,
+          platform);
     }
   }
   @Override

--- a/src/com/facebook/buck/apple/ApplePackageDescription.java
+++ b/src/com/facebook/buck/apple/ApplePackageDescription.java
@@ -99,19 +99,10 @@ public class ApplePackageDescription implements
           applePackageConfigAndPlatformInfo.get(),
           new BuildTargetSourcePath(bundle.getBuildTarget()));
     } else {
-      Set<Flavor> platformFlavors = getPlatformFlavorsOrDefault(params.getBuildTarget());
-      AppleCxxPlatform platform = null;
-
-      for (Flavor flavor : platformFlavors) {
-        AppleCxxPlatform iPlatform = appleCxxPlatformFlavorDomain.getValue(flavor);
-        platform = iPlatform;
-        break;
-      }
       return new BuiltinApplePackage(
           params,
           sourcePathResolver,
-          bundle,
-          platform);
+          bundle);
     }
   }
   @Override

--- a/src/com/facebook/buck/apple/BuiltinApplePackage.java
+++ b/src/com/facebook/buck/apple/BuiltinApplePackage.java
@@ -20,20 +20,25 @@ import com.facebook.buck.file.WriteFile;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargets;
 import com.facebook.buck.rules.AbstractBuildRule;
+import com.facebook.buck.rules.AddToRuleKey;
 import com.facebook.buck.rules.BuildContext;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildableContext;
 import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.buck.rules.Tool;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.fs.CopyStep;
 import com.facebook.buck.step.fs.MakeCleanDirectoryStep;
 import com.facebook.buck.step.fs.MkdirStep;
 import com.facebook.buck.step.fs.RmStep;
 import com.facebook.buck.step.fs.WriteFileStep;
+import com.facebook.buck.swift.SwiftPlatform;
 import com.facebook.buck.zip.ZipCompressionLevel;
 import com.facebook.buck.zip.ZipStep;
+import com.google.common.base.Function;
 import com.google.common.base.Optional;
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.ByteSource;
@@ -46,16 +51,27 @@ public class BuiltinApplePackage extends AbstractBuildRule {
   private final Path temp;
   private final BuildRule bundle;
 
+  @AddToRuleKey
+  private final Optional<Tool> swiftStdlibTool;
+
   public BuiltinApplePackage(
       BuildRuleParams params,
       SourcePathResolver resolver,
-      BuildRule bundle) {
+      BuildRule bundle,
+      AppleCxxPlatform appleCxxPlatform) {
     super(params, resolver);
     BuildTarget buildTarget = params.getBuildTarget();
     // TODO(ryu2): This will be different for Mac apps.
     this.pathToOutputFile = BuildTargets.getGenPath(getProjectFilesystem(), buildTarget, "%s.ipa");
     this.temp = BuildTargets.getScratchPath(getProjectFilesystem(), buildTarget, "__temp__%s");
     this.bundle = bundle;
+    this.swiftStdlibTool = appleCxxPlatform.getSwiftPlatform()
+        .transform(new Function<SwiftPlatform, Tool>() {
+          @Override
+          public Tool apply(SwiftPlatform input) {
+            return input.getSwiftStdlibTool();
+          }
+        });
   }
 
   @Override
@@ -83,6 +99,8 @@ public class BuiltinApplePackage extends AbstractBuildRule {
             payloadDir,
             CopyStep.DirectoryMode.DIRECTORY_AND_CONTENTS));
 
+    appendAdditionalSwiftSteps(commands);
+
     // do the zipping
     commands.add(new MkdirStep(getProjectFilesystem(), pathToOutputFile.getParent()));
     commands.add(
@@ -97,6 +115,38 @@ public class BuiltinApplePackage extends AbstractBuildRule {
     buildableContext.recordArtifact(getPathToOutput());
 
     return commands.build();
+  }
+
+  private void appendAdditionalSwiftSteps(ImmutableList.Builder<Step> commands) {
+    // For .ipas containing Swift code, Apple requires the following for App Store submissions:
+    // 1. Copy the Swift standard libraries to SwiftSupport/{platform}
+    if (swiftStdlibTool.isPresent() && bundle instanceof AppleBundle) {
+      AppleBundle appleBundle = (AppleBundle) bundle;
+
+      Path swiftSupportDir = temp.resolve("SwiftSupport/" + appleBundle.getPlatformName());
+
+      ImmutableList.Builder<String> swiftStdlibCommand = ImmutableList.builder();
+      swiftStdlibCommand.addAll(swiftStdlibTool.get().getCommandPrefix(getResolver()));
+      swiftStdlibCommand.add(
+          "--scan-executable",
+          appleBundle.getBundleBinaryPath().toString(),
+          "--scan-folder",
+          appleBundle.getFrameworksPath().toString(),
+          "--scan-folder",
+          appleBundle.getPlugInsPath().toString());
+
+      commands.add(
+          new SwiftStdlibStep(
+              getProjectFilesystem().getRootPath(),
+              BuildTargets.getScratchPath(
+                  getProjectFilesystem(),
+                  getBuildTarget(),
+                  "__swiftsupport_temp__%s"),
+              swiftSupportDir,
+              swiftStdlibCommand.build(),
+              Optional.<Supplier<CodeSignIdentity>>absent())
+      );
+    }
   }
 
   private void appendAdditionalAppleWatchSteps(ImmutableList.Builder<Step> commands) {

--- a/src/com/facebook/buck/apple/BuiltinApplePackage.java
+++ b/src/com/facebook/buck/apple/BuiltinApplePackage.java
@@ -34,7 +34,6 @@ import com.facebook.buck.step.fs.WriteFileStep;
 import com.facebook.buck.zip.ZipCompressionLevel;
 import com.facebook.buck.zip.ZipStep;
 import com.google.common.base.Optional;
-import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.ByteSource;
@@ -112,7 +111,7 @@ public class BuiltinApplePackage extends AbstractBuildRule {
 
       appleBundle.addSwiftStdlibStepIfNeeded(
         swiftSupportDir,
-        Optional.<Supplier<CodeSignIdentity>>absent(),
+        Optional.absent(),
         commands,
         true /* is for packaging? */
       );

--- a/src/com/facebook/buck/apple/BuiltinApplePackage.java
+++ b/src/com/facebook/buck/apple/BuiltinApplePackage.java
@@ -123,7 +123,7 @@ public class BuiltinApplePackage extends AbstractBuildRule {
     if (swiftStdlibTool.isPresent() && bundle instanceof AppleBundle) {
       AppleBundle appleBundle = (AppleBundle) bundle;
 
-      Path swiftSupportDir = temp.resolve("SwiftSupport/" + appleBundle.getPlatformName());
+      Path swiftSupportDir = temp.resolve("SwiftSupport").resolve(appleBundle.getPlatformName());
 
       ImmutableList.Builder<String> swiftStdlibCommand = ImmutableList.builder();
       swiftStdlibCommand.addAll(swiftStdlibTool.get().getCommandPrefix(getResolver()));

--- a/src/com/facebook/buck/apple/BuiltinApplePackage.java
+++ b/src/com/facebook/buck/apple/BuiltinApplePackage.java
@@ -113,7 +113,8 @@ public class BuiltinApplePackage extends AbstractBuildRule {
       appleBundle.addSwiftStdlibStepIfNeeded(
         swiftSupportDir,
         Optional.<Supplier<CodeSignIdentity>>absent(),
-        commands
+        commands,
+        true /* is for packaging? */
       );
     }
   }

--- a/test/com/facebook/buck/apple/BuiltinApplePackageIntegrationTest.java
+++ b/test/com/facebook/buck/apple/BuiltinApplePackageIntegrationTest.java
@@ -110,6 +110,26 @@ public class BuiltinApplePackageIntegrationTest {
   }
 
   @Test
+  public void packageHasProperStructureForSwift() throws IOException {
+    assumeTrue(Platform.detect() == Platform.MACOS);
+    ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(
+      this,
+      "simple_application_bundle_swift_no_debug",
+      tmp);
+    workspace.setUp();
+    workspace.enableDirCache();
+
+    BuildTarget packageTarget = BuildTargetFactory.newInstance("//:DemoAppPackage");
+    workspace.runBuckCommand("build", packageTarget.getFullyQualifiedName()).assertSuccess();
+
+    workspace.getBuildLog().assertTargetBuiltLocally(packageTarget.getFullyQualifiedName());
+
+    ZipInspector zipInspector = new ZipInspector(
+      workspace.getPath(BuildTargets.getGenPath(filesystem, packageTarget, "%s.ipa")));
+    zipInspector.assertFileExists("SwiftSupport/iphonesimulator/libswiftCore.dylib");
+  }
+
+  @Test
   public void packageHasProperStructureForWatch20() throws IOException, InterruptedException {
     assumeTrue(Platform.detect() == Platform.MACOS);
     ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(

--- a/test/com/facebook/buck/apple/BuiltinApplePackageIntegrationTest.java
+++ b/test/com/facebook/buck/apple/BuiltinApplePackageIntegrationTest.java
@@ -130,6 +130,26 @@ public class BuiltinApplePackageIntegrationTest {
   }
 
   @Test
+  public void swiftSupportIsOnlyAddedIfPackageContainsSwiftCode() throws IOException {
+    assumeTrue(Platform.detect() == Platform.MACOS);
+    ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(
+      this,
+      "simple_application_bundle_no_debug",
+      tmp);
+    workspace.setUp();
+    workspace.enableDirCache();
+
+    BuildTarget packageTarget = BuildTargetFactory.newInstance("//:DemoAppPackage");
+    workspace.runBuckCommand("build", packageTarget.getFullyQualifiedName()).assertSuccess();
+
+    workspace.getBuildLog().assertTargetBuiltLocally(packageTarget.getFullyQualifiedName());
+
+    ZipInspector zipInspector = new ZipInspector(
+      workspace.getPath(BuildTargets.getGenPath(filesystem, packageTarget, "%s.ipa")));
+    zipInspector.assertFileDoesNotExist("SwiftSupport");
+  }
+
+  @Test
   public void packageHasProperStructureForWatch20() throws IOException, InterruptedException {
     assumeTrue(Platform.detect() == Platform.MACOS);
     ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(

--- a/test/com/facebook/buck/apple/testdata/simple_application_bundle_swift_no_debug/.buckconfig
+++ b/test/com/facebook/buck/apple/testdata/simple_application_bundle_swift_no_debug/.buckconfig
@@ -1,0 +1,8 @@
+[cxx]
+  default_platform = iphonesimulator-x86_64
+  cflags = -g
+[apple]
+  default_debug_info_format_for_binaries = NONE
+  default_debug_info_format_for_libraries = NONE
+  default_debug_info_format_for_tests = NONE
+

--- a/test/com/facebook/buck/apple/testdata/simple_application_bundle_swift_no_debug/AppDelegate.swift
+++ b/test/com/facebook/buck/apple/testdata/simple_application_bundle_swift_no_debug/AppDelegate.swift
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import UIKit
+
+@UIApplicationMain
+final class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        let vc = UIViewController()
+        vc.view.backgroundColor = UIColor.red
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = vc
+
+        self.window = window
+        window.makeKeyAndVisible()
+
+        return true
+    }
+}

--- a/test/com/facebook/buck/apple/testdata/simple_application_bundle_swift_no_debug/BUCK.fixture
+++ b/test/com/facebook/buck/apple/testdata/simple_application_bundle_swift_no_debug/BUCK.fixture
@@ -1,0 +1,22 @@
+apple_bundle(
+  name = 'DemoApp',
+  binary = ':DemoAppBinary',
+  extension = 'app',
+  info_plist = 'Info.plist',
+)
+
+apple_binary(
+  name = 'DemoAppBinary',
+  srcs = glob([
+    '*.swift',
+  ]),
+  frameworks = [
+    '$SDKROOT/System/Library/Frameworks/UIKit.framework',
+    '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+  ]
+)
+
+apple_package(
+  name = 'DemoAppPackage',
+  bundle = ':DemoApp',
+)

--- a/test/com/facebook/buck/apple/testdata/simple_application_bundle_swift_no_debug/Info.plist
+++ b/test/com/facebook/buck/apple/testdata/simple_application_bundle_swift_no_debug/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>DemoApp</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.example.DemoApp</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>DemoApp</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
To submit an `.ipa` containing Swift code to the App Store for review, the Swift standard libraries need to be copied to a "SwiftSupport" directory at the root of the archive.