### PR TITLE
Add optimisation option to apple_asset_catalog

### DIFF
--- a/src/com/facebook/buck/apple/ActoolStep.java
+++ b/src/com/facebook/buck/apple/ActoolStep.java
@@ -37,6 +37,7 @@ class ActoolStep extends ShellStep {
   private final Path outputPlist;
   private final Optional<String> appIcon;
   private final Optional<String> launchImage;
+  private final AppleAssetCatalogDescription.Optimization optimization;
 
   public ActoolStep(
       Path workingDirectory,
@@ -47,7 +48,8 @@ class ActoolStep extends ShellStep {
       Path output,
       Path outputPlist,
       Optional<String> appIcon,
-      Optional<String> launchImage) {
+      Optional<String> launchImage,
+      AppleAssetCatalogDescription.Optimization optimization) {
     super(workingDirectory);
     this.applePlatformName = applePlatformName;
     this.environment = environment;
@@ -57,6 +59,7 @@ class ActoolStep extends ShellStep {
     this.outputPlist = outputPlist;
     this.appIcon = appIcon;
     this.launchImage = launchImage;
+    this.optimization = optimization;
   }
 
   @Override
@@ -98,6 +101,7 @@ class ActoolStep extends ShellStep {
       commandBuilder.add("--launch-image", launchImage.get());
     }
 
+    commandBuilder.add("--optimization", optimization.toArgument());
     commandBuilder.addAll(Iterables.transform(assetCatalogDirs, Object::toString));
 
     return commandBuilder.build();

--- a/src/com/facebook/buck/apple/AppleAssetCatalog.java
+++ b/src/com/facebook/buck/apple/AppleAssetCatalog.java
@@ -68,6 +68,9 @@ public class AppleAssetCatalog extends AbstractBuildRule {
   @AddToRuleKey
   private final Optional<String> launchImage;
 
+  @AddToRuleKey
+  private final AppleAssetCatalogDescription.Optimization optimization;
+
   AppleAssetCatalog(
       BuildRuleParams params,
       final SourcePathResolver resolver,
@@ -76,6 +79,7 @@ public class AppleAssetCatalog extends AbstractBuildRule {
       SortedSet<SourcePath> assetCatalogDirs,
       Optional<String> appIcon,
       Optional<String> launchImage,
+      AppleAssetCatalogDescription.Optimization optimization,
       String bundleName) {
     super(params, resolver);
     Preconditions.checkArgument(
@@ -95,6 +99,7 @@ public class AppleAssetCatalog extends AbstractBuildRule {
         "%s-output.plist");
     this.appIcon = appIcon;
     this.launchImage = launchImage;
+    this.optimization = optimization;
   }
 
   @Override
@@ -119,7 +124,8 @@ public class AppleAssetCatalog extends AbstractBuildRule {
             getProjectFilesystem().resolve(outputDir),
             getProjectFilesystem().resolve(outputPlist),
             appIcon,
-            launchImage));
+            launchImage,
+            optimization));
 
     buildableContext.recordArtifact(getOutputDir());
     buildableContext.recordArtifact(outputPlist);

--- a/src/com/facebook/buck/apple/AppleAssetCatalogDescription.java
+++ b/src/com/facebook/buck/apple/AppleAssetCatalogDescription.java
@@ -56,10 +56,27 @@ public class AppleAssetCatalogDescription implements Description<AppleAssetCatal
     return new NoopBuildRule(params, new SourcePathResolver(resolver));
   }
 
+  public enum Optimization {
+    SPACE("space"),
+    TIME("time"),
+    ;
+
+    private final String argument;
+
+    Optimization(String argument) {
+      this.argument = argument;
+    }
+
+    public String toArgument() {
+      return argument;
+    }
+  }
+
   @SuppressFieldNotInitialized
   public static class Arg extends AbstractDescriptionArg {
     public SortedSet<SourcePath> dirs;
     public Optional<String> appIcon;
     public Optional<String> launchImage;
+    public Optimization optimization = Optimization.SPACE;
   }
 }

--- a/src/com/facebook/buck/apple/AppleDescriptions.java
+++ b/src/com/facebook/buck/apple/AppleDescriptions.java
@@ -331,6 +331,9 @@ public class AppleDescriptions {
     Optional<String> appIcon = Optional.empty();
     Optional<String> launchImage = Optional.empty();
 
+    AppleAssetCatalogDescription.Arg firstConstructor = assetCatalogArgs.iterator().next();
+    AppleAssetCatalogDescription.Optimization optimization = firstConstructor.optimization;
+
     for (AppleAssetCatalogDescription.Arg arg : assetCatalogArgs) {
       assetCatalogDirsBuilder.addAll(arg.dirs);
       if (arg.appIcon.isPresent()) {
@@ -349,6 +352,11 @@ public class AppleDescriptions {
         }
 
         launchImage = arg.launchImage;
+      }
+
+      if (arg.optimization != optimization) {
+        throw new HumanReadableException("At most one asset catalog optimisation style can be " +
+            "specified in the dependencies %s", params.getBuildTarget());
       }
     }
 
@@ -373,6 +381,7 @@ public class AppleDescriptions {
             assetCatalogDirs,
             appIcon,
             launchImage,
+            optimization,
             MERGED_ASSET_CATALOG_NAME));
   }
 

--- a/src/com/facebook/buck/apple/AppleDescriptions.java
+++ b/src/com/facebook/buck/apple/AppleDescriptions.java
@@ -331,10 +331,13 @@ public class AppleDescriptions {
     Optional<String> appIcon = Optional.empty();
     Optional<String> launchImage = Optional.empty();
 
-    AppleAssetCatalogDescription.Arg firstConstructor = assetCatalogArgs.iterator().next();
-    AppleAssetCatalogDescription.Optimization optimization = firstConstructor.optimization;
+    AppleAssetCatalogDescription.Optimization optimization = null;
 
     for (AppleAssetCatalogDescription.Arg arg : assetCatalogArgs) {
+      if (optimization == null) {
+        optimization = arg.optimization;
+      }
+
       assetCatalogDirsBuilder.addAll(arg.dirs);
       if (arg.appIcon.isPresent()) {
         if (appIcon.isPresent()) {


### PR DESCRIPTION
Fixes #998. Syntax:

```
apple_asset_catalog(
  name = 'AssetCatalog',
  dirs = [ 'Resources/Images.xcassets' ],
  optimization = 'space',
)
```