### PR TITLE
Add the ability to have worker stick around between buck commands

### DIFF
--- a/docs/concept/buckconfig.soy
+++ b/docs/concept/buckconfig.soy
@@ -130,6 +130,7 @@ The following sections are recognized by Buck:
     'tools',
     'ui',
     'unknown_flavors_messages',
+    'worker',
     ]}
   <a href="#{$name}"><code>[{$name}]</code></a><br>
 {/foreach}
@@ -1550,7 +1551,7 @@ $ buck targets --resolve-alias app#src_jar
 {call buckconfig.section}
   {param name: 'intellij' /}
   {param description}
-    This section configures a project generated for IntelliJ IDEA by `buck project` command.
+    This section configures a project generated for IntelliJ IDEA by <code>buck project</code> command.
   {/param}
 {/call}
 
@@ -2702,6 +2703,26 @@ your <code>.buckjavaargs</code> file</a>:
         [unknown_flavors_messages]{\n}{sp}{sp}
             android-* = Make sure you have Android SDK & NDK installed and set up.
     </pre>
+  {/param}
+{/call}
+
+{call buckconfig.section}
+  {param name: 'worker' /}
+  {param description}
+    This section configures how Buck's workers (<code>worker_tool</code>s and similar) work.
+  {/param}
+{/call}
+
+{call buckconfig.entry}
+  {param section: 'worker' /}
+  {param name: 'persistent' /}
+  {param example_value: 'false' /}
+  {param description}
+    Specifies whether by default workers run in persistent mode (reusing the worker process
+    across builds). The <code>persistent</code> option of <code>worker_tool</code>
+    {sp}overrides this default.
+    The default value is false. Be careful when switching this to true since the workers will
+    not shut down after buck commands and will continue consuming system resources.
   {/param}
 {/call}
 

--- a/docs/rule/worker_tool.soy
+++ b/docs/rule/worker_tool.soy
@@ -75,6 +75,17 @@
   {/param}
 {/call}
 
+{call buck.arg}
+  {param name: 'persistent' /}
+  {param default: 'False' /}
+  {param desc}
+    If set to true, buck will not restart the tool unless the tool itself changes. This means the
+    tool will persist across multiple buck commands without being shut down and may see the same
+    rule being built more than once. Be careful when using this with tools that don't expect
+    to process the same input (with different contents) twice!
+  {/param}
+{/call}
+
 {/param}
 
 {param examples}

--- a/src/com/facebook/buck/cli/AbstractCommandRunnerParams.java
+++ b/src/com/facebook/buck/cli/AbstractCommandRunnerParams.java
@@ -24,6 +24,7 @@ import com.facebook.buck.parser.Parser;
 import com.facebook.buck.rules.ActionGraphCache;
 import com.facebook.buck.rules.Cell;
 import com.facebook.buck.rules.KnownBuildRuleTypesFactory;
+import com.facebook.buck.shell.WorkerProcessPool;
 import com.facebook.buck.step.ExecutorPool;
 import com.facebook.buck.timing.Clock;
 import com.facebook.buck.util.Console;
@@ -42,6 +43,7 @@ import org.immutables.value.Value;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentMap;
 
 @Value.Immutable(copy = false)
 @BuckStyleImmutable
