### PR TITLE
Use realpath instead of readlink in binary wrappers

### DIFF
--- a/bin/buck
+++ b/bin/buck
@@ -5,7 +5,7 @@
 # systems don't have this flag. *sigh*
 BUCK_PATH="$0"
 while [ -h "$BUCK_PATH" ]; do
-  BUCK_PATH=$(readlink "$BUCK_PATH")
+  BUCK_PATH=$(realpath "$BUCK_PATH")
 done
 BUCK_DIR=$(dirname "$BUCK_PATH")
 

--- a/bin/buckd
+++ b/bin/buckd
@@ -5,7 +5,7 @@
 # systems don't have this flag. *sigh*
 BUCK_PATH="$0"
 while [ -h "$BUCK_PATH" ]; do
-  BUCK_PATH=$(readlink "$BUCK_PATH")
+  BUCK_PATH=$(realpath "$BUCK_PATH")
 done
 BUCK_DIR=$(dirname "$BUCK_PATH")
 


### PR DESCRIPTION
Readlink directly returns the target of a symlink. If
the symlink is relative, readlink only returns the
relative path. This path is relative to the buck executable
on $PATH, not to the current working directory, so the
Python invocation fails.

Using realpath instead directly resolves the full absolute
path referred to by the symlink, allowing users to use
relative symlinks in their bin/ directory on $PATH.