### PR TITLE
Make swift compiler honor min target sdk version

### DIFF
--- a/src/com/facebook/buck/apple/AppleCxxPlatforms.java
+++ b/src/com/facebook/buck/apple/AppleCxxPlatforms.java
@@ -411,7 +411,7 @@ public class AppleCxxPlatforms {
     Optional<SwiftPlatform> swiftPlatform = getSwiftPlatform(
         applePlatform.getName(),
         targetArchitecture + "-apple-" +
-            applePlatform.getSwiftName().or(applePlatform.getName()) + targetSdk.getVersion(),
+            applePlatform.getSwiftName().or(applePlatform.getName()) + minVersion,
         version,
         swiftSdkPathsBuilder.build(),
         swiftOverrideSearchPathBuilder

--- a/test/com/facebook/buck/apple/AppleCxxPlatformsTest.java
+++ b/test/com/facebook/buck/apple/AppleCxxPlatformsTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -1002,6 +1003,12 @@ public class AppleCxxPlatformsTest {
 
     assertThat(swiftPlatformOptional.get().getSwiftRuntimePaths(),
         equalTo(ImmutableSet.of(temp.getRoot().resolve("usr/lib/swift/iphoneos"))));
+  }
+
+  @Test
+  public void checkSwiftPlatformUsesCorrectMinTargetSdk() throws IOException {
+    AppleCxxPlatform platformWithConfiguredSwift = buildAppleCxxPlatformWithSwiftToolchain(false);
+    assertThat(platformWithConfiguredSwift.getSwiftPlatform().get().getSwift(), notNullValue());
   }
 
   private AppleCxxPlatform buildAppleCxxPlatformWithSwiftToolchain(boolean useDefaultSwift)

--- a/test/com/facebook/buck/apple/AppleCxxPlatformsTest.java
+++ b/test/com/facebook/buck/apple/AppleCxxPlatformsTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.not;
@@ -1007,8 +1008,12 @@ public class AppleCxxPlatformsTest {
 
   @Test
   public void checkSwiftPlatformUsesCorrectMinTargetSdk() throws IOException {
-    AppleCxxPlatform platformWithConfiguredSwift = buildAppleCxxPlatformWithSwiftToolchain(false);
-    assertThat(platformWithConfiguredSwift.getSwiftPlatform().get().getSwift(), notNullValue());
+    AppleCxxPlatform platformWithConfiguredSwift = buildAppleCxxPlatformWithSwiftToolchain(true);
+    Tool swift = platformWithConfiguredSwift.getSwiftPlatform().get().getSwift();
+    assertThat(swift, notNullValue());
+    assertThat(swift, instanceOf(VersionedTool.class));
+    VersionedTool versionedSwift = (VersionedTool) swift;
+    assertThat(versionedSwift.getExtraArgs(), hasItem("i386-apple-ios7.0"));
   }
 
   private AppleCxxPlatform buildAppleCxxPlatformWithSwiftToolchain(boolean useDefaultSwift)
@@ -1035,7 +1040,7 @@ public class AppleCxxPlatformsTest {
         .build();
     return AppleCxxPlatforms.buildWithExecutableChecker(
         FakeAppleRuleDescriptions.DEFAULT_IPHONEOS_SDK,
-        "8.0",
+        "7.0",
         "i386",
         FakeAppleRuleDescriptions.DEFAULT_IPHONEOS_SDK_PATHS,
         FakeBuckConfig.builder().build(),


### PR DESCRIPTION
Previously, swift uses version of the sdk it is compiling with as the minimum target version for deployment. 

This causes the issue when you compile swift target with newer sdk, the resulting app will crash on the old target event if you specify correct target deployment in buckconfig, for example:

```
[apple]
  iphonesimulator_target_sdk_version = <old_sdk_version>
  iphoneos_target_sdk_version = <old_sdk_version>
```
This PR make swift compiler honor `*_target_sdk_version` settings.