### PR TITLE
Fixed `No rule found` on some platforms.

### DIFF
--- a/src/com/facebook/buck/apple/BUCK
+++ b/src/com/facebook/buck/apple/BUCK
@@ -1,3 +1,6 @@
+with allow_unsafe_import():
+    from sys import platform as os_platform
+
 PLATFORM_SRCS = [
   'AbstractAppleCxxPlatform.java',
   'AbstractApplePlatform.java',
@@ -37,7 +40,7 @@ java_immutables_library(
   tests = [
     '//test/com/facebook/buck/apple:apple',
     '//test/com/facebook/buck/apple:apple_test_integration',
-  ],
+  ] if os_platform == 'darwin' else [],
   deps = [
     '//src/com/facebook/buck/android:packageable',
   ],


### PR DESCRIPTION
`//test/com/facebook/buck/apple/BUCK` uses unsafe imports that's why `apple` and `apple_test_integration` targets are only available on `darwin` os which makes CI fail on any other platform.

to: @Coneko @dreiss 