### PR TITLE
Incremental build for swift - First iteration.

### DIFF
--- a/src/com/facebook/buck/apple/AppleCxxPlatforms.java
+++ b/src/com/facebook/buck/apple/AppleCxxPlatforms.java
@@ -446,7 +446,6 @@ public class AppleCxxPlatforms {
       ImmutableList<Path> toolSearchPaths,
       ExecutableFinder executableFinder) {
     ImmutableList<String> swiftParams = ImmutableList.of(
-        "-frontend",
         "-sdk",
         sdkPaths.getSdkPath().toString(),
         "-target",
@@ -460,7 +459,7 @@ public class AppleCxxPlatforms {
         platformName);
 
     Optional<Tool> swift = getOptionalToolWithParams(
-        "swift",
+        "swiftc",
         toolSearchPaths,
         executableFinder,
         version,

--- a/src/com/facebook/buck/cxx/CxxLibrary.java
+++ b/src/com/facebook/buck/cxx/CxxLibrary.java
@@ -192,7 +192,7 @@ public class CxxLibrary
     if (!isPlatformSupported(cxxPlatform)) {
       return ImmutableList.of();
     }
-    return FluentIterable.from(getDeclaredDeps())
+    return FluentIterable.from(getDeps())
         .filter(NativeLinkable.class);
   }
 

--- a/src/com/facebook/buck/swift/AbstractSwiftOutputEntry.java
+++ b/src/com/facebook/buck/swift/AbstractSwiftOutputEntry.java
@@ -1,0 +1,66 @@
+package com.facebook.buck.swift;
+
+import com.facebook.buck.io.MorePaths;
+import com.facebook.buck.util.immutables.BuckStyleImmutable;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import org.immutables.value.Value;
+
+import java.nio.file.Path;
+
+@Value.Immutable
+@BuckStyleImmutable
+@JsonSerialize(as = SwiftOutputEntry.class)
+abstract class AbstractSwiftOutputEntry {
+
+  @JsonIgnore
+  @Value.Parameter
+  public abstract Path outputPath();
+
+  @JsonIgnore
+  @Value.Parameter
+  public abstract Path source();
+
+  @JsonProperty("swiftmodule")
+  @Value.Default
+  public Path getSwiftModule() {
+    return appendSuffix("~partial.swiftmodule");
+  }
+
+  @JsonProperty("object")
+  @Value.Default
+  public Path getObject() {
+    return appendSuffix(".o");
+  }
+
+  @JsonProperty("llvm-bc")
+  @Value.Default
+  public Path getLLVMBitCode() {
+    return appendSuffix(".bc");
+  }
+
+  @JsonProperty("diagnostics")
+  @Value.Default
+  public Path getDiagnostics() {
+    return appendSuffix(".dia");
+  }
+
+  @JsonProperty("dependencies")
+  @Value.Default
+  public Path getDependencies() {
+    return appendSuffix(".d");
+  }
+
+  @JsonProperty("swift-dependencies")
+  @Value.Default
+  public Path getSwiftDependencies() {
+    return appendSuffix(".swiftdeps");
+  }
+
+  private Path appendSuffix(String suffix) {
+    return outputPath()
+            .resolve(MorePaths.getNameWithoutExtension(source()) + suffix);
+  }
+}

--- a/src/com/facebook/buck/swift/BUCK
+++ b/src/com/facebook/buck/swift/BUCK
@@ -1,4 +1,5 @@
 PLATFORM_SRCS = [
+  'AbstractSwiftOutputEntry.java',
   'AbstractSwiftPlatform.java',
   'SwiftPlatforms.java',
 ]

--- a/src/com/facebook/buck/swift/BUCK.autodeps
+++ b/src/com/facebook/buck/swift/BUCK.autodeps
@@ -1,12 +1,15 @@
-#@# GENERATED FILE: DO NOT MODIFY 5d6eaa2b2b7dc8b09061c6a49714ad07d78ce803 #@#
+#@# GENERATED FILE: DO NOT MODIFY c4126e5c216335e49ee858098d39ab6c1bdedadb #@#
 {
   "platform" : {
     "deps" : [
+      "//src/com/facebook/buck/io:MorePaths.java",
       "//third-party/java/immutables:processor"
     ],
     "exported_deps" : [
       "//src/com/facebook/buck/rules:build_rule",
-      "//src/com/facebook/buck/util/immutables:immutables"
+      "//src/com/facebook/buck/util/immutables:immutables",
+      "//third-party/java/jackson:jackson-annotations",
+      "//third-party/java/jackson:jackson-databind"
     ]
   },
   "swift" : {
@@ -17,7 +20,9 @@
       "//src/com/facebook/buck/step/fs:fs",
       "//src/com/facebook/buck/util:exceptions",
       "//src/com/facebook/buck/util:io",
-      "//src/com/facebook/buck/util:util"
+      "//src/com/facebook/buck/util:object_mapper",
+      "//src/com/facebook/buck/util:util",
+      "//third-party/java/gson:gson"
     ],
     "exported_deps" : [
       "//src/com/facebook/buck/cli:config",
@@ -32,7 +37,8 @@
       "//src/com/facebook/buck/step:step",
       "//src/com/facebook/buck/swift:platform",
       "//third-party/java/guava:guava",
-      "//third-party/java/infer-annotations:infer-annotations"
+      "//third-party/java/infer-annotations:infer-annotations",
+      "//third-party/java/jackson:jackson-databind"
     ]
   }
 }

--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -17,7 +17,6 @@
 package com.facebook.buck.swift;
 
 import static com.facebook.buck.cxx.CxxPreprocessables.IncludeType.LOCAL;
-import static com.facebook.buck.swift.SwiftUtil.Constants.SWIFT_MAIN_FILENAME;
 import static com.facebook.buck.swift.SwiftUtil.normalizeSwiftModuleName;
 import static com.facebook.buck.swift.SwiftUtil.toSwiftHeaderName;
 
@@ -39,16 +38,19 @@ import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.SourcePaths;
 import com.facebook.buck.rules.Tool;
 import com.facebook.buck.rules.args.Arg;
+import com.facebook.buck.rules.args.FileListableLinkerInputArg;
 import com.facebook.buck.rules.args.SourcePathArg;
 import com.facebook.buck.rules.args.StringArg;
 import com.facebook.buck.rules.coercer.FrameworkPath;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.fs.MkdirStep;
+import com.facebook.buck.step.fs.WriteFileStep;
+import com.facebook.buck.util.MoreFunctions;
 import com.facebook.buck.util.MoreIterables;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -57,6 +59,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.LinkedHashSet;
 
 /**
@@ -64,6 +67,8 @@ import java.util.LinkedHashSet;
  */
 class SwiftCompile
     extends AbstractBuildRule {
+
+  private static final Path EMPTY_PATH = Paths.get("");
 
   @AddToRuleKey
   private final Tool swiftCompiler;
@@ -75,7 +80,8 @@ class SwiftCompile
   private final Path outputPath;
 
   private final Path modulePath;
-  private final Path objectPath;
+  private final Path outputFileMap;
+  private final ImmutableMap<Path, AbstractSwiftOutputEntry> outputMapEntries;
 
   @AddToRuleKey
   private final ImmutableSortedSet<SourcePath> srcs;
@@ -84,12 +90,12 @@ class SwiftCompile
   private final CxxPlatform cxxPlatform;
   private final ImmutableSet<FrameworkPath> frameworks;
 
-  private final boolean hasMainEntry;
-  private final boolean enableObjcInterop;
   private final Optional<SourcePath> bridgingHeader;
   private final SwiftBuckConfig swiftBuckConfig;
 
   private final Iterable<CxxPreprocessorInput> cxxPreprocessorInputs;
+
+  private final ObjectMapper objectMapper;
 
   // Prepend "-I" before the input with no space (this is required by swift).
   private static final Function<String, String> PREPEND_INCLUDE_FLAG =
@@ -103,19 +109,20 @@ class SwiftCompile
   SwiftCompile(
       CxxPlatform cxxPlatform,
       SwiftBuckConfig swiftBuckConfig,
+      ObjectMapper objectMapper,
       BuildRuleParams params,
       SourcePathResolver resolver,
       Tool swiftCompiler,
       ImmutableSet<FrameworkPath> frameworks,
       String moduleName,
-      Path outputPath,
+      final Path outputPath,
       Iterable<SourcePath> srcs,
-      Optional<Boolean> enableObjcInterop,
       Optional<SourcePath> bridgingHeader) throws NoSuchBuildTargetException {
     super(params, resolver);
     this.cxxPlatform = cxxPlatform;
     this.frameworks = frameworks;
     this.swiftBuckConfig = swiftBuckConfig;
+    this.objectMapper = objectMapper;
     this.cxxPreprocessorInputs =
         CxxPreprocessables.getTransitiveCxxPreprocessorInput(cxxPlatform, params.getDeps());
     this.swiftCompiler = swiftCompiler;
@@ -125,29 +132,45 @@ class SwiftCompile
     String escapedModuleName = normalizeSwiftModuleName(moduleName);
     this.moduleName = escapedModuleName;
     this.modulePath = outputPath.resolve(escapedModuleName + ".swiftmodule");
-    this.objectPath = outputPath.resolve(escapedModuleName + ".o");
 
     this.srcs = ImmutableSortedSet.copyOf(srcs);
-    this.enableObjcInterop = enableObjcInterop.or(true);
     this.bridgingHeader = bridgingHeader;
-    this.hasMainEntry = FluentIterable.from(srcs).firstMatch(new Predicate<SourcePath>() {
-      @Override
-      public boolean apply(SourcePath input) {
-        return SWIFT_MAIN_FILENAME.equalsIgnoreCase(
-            getResolver().getAbsolutePath(input).getFileName().toString());
-      }
-    }).isPresent();
+
+    this.outputFileMap = outputPath.resolve(escapedModuleName + "-OutputFileMap.json");
+    this.outputMapEntries = FluentIterable.from(srcs)
+        .transform(new Function<SourcePath, Path>() {
+          @Override
+          public Path apply(SourcePath input) {
+            return getResolver().getRelativePath(input);
+          }
+        })
+        .toMap(new Function<Path, AbstractSwiftOutputEntry>() {
+          @Override
+          public AbstractSwiftOutputEntry apply(Path input) {
+            return SwiftOutputEntry.of(outputPath, input);
+          }
+        });
   }
 
   private SwiftCompileStep makeCompileStep() {
     ImmutableList.Builder<String> compilerCommand = ImmutableList.builder();
     compilerCommand.addAll(swiftCompiler.getCommandPrefix(getResolver()));
 
-    if (bridgingHeader.isPresent()) {
-      compilerCommand.add(
-          "-import-objc-header",
-          getResolver().getRelativePath(bridgingHeader.get()).toString());
-    }
+    compilerCommand.add(
+        "-incremental", // incremental build
+        "-Xfrontend",
+        "-serialize-debugging-options",
+        "-j",
+        String.valueOf(1), // only one job at a time for now
+        "-module-name",
+        moduleName,
+        "-Onone", // no optimization
+        "-parseable-output",
+        "-emit-module",
+        "-emit-module-path",
+        modulePath.toString(),
+        "-emit-objc-header-path",
+        headerPath.toString());
 
     final Function<FrameworkPath, Path> frameworkPathToSearchPath =
         CxxDescriptionEnhancer.frameworkPathToSearchPath(cxxPlatform, getResolver());
@@ -163,7 +186,8 @@ class SwiftCompile
         }));
 
     compilerCommand.addAll(
-        MoreIterables.zipAndConcat(Iterables.cycle("-Xcc"),
+        MoreIterables.zipAndConcat(
+            Iterables.cycle("-Xcc"),
             getSwiftIncludeArgs()));
     compilerCommand.addAll(MoreIterables.zipAndConcat(
         Iterables.cycle(LOCAL.getFlag()),
@@ -181,29 +205,41 @@ class SwiftCompile
     if (configFlags.isPresent()) {
       compilerCommand.addAll(configFlags.get());
     }
-    compilerCommand.add(
-        "-enable-testing",
-        "-c",
-        enableObjcInterop ? "-enable-objc-interop" : "",
-        hasMainEntry ? "" : "-parse-as-library",
-        "-module-name",
-        moduleName,
-        "-emit-module",
-        "-emit-module-path",
-        modulePath.toString(),
-        "-o",
-        objectPath.toString(),
-        "-emit-objc-header-path",
-        headerPath.toString());
+    if (bridgingHeader.isPresent()) {
+      compilerCommand.add(
+          "-import-objc-header",
+          getResolver().getRelativePath(bridgingHeader.get()).toString());
+    }
+
+    compilerCommand.add("-c"); // emit object file
     for (SourcePath sourcePath : srcs) {
       compilerCommand.add(getResolver().getRelativePath(sourcePath).toString());
     }
+
+    compilerCommand.add(
+        "-output-file-map",
+        outputFileMap.toString());
 
     ProjectFilesystem projectFilesystem = getProjectFilesystem();
     return new SwiftCompileStep(
         projectFilesystem.getRootPath(),
         ImmutableMap.<String, String>of(),
         compilerCommand.build());
+  }
+
+  private Step buildOutputFileMapStep(Path outputFileMap) {
+    String outputMapContent = MoreFunctions.toJsonFunction(objectMapper).apply(
+        ImmutableMap.builder()
+            .putAll(outputMapEntries)
+            .put(EMPTY_PATH,
+                SwiftOutputEntry.of(
+                    outputPath, Paths.get(moduleName + "-master"))) // for module master output
+            .build());
+    return new WriteFileStep(
+        getProjectFilesystem(),
+        outputMapContent,
+        outputFileMap,
+        false);
   }
 
   @Override
@@ -213,12 +249,35 @@ class SwiftCompile
     buildableContext.recordArtifact(outputPath);
     return ImmutableList.of(
         new MkdirStep(getProjectFilesystem(), outputPath),
+        buildOutputFileMapStep(outputFileMap),
         makeCompileStep());
   }
 
   @Override
   public Path getPathToOutput() {
     return outputPath;
+  }
+
+  ImmutableSet<Arg> getAstLinkArgs() {
+    return ImmutableSet.<Arg>builder()
+        .addAll(StringArg.from("-Xlinker", "-add_ast_path"))
+        .add(new SourcePathArg(
+            getResolver(),
+            new BuildTargetSourcePath(getBuildTarget(), modulePath)))
+        .build();
+  }
+
+  ImmutableList<Arg> getFileListLinkArgs() {
+    return FileListableLinkerInputArg.from(
+        FluentIterable.from(outputMapEntries.values())
+            .transform(new Function<AbstractSwiftOutputEntry, SourcePathArg>() {
+              @Override
+              public SourcePathArg apply(AbstractSwiftOutputEntry input) {
+                return new SourcePathArg(getResolver(),
+                    new BuildTargetSourcePath(getBuildTarget(), input.getObject()));
+              }
+            })
+            .toList());
   }
 
   /**
@@ -263,17 +322,5 @@ class SwiftCompile
     args.addAll(Iterables.transform(roots, PREPEND_INCLUDE_FLAG));
 
     return args.build();
-  }
-
-  ImmutableSet<Arg> getLinkArgs() {
-    return ImmutableSet.<Arg>builder()
-        .addAll(StringArg.from("-Xlinker", "-add_ast_path"))
-        .add(new SourcePathArg(
-            getResolver(),
-            new BuildTargetSourcePath(getBuildTarget(), modulePath)))
-        .add(new SourcePathArg(
-            getResolver(),
-            new BuildTargetSourcePath(getBuildTarget(), objectPath)))
-        .build();
   }
 }

--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -96,6 +96,7 @@ class SwiftCompile
   private final Iterable<CxxPreprocessorInput> cxxPreprocessorInputs;
 
   private final ObjectMapper objectMapper;
+  private final boolean compileAsLibrary;
 
   // Prepend "-I" before the input with no space (this is required by swift).
   private static final Function<String, String> PREPEND_INCLUDE_FLAG =
@@ -117,7 +118,8 @@ class SwiftCompile
       String moduleName,
       final Path outputPath,
       Iterable<SourcePath> srcs,
-      Optional<SourcePath> bridgingHeader) throws NoSuchBuildTargetException {
+      Optional<SourcePath> bridgingHeader,
+      boolean compileAsLibrary) throws NoSuchBuildTargetException {
     super(params, resolver);
     this.cxxPlatform = cxxPlatform;
     this.frameworks = frameworks;
@@ -135,6 +137,7 @@ class SwiftCompile
 
     this.srcs = ImmutableSortedSet.copyOf(srcs);
     this.bridgingHeader = bridgingHeader;
+    this.compileAsLibrary = compileAsLibrary;
 
     this.outputFileMap = outputPath.resolve(escapedModuleName + "-OutputFileMap.json");
     this.outputMapEntries = FluentIterable.from(srcs)
@@ -160,6 +163,7 @@ class SwiftCompile
         "-incremental", // incremental build
         "-Xfrontend",
         "-serialize-debugging-options",
+        compileAsLibrary ? "-parse-as-library" : "",
         "-j",
         String.valueOf(1), // only one job at a time for now
         "-module-name",

--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -165,7 +165,9 @@ class SwiftCompile
         "-serialize-debugging-options",
         compileAsLibrary ? "-parse-as-library" : "",
         "-j",
-        String.valueOf(1), // only one job at a time for now
+        // only one job at a time for now, this will be removed in the next iteration for
+        // incremental build, we will use buck jobs for parallelizing instead of swift builtin jobs.
+        String.valueOf(1),
         "-module-name",
         moduleName,
         "-Onone", // no optimization

--- a/src/com/facebook/buck/swift/SwiftCompileOutputParsing.java
+++ b/src/com/facebook/buck/swift/SwiftCompileOutputParsing.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.swift;
+
+import com.facebook.buck.log.Logger;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonStreamParser;
+
+import java.io.Reader;
+
+/**
+ * For parsing output data from swift incremental build.
+ */
+class SwiftCompileOutputParsing {
+
+  private static final Logger LOG = Logger.get(SwiftCompileOutputParsing.class);
+
+  static void streamOutputFromReader(Reader reader, SwiftOutputHandler handler) {
+    JsonStreamParser streamParser = new JsonStreamParser(reader);
+    try {
+      while (streamParser.hasNext()) {
+        dispatchEventCallback(streamParser.next(), handler);
+      }
+    } catch (JsonParseException e) {
+      LOG.warn(e, "Couldn't parse xctool JSON stream");
+    }
+  }
+
+  private static void dispatchEventCallback(
+      JsonElement element,
+      SwiftOutputHandler handler) {
+    if (element.isJsonPrimitive()) {
+      LOG.info("Next block of json size: %d", element.getAsInt());
+      return;
+    }
+
+    if (!element.isJsonObject()) {
+      LOG.warn("Could not parse JSON object from swift output: %s", element);
+      return;
+    }
+
+    JsonObject outputBlock = element.getAsJsonObject();
+    if (!outputBlock.has("kind")) {
+      LOG.warn("Ignore for now: %s", outputBlock);
+      return;
+    }
+
+    String kind = outputBlock.get("kind").getAsString();
+
+    switch (kind) {
+      case "finished":
+        int exitStatus = outputBlock.get("exit-status").getAsInt();
+        if (exitStatus != 0) {
+          String outputError = outputBlock.get("output").getAsString();
+          handler.recordError(outputError);
+        }
+        break;
+      default:
+        LOG.warn("Ignore kind [%s] for now: %s", kind, outputBlock);
+          break;
+    }
+  }
+
+  interface SwiftOutputHandler {
+    void recordError(String error);
+  }
+}

--- a/src/com/facebook/buck/swift/SwiftCompileOutputParsing.java
+++ b/src/com/facebook/buck/swift/SwiftCompileOutputParsing.java
@@ -29,6 +29,9 @@ import java.io.Reader;
  */
 class SwiftCompileOutputParsing {
 
+  /** Utility class: do not instantiate. */
+  private SwiftCompileOutputParsing() { }
+
   private static final Logger LOG = Logger.get(SwiftCompileOutputParsing.class);
 
   static void streamOutputFromReader(Reader reader, SwiftOutputHandler handler) {

--- a/src/com/facebook/buck/swift/SwiftLibrary.java
+++ b/src/com/facebook/buck/swift/SwiftLibrary.java
@@ -44,6 +44,7 @@ import com.facebook.buck.rules.HasRuntimeDeps;
 import com.facebook.buck.rules.NoopBuildRule;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.buck.rules.args.FileListableLinkerInputArg;
 import com.facebook.buck.rules.args.SourcePathArg;
 import com.facebook.buck.rules.coercer.FrameworkPath;
 import com.google.common.base.Optional;
@@ -154,9 +155,12 @@ class SwiftLibrary
         throw new IllegalStateException("unhandled linkage type: " + linkage);
     }
     if (isDynamic) {
-      inputBuilder.addArgs(new SourcePathArg(getResolver(),
-          new BuildTargetSourcePath(requireSwiftLinkRule(cxxPlatform.getFlavor())
-              .getBuildTarget())));
+      inputBuilder.addArgs(
+          FileListableLinkerInputArg.withSourcePathArg(
+              new SourcePathArg(
+                  getResolver(),
+                  new BuildTargetSourcePath(requireSwiftLinkRule(cxxPlatform.getFlavor())
+                      .getBuildTarget()))));
     }
     return inputBuilder.build();
   }

--- a/src/com/facebook/buck/swift/SwiftLibrary.java
+++ b/src/com/facebook/buck/swift/SwiftLibrary.java
@@ -141,7 +141,8 @@ class SwiftLibrary
         .addAllFrameworks(frameworks)
         .addAllLibraries(libraries);
     boolean isDynamic;
-    switch (linkage) {
+    Linkage preferredLinkage = getPreferredLinkage(cxxPlatform);
+    switch (preferredLinkage) {
       case STATIC:
         isDynamic = false;
         break;
@@ -152,15 +153,18 @@ class SwiftLibrary
         isDynamic = type == Linker.LinkableDepType.SHARED;
         break;
       default:
-        throw new IllegalStateException("unhandled linkage type: " + linkage);
+        throw new IllegalStateException("unhandled linkage type: " + preferredLinkage);
     }
     if (isDynamic) {
       inputBuilder.addArgs(
           FileListableLinkerInputArg.withSourcePathArg(
               new SourcePathArg(
                   getResolver(),
-                  new BuildTargetSourcePath(requireSwiftLinkRule(cxxPlatform.getFlavor())
-                      .getBuildTarget()))));
+                  new BuildTargetSourcePath(
+                      requireSwiftLinkRule(cxxPlatform.getFlavor())
+                          .getBuildTarget()))));
+    } else {
+      inputBuilder.addAllArgs(rule.getFileListLinkArgs());
     }
     return inputBuilder.build();
   }

