### PR TITLE
WIP: Add cgo support.

### DIFF
--- a/src/com/facebook/buck/cxx/CxxBinaryDescription.java
+++ b/src/com/facebook/buck/cxx/CxxBinaryDescription.java
@@ -341,6 +341,10 @@ public class CxxBinaryDescription implements
     return defaultCxxPlatform;
   }
 
+  public CxxBuckConfig getCxxBuckConfig() {
+    return cxxBuckConfig;
+  }
+
   @Override
   public <A extends Arg, U> Optional<U> createMetadata(
       BuildTarget buildTarget,

--- a/src/com/facebook/buck/cxx/CxxConstructorArg.java
+++ b/src/com/facebook/buck/cxx/CxxConstructorArg.java
@@ -45,7 +45,7 @@ public class CxxConstructorArg extends AbstractDescriptionArg
       PatternMatchedCollection.of();
   public SourceList headers = SourceList.EMPTY;
   public PatternMatchedCollection<SourceList> platformHeaders = PatternMatchedCollection.of();
-  public Optional<SourcePath> prefixHeader;
+  public Optional<SourcePath> prefixHeader = Optional.empty();
   public Optional<SourcePath> precompiledHeader = Optional.empty();
   public ImmutableList<String> compilerFlags = ImmutableList.of();
   public ImmutableMap<CxxSource.Type, ImmutableList<String>> langCompilerFlags = ImmutableMap.of();
@@ -62,8 +62,8 @@ public class CxxConstructorArg extends AbstractDescriptionArg
   public ImmutableSortedSet<FrameworkPath> frameworks = ImmutableSortedSet.of();
   public ImmutableSortedSet<FrameworkPath> libraries = ImmutableSortedSet.of();
   public ImmutableSortedSet<BuildTarget> deps = ImmutableSortedSet.of();
-  public Optional<String> headerNamespace;
-  public Optional<Linker.CxxRuntimeType> cxxRuntimeType;
+  public Optional<String> headerNamespace = Optional.empty();
+  public Optional<Linker.CxxRuntimeType> cxxRuntimeType = Optional.empty();
   public ImmutableList<String> includeDirs = ImmutableList.of();
 
   @Hint(isDep = false) public ImmutableSortedSet<BuildTarget> tests = ImmutableSortedSet.of();

--- a/src/com/facebook/buck/go/CGoCompile.java
+++ b/src/com/facebook/buck/go/CGoCompile.java
@@ -139,11 +139,13 @@ public class CGoCompile extends NoopBuildRule {
       BuildTarget buildTarget,
       String step,
       ImmutableSortedSet<BuildRule> deps,
-      Flags flags) throws NoSuchBuildTargetException {
+      Flags flags,
+      ImmutableSortedSet<BuildTarget> nativeDeps) throws NoSuchBuildTargetException {
     CxxBinaryDescription.Arg args = new CxxBinaryDescription.Arg();
     args.linkStyle = Optional.empty();
 
     args.srcs = prepareGeneratedSources(srcs);
+    args.deps = nativeDeps;
 
     args.langCompilerFlags = ImmutableMap.of(
         CxxSource.Type.C,
@@ -191,8 +193,8 @@ public class CGoCompile extends NoopBuildRule {
       ImmutableSet<SourcePath> cgoSrcs,
       Tool cgo,
       GoPlatform platform,
-      CxxBinaryDescription cxxBinaryDescription
-  ) throws NoSuchBuildTargetException {
+      CxxBinaryDescription cxxBinaryDescription,
+      ImmutableSortedSet<BuildTarget> nativeDeps) throws NoSuchBuildTargetException {
 
     Path cgoGenDir = BuildTargets.getGenPath(
         params.getProjectFilesystem(),
@@ -259,7 +261,8 @@ public class CGoCompile extends NoopBuildRule {
         params.getBuildTarget(),
         "cgo-first-step",
         ImmutableSortedSet.of(genCSource),
-        Flags.firstStep(platform));
+        Flags.firstStep(platform),
+        nativeDeps);
 
     BuildRule cgoImport = new GenGoImport(
         params
@@ -279,7 +282,8 @@ public class CGoCompile extends NoopBuildRule {
         params.getBuildTarget(),
         "cgo-second-step",
         ImmutableSortedSet.of(cgoImport),
-        Flags.secondStep(platform)
+        Flags.secondStep(platform),
+        ImmutableSortedSet.of()
     );
 
     BuildRule entryPoint = new CGoCompile(

--- a/src/com/facebook/buck/go/CGoCompile.java
+++ b/src/com/facebook/buck/go/CGoCompile.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.go;
+
+import com.facebook.buck.cxx.CxxBinary;
+import com.facebook.buck.cxx.CxxBinaryDescription;
+import com.facebook.buck.cxx.CxxDescriptionEnhancer;
+import com.facebook.buck.cxx.CxxLinkAndCompileRules;
+import com.facebook.buck.cxx.CxxSource;
+import com.facebook.buck.model.BuildTarget;
+import com.facebook.buck.model.BuildTargets;
+import com.facebook.buck.model.HasOutputName;
+import com.facebook.buck.model.ImmutableFlavor;
+import com.facebook.buck.parser.NoSuchBuildTargetException;
+import com.facebook.buck.rules.AbstractBuildRule;
+import com.facebook.buck.rules.AddToRuleKey;
+import com.facebook.buck.rules.BuildContext;
+import com.facebook.buck.rules.BuildRule;
+import com.facebook.buck.rules.BuildRuleParams;
+import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.BuildTargetSourcePath;
+import com.facebook.buck.rules.BuildableContext;
+import com.facebook.buck.rules.NoopBuildRule;
+import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.buck.rules.SourcePathRuleFinder;
+import com.facebook.buck.rules.SourceWithFlags;
+import com.facebook.buck.rules.Tool;
+import com.facebook.buck.step.Step;
+import com.facebook.buck.step.fs.MakeCleanDirectoryStep;
+import com.facebook.buck.util.HumanReadableException;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
+
+public class CGoCompile extends NoopBuildRule {
+  public final ImmutableList<SourcePath> generatedGoSrcs;
+  private final Path output;
+
+  public CGoCompile(
+      BuildRuleParams params,
+      SourcePathResolver pathResolver,
+      ImmutableList<SourcePath> generatedGoSrcs,
+      Path output
+  ) {
+    super(params, pathResolver);
+    this.generatedGoSrcs = generatedGoSrcs;
+    this.output = output;
+  }
+
+  private static SourcePath generatedSource(
+      BuildRuleResolver resolver,
+      BuildRuleParams generator,
+      Path futurePath) {
+
+    class NoopWithOutputName extends AbstractBuildRule implements HasOutputName {
+      private final Path output;
+
+      protected NoopWithOutputName(
+          BuildRuleParams buildRuleParams,
+          Path output) {
+        super(buildRuleParams);
+        this.output = output;
+      }
+
+      @Override
+      public String getOutputName() {
+        return output.toAbsolutePath().toString();
+      }
+
+      @Override
+      public ImmutableList<Step> getBuildSteps(
+          BuildContext context, BuildableContext buildableContext) {
+        return ImmutableList.of();
+      }
+
+      @Nullable
+      @Override
+      public Path getPathToOutput() {
+        return output;
+      }
+    }
+
+    BuildTarget target = generator.getBuildTarget()
+        .withFlavors(ImmutableFlavor.of(futurePath.getFileName().toString()));
+    BuildRule rule = new NoopWithOutputName(
+        generator
+            .copyWithBuildTarget(target)
+            .appendExtraDeps(resolver.getRule(generator.getBuildTarget())),
+        futurePath
+    );
+
+    resolver.addToIndex(rule);
+
+    return new BuildTargetSourcePath(target, futurePath);
+  }
+
+
+  private static ImmutableSortedSet<SourceWithFlags> prepareGeneratedSources(
+      Iterable<SourcePath> it) {
+    ImmutableSortedSet.Builder<SourceWithFlags> builder = ImmutableSortedSet.naturalOrder();
+    for (SourcePath p : it) {
+      builder.add(
+          SourceWithFlags.builder().setSourcePath(p).build()
+      );
+    }
+    return builder.build();
+  }
+
+  private static BuildRule nativeBinCompilation(
+      BuildRuleResolver resolver,
+      ImmutableList<SourcePath> srcs,
+      CxxBinaryDescription cxxBinaryDescription,
+      BuildRuleParams params,
+      BuildTarget buildTarget,
+      String step,
+      ImmutableSortedSet<BuildRule> deps,
+      Flags flags) throws NoSuchBuildTargetException {
+    CxxBinaryDescription.Arg args = new CxxBinaryDescription.Arg();
+    args.linkStyle = Optional.empty();
+
+    args.srcs = prepareGeneratedSources(srcs);
+
+    args.langCompilerFlags = ImmutableMap.of(
+        CxxSource.Type.C,
+        FluentIterable.from(flags.cflags).toList(),
+        CxxSource.Type.CXX,
+        FluentIterable.from(flags.cxxflags).toList()
+    );
+
+    args.linkerFlags = FluentIterable.from(flags.ldflags).toList();
+
+    BuildRuleParams binParams = params.copyWithBuildTarget(
+        buildTarget.withFlavors(ImmutableFlavor.of(step)))
+        .appendExtraDeps(deps);
+
+    CxxLinkAndCompileRules cxxLinkAndCompileRules =
+        CxxDescriptionEnhancer.createBuildRulesForCxxBinaryDescriptionArg(
+            binParams,
+            resolver,
+            cxxBinaryDescription.getCxxBuckConfig(),
+            cxxBinaryDescription.getDefaultCxxPlatform(),
+            args,
+            Optional.empty(),
+            Optional.empty()
+        );
+
+    SourcePathRuleFinder ruleFinder = new SourcePathRuleFinder(resolver);
+    ImmutableCollection<BuildRule> executableDeps = cxxLinkAndCompileRules.executable.getDeps(ruleFinder);
+    CxxBinary cxxBinary = new CxxBinary(
+        binParams.appendExtraDeps(executableDeps),
+        resolver,
+        ruleFinder,
+        cxxLinkAndCompileRules.getBinaryRule(),
+        cxxLinkAndCompileRules.executable,
+        args.frameworks,
+        args.tests,
+        binParams.getBuildTarget().withoutFlavors(cxxBinaryDescription.getCxxPlatforms().getFlavors()));
+    return cxxBinary;
+  }
+
+  public static BuildRule createBuildRule(
+      BuildRuleResolver resolver,
+      BuildRuleParams params,
+      SourcePathResolver pathResolver,
+      Path packageName,
+      ImmutableSet<SourcePath> cgoSrcs,
+      Tool cgo,
+      GoPlatform platform,
+      CxxBinaryDescription cxxBinaryDescription
+  ) throws NoSuchBuildTargetException {
+
+    Path cgoGenDir = BuildTargets.getGenPath(
+        params.getProjectFilesystem(),
+        params.getBuildTarget(),
+        "%s/gen/");
+
+    BuildRuleParams cParams =
+        params
+            .withFlavor(ImmutableFlavor.of("cgo-gen-source"));
+    BuildRule genCSource = new GenCSource(
+        cParams,
+        pathResolver,
+        cgoSrcs,
+        cgo,
+        platform,
+        cgoGenDir);
+    resolver.addToIndex(genCSource);
+
+    ImmutableList.Builder<SourcePath> goBuilder = ImmutableList.builder();
+    ImmutableList.Builder<SourcePath> commonCBuilder = ImmutableList.builder();
+    ImmutableList.Builder<SourcePath> cgoCBuilder = ImmutableList.builder();
+
+    goBuilder.add(generatedSource(
+        resolver,
+        cParams,
+        cgoGenDir.resolve("_cgo_gotypes.go")));
+    goBuilder.add(generatedSource(
+        resolver,
+        cParams,
+        cgoGenDir.resolve("_cgo_import.go")));
+
+    for (SourcePath sp : cgoSrcs) {
+      Path p = pathResolver.getAbsolutePath(sp);
+      // cgo generates 2 files for each Go sources, 1 .cgo1.go and 1 .cgo2.c
+      String[] split = p.toAbsolutePath()
+          .toString()
+          .replace(File.separatorChar, '_')
+          .split(Pattern.quote("."));
+
+      String filename = split[0];
+      goBuilder.add(generatedSource(
+          resolver,
+          cParams,
+          cgoGenDir.resolve(filename + ".cgo1.go")));
+      commonCBuilder.add(generatedSource(
+          resolver,
+          cParams,
+          cgoGenDir.resolve(filename + ".cgo2.c")));
+    }
+    commonCBuilder.add(generatedSource(resolver, cParams, cgoGenDir.resolve("_cgo_export.c")));
+    cgoCBuilder.add(generatedSource(resolver, cParams, cgoGenDir.resolve("_cgo_main.c")));
+
+    ImmutableList<SourcePath> cgoAllCCSrcs = commonCBuilder.build();
+    ImmutableList<SourcePath> cgoCSrcs =
+        FluentIterable.from(cgoAllCCSrcs).append(cgoCBuilder.build()).toList();
+    ImmutableList<SourcePath> generatedGoSrcs = goBuilder.build();
+
+
+    BuildRule cgoBin = nativeBinCompilation(
+        resolver,
+        cgoCSrcs,
+        cxxBinaryDescription,
+        params,
+        params.getBuildTarget(),
+        "cgo-first-step",
+        ImmutableSortedSet.of(genCSource),
+        Flags.firstStep(platform));
+
+    BuildRule cgoImport = new GenGoImport(
+        params
+            .withFlavor(ImmutableFlavor.of("cgo-gen-cgo_import.go"))
+            .appendExtraDeps(cgoBin),
+        pathResolver,
+        cgo,
+        platform,
+        packageName,
+        cgoGenDir);
+
+    BuildRule allBin = nativeBinCompilation(
+        resolver,
+        cgoAllCCSrcs,
+        cxxBinaryDescription,
+        params,
+        params.getBuildTarget(),
+        "cgo-second-step",
+        ImmutableSortedSet.of(cgoImport),
+        Flags.secondStep(platform)
+    );
+
+    BuildRule entryPoint = new CGoCompile(
+        params
+            .appendExtraDeps(allBin),
+        pathResolver,
+        generatedGoSrcs,
+        allBin.getPathToOutput());
+
+    return entryPoint;
+  }
+
+  public ImmutableList<SourcePath> getGeneratedGoSource() {
+    return this.generatedGoSrcs;
+  }
+
+  public Path getOutputBinary() {
+    return this.output;
+  }
+
+  static final class Flags {
+    public ImmutableSet<String> cflags = ImmutableSet.of();
+    public ImmutableSet<String> cxxflags = ImmutableSet.of();
+    public ImmutableSet<String> ldflags = ImmutableSet.of();
+
+    @SuppressWarnings("unused")
+    static Flags firstStep(GoPlatform platform) {
+      Flags flags = new Flags();
+      return flags;
+    }
+
+    static Flags secondStep(GoPlatform platform) {
+      Flags flags = new Flags();
+      switch (platform.getGoOs()) {
+        case "darwin":
+          flags.ldflags = ImmutableSet.of("-r", "-nostdlib");
+          break;
+        default:
+          flags.ldflags = ImmutableSet.of("-r", "-nostdlib", "-no-pie");
+          break;
+      }
+
+      return flags;
+    }
+  }
+
+  private static class GenCSource extends AbstractBuildRule {
+    private SourcePathResolver pathResolver;
+    @AddToRuleKey
+    private final ImmutableSet<SourcePath> cgoSrcs;
+    private final Tool cgo;
+    private final GoPlatform platform;
+    private final Path genDir;
+
+    public GenCSource(
+        BuildRuleParams params,
+        SourcePathResolver pathResolver,
+        ImmutableSet<SourcePath> cgoSrcs,
+        Tool cgo,
+        GoPlatform platform,
+        Path genDir
+    ) {
+      super(params);
+      this.pathResolver = pathResolver;
+      this.cgoSrcs = cgoSrcs;
+      this.cgo = cgo;
+      this.platform = platform;
+      this.genDir = genDir;
+    }
+
+    @Override
+    public ImmutableList<Step> getBuildSteps(
+        BuildContext context, BuildableContext buildableContext) {
+
+      ImmutableList.Builder<Step> steps = ImmutableList.builder();
+      steps.add(new MakeCleanDirectoryStep(getProjectFilesystem(), genDir));
+      steps.add(new CGoCompileStep(
+          getProjectFilesystem().getRootPath(),
+          cgo.getEnvironment(),
+          cgo.getCommandPrefix(this.pathResolver),
+          FluentIterable.from(cgoSrcs).transform(p -> this.pathResolver.getAbsolutePath(p)).toList(),
+          platform,
+          genDir));
+
+      return steps.build();
+    }
+
+    @Nullable
+    @Override
+    public Path getPathToOutput() {
+      return genDir;
+    }
+  }
+
+  private static class GenGoImport extends AbstractBuildRule {
+    private SourcePathResolver pathResolver;
+    private final Tool cgo;
+    private final GoPlatform platform;
+    private final Path packageName;
+    private final Path outputFile;
+
+    public GenGoImport(
+        BuildRuleParams params,
+        SourcePathResolver pathResolver,
+        Tool cgo,
+        GoPlatform platform,
+        Path packageName,
+        Path outputDir
+    ) {
+      super(params);
+      this.pathResolver = pathResolver;
+      this.cgo = cgo;
+      this.platform = platform;
+      this.packageName = packageName;
+
+      this.outputFile = outputDir.resolve("_cgo_import.go");
+    }
+
+    @Override
+    public ImmutableList<Step> getBuildSteps(
+        BuildContext context, BuildableContext buildableContext) {
+
+      ImmutableList<Path> binaries = FluentIterable.from(getDeps())
+          .filter(CxxBinary.class)
+          .transform(CxxBinary::getPathToOutput)
+          .toList();
+
+      if (binaries.size() > 1) {
+        throw new HumanReadableException(
+            "_cgo_import.go can be generated from only one binary, %i binaries found",
+            binaries.size());
+      }
+
+      final Path binary = binaries.get(0);
+      ImmutableList.Builder<Step> steps = ImmutableList.builder();
+      steps.add(new CGoGenerateImportStep(
+          getProjectFilesystem().getRootPath(),
+          cgo.getEnvironment(),
+          cgo.getCommandPrefix(this.pathResolver),
+          platform,
+          packageName,
+          binary,
+          this.outputFile
+      ));
+      return steps.build();
+    }
+
+    @Nullable
+    @Override
+    public Path getPathToOutput() {
+      return this.outputFile;
+    }
+  }
+}

--- a/src/com/facebook/buck/go/CGoCompileStep.java
+++ b/src/com/facebook/buck/go/CGoCompileStep.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.go;
+
+import com.facebook.buck.shell.ShellStep;
+import com.facebook.buck.step.ExecutionContext;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.nio.file.Path;
+
+public class CGoCompileStep extends ShellStep {
+
+  private final ImmutableMap<String, String> environment;
+  private final ImmutableList<String> cgoCommandPrefix;
+  private final ImmutableList<Path> srcs;
+  private final GoPlatform platform;
+  private final Path outputDir;
+
+
+  public CGoCompileStep(
+      Path workingDirectory,
+      ImmutableMap<String, String> environment,
+      ImmutableList<String> cgoCommandPrefix,
+      ImmutableList<Path> srcs,
+      GoPlatform platform,
+      Path outputDir) {
+    super(workingDirectory);
+    this.environment = environment;
+    this.cgoCommandPrefix = cgoCommandPrefix;
+    this.srcs = srcs;
+
+    this.outputDir = outputDir;
+    this.platform = platform;
+  }
+
+  @Override
+  protected ImmutableList<String> getShellCommandInternal(ExecutionContext context) {
+    ImmutableList.Builder<String> commandBuilder = ImmutableList.<String>builder()
+        .addAll(cgoCommandPrefix)
+        .add("-importpath", workingDirectory.toAbsolutePath().toString())
+        .add("-objdir", outputDir.toAbsolutePath().toString());
+    commandBuilder.addAll(FluentIterable.from(srcs).transform(Object::toString));
+
+    return commandBuilder.build();
+  }
+
+  @Override
+  public ImmutableMap<String, String> getEnvironmentVariables(ExecutionContext context) {
+   return ImmutableMap.<String, String>builder()
+        .putAll(environment)
+        .put("GOOS", platform.getGoOs())
+        .put("GOARCH", platform.getGoArch())
+       .build();
+  }
+
+  @Override
+  public String getShortName() {
+    return "cgo compile";
+  }
+}

--- a/src/com/facebook/buck/go/CGoGenerateImportStep.java
+++ b/src/com/facebook/buck/go/CGoGenerateImportStep.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.go;
+
+import com.facebook.buck.shell.ShellStep;
+import com.facebook.buck.step.ExecutionContext;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.nio.file.Path;
+
+public class CGoGenerateImportStep extends ShellStep {
+
+  private final ImmutableMap<String, String> environment;
+  private final ImmutableList<String> cgoCommandPrefix;
+  private final GoPlatform platform;
+  private final Path packageName;
+  private final Path bin;
+  private final Path outputFile;
+
+  public CGoGenerateImportStep(
+      Path workingDirectory,
+      ImmutableMap<String, String> environment,
+      ImmutableList<String> cgoCommandPrefix,
+      GoPlatform platform,
+      Path packageName,
+      Path bin,
+      Path outputFile) {
+    super(workingDirectory);
+    this.environment = environment;
+    this.cgoCommandPrefix = cgoCommandPrefix;
+    this.packageName = packageName;
+    this.bin = bin;
+    this.outputFile = outputFile;
+    this.platform = platform;
+  }
+
+  @Override
+  protected ImmutableList<String> getShellCommandInternal(ExecutionContext context) {
+    ImmutableList.Builder<String> commandBuilder = ImmutableList.<String>builder()
+        .addAll(cgoCommandPrefix)
+        .add("-dynpackage", packageName.toString())
+        .add("-dynimport", bin.toAbsolutePath().toString())
+        .add("-dynout", outputFile.toAbsolutePath().toString());
+    return commandBuilder.build();
+  }
+
+  @Override
+  public ImmutableMap<String, String> getEnvironmentVariables(ExecutionContext context) {
+   return ImmutableMap.<String, String>builder()
+        .putAll(environment)
+        .put("GOOS", platform.getGoOs())
+        .put("GOARCH", platform.getGoArch())
+       .build();
+  }
+
+  @Override
+  public String getShortName() {
+    return "cgo import generator";
+  }
+}

--- a/src/com/facebook/buck/go/GoBinaryDescription.java
+++ b/src/com/facebook/buck/go/GoBinaryDescription.java
@@ -16,6 +16,7 @@
 
 package com.facebook.buck.go;
 
+import com.facebook.buck.cxx.CxxBinaryDescription;
 import com.facebook.buck.cxx.CxxPlatform;
 import com.facebook.buck.cxx.CxxPlatforms;
 import com.facebook.buck.model.BuildTarget;
@@ -45,9 +46,13 @@ public class GoBinaryDescription implements
     Flavored {
 
   private final GoBuckConfig goBuckConfig;
+  private final CxxBinaryDescription cxxBinaryDescription;
 
-  public GoBinaryDescription(GoBuckConfig goBuckConfig) {
+  public GoBinaryDescription(
+      GoBuckConfig goBuckConfig,
+      CxxBinaryDescription cxxBinaryDescription) {
     this.goBuckConfig = goBuckConfig;
+    this.cxxBinaryDescription = cxxBinaryDescription;
   }
 
   @Override
@@ -74,10 +79,12 @@ public class GoBinaryDescription implements
         resolver,
         goBuckConfig,
         args.srcs,
+        args.cgoSrcs,
         args.compilerFlags,
         args.assemblerFlags,
         args.linkerFlags,
-        platform);
+        platform,
+        cxxBinaryDescription);
   }
 
   @Override
@@ -102,6 +109,7 @@ public class GoBinaryDescription implements
   @SuppressFieldNotInitialized
   public static class Arg extends AbstractDescriptionArg {
     public ImmutableSet<SourcePath> srcs;
+    public ImmutableSet<SourcePath> cgoSrcs = ImmutableSet.of();
     public List<String> compilerFlags = ImmutableList.of();
     public List<String> assemblerFlags = ImmutableList.of();
     public List<String> linkerFlags = ImmutableList.of();

--- a/src/com/facebook/buck/go/GoBinaryDescription.java
+++ b/src/com/facebook/buck/go/GoBinaryDescription.java
@@ -83,6 +83,7 @@ public class GoBinaryDescription implements
         args.compilerFlags,
         args.assemblerFlags,
         args.linkerFlags,
+        args.cgoNativeDeps,
         platform,
         cxxBinaryDescription);
   }
@@ -114,5 +115,6 @@ public class GoBinaryDescription implements
     public List<String> assemblerFlags = ImmutableList.of();
     public List<String> linkerFlags = ImmutableList.of();
     public ImmutableSortedSet<BuildTarget> deps = ImmutableSortedSet.of();
+    public ImmutableSortedSet<BuildTarget> cgoNativeDeps = ImmutableSortedSet.of();
   }
 }

--- a/src/com/facebook/buck/go/GoBuckConfig.java
+++ b/src/com/facebook/buck/go/GoBuckConfig.java
@@ -122,6 +122,9 @@ public class GoBuckConfig {
   Tool getAssembler() {
     return getGoTool("assembler", "asm", "asm_flags");
   }
+  Tool getCGo() {
+    return getGoTool("cgo", "cgo", "");
+  }
   Tool getPacker() {
     return getGoTool("packer", "pack", "");
   }

--- a/src/com/facebook/buck/go/GoCompileStep.java
+++ b/src/com/facebook/buck/go/GoCompileStep.java
@@ -92,7 +92,7 @@ public class GoCompileStep extends ShellStep {
     if (!allowExternalReferences) {
       // -complete means the package does not use any non Go code, so external functions
       // (e.g. Cgo, asm) aren't allowed.
-      commandBuilder.add("-complete");
+       commandBuilder.add("-complete");
     }
 
     commandBuilder.addAll(srcs.stream().map(Object::toString).iterator());

--- a/src/com/facebook/buck/go/GoDescriptors.java
+++ b/src/com/facebook/buck/go/GoDescriptors.java
@@ -16,6 +16,7 @@
 
 package com.facebook.buck.go;
 
+import com.facebook.buck.cxx.CxxBinaryDescription;
 import com.facebook.buck.file.WriteFile;
 import com.facebook.buck.graph.AbstractBreadthFirstThrowingTraversal;
 import com.facebook.buck.io.MorePaths;
@@ -31,6 +32,7 @@ import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildTargetSourcePath;
+import com.facebook.buck.rules.NoopBuildRule;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.SourcePathRuleFinder;
@@ -60,11 +62,10 @@ import java.util.Optional;
 
 abstract class GoDescriptors {
 
-  private static final Logger LOG = Logger.get(GoDescriptors.class);
-
-  private static final String TEST_MAIN_GEN_PATH = "com/facebook/buck/go/testmaingen.go";
   public static final Flavor TRANSITIVE_LINKABLES_FLAVOR =
       ImmutableFlavor.of("transitive-linkables");
+  private static final Logger LOG = Logger.get(GoDescriptors.class);
+  private static final String TEST_MAIN_GEN_PATH = "com/facebook/buck/go/testmaingen.go";
 
   @SuppressWarnings("unchecked")
   public static ImmutableSet<GoLinkable> requireTransitiveGoLinkables(
@@ -102,10 +103,12 @@ abstract class GoDescriptors {
       GoBuckConfig goBuckConfig,
       Path packageName,
       ImmutableSet<SourcePath> srcs,
+      ImmutableSet<SourcePath> cgoSrcs,
       List<String> compilerFlags,
       List<String> assemblerFlags,
       GoPlatform platform,
-      Iterable<BuildTarget> deps)
+      Iterable<BuildTarget> deps,
+      CxxBinaryDescription cxxBinaryDescription)
       throws NoSuchBuildTargetException {
     SourcePathRuleFinder ruleFinder = new SourcePathRuleFinder(resolver);
     SourcePathResolver pathResolver = new SourcePathResolver(ruleFinder);
@@ -123,7 +126,6 @@ abstract class GoDescriptors {
     for (GoLinkable linkable : linkables) {
       linkableDepsBuilder.addAll(linkable.getDeps(ruleFinder));
     }
-    ImmutableList<BuildRule> linkableDeps = linkableDepsBuilder.build();
 
     BuildTarget target = createSymlinkTreeTarget(params.getBuildTarget());
     SymlinkTree symlinkTree = makeSymlinkTree(
@@ -133,6 +135,29 @@ abstract class GoDescriptors {
         linkables);
     resolver.addToIndex(symlinkTree);
 
+    ImmutableList<BuildRule> linkableDeps = linkableDepsBuilder.build();
+
+    BuildRule cgoRule;
+    BuildRuleParams cgoParams = params.copyWithBuildTarget(
+        BuildTarget.builder(params.getBuildTarget())
+            .addFlavors(ImmutableFlavor.of("cgo"), platform.getFlavor())
+            .build());
+    if (!cgoSrcs.isEmpty()) {
+      cgoRule = CGoCompile.createBuildRule(
+          resolver,
+          cgoParams,
+          pathResolver,
+          packageName,
+          cgoSrcs,
+          goBuckConfig.getCGo(),
+          platform,
+          cxxBinaryDescription
+      );
+    } else {
+      cgoRule = new NoopBuildRule(cgoParams, pathResolver);
+    }
+    resolver.addToIndex(cgoRule);
+
     LOG.verbose(
         "Symlink tree for compiling %s: %s",
         params.getBuildTarget(), symlinkTree.getLinks());
@@ -140,18 +165,20 @@ abstract class GoDescriptors {
     return new GoCompile(
         params
             .appendExtraDeps(linkableDeps)
-            .appendExtraDeps(ImmutableList.of(symlinkTree)),
+            .appendExtraDeps(ImmutableList.of(symlinkTree))
+            .appendExtraDeps(cgoRule),
         symlinkTree,
         packageName,
-        getPackageImportMap(goBuckConfig.getVendorPaths(),
+        getPackageImportMap(
+            goBuckConfig.getVendorPaths(),
             params.getBuildTarget().getBasePath(),
             FluentIterable.from(linkables).transformAndConcat(
-              new Function<GoLinkable, ImmutableSet<Path>>() {
-                @Override
-                public ImmutableSet<Path> apply(GoLinkable input) {
-                  return input.getGoLinkInput().keySet();
-                }
-              })),
+                new Function<GoLinkable, ImmutableSet<Path>>() {
+                  @Override
+                  public ImmutableSet<Path> apply(GoLinkable input) {
+                    return input.getGoLinkInput().keySet();
+                  }
+                })),
         ImmutableSet.copyOf(srcs),
         ImmutableList.copyOf(compilerFlags),
         goBuckConfig.getCompiler(),
@@ -177,7 +204,7 @@ abstract class GoDescriptors {
       vendorPathsBuilder.add(prefix.resolve("vendor"));
     }
 
-    for (Path vendorPrefix: vendorPathsBuilder.build()) {
+    for (Path vendorPrefix : vendorPathsBuilder.build()) {
       for (Path vendoredPackage : packageNames.tailSet(vendorPrefix)) {
         if (!vendoredPackage.startsWith(vendorPrefix)) {
           break;
@@ -195,28 +222,35 @@ abstract class GoDescriptors {
       final BuildRuleResolver resolver,
       GoBuckConfig goBuckConfig,
       ImmutableSet<SourcePath> srcs,
+      ImmutableSet<SourcePath> cgoSrcs,
       List<String> compilerFlags,
       List<String> assemblerFlags,
       List<String> linkerFlags,
-      GoPlatform platform) throws NoSuchBuildTargetException {
+      GoPlatform platform,
+      CxxBinaryDescription cxxBinaryDescription
+  ) throws NoSuchBuildTargetException {
     BuildTarget libraryTarget =
         params.getBuildTarget().withAppendedFlavors(
             ImmutableFlavor.of("compile"), platform.getFlavor());
-    GoCompile library = GoDescriptors.createGoCompileRule(
+
+    SourcePathRuleFinder ruleFinder = new SourcePathRuleFinder(resolver);
+    SourcePathResolver pathResolver = new SourcePathResolver(ruleFinder);
+
+    GoCompile library = createGoCompileRule(
         params.copyWithBuildTarget(libraryTarget),
         resolver,
         goBuckConfig,
         Paths.get("main"),
         srcs,
+        cgoSrcs,
         compilerFlags,
         assemblerFlags,
         platform,
         FluentIterable.from(params.getDeclaredDeps().get())
-            .transform(HasBuildTarget::getBuildTarget));
+            .transform(HasBuildTarget::getBuildTarget),
+        cxxBinaryDescription);
     resolver.addToIndex(library);
 
-    SourcePathRuleFinder ruleFinder = new SourcePathRuleFinder(resolver);
-    SourcePathResolver pathResolver = new SourcePathResolver(ruleFinder);
     BuildTarget target = createTransitiveSymlinkTreeTarget(params.getBuildTarget());
     SymlinkTree symlinkTree = makeSymlinkTree(
         params.copyWithBuildTarget(target),
@@ -298,10 +332,14 @@ abstract class GoDescriptors {
                 resolver,
                 goBuckConfig,
                 ImmutableSet.of(new BuildTargetSourcePath(generatorSourceTarget)),
+                //XXX cgo
+                ImmutableSet.of(),
                 ImmutableList.of(),
                 ImmutableList.of(),
                 ImmutableList.of(),
-                goBuckConfig.getDefaultPlatform()));
+                goBuckConfig.getDefaultPlatform(),
+                null)
+        );
     return binary.getExecutableCommand();
   }
 

--- a/src/com/facebook/buck/go/GoLibraryDescription.java
+++ b/src/com/facebook/buck/go/GoLibraryDescription.java
@@ -16,6 +16,7 @@
 
 package com.facebook.buck.go;
 
+import com.facebook.buck.cxx.CxxBinaryDescription;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.Flavor;
 import com.facebook.buck.model.Flavored;
@@ -54,9 +55,13 @@ public class GoLibraryDescription implements
     MetadataProvidingDescription<GoLibraryDescription.Arg> {
 
   private final GoBuckConfig goBuckConfig;
+  private final CxxBinaryDescription cxxBinaryDescription;
 
-  public GoLibraryDescription(GoBuckConfig goBuckConfig) {
+  public GoLibraryDescription(
+      GoBuckConfig goBuckConfig,
+      CxxBinaryDescription cxxBinaryDescription) {
     this.goBuckConfig = goBuckConfig;
+    this.cxxBinaryDescription = cxxBinaryDescription;
   }
 
   @Override
@@ -127,12 +132,14 @@ public class GoLibraryDescription implements
           args.packageName.map(Paths::get)
               .orElse(goBuckConfig.getDefaultPackageName(params.getBuildTarget())),
           args.srcs,
+          args.cgoSrcs,
           args.compilerFlags,
           args.assemblerFlags,
           platform.get(),
           FluentIterable.from(params.getDeclaredDeps().get())
               .transform(HasBuildTarget::getBuildTarget)
-              .append(args.exportedDeps));
+              .append(args.exportedDeps),
+          cxxBinaryDescription);
     }
 
     return new NoopBuildRule(params, new SourcePathResolver(new SourcePathRuleFinder(resolver)));
@@ -141,6 +148,7 @@ public class GoLibraryDescription implements
   @SuppressFieldNotInitialized
   public static class Arg extends AbstractDescriptionArg implements HasTests {
     public ImmutableSortedSet<SourcePath> srcs = ImmutableSortedSet.of();
+    public ImmutableSortedSet<SourcePath> cgoSrcs = ImmutableSortedSet.of();
     public List<String> compilerFlags = ImmutableList.of();
     public List<String> assemblerFlags = ImmutableList.of();
     public Optional<String> packageName;

--- a/src/com/facebook/buck/go/GoLibraryDescription.java
+++ b/src/com/facebook/buck/go/GoLibraryDescription.java
@@ -139,6 +139,7 @@ public class GoLibraryDescription implements
           FluentIterable.from(params.getDeclaredDeps().get())
               .transform(HasBuildTarget::getBuildTarget)
               .append(args.exportedDeps),
+          args.cgoNativeDeps,
           cxxBinaryDescription);
     }
 
@@ -154,6 +155,7 @@ public class GoLibraryDescription implements
     public Optional<String> packageName;
     public ImmutableSortedSet<BuildTarget> deps = ImmutableSortedSet.of();
     public ImmutableSortedSet<BuildTarget> exportedDeps = ImmutableSortedSet.of();
+    public ImmutableSortedSet<BuildTarget> cgoNativeDeps = ImmutableSortedSet.of();
 
     @Hint(isDep = false) public ImmutableSortedSet<BuildTarget> tests = ImmutableSortedSet.of();
 

--- a/src/com/facebook/buck/go/GoTestDescription.java
+++ b/src/com/facebook/buck/go/GoTestDescription.java
@@ -16,6 +16,7 @@
 
 package com.facebook.buck.go;
 
+import com.facebook.buck.cxx.CxxBinaryDescription;
 import com.facebook.buck.cxx.CxxPlatform;
 import com.facebook.buck.cxx.CxxPlatforms;
 import com.facebook.buck.model.BuildTarget;
@@ -64,12 +65,15 @@ public class GoTestDescription implements
 
   private final GoBuckConfig goBuckConfig;
   private final Optional<Long> defaultTestRuleTimeoutMs;
+  private final CxxBinaryDescription cxxBinaryDescription;
 
   public GoTestDescription(
       GoBuckConfig goBuckConfig,
-      Optional<Long> defaultTestRuleTimeoutMs) {
+      Optional<Long> defaultTestRuleTimeoutMs,
+      CxxBinaryDescription cxxBinaryDescription) {
     this.goBuckConfig = goBuckConfig;
     this.defaultTestRuleTimeoutMs = defaultTestRuleTimeoutMs;
+    this.cxxBinaryDescription = cxxBinaryDescription;
   }
 
   @Override
@@ -216,10 +220,13 @@ public class GoTestDescription implements
         resolver,
         goBuckConfig,
         ImmutableSet.of(new BuildTargetSourcePath(generatedTestMain.getBuildTarget())),
+        args.cgoSrcs,
         args.compilerFlags,
         args.assemblerFlags,
         args.linkerFlags,
-        platform);
+        platform,
+        cxxBinaryDescription
+        );
     resolver.addToIndex(testMain);
     return testMain;
   }
@@ -296,6 +303,8 @@ public class GoTestDescription implements
               .addAll(libraryArg.srcs)
               .addAll(args.srcs)
               .build(),
+          // XXX cgo
+          ImmutableSet.of(),
           ImmutableList.<String>builder()
               .addAll(libraryArg.compilerFlags)
               .addAll(args.compilerFlags)
@@ -306,7 +315,8 @@ public class GoTestDescription implements
               .build(),
           platform,
           FluentIterable.from(params.getDeclaredDeps().get())
-              .transform(HasBuildTarget::getBuildTarget));
+              .transform(HasBuildTarget::getBuildTarget),
+          cxxBinaryDescription);
     } else {
       testLibrary = GoDescriptors.createGoCompileRule(
           params,
@@ -314,11 +324,13 @@ public class GoTestDescription implements
           goBuckConfig,
           packageName,
           args.srcs,
+          args.cgoSrcs,
           args.compilerFlags,
           args.assemblerFlags,
           platform,
           FluentIterable.from(params.getDeclaredDeps().get())
-              .transform(HasBuildTarget::getBuildTarget));
+              .transform(HasBuildTarget::getBuildTarget),
+          cxxBinaryDescription);
     }
 
     return testLibrary;
@@ -347,6 +359,7 @@ public class GoTestDescription implements
   @SuppressFieldNotInitialized
   public static class Arg extends AbstractDescriptionArg {
     public ImmutableSet<SourcePath> srcs;
+    public ImmutableSet<SourcePath> cgoSrcs = ImmutableSet.of();
     public Optional<BuildTarget> library;
     public Optional<String> packageName;
     public List<String> compilerFlags = ImmutableList.of();

--- a/src/com/facebook/buck/go/GoTestDescription.java
+++ b/src/com/facebook/buck/go/GoTestDescription.java
@@ -224,6 +224,7 @@ public class GoTestDescription implements
         args.compilerFlags,
         args.assemblerFlags,
         args.linkerFlags,
+        args.cgoNativeDeps,
         platform,
         cxxBinaryDescription
         );
@@ -316,6 +317,7 @@ public class GoTestDescription implements
           platform,
           FluentIterable.from(params.getDeclaredDeps().get())
               .transform(HasBuildTarget::getBuildTarget),
+          args.cgoNativeDeps,
           cxxBinaryDescription);
     } else {
       testLibrary = GoDescriptors.createGoCompileRule(
@@ -330,6 +332,7 @@ public class GoTestDescription implements
           platform,
           FluentIterable.from(params.getDeclaredDeps().get())
               .transform(HasBuildTarget::getBuildTarget),
+          args.cgoNativeDeps,
           cxxBinaryDescription);
     }
 