@@ -73,6 +75,8 @@ public interface AbstractCommandRunnerParams {
   Optional<ProcessManager> getProcessManager();
 
   Optional<WebServer> getWebServer();
+
+  Optional<ConcurrentMap<String, WorkerProcessPool>> getPersistentWorkerPools();
 
   BuckConfig getBuckConfig();
 

--- a/src/com/facebook/buck/cli/BUCK.autodeps
+++ b/src/com/facebook/buck/cli/BUCK.autodeps
@@ -103,6 +103,7 @@
       "//src/com/facebook/buck/rules:interfaces",
       "//src/com/facebook/buck/rules:rules",
       "//src/com/facebook/buck/rules:types",
+      "//src/com/facebook/buck/shell:worker_process",
       "//src/com/facebook/buck/step:step",
       "//src/com/facebook/buck/test:test",
       "//src/com/facebook/buck/test/selectors:selectors",

--- a/src/com/facebook/buck/cli/BuildCommand.java
+++ b/src/com/facebook/buck/cli/BuildCommand.java
@@ -61,6 +61,7 @@ import com.facebook.buck.rules.TargetGraphAndBuildTargets;
 import com.facebook.buck.rules.TargetNode;
 import com.facebook.buck.rules.TargetNodeFactory;
 import com.facebook.buck.rules.keys.DefaultRuleKeyBuilderFactory;
+import com.facebook.buck.shell.WorkerProcessPool;
 import com.facebook.buck.step.AdbOptions;
 import com.facebook.buck.step.DefaultStepRunner;
 import com.facebook.buck.step.ExecutorPool;
@@ -96,6 +97,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentMap;
 
 import javax.annotation.Nullable;
 
@@ -280,6 +282,7 @@ public class BuildCommand extends AbstractCommand {
       Console console,
       BuckEventBus eventBus,
       Optional<TargetDevice> targetDevice,
+      Optional<ConcurrentMap<String, WorkerProcessPool>> persistentWorkerPools,
       Platform platform,
       ImmutableMap<String, String> environment,
       ObjectMapper objectMapper,
@@ -312,6 +315,7 @@ public class BuildCommand extends AbstractCommand {
         getConcurrencyLimit(buckConfig),
         adbOptions,
         targetDeviceOptions,
+        persistentWorkerPools,
         executors);
   }
 
@@ -677,6 +681,7 @@ public class BuildCommand extends AbstractCommand {
         params.getConsole(),
         params.getBuckEventBus(),
         Optional.empty(),
+        params.getPersistentWorkerPools(),
         rootCellBuckConfig.getPlatform(),
         rootCellBuckConfig.getEnvironment(),
         params.getObjectMapper(),

--- a/src/com/facebook/buck/cli/FetchCommand.java
+++ b/src/com/facebook/buck/cli/FetchCommand.java
@@ -121,6 +121,7 @@ public class FetchCommand extends BuildCommand {
           params.getConsole(),
           params.getBuckEventBus(),
           Optional.empty(),
+          params.getPersistentWorkerPools(),
           params.getPlatform(),
           params.getEnvironment(),
           params.getObjectMapper(),

--- a/src/com/facebook/buck/cli/TestCommand.java
+++ b/src/com/facebook/buck/cli/TestCommand.java
@@ -528,6 +528,7 @@ public class TestCommand extends BuildCommand {
           params.getConsole(),
           params.getBuckEventBus(),
           getTargetDeviceOptional(),
+          params.getPersistentWorkerPools(),
           params.getPlatform(),
           params.getEnvironment(),
           params.getObjectMapper(),

--- a/src/com/facebook/buck/command/BUCK.autodeps
+++ b/src/com/facebook/buck/command/BUCK.autodeps
@@ -21,6 +21,7 @@
       "//src/com/facebook/buck/rules:build_rule",
       "//src/com/facebook/buck/rules:rules",
       "//src/com/facebook/buck/rules:types",
+      "//src/com/facebook/buck/shell:worker_process",
       "//src/com/facebook/buck/step:step",
       "//src/com/facebook/buck/timing:timing",
       "//src/com/facebook/buck/util:io",

--- a/src/com/facebook/buck/command/Build.java
+++ b/src/com/facebook/buck/command/Build.java
@@ -39,6 +39,7 @@ import com.facebook.buck.rules.BuildResult;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.Cell;
+import com.facebook.buck.shell.WorkerProcessPool;
 import com.facebook.buck.step.AdbOptions;
 import com.facebook.buck.step.ExecutionContext;
 import com.facebook.buck.step.ExecutorPool;
@@ -77,6 +78,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.StreamSupport;
 
@@ -117,6 +119,7 @@ public class Build implements Closeable {
       ConcurrencyLimit concurrencyLimit,
       Optional<AdbOptions> adbOptions,
       Optional<TargetDeviceOptions> targetDeviceOptions,
+      Optional<ConcurrentMap<String, WorkerProcessPool>> persistentWorkerPools,
       Map<ExecutorPool, ListeningExecutorService> executors) {
     this.actionGraph = actionGraph;
     this.ruleResolver = ruleResolver;
@@ -136,6 +139,7 @@ public class Build implements Closeable {
         .setObjectMapper(objectMapper)
         .setConcurrencyLimit(concurrencyLimit)
         .setAdbOptions(adbOptions)
+        .setPersistentWorkerPools(persistentWorkerPools)
         .setTargetDeviceOptions(targetDeviceOptions)
         .setExecutors(executors)
         .build();

--- a/src/com/facebook/buck/distributed/DistBuildSlaveExecutor.java
+++ b/src/com/facebook/buck/distributed/DistBuildSlaveExecutor.java
@@ -120,6 +120,7 @@ public class DistBuildSlaveExecutor {
             config.getMaximumResourceAmounts().withCpu(4)),
         Optional.empty(),
         Optional.empty(),
+        Optional.empty(),
         args.getExecutors())) {
 
       // TODO(ruibm): We need to pass to the distbuild target via de distributed build

--- a/src/com/facebook/buck/js/ReactNativeBundleWorkerStep.java
+++ b/src/com/facebook/buck/js/ReactNativeBundleWorkerStep.java
@@ -60,7 +60,9 @@ public class ReactNativeBundleWorkerStep extends WorkerShellStep {
                     outputFile.toString(),
                     resourcePath.toString(),
                     sourceMapFile.toString()),
-                1)),
+                1,
+                Optional.empty(),
+                Optional.empty())),
         Optional.empty(),
         Optional.empty());
   }

