### PR TITLE
Better vim swap file ignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,8 +67,7 @@ src/com/facebook/buck/intellij/ideabuck/.idea/copyright/profiles_settings.xml
 .DS_Store
 
 # vim swp files
-.*.swp
-.*.swo
+.*.sw[a-p]
 
 
 # Emacs backup files


### PR DESCRIPTION
Swap files start from `p` and traverse upwards towards `a`. They do go other places (e.g. `.svp` after `.sw*` gets exhausted) but it's rare and might conflict with other file formats.