### PR TITLE
Swift compiler flags

### DIFF
--- a/src/com/facebook/buck/apple/AppleNativeTargetDescriptionArg.java
+++ b/src/com/facebook/buck/apple/AppleNativeTargetDescriptionArg.java
@@ -18,6 +18,7 @@ package com.facebook.buck.apple;
 
 import com.facebook.buck.cxx.CxxLibraryDescription;
 import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.swift.HasSwiftCompilerFlags;
 import com.facebook.infer.annotation.SuppressFieldNotInitialized;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -29,8 +30,15 @@ import java.util.Optional;
  * Arguments common to Apple targets.
  */
 @SuppressFieldNotInitialized
-public class AppleNativeTargetDescriptionArg extends CxxLibraryDescription.Arg {
+public class AppleNativeTargetDescriptionArg extends CxxLibraryDescription.Arg
+  implements HasSwiftCompilerFlags {
   public ImmutableSortedMap<String, ImmutableMap<String, String>> configs = ImmutableSortedMap.of();
   public ImmutableList<SourcePath> extraXcodeSources = ImmutableList.of();
   public Optional<String> headerPathPrefix;
+  public ImmutableList<String> swiftCompilerFlags = ImmutableList.of();
+
+  @Override
+  public ImmutableList<String> getSwiftCompilerFlags() {
+    return swiftCompilerFlags;
+  }
 }

--- a/src/com/facebook/buck/swift/HasSwiftCompilerFlags.java
+++ b/src/com/facebook/buck/swift/HasSwiftCompilerFlags.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.swift;
+
+import com.google.common.collect.ImmutableList;
+
+public interface HasSwiftCompilerFlags {
+  ImmutableList<String> getSwiftCompilerFlags();
+}

--- a/src/com/facebook/buck/swift/SwiftBuckConfig.java
+++ b/src/com/facebook/buck/swift/SwiftBuckConfig.java
@@ -26,7 +26,7 @@ import java.util.Optional;
  */
 public class SwiftBuckConfig {
   private static final String SECTION_NAME = "swift";
-  private static final String COMPILE_FLAGS_NAME = "compile_flags";
+  private static final String COMPILER_FLAGS_NAME = "compiler_flags";
 
   private final BuckConfig delegate;
 
@@ -35,7 +35,7 @@ public class SwiftBuckConfig {
   }
 
   public Optional<Iterable<String>> getFlags() {
-    Optional<String> value = delegate.getValue(SECTION_NAME, COMPILE_FLAGS_NAME);
+    Optional<String> value = delegate.getValue(SECTION_NAME, COMPILER_FLAGS_NAME);
     return value.map(input -> Splitter.on(" ").split(input.trim()));
   }
 

--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -82,6 +82,9 @@ class SwiftCompile
   @AddToRuleKey
   private final ImmutableSortedSet<SourcePath> srcs;
 
+  @AddToRuleKey
+  private final ImmutableList<String> compilerFlags;
+
   private final Path headerPath;
   private final CxxPlatform cxxPlatform;
   private final ImmutableSet<FrameworkPath> frameworks;
@@ -103,6 +106,7 @@ class SwiftCompile
       String moduleName,
       Path outputPath,
       Iterable<SourcePath> srcs,
+      ImmutableList<String> compilerFlags,
       Optional<Boolean> enableObjcInterop,
       Optional<SourcePath> bridgingHeader) throws NoSuchBuildTargetException {
     super(params, resolver);
@@ -121,6 +125,7 @@ class SwiftCompile
     this.objectPath = outputPath.resolve(escapedModuleName + ".o");
 
     this.srcs = ImmutableSortedSet.copyOf(srcs);
+    this.compilerFlags = compilerFlags;
     this.enableObjcInterop = enableObjcInterop.orElse(true);
     this.bridgingHeader = bridgingHeader;
     this.hasMainEntry = FluentIterable.from(srcs).firstMatch(
@@ -186,6 +191,7 @@ class SwiftCompile
         objectPath.toString(),
         "-emit-objc-header-path",
         headerPath.toString());
+    compilerCommand.addAll(compilerFlags);
     for (SourcePath sourcePath : srcs) {
       compilerCommand.add(getResolver().getRelativePath(sourcePath).toString());
     }

--- a/src/com/facebook/buck/swift/SwiftDescriptions.java
+++ b/src/com/facebook/buck/swift/SwiftDescriptions.java
@@ -57,7 +57,11 @@ class SwiftDescriptions {
       BuildTarget buildTarget) {
 
     output.srcs = filterSwiftSources(sourcePathResolver, args.srcs);
-    output.compilerFlags = args.compilerFlags;
+    if (args instanceof HasSwiftCompilerFlags) {
+      output.compilerFlags = ((HasSwiftCompilerFlags) args).getSwiftCompilerFlags();
+    } else {
+      output.compilerFlags = args.compilerFlags;
+    }
     output.frameworks = args.frameworks;
     output.libraries = args.libraries;
     output.deps = args.deps;

--- a/src/com/facebook/buck/swift/SwiftLibraryDescription.java
+++ b/src/com/facebook/buck/swift/SwiftLibraryDescription.java
@@ -238,6 +238,7 @@ public class SwiftLibraryDescription implements
               params.getProjectFilesystem(),
               buildTarget, "%s"),
           args.srcs,
+          args.compilerFlags,
           args.enableObjcInterop,
           args.bridgingHeader);
     }

--- a/test/com/facebook/buck/swift/SwiftBuckConfigTest.java
+++ b/test/com/facebook/buck/swift/SwiftBuckConfigTest.java
@@ -36,7 +36,7 @@ public class SwiftBuckConfigTest {
         FakeBuckConfig.builder().setSections(
             ImmutableMap.of(
                 "swift",
-                ImmutableMap.of("compile_flags", "-g")))
+                ImmutableMap.of("compiler_flags", "-g")))
             .build());
     assertThat(swiftBuckConfig.getFlags(), not(equalTo(Optional.empty())));
     assertThat(swiftBuckConfig.getFlags().get(), contains("-g"));


### PR DESCRIPTION
- Adds swift_compiler_flags to apple_library, which are used as compile
  flags for companion swift target.
- Appends compiler_flags of swift_library to compiler command in
  SwiftCompile.
- Fixes typo in global swift config: compile_flags -> compiler_flags.