### PR TITLE
Parallelize swift compilation by compiling file individually

### DIFF
--- a/src/com/facebook/buck/cxx/CxxWriteArgsToFileStep.java
+++ b/src/com/facebook/buck/cxx/CxxWriteArgsToFileStep.java
@@ -44,7 +44,7 @@ public class CxxWriteArgsToFileStep implements Step {
   private final Optional<Function<String, String>> escaper;
   private final Path currentCellPath;
 
-  CxxWriteArgsToFileStep(
+  public CxxWriteArgsToFileStep(
       Path argFilePath,
       ImmutableList<Arg> args,
       Optional<Function<String, String>> escaper,

--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -404,7 +404,9 @@ class SwiftCompile
           swiftCompiler,
           frameworkPaths,
           moduleName,
-          Optional.of(srcs.iterator().next()),
+          srcs.isEmpty() ?
+              Optional.empty() :
+              Optional.of(srcs.iterator().next()),
           enableObjcInterop,
           bridgingHeader,
           Optional.empty());

--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -83,9 +83,6 @@ class SwiftCompile
           .stream()
           .anyMatch(flavor -> flavor.getName().startsWith(COMPILE_FLAVOR_PREFIX));
 
-  // Prepend "-I" before the input with no space (this is required by swift).
-  private static final Function<String, String> PREPEND_INCLUDE_FLAG = INCLUDE_FLAG::concat;
-
   @AddToRuleKey
   private final Tool swiftCompiler;
 

--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -21,18 +21,25 @@ import static com.facebook.buck.swift.SwiftUtil.normalizeSwiftModuleName;
 import static com.facebook.buck.swift.SwiftUtil.toSwiftHeaderName;
 
 import com.facebook.buck.cxx.CxxDescriptionEnhancer;
+import com.facebook.buck.cxx.CxxFlavorSanitizer;
 import com.facebook.buck.cxx.CxxHeaders;
 import com.facebook.buck.cxx.CxxPlatform;
 import com.facebook.buck.cxx.CxxPreprocessables;
 import com.facebook.buck.cxx.CxxPreprocessorInput;
 import com.facebook.buck.cxx.HeaderVisibility;
+import com.facebook.buck.io.MorePaths;
 import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.model.BuildTarget;
+import com.facebook.buck.model.BuildTargets;
+import com.facebook.buck.model.Flavor;
+import com.facebook.buck.model.ImmutableFlavor;
 import com.facebook.buck.parser.NoSuchBuildTargetException;
 import com.facebook.buck.rules.AbstractBuildRule;
 import com.facebook.buck.rules.AddToRuleKey;
 import com.facebook.buck.rules.BuildContext;
+import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleParams;
+import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildTargetSourcePath;
 import com.facebook.buck.rules.BuildableContext;
 import com.facebook.buck.rules.SourcePath;
@@ -40,14 +47,17 @@ import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.SourcePaths;
 import com.facebook.buck.rules.Tool;
 import com.facebook.buck.rules.args.Arg;
+import com.facebook.buck.rules.args.FileListableLinkerInputArg;
 import com.facebook.buck.rules.args.SourcePathArg;
 import com.facebook.buck.rules.args.StringArg;
 import com.facebook.buck.rules.coercer.FrameworkPath;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.fs.MkdirStep;
+import com.facebook.buck.util.MoreCollectors;
 import com.facebook.buck.util.MoreIterables;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -66,6 +76,15 @@ class SwiftCompile
     extends AbstractBuildRule {
 
   private static final String INCLUDE_FLAG = "-I";
+  private static final String COMPILE_FLAVOR_PREFIX = "compile-swift-";
+  private static final Flavor PREPARE_FLAVOR = ImmutableFlavor.of("prepare-compile");
+  private static final java.util.function.Predicate<SwiftCompile> IS_COMPILE_INDIVIDUAL =
+      input -> input.getBuildTarget().getFlavors()
+          .stream()
+          .anyMatch(flavor -> flavor.getName().startsWith(COMPILE_FLAVOR_PREFIX));
+
+  // Prepend "-I" before the input with no space (this is required by swift).
+  private static final Function<String, String> PREPEND_INCLUDE_FLAG = INCLUDE_FLAG::concat;
 
   @AddToRuleKey
   private final Tool swiftCompiler;
@@ -80,7 +99,10 @@ class SwiftCompile
   private final Path objectPath;
 
   @AddToRuleKey
-  private final ImmutableSortedSet<SourcePath> srcs;
+  private final Optional<SourcePath> src;
+
+  @AddToRuleKey
+  private final Optional<SourcePath> bridgingHeader;
 
   private final Path headerPath;
   private final CxxPlatform cxxPlatform;
@@ -88,49 +110,104 @@ class SwiftCompile
 
   private final boolean hasMainEntry;
   private final boolean enableObjcInterop;
-  private final Optional<SourcePath> bridgingHeader;
   private final SwiftBuckConfig swiftBuckConfig;
-
+  private final Optional<Path> fileListPath;
   private final Iterable<CxxPreprocessorInput> cxxPreprocessorInputs;
 
-  SwiftCompile(
+  private SwiftCompile(
       CxxPlatform cxxPlatform,
       SwiftBuckConfig swiftBuckConfig,
       BuildRuleParams params,
-      SourcePathResolver resolver,
+      SourcePathResolver sourcePathResolver,
       Tool swiftCompiler,
       ImmutableSet<FrameworkPath> frameworks,
       String moduleName,
-      Path outputPath,
-      Iterable<SourcePath> srcs,
+      Optional<SourcePath> src,
       Optional<Boolean> enableObjcInterop,
-      Optional<SourcePath> bridgingHeader) throws NoSuchBuildTargetException {
-    super(params, resolver);
+      Optional<SourcePath> bridgingHeader,
+      Optional<Path> fileListPath) throws NoSuchBuildTargetException {
+    super(params, sourcePathResolver);
     this.cxxPlatform = cxxPlatform;
     this.frameworks = frameworks;
     this.swiftBuckConfig = swiftBuckConfig;
+    this.fileListPath = fileListPath;
     this.cxxPreprocessorInputs =
         CxxPreprocessables.getTransitiveCxxPreprocessorInput(cxxPlatform, params.getDeps());
     this.swiftCompiler = swiftCompiler;
-    this.outputPath = outputPath;
-    this.headerPath = outputPath.resolve(toSwiftHeaderName(moduleName) + ".h");
+    this.outputPath = BuildTargets.getGenPath(
+        params.getProjectFilesystem(), params.getBuildTarget(), "%s");
 
-    String escapedModuleName = normalizeSwiftModuleName(moduleName);
-    this.moduleName = escapedModuleName;
-    this.modulePath = outputPath.resolve(escapedModuleName + ".swiftmodule");
-    this.objectPath = outputPath.resolve(escapedModuleName + ".o");
+    String partialModuleName = src.isPresent() ?
+        MorePaths.getNameWithoutExtension(sourcePathResolver.getAbsolutePath(src.get())) :
+        moduleName;
+    this.headerPath = this.outputPath.resolve(toSwiftHeaderName(partialModuleName) + ".h");
 
-    this.srcs = ImmutableSortedSet.copyOf(srcs);
+    String escapedModuleName = normalizeSwiftModuleName(partialModuleName);
+    this.moduleName = normalizeSwiftModuleName(moduleName);
+    this.modulePath = this.outputPath.resolve(escapedModuleName + ".swiftmodule");
+    this.objectPath = this.outputPath.resolve(escapedModuleName + ".o");
+
+    this.src = src;
     this.enableObjcInterop = enableObjcInterop.orElse(true);
     this.bridgingHeader = bridgingHeader;
-    this.hasMainEntry = FluentIterable.from(srcs).firstMatch(
-        input -> SWIFT_MAIN_FILENAME.equalsIgnoreCase(
-            getResolver().getAbsolutePath(input).getFileName().toString())).isPresent();
+    this.hasMainEntry = src.isPresent() && SWIFT_MAIN_FILENAME.equalsIgnoreCase(
+        getResolver().getAbsolutePath(src.get()).getFileName().toString());
   }
 
   private SwiftCompileStep makeCompileStep() {
     ImmutableList.Builder<String> compilerCommand = ImmutableList.builder();
     compilerCommand.addAll(swiftCompiler.getCommandPrefix(getResolver()));
+
+    String[] moduleLists = getDeps().stream()
+        .filter(SwiftCompile.class::isInstance)
+        .map(SwiftCompile.class::cast)
+        .filter(IS_COMPILE_INDIVIDUAL)
+        .map(input -> input.modulePath.toString())
+        .toArray(String[]::new);
+
+    compilerCommand.add(
+        "-enable-testing",
+        "-c",
+        enableObjcInterop ? "-enable-objc-interop" : "",
+        hasMainEntry ? "" : "-parse-as-library",
+        "-module-name",
+        moduleName,
+        "-emit-objc-header-path",
+        headerPath.toString());
+
+    compilerCommand.add("-emit-module");
+    compilerCommand.add(moduleLists);
+
+    if (fileListPath.isPresent()) {
+      compilerCommand.add("-filelist", fileListPath.get().toString());
+    }
+
+    final Function<FrameworkPath, Path> frameworkPathToSearchPath =
+        CxxDescriptionEnhancer.frameworkPathToSearchPath(cxxPlatform, getResolver());
+
+    compilerCommand.addAll(
+        frameworks.stream()
+            .map(frameworkPathToSearchPath::apply)
+            .flatMap(searchPath -> ImmutableSet.of("-F", searchPath.toString()).stream())
+            .iterator());
+
+    compilerCommand.addAll(
+        MoreIterables.zipAndConcat(
+            Iterables.cycle("-Xcc"),
+            getSwiftIncludeArgs()));
+
+    compilerCommand.addAll(MoreIterables.zipAndConcat(
+        Iterables.cycle(INCLUDE_FLAG),
+        FluentIterable.from(getDeps())
+            .filter(SwiftCompile.class)
+            .transform(SourcePaths.getToBuildTargetSourcePath())
+            .transform(input -> getResolver().getAbsolutePath(input).toString())
+            .toSet()));
+
+    Optional<Iterable<String>> configFlags = swiftBuckConfig.getFlags();
+    if (configFlags.isPresent()) {
+      compilerCommand.addAll(configFlags.get());
+    }
 
     if (bridgingHeader.isPresent()) {
       compilerCommand.add(
@@ -149,45 +226,18 @@ class SwiftCompile
       }
     }
 
-    final Function<FrameworkPath, Path> frameworkPathToSearchPath =
-        CxxDescriptionEnhancer.frameworkPathToSearchPath(cxxPlatform, getResolver());
-
-    compilerCommand.addAll(
-        frameworks.stream()
-            .map(frameworkPathToSearchPath::apply)
-            .flatMap(searchPath -> ImmutableSet.of("-F", searchPath.toString()).stream())
-            .iterator());
-
-    compilerCommand.addAll(
-        MoreIterables.zipAndConcat(Iterables.cycle("-Xcc"),
-            getSwiftIncludeArgs()));
-    compilerCommand.addAll(MoreIterables.zipAndConcat(
-        Iterables.cycle(INCLUDE_FLAG),
-        FluentIterable.from(getDeps())
-            .filter(SwiftCompile.class)
-            .transform(SourcePaths.getToBuildTargetSourcePath())
-            .transform(input -> getResolver().getAbsolutePath(input).toString())));
-
-    Optional<Iterable<String>> configFlags = swiftBuckConfig.getFlags();
-    if (configFlags.isPresent()) {
-      compilerCommand.addAll(configFlags.get());
-    }
-    compilerCommand.add(
-        "-enable-testing",
-        "-c",
-        enableObjcInterop ? "-enable-objc-interop" : "",
-        hasMainEntry ? "" : "-parse-as-library",
-        "-module-name",
-        moduleName,
-        "-emit-module",
-        "-emit-module-path",
-        modulePath.toString(),
-        "-o",
-        objectPath.toString(),
-        "-emit-objc-header-path",
-        headerPath.toString());
-    for (SourcePath sourcePath : srcs) {
-      compilerCommand.add(getResolver().getRelativePath(sourcePath).toString());
+    if (src.isPresent()) {
+      compilerCommand.add(
+          "-primary-file",
+          getResolver().getAbsolutePath(src.get()).toString(),
+          "-emit-module-path",
+          modulePath.toString(),
+          "-o",
+          objectPath.toString());
+    } else {
+      compilerCommand.add(
+          "-o",
+          modulePath.toString());
     }
 
     ProjectFilesystem projectFilesystem = getProjectFilesystem();
@@ -202,9 +252,10 @@ class SwiftCompile
       BuildContext context,
       BuildableContext buildableContext) {
     buildableContext.recordArtifact(outputPath);
-    return ImmutableList.of(
-        new MkdirStep(getProjectFilesystem(), outputPath),
-        makeCompileStep());
+    ImmutableList.Builder<Step> builder = ImmutableList.<Step>builder()
+        .add(new MkdirStep(getProjectFilesystem(), outputPath))
+        .add(makeCompileStep());
+    return builder.build();
   }
 
   @Override
@@ -214,8 +265,8 @@ class SwiftCompile
 
   /**
    * @return the arguments to add to the preprocessor command line to include the given header packs
-   *     in preprocessor search path.
-   *
+   * in preprocessor search path.
+   * <p>
    * We can't use CxxHeaders.getArgs() because
    * 1. we don't need the system include roots.
    * 2. swift doesn't like spaces after the "-I" flag.
@@ -256,15 +307,108 @@ class SwiftCompile
     return args.build();
   }
 
-  ImmutableSet<Arg> getLinkArgs() {
+  ImmutableSet<Arg> getAstLinkArgs() {
     return ImmutableSet.<Arg>builder()
         .addAll(StringArg.from("-Xlinker", "-add_ast_path"))
         .add(new SourcePathArg(
             getResolver(),
             new BuildTargetSourcePath(getBuildTarget(), modulePath)))
-        .add(new SourcePathArg(
-            getResolver(),
-            new BuildTargetSourcePath(getBuildTarget(), objectPath)))
         .build();
   }
+
+  ImmutableList<Arg> getFileListLinkArgs() {
+    return FileListableLinkerInputArg.from(
+        SourcePathArg.from(getResolver(), getObjectLists()).stream()
+            .filter(SourcePathArg.class::isInstance)
+            .map(SourcePathArg.class::cast)
+            .collect(MoreCollectors.toImmutableList()));
+  }
+
+  private ImmutableList<SourcePath> getObjectLists() {
+    return getDeclaredDeps().stream()
+        .filter(SwiftCompile.class::isInstance)
+        .map(SwiftCompile.class::cast)
+        .filter(IS_COMPILE_INDIVIDUAL)
+        .map(input -> new BuildTargetSourcePath(getBuildTarget(), input.objectPath))
+        .collect(MoreCollectors.toImmutableList());
+  }
+
+  public static BuildRule of(
+      CxxPlatform cxxPlatform,
+      SwiftBuckConfig swiftBuckConfig,
+      BuildRuleParams params,
+      BuildRuleResolver resolver,
+      SourcePathResolver sourcePathResolver,
+      Tool swiftCompiler,
+      ImmutableSortedSet<FrameworkPath> frameworkPaths,
+      String moduleName,
+      ImmutableSet<SourcePath> srcs,
+      Optional<Boolean> enableObjcInterop,
+      Optional<SourcePath> bridgingHeader) throws NoSuchBuildTargetException {
+
+    if (srcs.size() > 1) {
+      BuildRuleParams prepareForCompileParams = params.withFlavor(PREPARE_FLAVOR);
+      SwiftPrepareForCompile prepareForCompile = new SwiftPrepareForCompile(
+          prepareForCompileParams,
+          sourcePathResolver,
+          srcs);
+      params = params.appendExtraDeps(resolver.addToIndex(prepareForCompile));
+
+      ImmutableSortedSet.Builder<BuildRule> deps = ImmutableSortedSet.naturalOrder();
+      deps.addAll(params.getDeclaredDeps().get());
+      // create swift compile for every single file
+      for (SourcePath src : srcs) {
+        String outputName = CxxFlavorSanitizer.sanitize(
+            sourcePathResolver.getAbsolutePath(src).getFileName() + ".o");
+        BuildRuleParams newParams = params.withFlavor(
+            ImmutableFlavor.of(
+                COMPILE_FLAVOR_PREFIX + outputName));
+        BuildRule compileSingleFile =
+            new SwiftCompile(
+                cxxPlatform,
+                swiftBuckConfig,
+                newParams,
+                sourcePathResolver,
+                swiftCompiler,
+                frameworkPaths,
+                moduleName,
+                Optional.of(src),
+                enableObjcInterop,
+                bridgingHeader,
+                Optional.ofNullable(prepareForCompile.getPathToOutput()));
+        resolver.addToIndex(compileSingleFile);
+        deps.add(compileSingleFile);
+      }
+
+      // for merging all single file build outputs
+      return new SwiftCompile(
+          cxxPlatform,
+          swiftBuckConfig,
+          params.copyWithDeps(
+              Suppliers.ofInstance(deps.build()),
+              params.getExtraDeps()),
+          sourcePathResolver,
+          swiftCompiler,
+          frameworkPaths,
+          moduleName,
+          Optional.empty(),
+          enableObjcInterop,
+          bridgingHeader,
+          Optional.empty());
+    } else {
+      return new SwiftCompile(
+          cxxPlatform,
+          swiftBuckConfig,
+          params,
+          sourcePathResolver,
+          swiftCompiler,
+          frameworkPaths,
+          moduleName,
+          Optional.of(srcs.iterator().next()),
+          enableObjcInterop,
+          bridgingHeader,
+          Optional.empty());
+    }
+  }
+
 }

--- a/src/com/facebook/buck/swift/SwiftLibrary.java
+++ b/src/com/facebook/buck/swift/SwiftLibrary.java
@@ -44,6 +44,7 @@ import com.facebook.buck.rules.HasRuntimeDeps;
 import com.facebook.buck.rules.NoopBuildRule;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.buck.rules.args.FileListableLinkerInputArg;
 import com.facebook.buck.rules.args.SourcePathArg;
 import com.facebook.buck.rules.coercer.FrameworkPath;
 import com.google.common.cache.LoadingCache;
@@ -136,7 +137,7 @@ class SwiftLibrary
     SwiftCompile rule = requireSwiftCompileRule(cxxPlatform.getFlavor());
     NativeLinkableInput.Builder inputBuilder = NativeLinkableInput.builder();
     inputBuilder
-        .addAllArgs(rule.getLinkArgs())
+        .addAllArgs(rule.getAstLinkArgs())
         .addAllFrameworks(frameworks)
         .addAllLibraries(libraries);
     boolean isDynamic;
@@ -155,9 +156,15 @@ class SwiftLibrary
         throw new IllegalStateException("unhandled linkage type: " + preferredLinkage);
     }
     if (isDynamic) {
-      inputBuilder.addArgs(new SourcePathArg(getResolver(),
-          new BuildTargetSourcePath(requireSwiftLinkRule(cxxPlatform.getFlavor())
-              .getBuildTarget())));
+      inputBuilder.addArgs(
+          FileListableLinkerInputArg.withSourcePathArg(
+              new SourcePathArg(
+                  getResolver(),
+                  new BuildTargetSourcePath(
+                      requireSwiftLinkRule(cxxPlatform.getFlavor())
+                          .getBuildTarget()))));
+    } else {
+      inputBuilder.addAllArgs(rule.getFileListLinkArgs());
     }
     return inputBuilder.build();
   }

--- a/src/com/facebook/buck/swift/SwiftPrepareForCompile.java
+++ b/src/com/facebook/buck/swift/SwiftPrepareForCompile.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.swift;
+
+import com.facebook.buck.cxx.CxxWriteArgsToFileStep;
+import com.facebook.buck.cxx.HeaderSymlinkTree;
+import com.facebook.buck.model.BuildTargets;
+import com.facebook.buck.rules.AbstractBuildRule;
+import com.facebook.buck.rules.BuildContext;
+import com.facebook.buck.rules.BuildRuleParams;
+import com.facebook.buck.rules.BuildableContext;
+import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.buck.rules.args.Arg;
+import com.facebook.buck.rules.args.FileListableLinkerInputArg;
+import com.facebook.buck.rules.args.SourcePathArg;
+import com.facebook.buck.step.Step;
+import com.facebook.buck.util.MoreCollectors;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+class SwiftPrepareForCompile extends AbstractBuildRule {
+
+  private final ImmutableSet<SourcePath> srcs;
+  private final Path fileListPath;
+
+  SwiftPrepareForCompile(
+      BuildRuleParams buildRuleParams,
+      SourcePathResolver resolver,
+      ImmutableSet<SourcePath> srcs) {
+    super(buildRuleParams, resolver);
+    this.srcs = srcs;
+    this.fileListPath = BuildTargets.getScratchPath(
+        getProjectFilesystem(), getBuildTarget(), "%s__filelist.txt");
+  }
+
+  private Step createFileListStep() {
+    ImmutableList<Arg> sourceListArgs = FileListableLinkerInputArg.from(
+        SourcePathArg.from(getResolver(), srcs).stream()
+            .filter(SourcePathArg.class::isInstance)
+            .map(input -> (SourcePathArg) input)
+            .collect(MoreCollectors.toImmutableList()));
+
+    return new CxxWriteArgsToFileStep(
+        fileListPath,
+        sourceListArgs,
+        Optional.empty());
+  }
+
+  @Override
+  public ImmutableList<Step> getBuildSteps(
+      BuildContext context, BuildableContext buildableContext) {
+    buildableContext.recordArtifact(fileListPath);
+    return ImmutableList.of(createFileListStep());
+  }
+
+  /**
+   * @see HeaderSymlinkTree#isCacheable()
+   */
+  @Override
+  public boolean isCacheable() {
+    return false;
+  }
+
+  @Nullable
+  @Override
+  public Path getPathToOutput() {
+    return fileListPath;
+  }
+
+}

--- a/src/com/facebook/buck/swift/SwiftPrepareForCompile.java
+++ b/src/com/facebook/buck/swift/SwiftPrepareForCompile.java
@@ -63,7 +63,8 @@ class SwiftPrepareForCompile extends AbstractBuildRule {
     return new CxxWriteArgsToFileStep(
         fileListPath,
         sourceListArgs,
-        Optional.empty());
+        Optional.empty(),
+        getBuildTarget().getCellPath());
   }
 
   @Override


### PR DESCRIPTION
This PR is one of the effort to rework the incremental build support https://github.com/facebook/buck/pull/907.

Instead of compiling all swift files in a target in one shot, we create build rule for each of the file so that we can compile them in parallel, therefore speed up the compilation process, especially useful for a target with a lot of swift files.
