### PR TITLE
Remove one 'class' word in the error message

### DIFF
--- a/src/com/facebook/buck/cxx/CxxPreprocessables.java
+++ b/src/com/facebook/buck/cxx/CxxPreprocessables.java
@@ -198,7 +198,7 @@ public class CxxPreprocessables {
         "Attempt to add %s of type %s and class %s to %s",
         rule.getFullyQualifiedName(),
         rule.getType(),
-        rule.getClass(),
+        rule.getClass().getName(),
         target);
     HeaderSymlinkTree symlinkTree = (HeaderSymlinkTree) rule;
     builder.addIncludes(CxxSymlinkTreeHeaders.from(symlinkTree, includeType));


### PR DESCRIPTION
Just wanted to correct something annoys me while working with header symlink tree 😠 

> java.lang.IllegalStateException: Attempt to add //:child#headers,macosx-x86_64,swift-companion of type swift_library and **class class** com.facebook.buck.swift.SwiftLibrary to //:child#swift-companion