### PR TITLE
Get rid of Optional<Int> for worker_tool pool size

### DIFF
--- a/src/com/facebook/buck/js/ReactNativeBundleWorkerStep.java
+++ b/src/com/facebook/buck/js/ReactNativeBundleWorkerStep.java
@@ -60,7 +60,7 @@ public class ReactNativeBundleWorkerStep extends WorkerShellStep {
                     outputFile.toString(),
                     resourcePath.toString(),
                     sourceMapFile.toString()),
-                Optional.of(1))),
+                1)),
         Optional.absent(),
         Optional.absent());
   }

--- a/src/com/facebook/buck/js/ReactNativeDepsWorkerStep.java
+++ b/src/com/facebook/buck/js/ReactNativeDepsWorkerStep.java
@@ -51,7 +51,7 @@ public class ReactNativeDepsWorkerStep extends WorkerShellStep {
                     platform.toString(),
                     entryFile.toString(),
                     outputFile.toString()),
-                Optional.of(1))),
+                1)),
         Optional.absent(),
         Optional.absent());
   }

--- a/src/com/facebook/buck/rules/args/WorkerMacroArg.java
+++ b/src/com/facebook/buck/rules/args/WorkerMacroArg.java
@@ -27,7 +27,6 @@ import com.facebook.buck.rules.Tool;
 import com.facebook.buck.rules.macros.MacroHandler;
 import com.facebook.buck.rules.macros.WorkerMacroExpander;
 import com.facebook.buck.shell.WorkerTool;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -100,7 +99,7 @@ public class WorkerMacroArg extends MacroArg {
     return workerTool.getArgs();
   }
 
-  public Optional<Integer> getMaxWorkers() {
+  public int getMaxWorkers() {
     return workerTool.getMaxWorkers();
   }
 

--- a/src/com/facebook/buck/shell/AbstractWorkerJobParams.java
+++ b/src/com/facebook/buck/shell/AbstractWorkerJobParams.java
@@ -17,7 +17,6 @@
 package com.facebook.buck.shell;
 
 import com.facebook.buck.util.immutables.BuckStyleTuple;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -33,5 +32,5 @@ interface AbstractWorkerJobParams {
   String getStartupArgs();
   ImmutableMap<String, String> getStartupEnvironment();
   String getJobArgs();
-  Optional<Integer> getMaxWorkers();
+  int getMaxWorkers();
 }

--- a/src/com/facebook/buck/shell/DefaultWorkerTool.java
+++ b/src/com/facebook/buck/shell/DefaultWorkerTool.java
@@ -26,7 +26,6 @@ import com.facebook.buck.rules.NoopBuildRule;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.SourcePaths;
 import com.facebook.buck.rules.Tool;
-import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
@@ -39,7 +38,7 @@ public class DefaultWorkerTool extends NoopBuildRule implements HasRuntimeDeps, 
   private final BinaryBuildRule exe;
   private final String args;
   private final ImmutableMap<String, String> env;
-  private final Optional<Integer> maxWorkers;
+  private final int maxWorkers;
 
   protected DefaultWorkerTool(
       BuildRuleParams ruleParams,
@@ -47,7 +46,7 @@ public class DefaultWorkerTool extends NoopBuildRule implements HasRuntimeDeps, 
       BinaryBuildRule exe,
       String args,
       ImmutableMap<String, String> env,
-      Optional<Integer> maxWorkers) {
+      int maxWorkers) {
     super(ruleParams, resolver);
     this.exe = exe;
     this.args = args;
@@ -81,7 +80,7 @@ public class DefaultWorkerTool extends NoopBuildRule implements HasRuntimeDeps, 
   }
 
   @Override
-  public Optional<Integer> getMaxWorkers() {
+  public int getMaxWorkers() {
     return maxWorkers;
   }
 

--- a/src/com/facebook/buck/shell/WorkerShellStep.java
+++ b/src/com/facebook/buck/shell/WorkerShellStep.java
@@ -129,14 +129,14 @@ public class WorkerShellStep implements Step {
     }
 
     int poolCapacity = pool.getCapacity();
-    if (poolCapacity != paramsToUse.getMaxWorkers().or(WorkerProcessPool.UNLIMITED_CAPACITY)) {
+    if (poolCapacity != paramsToUse.getMaxWorkers()) {
       context.postEvent(ConsoleEvent.warning(
           "There are two 'worker_tool' targets declared with the same command (%s), but " +
               "different 'max_worker' settings (%d and %d). Only the first capacity is applied. " +
               "Consolidate these workers to avoid this warning.",
           key,
           poolCapacity,
-          paramsToUse.getMaxWorkers().or(WorkerProcessPool.UNLIMITED_CAPACITY)));
+          paramsToUse.getMaxWorkers()));
     }
 
     return pool;

--- a/src/com/facebook/buck/shell/WorkerTool.java
+++ b/src/com/facebook/buck/shell/WorkerTool.java
@@ -17,7 +17,6 @@
 package com.facebook.buck.shell;
 
 import com.facebook.buck.rules.Tool;
-import com.google.common.base.Optional;
 
 import java.nio.file.Path;
 
@@ -25,5 +24,5 @@ public interface WorkerTool {
   Tool getTool();
   String getArgs();
   Path getTempDir();
-  Optional<Integer> getMaxWorkers();
+  int getMaxWorkers();
 }

--- a/src/com/facebook/buck/shell/WorkerToolDescription.java
+++ b/src/com/facebook/buck/shell/WorkerToolDescription.java
@@ -110,13 +110,13 @@ public class WorkerToolDescription implements Description<WorkerToolDescription.
               }
             }));
 