--- a/src/com/facebook/buck/swift/SwiftLibrary.java
+++ b/src/com/facebook/buck/swift/SwiftLibrary.java
@@ -136,7 +136,7 @@ class SwiftLibrary
     SwiftCompile rule = requireSwiftCompileRule(cxxPlatform.getFlavor());
     NativeLinkableInput.Builder inputBuilder = NativeLinkableInput.builder();
     inputBuilder
-        .addAllArgs(rule.getLinkArgs())
+        .addAllArgs(rule.getAstLinkArgs())
         .addAllFrameworks(frameworks)
         .addAllLibraries(libraries);
     boolean isDynamic;

--- a/src/com/facebook/buck/swift/SwiftLibraryDescription.java
+++ b/src/com/facebook/buck/swift/SwiftLibraryDescription.java
@@ -224,7 +224,8 @@ public class SwiftLibraryDescription implements
               params.getProjectFilesystem(),
               buildTarget, "%s"),
           args.srcs.get(),
-          args.bridgingHeader);
+          args.bridgingHeader,
+          true);
     }
 
     // Otherwise, we return the generic placeholder of this library.


### PR DESCRIPTION
Chapter one:
- Use swift driver (swiftc) for incremental build (give swiftc input and get information from its output).
- Fix all problems related to linking when switching to incremental build.
- Implement log parsing for output from swift compiler.

TODO (in the second iteration):
- Instead of using swift driver for run all the compilation jobs and caching, we pass them to buck. This is also for parallelizing the jobs.
- Better output parsing.