--- a/src/com/facebook/buck/js/ReactNativeDepsWorkerStep.java
+++ b/src/com/facebook/buck/js/ReactNativeDepsWorkerStep.java
@@ -51,7 +51,9 @@ public class ReactNativeDepsWorkerStep extends WorkerShellStep {
                     platform.toString(),
                     entryFile.toString(),
                     outputFile.toString()),
-                1)),
+                1,
+                Optional.empty(),
+                Optional.empty())),
         Optional.empty(),
         Optional.empty());
   }

--- a/src/com/facebook/buck/rules/BuildInfo.java
+++ b/src/com/facebook/buck/rules/BuildInfo.java
@@ -47,7 +47,7 @@ public class BuildInfo {
   /**
    * Key for {@link OnDiskBuildInfo} to identify the RuleKey for a build rule.
    */
-  static final String METADATA_KEY_FOR_RULE_KEY = "RULE_KEY";
+  public static final String METADATA_KEY_FOR_RULE_KEY = "RULE_KEY";
 
   /**
    * Key for {@link OnDiskBuildInfo} to identify the input RuleKey for a build rule.

--- a/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
+++ b/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
@@ -799,7 +799,7 @@ public class KnownBuildRuleTypes {
                 new ThriftPythonEnhancer(thriftBuckConfig, ThriftPythonEnhancer.Type.NORMAL),
                 new ThriftPythonEnhancer(thriftBuckConfig, ThriftPythonEnhancer.Type.TWISTED),
                 new ThriftPythonEnhancer(thriftBuckConfig, ThriftPythonEnhancer.Type.ASYNCIO))));
-    builder.register(new WorkerToolDescription());
+    builder.register(new WorkerToolDescription(config));
     builder.register(new XcodePostbuildScriptDescription());
     builder.register(new XcodePrebuildScriptDescription());
     builder.register(new XcodeWorkspaceConfigDescription());

--- a/src/com/facebook/buck/shell/AbstractWorkerJobParams.java
+++ b/src/com/facebook/buck/shell/AbstractWorkerJobParams.java
@@ -19,10 +19,12 @@ package com.facebook.buck.shell;
 import com.facebook.buck.util.immutables.BuckStyleTuple;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.HashCode;
 
 import org.immutables.value.Value;
 
 import java.nio.file.Path;
+import java.util.Optional;
 
 @Value.Immutable
 @BuckStyleTuple
@@ -33,4 +35,6 @@ interface AbstractWorkerJobParams {
   ImmutableMap<String, String> getStartupEnvironment();
   String getJobArgs();
   int getMaxWorkers();
+  Optional<String> getPersistentWorkerKey();
+  Optional<HashCode> getWorkerHash();
 }

--- a/src/com/facebook/buck/shell/BUCK.autodeps
+++ b/src/com/facebook/buck/shell/BUCK.autodeps
@@ -59,11 +59,13 @@
       "//third-party/java/immutables:processor"
     ],
     "exported_deps" : [
+      "//src/com/facebook/buck/cli:config",
       "//src/com/facebook/buck/io:io",
       "//src/com/facebook/buck/model:model",
       "//src/com/facebook/buck/parser:rule_pattern",
       "//src/com/facebook/buck/rules:build_rule",
       "//src/com/facebook/buck/rules:interfaces",
+      "//src/com/facebook/buck/rules:rule_key",
       "//src/com/facebook/buck/rules:rules",
       "//src/com/facebook/buck/rules/macros:macros",
       "//src/com/facebook/buck/shell:worker_process",

--- a/src/com/facebook/buck/shell/Genrule.java
+++ b/src/com/facebook/buck/shell/Genrule.java
@@ -334,7 +334,9 @@ public class Genrule extends AbstractBuildRule
           workerMacroArg.getStartupArgs(),
           workerMacroArg.getEnvironment(),
           workerMacroArg.getJobArgs(),
-          workerMacroArg.getMaxWorkers());
+          workerMacroArg.getMaxWorkers(),
+          workerMacroArg.getPersistentWorkerKey(),
+          Optional.of(workerMacroArg.getWorkerHash()));
     });
   }
 

--- a/src/com/facebook/buck/shell/WorkerProcessPool.java
+++ b/src/com/facebook/buck/shell/WorkerProcessPool.java
@@ -16,6 +16,8 @@
 
 package com.facebook.buck.shell;
 
+import com.google.common.hash.HashCode;
+
 import java.io.IOException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Semaphore;
@@ -25,11 +27,13 @@ public abstract class WorkerProcessPool {
   private final Semaphore available;
   private final int capacity;
   private final LinkedBlockingQueue<WorkerProcess> workerProcesses;
+  private final HashCode poolHash;
 
-  public WorkerProcessPool(int maxWorkers) {
+  public WorkerProcessPool(int maxWorkers, HashCode poolHash) {
     capacity = maxWorkers;
     available = new Semaphore(capacity, true);
     workerProcesses = new LinkedBlockingQueue<>();
+    this.poolHash = poolHash;
   }
 
   public WorkerProcess borrowWorkerProcess()
@@ -55,4 +59,8 @@ public abstract class WorkerProcessPool {
   }
 
   protected abstract WorkerProcess startWorkerProcess() throws IOException;
+
+  public HashCode getPoolHash() {
+    return poolHash;
+  }
 }

--- a/src/com/facebook/buck/shell/WorkerTool.java
+++ b/src/com/facebook/buck/shell/WorkerTool.java
@@ -17,6 +17,7 @@
 package com.facebook.buck.shell;
 
 import com.facebook.buck.rules.Tool;
+import com.google.common.hash.HashCode;
 
 import java.nio.file.Path;
 
@@ -25,4 +26,6 @@ public interface WorkerTool {
   String getArgs();
   Path getTempDir();
   int getMaxWorkers();
+  boolean isPersistent();
+  HashCode getInstanceKey();
 }

--- a/src/com/facebook/buck/shell/WorkerToolDescription.java
+++ b/src/com/facebook/buck/shell/WorkerToolDescription.java
@@ -16,6 +16,7 @@
 
 package com.facebook.buck.shell;
 
+import com.facebook.buck.cli.BuckConfig;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.MacroException;
 import com.facebook.buck.parser.NoSuchBuildTargetException;
@@ -50,12 +51,21 @@ public class WorkerToolDescription implements Description<WorkerToolDescription.
 
   public static final BuildRuleType TYPE = BuildRuleType.of("worker_tool");
 
+  private static final String CONFIG_SECTION = "worker";
+  private static final String CONFIG_PERSISTENT_KEY = "persistent";
+
   public static final MacroHandler MACRO_HANDLER = new MacroHandler(
       ImmutableMap.<String, MacroExpander>builder()
           .put("location", new LocationMacroExpander())
           .put("classpath", new ClasspathMacroExpander())
           .put("exe", new ExecutableMacroExpander())
           .build());
+
+  private final BuckConfig buckConfig;
+
+  public WorkerToolDescription(BuckConfig buckConfig) {
+    this.buckConfig = buckConfig;
+  }
 
   @Override
   public BuildRuleType getBuildRuleType() {
@@ -125,7 +135,9 @@ public class WorkerToolDescription implements Description<WorkerToolDescription.
         (BinaryBuildRule) rule,
         expandedStartupArgs,
         expandedEnv,
-        maxWorkers);
+        maxWorkers,
+        args.persistent.orElse(
+            buckConfig.getBooleanValue(CONFIG_SECTION, CONFIG_PERSISTENT_KEY, false)));
   }
 
   @Override
@@ -158,5 +170,6 @@ public class WorkerToolDescription implements Description<WorkerToolDescription.
     public Optional<String> args;
     public BuildTarget exe;
     public Optional<Integer> maxWorkers;
+    public Optional<Boolean> persistent;
   }
 }

--- a/src/com/facebook/buck/step/AbstractExecutionContext.java
+++ b/src/com/facebook/buck/step/AbstractExecutionContext.java
@@ -85,6 +85,9 @@ abstract class AbstractExecutionContext implements Closeable {
   @Value.Parameter
   abstract Optional<AdbOptions> getAdbOptions();
 
+  @Value.Parameter
+  abstract Optional<ConcurrentMap<String, WorkerProcessPool>> getPersistentWorkerPools();
+
   /**
    * Returns an {@link AndroidPlatformTarget} if the user specified one. If the user failed to
    * specify one, an exception will be thrown.

--- a/test/com/facebook/buck/shell/BUCK.autodeps
+++ b/test/com/facebook/buck/shell/BUCK.autodeps
@@ -28,6 +28,7 @@
       "//src/com/facebook/buck/util/cache:cache",
       "//src/com/facebook/buck/util/environment:environment",
       "//src/com/facebook/buck/util/environment:platform",
+      "//test/com/facebook/buck/cli:FakeBuckConfig",
       "//test/com/facebook/buck/event:testutil",
       "//test/com/facebook/buck/jvm/java:testutil",
       "//test/com/facebook/buck/model:testutil",
@@ -50,6 +51,7 @@
   "testutil" : {
     "deps" : [
       "//src/com/facebook/buck/util:io",
+      "//test/com/facebook/buck/cli:FakeBuckConfig",
       "//test/com/facebook/buck/testutil:testutil",
       "//test/com/facebook/buck/util:testutil",
       "//third-party/java/jsr:jsr305"

--- a/test/com/facebook/buck/shell/WorkerProcessPoolTest.java
+++ b/test/com/facebook/buck/shell/WorkerProcessPoolTest.java
@@ -19,6 +19,7 @@ package com.facebook.buck.shell;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.Hashing;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -132,7 +133,7 @@ public class WorkerProcessPoolTest {
   }
 
   private static WorkerProcessPool createPool(int maxWorkers) {
-    return new WorkerProcessPool(maxWorkers) {
+    return new WorkerProcessPool(maxWorkers, Hashing.sha1().hashLong(0)) {
       @Override
       protected WorkerProcess startWorkerProcess() throws IOException {
         return new FakeWorkerProcess(ImmutableMap.of());

--- a/test/com/facebook/buck/shell/WorkerToolBuilder.java
+++ b/test/com/facebook/buck/shell/WorkerToolBuilder.java
@@ -16,6 +16,7 @@
 
 package com.facebook.buck.shell;
 
+import com.facebook.buck.cli.FakeBuckConfig;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.rules.AbstractNodeBuilder;
 
@@ -25,7 +26,7 @@ import javax.annotation.Nullable;
 
 public class WorkerToolBuilder extends AbstractNodeBuilder<WorkerToolDescription.Arg> {
   private WorkerToolBuilder(BuildTarget target) {
-    super(new WorkerToolDescription(), target);
+    super(new WorkerToolDescription(FakeBuckConfig.builder().build()), target);
   }
 
   public static WorkerToolBuilder newWorkerToolBuilder(BuildTarget target) {

--- a/test/com/facebook/buck/shell/WorkerToolDescriptionTest.java
+++ b/test/com/facebook/buck/shell/WorkerToolDescriptionTest.java
@@ -19,6 +19,7 @@ package com.facebook.buck.shell;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+import com.facebook.buck.cli.FakeBuckConfig;
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.parser.NoSuchBuildTargetException;
 import com.facebook.buck.rules.BuildRule;
@@ -70,8 +71,10 @@ public class WorkerToolDescriptionTest {
     args.exe = shBinaryRule.getBuildTarget();
     args.args = Optional.empty();
     args.maxWorkers = Optional.of(maxWorkers);
+    args.persistent = Optional.empty();
 
-    Description<WorkerToolDescription.Arg> workerToolDescription = new WorkerToolDescription();
+    Description<WorkerToolDescription.Arg> workerToolDescription = new WorkerToolDescription(
+        FakeBuckConfig.builder().build());
     return (WorkerTool) workerToolDescription.createBuildRule(
         targetGraph,
         new FakeBuildRuleParamsBuilder("//arbitrary:target").build(),

--- a/test/com/facebook/buck/shell/testdata/worker_tool_test/BUCK.fixture
+++ b/test/com/facebook/buck/shell/testdata/worker_tool_test/BUCK.fixture
@@ -15,6 +15,13 @@ worker_tool(
   exe = ':external_tool',
 )
 
+worker_tool(
+  name = 'worker3',
+  args = '--num-jobs 2',
+  exe = ':concurrent_tool',
+  persistent = True,
+)
+
 genrule(
   name = 'test1',
   srcs = [],
@@ -59,4 +66,18 @@ genrule(
   srcs = [],
   out = 'output.txt',
   cmd = '$(worker :concurrent_worker) $OUT',
+)
+
+genrule(
+  name = 'test6',
+  srcs = [],
+  out = 'output.txt',
+  cmd = '$(worker :worker3) $OUT',
+)
+
+genrule(
+  name = 'test7',
+  srcs = [],
+  out = 'output.txt',
+  cmd = '$(worker :worker3) $OUT',
 )


### PR DESCRIPTION
This adds the idea of a `persistent` worker tool as mentioned in #712 . These workers have the same lifetime as `buckd`, unless the worker inputs themselves change, which causes a restart. We use the `RuleKey` via `InitializableFromDisk` to decide when that needs to happen.