### PR TITLE
Fix consistent build error with ant

### DIFF
--- a/src/com/facebook/buck/rules/coercer/CollectionTypeCoercer.java
+++ b/src/com/facebook/buck/rules/coercer/CollectionTypeCoercer.java
@@ -51,7 +51,7 @@ public abstract class CollectionTypeCoercer<C extends ImmutableCollection<T>, T>
       CellPathResolver cellRoots,
       ProjectFilesystem filesystem,
       Path pathRelativeToProjectRoot,
-      C.Builder<T> builder,
+      ImmutableCollection.Builder<T> builder,
       Object object) throws CoerceFailedException {
     if (object instanceof Collection) {
       for (Object element : (Iterable<?>) object) {


### PR DESCRIPTION
I got following build error consistently when rebuilding `buck` with `ant` after switching between branches. This can be fixed easily, and could save us development times.

```
compile:
    [javac] Compiling 685 source files to buck/build/classes
    [javac] [total compilation time: 1070]
    [javac] ----------
    [javac] 1. ERROR in /Users/thonguyen/Desktop/uber-buck/src/com/facebook/buck/rules/coercer/ListTypeCoercer.java (at line 26)
    [javac] 	public class ListTypeCoercer<T> extends CollectionTypeCoercer<ImmutableList<T>, T> {
    [javac] 	                                        ^^^^^^^^^^^^^^^^^^^^^
    [javac] Inconsistent classfile encountered: The undefined type parameter C.Builder is referenced from within CollectionTypeCoercer<C,T>
    [javac] ----------
    [javac] 1 problem (1 error)

BUILD FAILED
...
```