### PR TITLE
fix is_git detection when .git dir is located elsewhere 

### DIFF
--- a/programs/buck_version.py
+++ b/programs/buck_version.py
@@ -34,17 +34,17 @@ class EmptyTempFile(object):
 
 def is_git(dirpath):
     dot_git = os.path.join(dirpath, '.git')
-    if(all([
-        os.path.exists(dot_git),
-        os.path.isdir(dot_git),
-        which('git'),
-        sys.platform != 'cygwin',
-    ])):
-        return True
-    output = check_output(
-        ['git', 'rev-parse', '--is-inside-work-tree'],
-        cwd=dirpath)
-    return output.strip() == 'true'
+    if(which('git') and sys.platform != 'cygwin'):
+        if(os.path.exists(dot_git) and os.path.isdir(dot_git)):
+            return True
+        output = check_output(
+            ['git', 'rev-parse', '--is-inside-work-tree'],
+            cwd=dirpath)
+        return output.strip() == 'true'
+    return False
+
+
+
 
 
 def is_dirty(dirpath):

--- a/programs/buck_version.py
+++ b/programs/buck_version.py
@@ -44,7 +44,7 @@ def is_git(dirpath):
     output = check_output(
         ['git', 'rev-parse', '--is-inside-work-tree'],
         cwd=dirpath)
-    return output == 'true'
+    return output.strip() == 'true'
 
 
 def is_dirty(dirpath):

--- a/programs/buck_version.py
+++ b/programs/buck_version.py
@@ -34,12 +34,17 @@ class EmptyTempFile(object):
 
 def is_git(dirpath):
     dot_git = os.path.join(dirpath, '.git')
-    return all([
+    if(all([
         os.path.exists(dot_git),
         os.path.isdir(dot_git),
         which('git'),
         sys.platform != 'cygwin',
-    ])
+    ])):
+        return True
+    output = check_output(
+        ['git', 'rev-parse', '--is-inside-work-tree'],
+        cwd=dirpath)
+    return output == 'true'
 
 
 def is_dirty(dirpath):


### PR DESCRIPTION
The .git dir may be in a different location, and have .git be a text file that points to that dir.  This fixes is_git detection when the .git dir is somewhere else.

https://git-scm.com/docs/gitrepository-layout