### PR TITLE
Move Frameworksdependency from apple to cxx

### DIFF
--- a/src/com/facebook/buck/apple/AppleBinaryDescription.java
+++ b/src/com/facebook/buck/apple/AppleBinaryDescription.java
@@ -22,6 +22,7 @@ import com.facebook.buck.cxx.CxxBinaryDescription;
 import com.facebook.buck.cxx.CxxCompilationDatabase;
 import com.facebook.buck.cxx.CxxPlatform;
 import com.facebook.buck.cxx.CxxStrip;
+import com.facebook.buck.cxx.FrameworkDependencies;
 import com.facebook.buck.cxx.ProvidesLinkedBinaryDeps;
 import com.facebook.buck.cxx.StripStyle;
 import com.facebook.buck.file.WriteFile;

--- a/src/com/facebook/buck/apple/AppleDescriptions.java
+++ b/src/com/facebook/buck/apple/AppleDescriptions.java
@@ -25,6 +25,7 @@ import com.facebook.buck.cxx.CxxDescriptionEnhancer;
 import com.facebook.buck.cxx.CxxLibraryDescription;
 import com.facebook.buck.cxx.CxxPlatform;
 import com.facebook.buck.cxx.CxxStrip;
+import com.facebook.buck.cxx.FrameworkDependencies;
 import com.facebook.buck.cxx.ProvidesLinkedBinaryDeps;
 import com.facebook.buck.cxx.StripStyle;
 import com.facebook.buck.io.MorePaths;

--- a/src/com/facebook/buck/apple/AppleLibraryDescription.java
+++ b/src/com/facebook/buck/apple/AppleLibraryDescription.java
@@ -23,6 +23,7 @@ import com.facebook.buck.cxx.CxxDescriptionEnhancer;
 import com.facebook.buck.cxx.CxxLibraryDescription;
 import com.facebook.buck.cxx.CxxPlatform;
 import com.facebook.buck.cxx.CxxStrip;
+import com.facebook.buck.cxx.FrameworkDependencies;
 import com.facebook.buck.cxx.Linker;
 import com.facebook.buck.cxx.ProvidesLinkedBinaryDeps;
 import com.facebook.buck.cxx.StripStyle;

--- a/src/com/facebook/buck/apple/PrebuiltAppleFrameworkDescription.java
+++ b/src/com/facebook/buck/apple/PrebuiltAppleFrameworkDescription.java
@@ -16,6 +16,7 @@
 package com.facebook.buck.apple;
 
 import com.facebook.buck.cxx.CxxFlags;
+import com.facebook.buck.cxx.FrameworkDependencies;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.parser.NoSuchBuildTargetException;
 import com.facebook.buck.rules.AbstractDescriptionArg;

--- a/src/com/facebook/buck/cxx/AbstractFrameworkDependencies.java
+++ b/src/com/facebook/buck/cxx/AbstractFrameworkDependencies.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.facebook.buck.apple;
+package com.facebook.buck.cxx;
 
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.util.immutables.BuckStyleImmutable;


### PR DESCRIPTION
Although darwin style frameworks are an apple concept, they are
used by the linker and compiler at a cxx level. This will allow
classes like Cxx description enhancer to know about framworks
without a cyclic dependency on apple things.