### PR TITLE
Add rt.jar to java bootclasspath

### DIFF
--- a/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
+++ b/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
@@ -440,6 +440,7 @@ public class DefaultJavaLibrary extends AbstractBuildRule
     ImmutableSortedSet<Path> declared = ImmutableSortedSet.<Path>naturalOrder()
         .addAll(declaredClasspaths)
         .addAll(additionalClasspathEntries)
+        .add(Paths.get(System.getProperty("java.home")).resolve("lib").resolve("rt.jar"))
         .addAll(provided)
         .build();
 


### PR DESCRIPTION
This is in the same vein as https://github.com/facebook/buck/pull/732. 

This adds `rt.jar` to the `javac` classpath so that buck can build java 8 sources correctly. This is needed, for example, with the use of retrolambda in an Android project.

Previously we worked around this by adding something like the following to our `android_library` rules (a la https://github.com/uber/okbuck/pull/81):

```
 extra_arguments = [
  ...
  '-bootclasspath',
  '/Users/some_user/path/to/android-24/android.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_74.jdk/Contents/Home/jre/lib/rt.jar',
 ],
```

The problem with this is that the absolute paths in the BUCK files break caching as the jvm arguments are part of definition of the rule key as far as I can tell.

cc @kageiit @felipecsl