### PR TITLE
Demote error log to warning.  The parser is going to continue anyway,…

### DIFF
--- a/src/com/facebook/buck/jvm/java/JavaFileParser.java
+++ b/src/com/facebook/buck/jvm/java/JavaFileParser.java
@@ -642,7 +642,7 @@ public class JavaFileParser {
 
           simpleImportedTypes.put(name, enclosingType);
         } else {
-          LOG.error("Suspicious import lacks obvious enclosing type: %s", fullyQualifiedName);
+          LOG.warn("Suspicious import lacks obvious enclosing type: %s", fullyQualifiedName);
           // The one example we have seen of this in the wild is
           // "org.whispersystems.curve25519.java.curve_sigs". In practice, we still need to add it
           // as a required symbol in this case.


### PR DESCRIPTION
… so a log level of warn makes more sense and is less alarming to the user.