### PR TITLE
Refactor CxxPrepareForLinkStep for a reuseable & more generic step

### DIFF
--- a/src/com/facebook/buck/cxx/CxxLink.java
+++ b/src/com/facebook/buck/cxx/CxxLink.java
@@ -32,6 +32,7 @@ import com.facebook.buck.step.Step;
 import com.facebook.buck.step.fs.FileScrubberStep;
 import com.facebook.buck.step.fs.MakeCleanDirectoryStep;
 import com.facebook.buck.step.fs.MkdirStep;
+import com.facebook.buck.step.fs.RmStep;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
@@ -105,6 +106,8 @@ public class CxxLink
     return ImmutableList.of(
         new MkdirStep(getProjectFilesystem(), output.getParent()),
         new MakeCleanDirectoryStep(getProjectFilesystem(), scratchDir),
+        new RmStep(getProjectFilesystem(), argFilePath, true),
+        new RmStep(getProjectFilesystem(), fileListPath, true),
         CxxPrepareForLinkStep.create(
             argFilePath,
             fileListPath,

--- a/src/com/facebook/buck/cxx/CxxLink.java
+++ b/src/com/facebook/buck/cxx/CxxLink.java
@@ -105,7 +105,7 @@ public class CxxLink
     return ImmutableList.of(
         new MkdirStep(getProjectFilesystem(), output.getParent()),
         new MakeCleanDirectoryStep(getProjectFilesystem(), scratchDir),
-        new CxxPrepareForLinkStep(
+        CxxPrepareForLinkStep.create(
             argFilePath,
             fileListPath,
             linker.fileList(fileListPath),

--- a/src/com/facebook/buck/cxx/CxxPrepareForLinkStep.java
+++ b/src/com/facebook/buck/cxx/CxxPrepareForLinkStep.java
@@ -20,17 +20,16 @@ import com.facebook.buck.jvm.java.Javac;
 import com.facebook.buck.log.Logger;
 import com.facebook.buck.rules.args.Arg;
 import com.facebook.buck.rules.args.FileListableLinkerInputArg;
+import com.facebook.buck.rules.args.StringArg;
+import com.facebook.buck.step.CompositeStep;
 import com.facebook.buck.step.ExecutionContext;
 import com.facebook.buck.step.Step;
-import com.facebook.buck.step.StepExecutionResult;
 import com.facebook.buck.util.MoreCollectors;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * Prepares argfile for the CxxLinkStep, so all arguments to the linker will be stored in a
@@ -38,109 +37,48 @@ import java.nio.file.Path;
  * This allows us to break the constraints that command line sets for the maximum length of
  * the commands.
  */
-public class CxxPrepareForLinkStep implements Step {
-
-  private final Path argFilePath;
-  private final Path fileListPath;
-  private final ImmutableList<Arg> linkerArgsToSupportFileList;
-  private final Path output;
-  private final ImmutableList<Arg> args;
-  private final Linker linker;
+public class CxxPrepareForLinkStep extends CompositeStep {
 
   private static final Logger LOG = Logger.get(CxxPrepareForLinkStep.class);
 
-  public CxxPrepareForLinkStep(
+  public static CxxPrepareForLinkStep create(
       Path argFilePath,
       Path fileListPath,
       Iterable<Arg> linkerArgsToSupportFileList,
       Path output,
       ImmutableList<Arg> args,
       Linker linker) {
-    this.argFilePath = argFilePath;
-    this.fileListPath = fileListPath;
-    this.linkerArgsToSupportFileList = ImmutableList.copyOf(linkerArgsToSupportFileList);
-    this.output = output;
-    this.args = args;
-    this.linker = linker;
-  }
 
-  private void prepareFileContents() throws IOException {
-    cleanupPreviousFiles();
-    createFileList();
-    createArgFile();
-  }
-
-  private void createFileList() throws IOException {
-    if (Files.notExists(fileListPath.getParent())) {
-      Files.createDirectories(fileListPath.getParent());
-    }
-    if (linkerArgsToSupportFileList.isEmpty()) {
-      LOG.verbose("linkerArgsToSupportFileList are empty, filelist feature is not supported");
-      return;
-    }
-    LOG.verbose("Creating filelist");
-    ImmutableList<String> contents = Arg.stringify(getFileListArgs());
-    storeContentsInFile(contents, fileListPath);
-  }
-
-  private void createArgFile() throws IOException {
-    if (Files.notExists(argFilePath.getParent())) {
-      Files.createDirectories(argFilePath.getParent());
-    }
-    LOG.verbose("Creating argfile");
-    ImmutableList<String> argFileContents =
-        getLinkerOptions().stream()
-            .map(Javac.ARGFILES_ESCAPER::apply)
-            .collect(MoreCollectors.toImmutableList());
-    storeContentsInFile(argFileContents, argFilePath);
-  }
-
-  private void storeContentsInFile(ImmutableList<String> contents, Path path) throws IOException {
-    try (PrintWriter pr = new PrintWriter(path.toString())) {
-      for (String option : contents) {
-        pr.println(option);
-      }
-    }
-  }
-
-  private void cleanupPreviousFiles() throws IOException {
-    LOG.verbose("Cleaning up previous argfile at " + argFilePath.toString());
-    Files.deleteIfExists(argFilePath);
-    LOG.verbose("Cleaning up previous filelist at " + fileListPath.toString());
-    Files.deleteIfExists(fileListPath);
-  }
-
-  private ImmutableList<Arg> getFileListArgs() {
-    if (linkerArgsToSupportFileList.isEmpty()) {
-      return ImmutableList.of();
-    }
-    return FluentIterable.from(args)
-        .filter(input -> input instanceof FileListableLinkerInputArg)
-        .toList();
-  }
-
-  private ImmutableList<Arg> getLinkerArgsWithoutFileListArgs() {
-    if (linkerArgsToSupportFileList.isEmpty()) {
-      return args;
-    }
-    return FluentIterable.from(args)
-        .filter(input -> !(input instanceof FileListableLinkerInputArg))
-        .toList();
-  }
-
-  private ImmutableList<String> getLinkerOptions() {
-    return ImmutableList.<String>builder()
-        .addAll(linker.outputArgs(output.toString()))
-        .addAll(Arg.stringify(getLinkerArgsWithoutFileListArgs()))
-        .addAll(Arg.stringify(linkerArgsToSupportFileList))
+    ImmutableList<Arg> allArgs = ImmutableList.<Arg>builder()
+        .addAll(StringArg.from(linker.outputArgs(output.toString())))
+        .addAll(args)
+        .addAll(linkerArgsToSupportFileList)
         .build();
+
+    CxxWriteArgsToFileStep createArgFileStep = new CxxWriteArgsToFileStep(
+        argFilePath,
+        allArgs.stream()
+            .filter(input -> !(input instanceof FileListableLinkerInputArg))
+            .collect(MoreCollectors.toImmutableList()),
+        Optional.of(Javac.ARGFILES_ESCAPER));
+
+    if (!linkerArgsToSupportFileList.iterator().hasNext()) {
+      LOG.verbose("linkerArgsToSupportFileList are empty, filelist feature is not supported");
+      return new CxxPrepareForLinkStep(ImmutableList.of(createArgFileStep));
+    }
+
+    CxxWriteArgsToFileStep createFileListStep = new CxxWriteArgsToFileStep(
+        fileListPath,
+        allArgs.stream()
+            .filter(input -> input instanceof FileListableLinkerInputArg)
+            .collect(MoreCollectors.toImmutableList()),
+        Optional.empty());
+
+    return new CxxPrepareForLinkStep(ImmutableList.of(createArgFileStep, createFileListStep));
   }
 
-  @Override
-  public StepExecutionResult execute(ExecutionContext context)
-      throws IOException, InterruptedException {
-    prepareFileContents();
-    return StepExecutionResult.SUCCESS;
+  private CxxPrepareForLinkStep(List<? extends Step> commands) {
+    super(commands);
   }
 
   @Override

--- a/src/com/facebook/buck/cxx/CxxPrepareForLinkStep.java
+++ b/src/com/facebook/buck/cxx/CxxPrepareForLinkStep.java
@@ -55,15 +55,17 @@ public class CxxPrepareForLinkStep extends CompositeStep {
         .addAll(linkerArgsToSupportFileList)
         .build();
 
+    boolean hasLinkArgsToSupportFileList = linkerArgsToSupportFileList.iterator().hasNext();
+
     CxxWriteArgsToFileStep createArgFileStep = new CxxWriteArgsToFileStep(
         argFilePath,
-        allArgs.stream()
+        hasLinkArgsToSupportFileList ? allArgs.stream()
             .filter(input -> !(input instanceof FileListableLinkerInputArg))
-            .collect(MoreCollectors.toImmutableList()),
+            .collect(MoreCollectors.toImmutableList()) : allArgs,
         Optional.of(Javac.ARGFILES_ESCAPER));
 
-    if (!linkerArgsToSupportFileList.iterator().hasNext()) {
-      LOG.verbose("linkerArgsToSupportFileList are empty, filelist feature is not supported");
+    if (!hasLinkArgsToSupportFileList) {
+      LOG.verbose("linkerArgsToSupportFileList is empty, filelist feature is not supported");
       return new CxxPrepareForLinkStep(ImmutableList.of(createArgFileStep));
     }
 

--- a/src/com/facebook/buck/cxx/CxxWriteArgsToFileStep.java
+++ b/src/com/facebook/buck/cxx/CxxWriteArgsToFileStep.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.cxx;
+
+import com.facebook.buck.io.MoreFiles;
+import com.facebook.buck.rules.args.Arg;
+import com.facebook.buck.step.ExecutionContext;
+import com.facebook.buck.step.Step;
+import com.facebook.buck.step.StepExecutionResult;
+import com.google.common.base.Function;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * This step takes a list of args, stringify, escape them (if {@link #escaper} is present), and
+ * finally store to a file {@link #argFilePath}.
+ */
+public class CxxWriteArgsToFileStep implements Step {
+
+  private final Path argFilePath;
+  private final ImmutableList<Arg> args;
+  private final Optional<Function<String, String>> escaper;
+
+  public CxxWriteArgsToFileStep(
+      Path argFilePath,
+      ImmutableList<Arg> args,
+      Optional<Function<String, String>> escaper) {
+    this.argFilePath = argFilePath;
+    this.args = args;
+    this.escaper = escaper;
+  }
+
+  private void createArgFile() throws IOException {
+    if (Files.notExists(argFilePath.getParent())) {
+      Files.createDirectories(argFilePath.getParent());
+    }
+    ImmutableList<String> argFileContents = Arg.stringify(args);
+    if (escaper.isPresent()) {
+      argFileContents = FluentIterable.from(argFileContents)
+          .transform(escaper.get())
+          .toList();
+    }
+    MoreFiles.writeLinesToFile(argFileContents, argFilePath);
+  }
+
+  @Override
+  public StepExecutionResult execute(ExecutionContext context)
+      throws IOException, InterruptedException {
+    createArgFile();
+    return StepExecutionResult.SUCCESS;
+  }
+
+  @Override
+  public String getShortName() {
+    return "write args to file";
+  }
+
+  @Override
+  public String getDescription(ExecutionContext context) {
+    return "Write list of args to file, use string escape if provided.";
+  }
+}

--- a/src/com/facebook/buck/cxx/CxxWriteArgsToFileStep.java
+++ b/src/com/facebook/buck/cxx/CxxWriteArgsToFileStep.java
@@ -21,8 +21,8 @@ import com.facebook.buck.rules.args.Arg;
 import com.facebook.buck.step.ExecutionContext;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.StepExecutionResult;
+import com.facebook.buck.util.MoreCollectors;
 import com.google.common.base.Function;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
@@ -40,7 +40,7 @@ public class CxxWriteArgsToFileStep implements Step {
   private final ImmutableList<Arg> args;
   private final Optional<Function<String, String>> escaper;
 
-  public CxxWriteArgsToFileStep(
+  CxxWriteArgsToFileStep(
       Path argFilePath,
       ImmutableList<Arg> args,
       Optional<Function<String, String>> escaper) {
@@ -55,9 +55,9 @@ public class CxxWriteArgsToFileStep implements Step {
     }
     ImmutableList<String> argFileContents = Arg.stringify(args);
     if (escaper.isPresent()) {
-      argFileContents = FluentIterable.from(argFileContents)
-          .transform(escaper.get())
-          .toList();
+      argFileContents = argFileContents.stream()
+          .map(escaper.get()::apply)
+          .collect(MoreCollectors.toImmutableList());
     }
     MoreFiles.writeLinesToFile(argFileContents, argFilePath);
   }

--- a/test/com/facebook/buck/cxx/CxxWriteArgsToFileStepTest.java
+++ b/test/com/facebook/buck/cxx/CxxWriteArgsToFileStepTest.java
@@ -19,7 +19,6 @@ package com.facebook.buck.cxx;
 import static org.junit.Assert.assertThat;
 
 import com.facebook.buck.io.ProjectFilesystem;
-import com.facebook.buck.jvm.java.Javac;
 import com.facebook.buck.rules.args.Arg;
 import com.facebook.buck.rules.args.StringArg;
 import com.facebook.buck.step.ExecutionContext;
@@ -63,9 +62,9 @@ public class CxxWriteArgsToFileStepTest {
 
     runTestForArgFilePathAndOutputPath(
         fileListPath,
-        Optional.of(Javac.ARGFILES_ESCAPER),
-        ImmutableList.of(new StringArg("-dummy"), new StringArg("\"")),
-        ImmutableList.of("-dummy", "\"\\\"\""));
+        Optional.of(input -> "foo".equals(input) ? "bar" : input),
+        ImmutableList.of(new StringArg("-dummy"), new StringArg("foo")),
+        ImmutableList.of("-dummy", "bar"));
   }
 
   private void runTestForArgFilePathAndOutputPath(


### PR DESCRIPTION
Implement `CxxPrepareForLinkStep` as a composite step of 2 `CxxWriteArgsToFileStep` steps, as requested to simplify https://github.com/facebook/buck/pull/917.