### PR TITLE
Allow apple_library to be imported as a module

### DIFF
--- a/src/com/facebook/buck/cxx/BUCK
+++ b/src/com/facebook/buck/cxx/BUCK
@@ -92,7 +92,6 @@ java_immutables_library(
   autodeps = True,
   resources = [
     'modulemap.st',
-    'umbrella_header.st',
   ],
   visibility = [
     'PUBLIC'

--- a/src/com/facebook/buck/cxx/BUCK
+++ b/src/com/facebook/buck/cxx/BUCK
@@ -90,6 +90,10 @@ java_immutables_library(
     '//test/com/facebook/buck/cxx:cxx',
   ],
   autodeps = True,
+  resources = [
+    'modulemap.st',
+    'umbrella_header.st',
+  ],
   visibility = [
     'PUBLIC'
   ],

--- a/src/com/facebook/buck/cxx/CxxPreprocessables.java
+++ b/src/com/facebook/buck/cxx/CxxPreprocessables.java
@@ -162,7 +162,7 @@ public class CxxPreprocessables {
             Suppliers.ofInstance(ImmutableSortedSet.of()));
 
     if (useHeaderMap) {
-      return new HeaderSymlinkTreeWithHeaderMap(
+      return HeaderSymlinkTreeWithHeaderMap.create(
           paramsWithoutDeps,
           resolver,
           root,

--- a/src/com/facebook/buck/cxx/HeaderSymlinkTreeWithHeaderMap.java
+++ b/src/com/facebook/buck/cxx/HeaderSymlinkTreeWithHeaderMap.java
@@ -27,27 +27,71 @@ import com.facebook.buck.rules.BuildableContext;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.step.Step;
+import com.facebook.buck.step.fs.WriteFileStep;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+
+import org.stringtemplate.v4.ST;
 
 import java.nio.file.Path;
 import java.util.Optional;
 
-public class HeaderSymlinkTreeWithHeaderMap extends HeaderSymlinkTree {
+public final class HeaderSymlinkTreeWithHeaderMap extends HeaderSymlinkTree {
 
   private static final Logger LOG = Logger.get(HeaderSymlinkTreeWithHeaderMap.class);
+
+  private static final String MODULE_MAP = "module.modulemap";
+  private static final String MODULEMAP_TEMPLATE_PATH = getTemplate("modulemap.st");
+  private static final String UMBRELLA_HEADER_TEMPLATE_PATH = getTemplate("umbrella_header.st");
+
+  private static String getTemplate(String template) {
+    try {
+      return Resources.toString(
+          Resources.getResource(
+              HeaderSymlinkTreeWithHeaderMap.class,
+              template),
+          Charsets.UTF_8);
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+  }
 
   @AddToRuleKey(stringify = true)
   private final Path headerMapPath;
 
-  public HeaderSymlinkTreeWithHeaderMap(
+  @AddToRuleKey
+  private final boolean shouldCreateModule;
+
+  private HeaderSymlinkTreeWithHeaderMap(
+      BuildRuleParams params,
+      SourcePathResolver resolver,
+      Path root,
+      ImmutableMap<Path, SourcePath> links,
+      Path headerMapPath,
+      boolean shouldCreateModule) {
+    super(params, resolver, root, links);
+    this.headerMapPath = headerMapPath;
+    this.shouldCreateModule = shouldCreateModule;
+  }
+
+  public static HeaderSymlinkTreeWithHeaderMap create(
       BuildRuleParams params,
       SourcePathResolver resolver,
       Path root,
       ImmutableMap<Path, SourcePath> links) {
-    super(params, resolver, root, links);
-    this.headerMapPath = getPath(params.getProjectFilesystem(), params.getBuildTarget());
+    Path headerMapPath = getPath(params.getProjectFilesystem(), params.getBuildTarget());
+    boolean shouldCreateModule = params.getBuildTarget().getFlavors()
+        .contains(CxxDescriptionEnhancer.EXPORTED_HEADER_SYMLINK_TREE_FLAVOR);
+    return new HeaderSymlinkTreeWithHeaderMap(
+        params,
+        resolver,
+        root,
+        links,
+        headerMapPath,
+        shouldCreateModule);
   }
 
   @Override
@@ -73,10 +117,41 @@ public class HeaderSymlinkTreeWithHeaderMap extends HeaderSymlinkTree {
       // aligning in order to get this to work. May we find peace in another life.
       headerMapEntries.put(key, buckOut.relativize(getRoot().resolve(key)));
     }
-    return ImmutableList.<Step>builder()
+    ImmutableList.Builder<Step> builder = ImmutableList.<Step>builder()
         .addAll(super.getBuildSteps(context, buildableContext))
-        .add(new HeaderMapStep(getProjectFilesystem(), headerMapPath, headerMapEntries.build()))
-        .build();
+        .add(new HeaderMapStep(getProjectFilesystem(), headerMapPath, headerMapEntries.build()));
+
+    if (shouldCreateModule) {
+      String moduleName = getBuildTarget().getShortName();
+      String umbrellaHeaderName = moduleName + "-umbrella.h";
+      builder
+          .add(createUmbrellaHeaderStep(umbrellaHeaderName))
+          .add(createCreateModuleStep(moduleName, umbrellaHeaderName));
+    }
+    return builder.build();
+  }
+
+  // TODO(nguyentruongtho) use existing umbrella header is present, umbrella header file name
+  // should be named in this format: <module_name>-umbrella.h
+  private Step createUmbrellaHeaderStep(String umbrellaHeaderName) {
+    return new WriteFileStep(
+        getProjectFilesystem(),
+        new ST(UMBRELLA_HEADER_TEMPLATE_PATH)
+            .add("exported_headers", getLinks().keySet())
+            .render(),
+        getProjectFilesystem().relativize(getRoot().resolve(umbrellaHeaderName)),
+        /* executable */ false);
+  }
+
+  private Step createCreateModuleStep(String moduleName, String umbrellaHeaderFilename) {
+    return new WriteFileStep(
+        getProjectFilesystem(),
+        new ST(MODULEMAP_TEMPLATE_PATH)
+            .add("module_name", moduleName)
+            .add("umbrella_header_name", umbrellaHeaderFilename)
+            .render(),
+        getProjectFilesystem().relativize(getRoot().resolve(MODULE_MAP)),
+        false);
   }
 
   @Override

--- a/src/com/facebook/buck/cxx/modulemap.st
+++ b/src/com/facebook/buck/cxx/modulemap.st
@@ -1,5 +1,9 @@
 module <module_name> {
+    <if(use_umbrella_header)>
     umbrella header "<umbrella_header_name>"
+    <else>
+    umbrella "<umbrella_directory>"
+    <endif>
 
     export *
     module * { export * }

--- a/src/com/facebook/buck/cxx/modulemap.st
+++ b/src/com/facebook/buck/cxx/modulemap.st
@@ -1,0 +1,6 @@
+module <module_name> {
+    umbrella header "<umbrella_header_name>"
+
+    export *
+    module * { export * }
+}

--- a/src/com/facebook/buck/cxx/umbrella_header.st
+++ b/src/com/facebook/buck/cxx/umbrella_header.st
@@ -1,0 +1,1 @@
+<exported_headers:{x| #import \<<x>><\n>}>

--- a/src/com/facebook/buck/cxx/umbrella_header.st
+++ b/src/com/facebook/buck/cxx/umbrella_header.st
@@ -1,1 +1,0 @@
-<exported_headers:{x| #import \<<x>><\n>}>

--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -44,11 +44,11 @@ import com.facebook.buck.rules.args.StringArg;
 import com.facebook.buck.rules.coercer.FrameworkPath;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.fs.MkdirStep;
+import com.facebook.buck.util.MoreCollectors;
 import com.facebook.buck.util.MoreIterables;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -56,6 +56,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Optional;
 
@@ -91,7 +92,7 @@ class SwiftCompile
   private final Optional<SourcePath> bridgingHeader;
   private final SwiftBuckConfig swiftBuckConfig;
 
-  private final Iterable<CxxPreprocessorInput> cxxPreprocessorInputs;
+  private final Collection<CxxPreprocessorInput> cxxPreprocessorInputs;
 
   SwiftCompile(
       CxxPlatform cxxPlatform,
@@ -123,9 +124,11 @@ class SwiftCompile
     this.srcs = ImmutableSortedSet.copyOf(srcs);
     this.enableObjcInterop = enableObjcInterop.orElse(true);
     this.bridgingHeader = bridgingHeader;
-    this.hasMainEntry = FluentIterable.from(srcs).firstMatch(
+    this.hasMainEntry = Iterables.tryFind(
+        srcs,
         input -> SWIFT_MAIN_FILENAME.equalsIgnoreCase(
-            getResolver().getAbsolutePath(input).getFileName().toString())).isPresent();
+            getResolver().getAbsolutePath(input).getFileName().toString()))
+        .isPresent();
     performChecks(params);
   }
 
@@ -159,14 +162,26 @@ class SwiftCompile
             .iterator());
 
     compilerCommand.addAll(
-        MoreIterables.zipAndConcat(Iterables.cycle("-Xcc"),
+        MoreIterables.zipAndConcat(
+            Iterables.cycle("-Xcc"),
             getSwiftIncludeArgs()));
+
     compilerCommand.addAll(MoreIterables.zipAndConcat(
         Iterables.cycle(INCLUDE_FLAG),
-        FluentIterable.from(getDeps())
-            .filter(SwiftCompile.class)
-            .transform(SourcePaths.getToBuildTargetSourcePath())
-            .transform(input -> getResolver().getAbsolutePath(input).toString())));
+        getDeps().stream()
+            .filter(SwiftCompile.class::isInstance)
+            .map(SwiftCompile.class::cast)
+            .map(SourcePaths.getToBuildTargetSourcePath()::apply)
+            .map(input -> getResolver().getAbsolutePath(input).toString())
+            .collect(MoreCollectors.toImmutableSet())));
+
+    compilerCommand.addAll(MoreIterables.zipAndConcat(
+        Iterables.cycle(INCLUDE_FLAG),
+        cxxPreprocessorInputs.stream()
+            .flatMap(input -> input.getIncludes().stream())
+            .map(input -> input.getRoot())
+            .map(input -> getResolver().getAbsolutePath(input).toString())
+            .collect(MoreCollectors.toImmutableSet())));
 
     Optional<Iterable<String>> configFlags = swiftBuckConfig.getFlags();
     if (configFlags.isPresent()) {
@@ -214,8 +229,8 @@ class SwiftCompile
 
   /**
    * @return the arguments to add to the preprocessor command line to include the given header packs
-   *     in preprocessor search path.
-   *
+   * in preprocessor search path.
+   * <p>
    * We can't use CxxHeaders.getArgs() because
    * 1. we don't need the system include roots.
    * 2. swift doesn't like spaces after the "-I" flag.

--- a/test/com/facebook/buck/cxx/HeaderSymlinkTreeWithHeaderMapTest.java
+++ b/test/com/facebook/buck/cxx/HeaderSymlinkTreeWithHeaderMapTest.java
@@ -101,7 +101,7 @@ public class HeaderSymlinkTreeWithHeaderMapTest {
         BuildTargets.getGenPath(projectFilesystem, buildTarget, "%s/symlink-tree-root"));
 
     // Setup the symlink tree buildable.
-    symlinkTreeBuildRule = new HeaderSymlinkTreeWithHeaderMap(
+    symlinkTreeBuildRule = HeaderSymlinkTreeWithHeaderMap.create(
         new FakeBuildRuleParamsBuilder(buildTarget).build(),
         new SourcePathResolver(
             new BuildRuleResolver(
@@ -153,7 +153,7 @@ public class HeaderSymlinkTreeWithHeaderMapTest {
   public void testSymlinkTreeRuleKeyChangesIfLinkMapChanges() throws Exception {
     Path aFile = tmpDir.newFile();
     Files.write(aFile, "hello world".getBytes(Charsets.UTF_8));
-    AbstractBuildRule modifiedSymlinkTreeBuildRule = new HeaderSymlinkTreeWithHeaderMap(
+    AbstractBuildRule modifiedSymlinkTreeBuildRule = HeaderSymlinkTreeWithHeaderMap.create(
         new FakeBuildRuleParamsBuilder(buildTarget).build(),
         new SourcePathResolver(
             new BuildRuleResolver(

--- a/test/com/facebook/buck/cxx/PrebuiltCxxLibraryDescriptionTest.java
+++ b/test/com/facebook/buck/cxx/PrebuiltCxxLibraryDescriptionTest.java
@@ -63,6 +63,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -116,13 +117,12 @@ public class PrebuiltCxxLibraryDescriptionTest {
             .build());
   }
 
-  private static ImmutableSet<Path> getHeaderNames(Iterable<CxxHeaders> includes) {
-    ImmutableSet.Builder<Path> names = ImmutableSet.builder();
-    for (CxxHeaders headers : includes) {
-      CxxSymlinkTreeHeaders symlinkTreeHeaders = (CxxSymlinkTreeHeaders) headers;
-      names.addAll(symlinkTreeHeaders.getNameToPathMap().keySet());
-    }
-    return names.build();
+  private static ImmutableSet<Path> getHeaderNames(Collection<CxxHeaders> includes) {
+    return includes.stream()
+        .filter(CxxSymlinkTreeHeaders.class::isInstance)
+        .map(CxxSymlinkTreeHeaders.class::cast)
+        .flatMap(input -> input.getNameToPathMap().keySet().stream())
+        .collect(MoreCollectors.toImmutableSet());
   }
 
   @Test

--- a/test/com/facebook/buck/swift/SwiftLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/swift/SwiftLibraryIntegrationTest.java
@@ -67,7 +67,7 @@ public class SwiftLibraryIntegrationTest {
     // Setup the map representing the link tree.
     ImmutableMap<Path, SourcePath> links = ImmutableMap.of();
 
-    BuildRule symlinkTreeBuildRule = new HeaderSymlinkTreeWithHeaderMap(
+    BuildRule symlinkTreeBuildRule = HeaderSymlinkTreeWithHeaderMap.create(
         new FakeBuildRuleParamsBuilder(symlinkTarget).build(),
         pathResolver,
         symlinkTreeRoot,

--- a/test/com/facebook/buck/swift/SwiftOSXBinaryIntegrationTest.java
+++ b/test/com/facebook/buck/swift/SwiftOSXBinaryIntegrationTest.java
@@ -125,4 +125,24 @@ public class SwiftOSXBinaryIntegrationTest {
         containsString("Hello ObjC\n"));
   }
 
+  @Test
+  public void testSwiftImportObjcGeneratedModule() throws IOException {
+    assumeThat(
+        AppleNativeIntegrationTestUtils.isSwiftAvailable(ApplePlatform.MACOSX),
+        is(true));
+    ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(
+        this, "modules_import", tmp);
+    workspace.setUp();
+    workspace.writeContentsToPath(
+        "[swift]\n  version = 2.3\n",
+        ".buckconfig.local");
+
+    ProjectWorkspace.ProcessResult runResult = workspace.runBuckCommand(
+        "run", ":main#macosx-x86_64");
+    runResult.assertSuccess();
+    assertThat(
+        runResult.getStdout(),
+        equalTo("One = 1\n"));
+  }
+
 }

--- a/test/com/facebook/buck/swift/testdata/modules_import/BUCK.fixture
+++ b/test/com/facebook/buck/swift/testdata/modules_import/BUCK.fixture
@@ -1,0 +1,20 @@
+apple_library(
+  name = 'one',
+  exported_headers = ['one/one.h'],
+  srcs = ['one/one.m'],
+)
+
+apple_library(
+  name = 'parent',
+  srcs = [ 'parent.swift' ],
+  deps = [ ':one' ],
+)
+
+apple_binary(
+  name = 'main',
+  srcs = ['main.swift'],
+  deps = [':parent'],
+  frameworks = [
+    '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+  ],
+)

--- a/test/com/facebook/buck/swift/testdata/modules_import/main.swift
+++ b/test/com/facebook/buck/swift/testdata/modules_import/main.swift
@@ -1,0 +1,3 @@
+import parent
+
+Parent.printOne()

--- a/test/com/facebook/buck/swift/testdata/modules_import/one/module.modulemap
+++ b/test/com/facebook/buck/swift/testdata/modules_import/one/module.modulemap
@@ -1,0 +1,6 @@
+module one {
+   umbrella header "one-umbrella.h"
+
+   export *
+   module * { export * }
+}

--- a/test/com/facebook/buck/swift/testdata/modules_import/one/one-umbrella.h
+++ b/test/com/facebook/buck/swift/testdata/modules_import/one/one-umbrella.h
@@ -1,0 +1,1 @@
+#import "one.h"

--- a/test/com/facebook/buck/swift/testdata/modules_import/one/one.h
+++ b/test/com/facebook/buck/swift/testdata/modules_import/one/one.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface One:NSObject
+- (int)getOne;
+@end

--- a/test/com/facebook/buck/swift/testdata/modules_import/one/one.m
+++ b/test/com/facebook/buck/swift/testdata/modules_import/one/one.m
@@ -1,0 +1,9 @@
+#import "one.h"
+
+@implementation One
+
+- (int)getOne {
+   return 1;
+}
+
+@end

--- a/test/com/facebook/buck/swift/testdata/modules_import/parent.swift
+++ b/test/com/facebook/buck/swift/testdata/modules_import/parent.swift
@@ -1,0 +1,8 @@
+import one
+
+public class Parent {
+  public class func printOne() {
+    let oneVal = One()
+    print("One = " + String(oneVal.getOne()))
+  }
+}


### PR DESCRIPTION
This PR will enable Swift target to be able to import apple_library. Quite a few things are imported from https://github.com/facebook/buck/pull/842