### PR TITLE
Use newer java 8 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ addons:
       - libstdc++6:i386
       - zlib1g:i386
       - groovy
+      # Getting compile errors on javac 1.8.0_31-b13
+      - oracle-java8-installer
 
 before_install:
   # Limit Ant's and Buck's memory usage to avoid the OOM killer.


### PR DESCRIPTION
Per https://github.com/travis-ci/travis-ci/issues/4042, this should
give us a newer jdk on Travis CI.