### PR TITLE
Compile Uber R.java file with a correct language level

### DIFF
--- a/src/com/facebook/buck/android/AndroidBinaryGraphEnhancer.java
+++ b/src/com/facebook/buck/android/AndroidBinaryGraphEnhancer.java
@@ -451,7 +451,10 @@ public class AndroidBinaryGraphEnhancer {
         new BuildTargetSourcePath(compileUberRDotJavaTarget),
         /* trackClassUsage */ false,
         /* additionalClasspathEntries */ ImmutableSet.of(),
-        new JavacToJarStepFactory(javacOptions, JavacOptionsAmender.IDENTITY),
+        new JavacToJarStepFactory(
+            javacOptions.withSourceLevel("7").withTargetLevel("7"),
+            JavacOptionsAmender.IDENTITY
+        ),
         /* resourcesRoot */ Optional.absent(),
         /* manifest file */ Optional.absent(),
         /* mavenCoords */ Optional.absent(),


### PR DESCRIPTION
Travis is failing with:

```
com.android.dx.cf.iface.ParseException: bad class file magic (cafebabe) or version (0034.0000)
	at com.android.dx.cf.direct.DirectClassFile.parse0(DirectClassFile.java:476)
	at com.android.dx.cf.direct.DirectClassFile.parse(DirectClassFile.java:406)
        ...
...while parsing com/facebook/buck_generated/AppWithoutResourcesStub.class
...
BUILD FAILED: //src/com/facebook/buck/android/agent:agent#dex_uber_r_dot_java failed with exit code 1:
```

This change fixes the issue by explicitly setting language level to 7.