@@ -366,6 +369,7 @@ public class GoTestDescription implements
     public List<String> assemblerFlags = ImmutableList.of();
     public List<String> linkerFlags = ImmutableList.of();
     public ImmutableSortedSet<BuildTarget> deps = ImmutableSortedSet.of();
+    public ImmutableSortedSet<BuildTarget> cgoNativeDeps = ImmutableSortedSet.of();
     public ImmutableSet<String> contacts = ImmutableSet.of();
     public Optional<Long> testRuleTimeoutMs;
     public Optional<Boolean> runTestSeparately;

--- a/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
+++ b/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
@@ -699,13 +699,20 @@ public class KnownBuildRuleTypes {
     builder.register(new ExportFileDescription());
     builder.register(new GenruleDescription());
     builder.register(new GenAidlDescription());
-    builder.register(new GoBinaryDescription(goBuckConfig));
-    builder.register(new GoLibraryDescription(goBuckConfig));
+    builder.register(new GoBinaryDescription(
+        goBuckConfig,
+        cxxBinaryDescription));
+    builder.register(new GoLibraryDescription(
+        goBuckConfig,
+        cxxBinaryDescription));
     builder.register(
         new GoTestDescription(
             goBuckConfig,
-            defaultTestRuleTimeoutMs));
-    builder.register(new GraphqlLibraryDescription());
+            defaultTestRuleTimeoutMs,
+            cxxBinaryDescription));
+
+    builder.register(new GraphQlLibraryDescription());
+
     GroovyBuckConfig groovyBuckConfig = new GroovyBuckConfig(config);
     builder.register(
         new GroovyLibraryDescription(


### PR DESCRIPTION
This is a work in progress to add CGo support in Buck based on @mikekap work.

There are still a couple of issue to fix:

* On Mac OS X this does not totally works:
 * ~-fno-pie does not exist and I did not yet find a standard way to check C/CXX compiler flags availability~ -> I've a switch-case on the platform;
 * The scrub on Mac OS X does not like, at all, the generated binary
* Unit tests

But before going further I'd like a feedback on how I've been doing.
First, about cgo
* cgo sources *need* to be handled specifically by the cgo tool, the cgo tool acts a bit like a preprocessor
* Thus upon cgo tool execution a couple of file are generated:
 * some C files from which at first we generate 1 binary and from it, we generate a go file
 * Then again, we regenerate a binary that will be linked by go during the last stage
* All the generated Go sources and "regular" Go sources are to be compiled together and then linked.

First I've implemented a simple Cgo support with only Go sources. It allows one to have C source in Go source.
The second step was to allow Cgo extension to be linked against a native library and let all the transitivity rules kicking in (esp. w.r.t the include paths).
The main caevat of using buck for Cgo sources is that we _can't_ depends on the {c/l}flags in the sources because we don't use `go build`

The approach taken minimally changed the existing code.

