### PR TITLE
Use java8 sdk as default in IntelliJ

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -35,7 +35,7 @@
   <component name="ProjectResources">
     <default-html-doctype>http://www.w3.org/1999/xhtml</default-html-doctype>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="false" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="false" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build-ij/classes" />
   </component>
   <component name="PythonCompatibilityInspectionAdvertiser">


### PR DESCRIPTION
`oshi` lib is compiled with java8, but the current intellij project is using java sdk 7, which causes the failure when running test inside Intellij:

![image](https://cloud.githubusercontent.com/assets/1457567/19192112/5caec3b2-8ca5-11e6-9489-6a691389ee2f.png)

We should set default java sdk to 8.