-    Optional<Integer> maxWorkers;
+    int maxWorkers;
     if (args.maxWorkers.isPresent()) {
       // negative or zero: unlimited number of worker processes
-      maxWorkers = args.maxWorkers.get() < 1 ? Optional.absent() : args.maxWorkers;
+      maxWorkers = args.maxWorkers.get() < 1 ? Integer.MAX_VALUE : args.maxWorkers.get();
     } else {
       // default is 1 worker process (for backwards compatibility)
-      maxWorkers = Optional.of(1);
+      maxWorkers = 1;
     }
 
     return new DefaultWorkerTool(

--- a/test/com/facebook/buck/shell/WorkerProcessPoolTest.java
+++ b/test/com/facebook/buck/shell/WorkerProcessPoolTest.java
@@ -18,7 +18,6 @@ package com.facebook.buck.shell;
 
 import static org.junit.Assert.assertThat;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
 import org.hamcrest.Matchers;
@@ -35,7 +34,7 @@ public class WorkerProcessPoolTest {
   @Test
   public void testProvidesWorkersAccordingToCapacityThenBlocks() throws InterruptedException {
     int maxWorkers = 3;
-    final WorkerProcessPool pool = createPool(Optional.of(maxWorkers));
+    final WorkerProcessPool pool = createPool(maxWorkers);
     final Set<WorkerProcess> createdWorkers = concurrentSet();
 
     Thread[] tasks = new Thread[maxWorkers + 1];
@@ -57,7 +56,7 @@ public class WorkerProcessPoolTest {
   @Test
   public void testReusesWorkerProcesses() throws InterruptedException {
     int maxWorkers = 3;
-    final WorkerProcessPool pool = createPool(Optional.of(maxWorkers));
+    final WorkerProcessPool pool = createPool(maxWorkers);
     final ConcurrentHashMap<Runnable, WorkerProcess> usedWorkers = new ConcurrentHashMap<>();
 
     Thread[] threads = {
@@ -85,7 +84,7 @@ public class WorkerProcessPoolTest {
   @Test
   public void testUnlimitedPool() throws InterruptedException {
     int numThreads = 20;
-    final WorkerProcessPool pool = createPool(Optional.absent());
+    final WorkerProcessPool pool = createPool(Integer.MAX_VALUE);
     final Set<WorkerProcess> createdWorkers = concurrentSet();
 
     Thread[] threads = new Thread[numThreads];
@@ -104,7 +103,7 @@ public class WorkerProcessPoolTest {
   @Test
   public void testReusesWorkerProcessesInUnlimitedPools() throws InterruptedException {
     int numThreads = 3;
-    final WorkerProcessPool pool = createPool(Optional.absent());
+    final WorkerProcessPool pool = createPool(Integer.MAX_VALUE);
     final ConcurrentHashMap<Runnable, WorkerProcess> usedWorkers = new ConcurrentHashMap<>();
 
     Thread[] threads = new Thread[numThreads];
@@ -132,7 +131,7 @@ public class WorkerProcessPoolTest {
 
   }
 
-  private static WorkerProcessPool createPool(final Optional<Integer> maxWorkers) {
+  private static WorkerProcessPool createPool(int maxWorkers) {
     return new WorkerProcessPool(maxWorkers) {
       @Override
       protected WorkerProcess startWorkerProcess() throws IOException {

--- a/test/com/facebook/buck/shell/WorkerShellStepTest.java
+++ b/test/com/facebook/buck/shell/WorkerShellStepTest.java
@@ -86,7 +86,7 @@ public class WorkerShellStepTest {
       String startupArgs,
       ImmutableMap<String, String> startupEnv,
       String jobArgs) {
-    return createJobParams(startupCommand, startupArgs, startupEnv, jobArgs, Optional.of(1));
+    return createJobParams(startupCommand, startupArgs, startupEnv, jobArgs, 1);
   }
 
   private WorkerJobParams createJobParams(
@@ -94,7 +94,7 @@ public class WorkerShellStepTest {
       String startupArgs,
       ImmutableMap<String, String> startupEnv,
       String jobArgs,
-      Optional<Integer> maxWorkers) {
+      int maxWorkers) {
     return WorkerJobParams.of(
         Paths.get("tmp").toAbsolutePath().normalize(),
         startupCommand,
@@ -118,12 +118,12 @@ public class WorkerShellStepTest {
 
   private ExecutionContext createExecutionContextWith(
       final ImmutableMap<String, WorkerJobResult> jobArgs) {
-    return createExecutionContextWith(jobArgs, Optional.of(1));
+    return createExecutionContextWith(jobArgs, 1);
   }
 
   private ExecutionContext createExecutionContextWith(
       final ImmutableMap<String, WorkerJobResult> jobArgs,
-      final Optional<Integer> poolCapacity) {
+      final int poolCapacity) {
     ConcurrentHashMap<String, WorkerProcessPool> workerProcessMap = new ConcurrentHashMap<>();
     WorkerProcessPool workerProcessPool = new WorkerProcessPool(poolCapacity) {
       @Override
@@ -298,7 +298,7 @@ public class WorkerShellStepTest {
         startupArgs,
         ImmutableMap.of(),
         jobArgs1,
-        Optional.of(1));
+        1);
 
     WorkerShellStep step1 = createWorkerShellStep(params, null, null);
     final WorkerShellStep step2 =
@@ -431,7 +431,7 @@ public class WorkerShellStepTest {
         startupArgs,
         ImmutableMap.of(),
         jobArgsA,
-        Optional.of(2));
+        2);
     WorkerShellStep stepA = new WorkerShellStepWithFakeProcesses(jobParamsA);
     WorkerShellStep stepB = new WorkerShellStepWithFakeProcesses(jobParamsA.withJobArgs(jobArgsB));
 
@@ -463,7 +463,7 @@ public class WorkerShellStepTest {
 
     ExecutionContext context = createExecutionContextWith(
         ImmutableMap.of("jobArgs", WorkerJobResult.of(0, Optional.of(""), Optional.of(""))),
-        Optional.of(existingPoolSize));
+        existingPoolSize);
 
     FakeBuckEventListener listener = new FakeBuckEventListener();
     context.getBuckEventBus().register(listener);
@@ -473,7 +473,7 @@ public class WorkerShellStepTest {
         startupArgs,
         ImmutableMap.of(),
         "jobArgs",
-        Optional.of(stepPoolSize));
+        stepPoolSize);
 
     WorkerShellStep step = createWorkerShellStep(params, null, null);
     step.execute(context);


### PR DESCRIPTION
Just use Integer.MAX_VALUE. Part of #953