### PR TITLE
Fix silent buckd failure on openpty

### DIFF
--- a/src/com/facebook/buck/cli/Main.java
+++ b/src/com/facebook/buck/cli/Main.java
@@ -1786,8 +1786,7 @@ public final class Main {
     IntByReference master = new IntByReference();
     IntByReference slave = new IntByReference();
 
-    int success = openPtyLibrary.openpty(master, slave, Pointer.NULL, Pointer.NULL, Pointer.NULL);
-    if (success != 0) {
+    if (openPtyLibrary.openpty(master, slave, Pointer.NULL, Pointer.NULL, Pointer.NULL) != 0) {
       throw new RuntimeException("Failed to open pty");
     }
 
@@ -1797,11 +1796,10 @@ public final class Main {
     markFdCloseOnExec(slave.getValue());
 
     // Make the pty our controlling terminal; works because we disconnected above with setsid.
-    success = Libc.INSTANCE.ioctl(
+    if (Libc.INSTANCE.ioctl(
         slave.getValue(),
         Pointer.createConstant(Libc.Constants.rTIOCSCTTY),
-        0);
-    if (success == -1) {
+        0) == -1) {
       throw new RuntimeException("Failed to set pty");
     }
 

--- a/src/com/facebook/buck/util/Libc.java
+++ b/src/com/facebook/buck/util/Libc.java
@@ -31,17 +31,17 @@ public interface Libc extends Library {
   int kill(int pid, int sig) throws LastErrorException;
 
   public interface OpenPtyLibrary extends Library {
-    void openpty(
+    int openpty(
         IntByReference master,
         IntByReference slave,
         Pointer name,
         Pointer terp,
-        Pointer winp) throws LastErrorException;
+        Pointer winp);
   }
 
   int setsid();
 
-  void ioctl(int fd, Pointer request, Object... args) throws LastErrorException;
+  int ioctl(int fd, Pointer request, Object... args);
   int fcntl(int fd, int cmd, Object... args);
 
   public static final class Constants {


### PR DESCRIPTION
`throws LastErrorException` will throw whenever errno is nonzero, but the value of errno is undefined unless the function otherwise indicates an error.

In certain situations, the system does in fact set errno to a nonzero value while still returning a success result.  In this case, an exception will be thrown and buckd will fail to start.

This change properly checks the success of the system calls by looking at the return value as specified by the standard.

fixes #931 