### PR TITLE
Fixed passing enableObjcInterop argument

### DIFF
--- a/src/com/facebook/buck/swift/SwiftLibraryDescription.java
+++ b/src/com/facebook/buck/swift/SwiftLibraryDescription.java
@@ -212,7 +212,7 @@ public class SwiftLibraryDescription implements
               params.getProjectFilesystem(),
               buildTarget, "%s"),
           args.srcs.get(),
-          Optional.absent(),
+          args.enableObjcInterop,
           args.bridgingHeader);
     }
 


### PR DESCRIPTION
We should pass `enableObjcInterop` from the arguments. Seems it was missed initially.