### PR TITLE
Support apple_library as a dependency of swift_library

### DIFF
--- a/src/com/facebook/buck/apple/AppleBuildRules.java
+++ b/src/com/facebook/buck/apple/AppleBuildRules.java
@@ -25,6 +25,7 @@ import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleType;
 import com.facebook.buck.rules.TargetGraph;
 import com.facebook.buck.rules.TargetNode;
+import com.facebook.buck.swift.SwiftLibraryDescription;
 import com.google.common.base.Function;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
@@ -121,7 +122,8 @@ public final class AppleBuildRules {
         types);
 
     GraphTraversable<TargetNode<?>> graphTraversable = node -> {
-      if (!isXcodeTargetBuildRuleType(node.getType())) {
+      if (!isXcodeTargetBuildRuleType(node.getType())
+          || SwiftLibraryDescription.isSwiftTarget(node.getBuildTarget())) {
         return Collections.emptyIterator();
       }
 

--- a/src/com/facebook/buck/apple/AppleBuildRules.java
+++ b/src/com/facebook/buck/apple/AppleBuildRules.java
@@ -122,8 +122,8 @@ public final class AppleBuildRules {
         types);
 
     GraphTraversable<TargetNode<?>> graphTraversable = node -> {
-      if (!isXcodeTargetBuildRuleType(node.getType())
-          || SwiftLibraryDescription.isSwiftTarget(node.getBuildTarget())) {
+      if (!isXcodeTargetBuildRuleType(node.getType()) ||
+          SwiftLibraryDescription.isSwiftTarget(node.getBuildTarget())) {
         return Collections.emptyIterator();
       }
 

--- a/src/com/facebook/buck/apple/AppleLibraryDescription.java
+++ b/src/com/facebook/buck/apple/AppleLibraryDescription.java
@@ -240,6 +240,10 @@ public class AppleLibraryDescription implements
       if (isSwiftTarget(params.getBuildTarget())) {
         return swiftCompanionBuildRule.get();
       } else {
+        args.exportedDeps = ImmutableSortedSet.<BuildTarget>naturalOrder()
+            .addAll(args.exportedDeps)
+            .add(swiftCompanionBuildRule.get().getBuildTarget())
+            .build();
         params = params.appendExtraDeps(ImmutableSet.of(swiftCompanionBuildRule.get()));
       }
     }

--- a/src/com/facebook/buck/swift/SwiftDescriptions.java
+++ b/src/com/facebook/buck/swift/SwiftDescriptions.java
@@ -16,6 +16,8 @@
 
 package com.facebook.buck.swift;
 
+import static com.facebook.buck.cxx.NativeLinkable.Linkage.STATIC;
+import static com.facebook.buck.swift.SwiftLibraryDescription.SWIFT_COMPANION_FLAVOR;
 import static com.facebook.buck.swift.SwiftUtil.Constants.SWIFT_EXTENSION;
 
 import com.facebook.buck.cxx.CxxLibraryDescription;
@@ -71,7 +73,9 @@ class SwiftDescriptions {
         args.moduleName.map(Optional::of).orElse(Optional.of(buildTarget.getShortName()));
     output.enableObjcInterop = Optional.of(true);
     output.bridgingHeader = args.bridgingHeader;
-    output.preferredLinkage = args.preferredLinkage;
+
+    boolean isCompanionTarget = buildTarget.getFlavors().contains(SWIFT_COMPANION_FLAVOR);
+    output.preferredLinkage = isCompanionTarget ? Optional.of(STATIC) : args.preferredLinkage;
   }
 
 }

--- a/src/com/facebook/buck/swift/SwiftLibrary.java
+++ b/src/com/facebook/buck/swift/SwiftLibrary.java
@@ -140,7 +140,8 @@ class SwiftLibrary
         .addAllFrameworks(frameworks)
         .addAllLibraries(libraries);
     boolean isDynamic;
-    switch (linkage) {
+    Linkage preferredLinkage = getPreferredLinkage(cxxPlatform);
+    switch (preferredLinkage) {
       case STATIC:
         isDynamic = false;
         break;
@@ -151,7 +152,7 @@ class SwiftLibrary
         isDynamic = type == Linker.LinkableDepType.SHARED;
         break;
       default:
-        throw new IllegalStateException("unhandled linkage type: " + linkage);
+        throw new IllegalStateException("unhandled linkage type: " + preferredLinkage);
     }
     if (isDynamic) {
       inputBuilder.addArgs(new SourcePathArg(getResolver(),

--- a/src/com/facebook/buck/swift/SwiftLibrary.java
+++ b/src/com/facebook/buck/swift/SwiftLibrary.java
@@ -265,7 +265,13 @@ class SwiftLibrary
   public ImmutableMap<BuildTarget, CxxPreprocessorInput> getTransitiveCxxPreprocessorInput(
       CxxPlatform cxxPlatform,
       HeaderVisibility headerVisibility) throws NoSuchBuildTargetException {
-    return transitiveCxxPreprocessorInputCache.getUnchecked(
-        ImmutableCxxPreprocessorInputCacheKey.of(cxxPlatform, headerVisibility));
+    if (getBuildTarget().getFlavors().contains(SWIFT_COMPANION_FLAVOR)) {
+      return ImmutableMap.of(
+          getBuildTarget(),
+          getCxxPreprocessorInput(cxxPlatform, headerVisibility));
+    } else {
+      return transitiveCxxPreprocessorInputCache.getUnchecked(
+          ImmutableCxxPreprocessorInputCacheKey.of(cxxPlatform, headerVisibility));
+    }
   }
 }

--- a/test/com/facebook/buck/swift/SwiftIOSBundleIntegrationTest.java
+++ b/test/com/facebook/buck/swift/SwiftIOSBundleIntegrationTest.java
@@ -281,7 +281,7 @@ public class SwiftIOSBundleIntegrationTest {
   }
 
   @Test
-  public void swiftDependsOnObjCRunsAndPrintsMessageOnOSX() throws Exception {
+  public void swiftDependsOnObjCRunsAndPrintsMessage() throws Exception {
     assumeThat(
         AppleNativeIntegrationTestUtils.isSwiftAvailable(ApplePlatform.IPHONESIMULATOR),
         is(true));

--- a/test/com/facebook/buck/swift/SwiftIOSBundleIntegrationTest.java
+++ b/test/com/facebook/buck/swift/SwiftIOSBundleIntegrationTest.java
@@ -279,4 +279,33 @@ public class SwiftIOSBundleIntegrationTest {
         workspace.runCommand("nm", binaryOutput.toString()).getStdout().orElse(""),
         containsString("baz"));
   }
+
+  @Test
+  public void swiftDependsOnObjCRunsAndPrintsMessageOnOSX() throws Exception {
+    assumeThat(
+        AppleNativeIntegrationTestUtils.isSwiftAvailable(ApplePlatform.IPHONESIMULATOR),
+        is(true));
+    ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(
+        this, "swift_on_objc", tmp);
+    workspace.setUp();
+    ProjectFilesystem filesystem = new ProjectFilesystem(workspace.getDestPath());
+
+    BuildTarget target = workspace.newBuildTarget("//:binary#iphonesimulator-x86_64");
+    workspace.runBuckCommand("build", target.getFullyQualifiedName()).assertSuccess();
+
+    target = workspace.newBuildTarget("//:bundle#iphonesimulator-x86_64,no-debug");
+    workspace.runBuckCommand("build", target.getFullyQualifiedName()).assertSuccess();
+
+    Path appPath = workspace.getPath(
+        BuildTargets
+            .getGenPath(
+                filesystem,
+                BuildTarget.builder(target)
+                    .addFlavors(AppleDescriptions.NO_INCLUDE_FRAMEWORKS_FLAVOR)
+                    .build(),
+                "%s")
+            .resolve(target.getShortName() + ".app"));
+    assertTrue(Files.exists(appPath.resolve(target.getShortName())));
+  }
+
 }

--- a/test/com/facebook/buck/swift/SwiftOSXBinaryIntegrationTest.java
+++ b/test/com/facebook/buck/swift/SwiftOSXBinaryIntegrationTest.java
@@ -124,4 +124,5 @@ public class SwiftOSXBinaryIntegrationTest {
         runResult.getStdout(),
         containsString("Hello ObjC\n"));
   }
+
 }

--- a/test/com/facebook/buck/swift/testdata/swift_on_objc/.buckconfig
+++ b/test/com/facebook/buck/swift/testdata/swift_on_objc/.buckconfig
@@ -1,0 +1,2 @@
+[cxx]
+  default_platform = iphonesimulator-x86_64

--- a/test/com/facebook/buck/swift/testdata/swift_on_objc/AppDelegate.h
+++ b/test/com/facebook/buck/swift/testdata/swift_on_objc/AppDelegate.h
@@ -1,0 +1,8 @@
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+
+@end

--- a/test/com/facebook/buck/swift/testdata/swift_on_objc/AppDelegate.m
+++ b/test/com/facebook/buck/swift/testdata/swift_on_objc/AppDelegate.m
@@ -1,0 +1,25 @@
+#import "AppDelegate.h"
+#import <binary-Swift.h>
+#import <UIKit/UIKit.h>
+#import <dep1-Swift.h>
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    [Test0 func0:@"message0"];
+
+    UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"From AppDelegate.m"
+                                                    message:@"Dee dee doo doo."
+                                                   delegate:self
+                                          cancelButtonTitle:@"OK"
+                                          otherButtonTitles:nil];
+    [alert show];
+    return YES;
+}
+
+@end

--- a/test/com/facebook/buck/swift/testdata/swift_on_objc/BUCK.fixture
+++ b/test/com/facebook/buck/swift/testdata/swift_on_objc/BUCK.fixture
@@ -1,0 +1,47 @@
+apple_library(
+  name = 'dep1',
+  srcs = [
+    'Test1.swift',
+  ],
+)
+
+swift_library(
+  name = 'dep2',
+  srcs = [
+    'Test2.swift',
+  ],
+  deps = [
+    ':dep1',
+  ],
+)
+
+apple_binary(
+  name='binary',
+  headers= [
+      'AppDelegate.h'
+  ],
+  srcs = [
+      'AppDelegate.m',
+      'main.m',
+      'Test0.swift',
+  ],
+  deps = [
+    ':dep2',
+  ],
+  frameworks = [
+    '$SDKROOT/System/Library/Frameworks/UIKit.framework',
+    '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+  ],
+)
+
+apple_bundle(
+    name='bundle',
+    binary=':binary',
+    extension='app',
+    info_plist='Info.plist',
+    product_name = 'bundle',
+    info_plist_substitutions={
+        'PRODUCT_BUNDLE_IDENTIFIER': 'com.uber.test1',
+        'EXECUTABLE_NAME': 'bundle'
+    }
+)

--- a/test/com/facebook/buck/swift/testdata/swift_on_objc/Info.plist
+++ b/test/com/facebook/buck/swift/testdata/swift_on_objc/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/test/com/facebook/buck/swift/testdata/swift_on_objc/Test0.swift
+++ b/test/com/facebook/buck/swift/testdata/swift_on_objc/Test0.swift
@@ -3,7 +3,7 @@ import UIKit
 public class Test0 : NSObject {
     public class func func0(_ str: String) {
         let alert = UIAlertView()
-        alert.title = "From Test1.swift"
+        alert.title = "From Test0.swift"
         alert.message = str
         alert.addButton(withTitle: "Yes")
         alert.addButton(withTitle: "No")

--- a/test/com/facebook/buck/swift/testdata/swift_on_objc/Test0.swift
+++ b/test/com/facebook/buck/swift/testdata/swift_on_objc/Test0.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+public class Test0 : NSObject {
+    public class func func0(_ str: String) {
+        let alert = UIAlertView()
+        alert.title = "From Test1.swift"
+        alert.message = str
+        alert.addButton(withTitle: "Yes")
+        alert.addButton(withTitle: "No")
+        alert.show()
+    }
+}

--- a/test/com/facebook/buck/swift/testdata/swift_on_objc/Test1.swift
+++ b/test/com/facebook/buck/swift/testdata/swift_on_objc/Test1.swift
@@ -3,7 +3,7 @@ import UIKit
 public class Test1 : NSObject {
     public class func func1(_ str: String) {
         let alert = UIAlertView()
-        alert.title = "From Test2.swift"
+        alert.title = "From Test1.swift"
         alert.message = str
         alert.addButton(withTitle: "Yes")
         alert.addButton(withTitle: "No")

--- a/test/com/facebook/buck/swift/testdata/swift_on_objc/Test1.swift
+++ b/test/com/facebook/buck/swift/testdata/swift_on_objc/Test1.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+public class Test1 : NSObject {
+    public class func func1(_ str: String) {
+        let alert = UIAlertView()
+        alert.title = "From Test2.swift"
+        alert.message = str
+        alert.addButton(withTitle: "Yes")
+        alert.addButton(withTitle: "No")
+        alert.show()
+    }
+}

--- a/test/com/facebook/buck/swift/testdata/swift_on_objc/Test2.swift
+++ b/test/com/facebook/buck/swift/testdata/swift_on_objc/Test2.swift
@@ -1,0 +1,7 @@
+import dep1
+
+public class Test2 {
+  public class func func2() {
+    Test1.func1("hello")
+  }
+}

--- a/test/com/facebook/buck/swift/testdata/swift_on_objc/main.m
+++ b/test/com/facebook/buck/swift/testdata/swift_on_objc/main.m
@@ -1,0 +1,10 @@
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+#import <binary-Swift.h>
+
+int main(int argc, char * argv[]) {
+    [Test0 func0:@"tho12345"];
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/test/com/facebook/buck/swift/testdata/swift_on_objc/main.m
+++ b/test/com/facebook/buck/swift/testdata/swift_on_objc/main.m
@@ -1,6 +1,6 @@
 #import <UIKit/UIKit.h>
 #import "AppDelegate.h"
-#import <binary-Swift.h>
+#import "binary-Swift.h"
 
 int main(int argc, char * argv[]) {
     [Test0 func0:@"tho12345"];


### PR DESCRIPTION
This PR will enable `apple_library` to be a (transparent) dependency of `swift_library`, yet only for `apple_library` without objc source that is referenced from library that depends on it.