### PR TITLE
Fix various minor IntelliJ project file formatting issues.

### DIFF
--- a/src/com/facebook/buck/jvm/java/intellij/IjProjectTemplateDataPreparer.java
+++ b/src/com/facebook/buck/jvm/java/intellij/IjProjectTemplateDataPreparer.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Ordering;
 
 import org.immutables.value.Value;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
@@ -348,7 +349,12 @@ public class IjProjectTemplateDataPreparer {
         return 0;
       }
 
-      return getFilePath().compareTo(o.getFilePath());
+      return getFilePath()
+          .toString()
+          .replace(File.separatorChar, ' ')
+          .compareTo(o.getFilePath()
+              .toString()
+              .replace(File.separatorChar, ' '));
     }
   }
 

--- a/src/com/facebook/buck/jvm/java/intellij/ij-library.st
+++ b/src/com/facebook/buck/jvm/java/intellij/ij-library.st
@@ -14,11 +14,15 @@
     <JAVADOC>
       <root url="%javadocUrl%" />
     </JAVADOC>
+%else%
+    <JAVADOC />
 %endif%
 %if(sourceJar)%
     <SOURCES>
       <root url="jar://$PROJECT_DIR$/%sourceJar%!/" />
     </SOURCES>
+%else%
+    <SOURCES />
 %endif%
   </library>
 </component>

--- a/src/com/facebook/buck/jvm/java/intellij/ij-module-index.st
+++ b/src/com/facebook/buck/jvm/java/intellij/ij-module-index.st
@@ -3,9 +3,8 @@
   <component name="ProjectModuleManager">
     <modules>
 %modules:{module |
-      <module fileurl="%module.fileUrl%" filepath="$PROJECT_DIR$/%module.filePath%" %\\%
-        %if (module.group)% group="%module.group%" %endif% />
-}%
-   </modules>
+      <module fileurl="%module.fileUrl%" filepath="$PROJECT_DIR$/%module.filePath%"%\\%
+        %if (module.group)% group="%module.group%"%endif% />
+}%    </modules>
   </component>
 </project>

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project1/.idea/libraries/library_libs_generated.xml.expected
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project1/.idea/libraries/library_libs_generated.xml.expected
@@ -3,5 +3,7 @@
     <CLASSES>
       <root url="jar://$PROJECT_DIR$/buck-out/gen/libs/generated_jar/generated.jar!/" />
     </CLASSES>
+    <JAVADOC />
+    <SOURCES />
   </library>
 </component>

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project1/.idea/libraries/library_libs_guava.xml.expected
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project1/.idea/libraries/library_libs_guava.xml.expected
@@ -3,5 +3,7 @@
     <CLASSES>
       <root url="jar://$PROJECT_DIR$/libs/guava.jar!/" />
     </CLASSES>
+    <JAVADOC />
+    <SOURCES />
   </library>
 </component>

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project1/.idea/libraries/library_libs_jsr305.xml.expected
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project1/.idea/libraries/library_libs_jsr305.xml.expected
@@ -3,5 +3,7 @@
     <CLASSES>
       <root url="jar://$PROJECT_DIR$/libs/jsr305.jar!/" />
     </CLASSES>
+    <JAVADOC />
+    <SOURCES />
   </library>
 </component>

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project1/.idea/libraries/library_libs_junit.xml.expected
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project1/.idea/libraries/library_libs_junit.xml.expected
@@ -3,5 +3,7 @@
     <CLASSES>
       <root url="jar://$PROJECT_DIR$/libs/junit.jar!/" />
     </CLASSES>
+    <JAVADOC />
+    <SOURCES />
   </library>
 </component>

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project1/.idea/libraries/library_modules_dep1_generated.xml.expected
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project1/.idea/libraries/library_modules_dep1_generated.xml.expected
@@ -3,5 +3,7 @@
     <CLASSES>
       <root url="jar://$PROJECT_DIR$/buck-out/gen/modules/dep1/lib__generated__output/generated.jar!/" />
     </CLASSES>
+    <JAVADOC />
+    <SOURCES />
   </library>
 </component>

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project1/.idea/modules.xml.expected
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project1/.idea/modules.xml.expected
@@ -2,10 +2,9 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/modules/dep1/modules_dep1.iml" filepath="$PROJECT_DIR$/modules/dep1/modules_dep1.iml"  group="modules"  />
-      <module fileurl="file://$PROJECT_DIR$/modules/tip/modules_tip.iml" filepath="$PROJECT_DIR$/modules/tip/modules_tip.iml"  group="modules"  />
-      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml"  />
-
-   </modules>
+      <module fileurl="file://$PROJECT_DIR$/modules/dep1/modules_dep1.iml" filepath="$PROJECT_DIR$/modules/dep1/modules_dep1.iml" group="modules" />
+      <module fileurl="file://$PROJECT_DIR$/modules/tip/modules_tip.iml" filepath="$PROJECT_DIR$/modules/tip/modules_tip.iml" group="modules" />
+      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml" />
+    </modules>
   </component>
 </project>

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project_slice/.idea/modules.xml.expected
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project_slice/.idea/modules.xml.expected
@@ -2,10 +2,9 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/modules/dep1/modules_dep1.iml" filepath="$PROJECT_DIR$/modules/dep1/modules_dep1.iml"  group="modules"  />
-      <module fileurl="file://$PROJECT_DIR$/modules/dep2/modules_dep2.iml" filepath="$PROJECT_DIR$/modules/dep2/modules_dep2.iml"  group="modules"  />
-      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml"  />
-
-   </modules>
+      <module fileurl="file://$PROJECT_DIR$/modules/dep1/modules_dep1.iml" filepath="$PROJECT_DIR$/modules/dep1/modules_dep1.iml" group="modules" />
+      <module fileurl="file://$PROJECT_DIR$/modules/dep2/modules_dep2.iml" filepath="$PROJECT_DIR$/modules/dep2/modules_dep2.iml" group="modules" />
+      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml" />
+    </modules>
   </component>
 </project>

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project_source_merge/.idea/modules.xml.expected
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project_source_merge/.idea/modules.xml.expected
@@ -2,9 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/java/code/modules/java_code_modules.iml" filepath="$PROJECT_DIR$/java/code/modules/java_code_modules.iml"  group="modules"  />
-      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml"  />
-
-   </modules>
+      <module fileurl="file://$PROJECT_DIR$/java/code/modules/java_code_modules.iml" filepath="$PROJECT_DIR$/java/code/modules/java_code_modules.iml" group="modules" />
+      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml" />
+    </modules>
   </component>
 </project>

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project_with_artifacts/.idea/modules.xml.expected
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project_with_artifacts/.idea/modules.xml.expected
@@ -2,9 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/modules/tip/modules_tip.iml" filepath="$PROJECT_DIR$/modules/tip/modules_tip.iml"  group="modules"  />
-      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml"  />
-
-   </modules>
+      <module fileurl="file://$PROJECT_DIR$/modules/tip/modules_tip.iml" filepath="$PROJECT_DIR$/modules/tip/modules_tip.iml" group="modules" />
+      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml" />
+    </modules>
   </component>
 </project>

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project_with_excluded_resources/.idea/modules.xml.expected
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project_with_excluded_resources/.idea/modules.xml.expected
@@ -2,9 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/modules/dep1/modules_dep1.iml" filepath="$PROJECT_DIR$/modules/dep1/modules_dep1.iml"  group="modules"  />
-      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml"  />
-
-   </modules>
+      <module fileurl="file://$PROJECT_DIR$/modules/dep1/modules_dep1.iml" filepath="$PROJECT_DIR$/modules/dep1/modules_dep1.iml" group="modules" />
+      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml" />
+    </modules>
   </component>
 </project>

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project_with_language_level/.idea/modules.xml.expected
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project_with_language_level/.idea/modules.xml.expected
@@ -2,9 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/modules/dep1/modules_dep1.iml" filepath="$PROJECT_DIR$/modules/dep1/modules_dep1.iml"  group="modules"  />
-      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml"  />
-
-   </modules>
+      <module fileurl="file://$PROJECT_DIR$/modules/dep1/modules_dep1.iml" filepath="$PROJECT_DIR$/modules/dep1/modules_dep1.iml" group="modules" />
+      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml" />
+    </modules>
   </component>
 </project>

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project_with_project_settings/.idea/modules.xml.expected
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project_with_project_settings/.idea/modules.xml.expected
@@ -2,9 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/modules/dep1/modules_dep1.iml" filepath="$PROJECT_DIR$/modules/dep1/modules_dep1.iml"  group="modules"  />
-      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml"  />
-
-   </modules>
+      <module fileurl="file://$PROJECT_DIR$/modules/dep1/modules_dep1.iml" filepath="$PROJECT_DIR$/modules/dep1/modules_dep1.iml" group="modules" />
+      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml" />
+    </modules>
   </component>
 </project>

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project_with_scripts/.idea/modules.xml.expected
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project_with_scripts/.idea/modules.xml.expected
@@ -2,9 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/modules/dep1/modules_dep1.iml" filepath="$PROJECT_DIR$/modules/dep1/modules_dep1.iml"  group="modules"  />
-      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml"  />
-
-   </modules>
+      <module fileurl="file://$PROJECT_DIR$/modules/dep1/modules_dep1.iml" filepath="$PROJECT_DIR$/modules/dep1/modules_dep1.iml" group="modules" />
+      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml" />
+    </modules>
   </component>
 </project>

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project_without_artifacts/.idea/modules.xml.expected
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project_without_artifacts/.idea/modules.xml.expected
@@ -2,9 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/modules/tip/modules_tip.iml" filepath="$PROJECT_DIR$/modules/tip/modules_tip.iml"  group="modules"  />
-      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml"  />
-
-   </modules>
+      <module fileurl="file://$PROJECT_DIR$/modules/tip/modules_tip.iml" filepath="$PROJECT_DIR$/modules/tip/modules_tip.iml"  group="modules" />
+      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml" />
+    </modules>
   </component>
 </project>

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project_without_autogeneration/.idea/modules.xml.expected
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/experimental_project_without_autogeneration/.idea/modules.xml.expected
@@ -2,9 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/modules/dep1/modules_dep1.iml" filepath="$PROJECT_DIR$/modules/dep1/modules_dep1.iml"  group="modules"  />
-      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml"  />
-
-   </modules>
+      <module fileurl="file://$PROJECT_DIR$/modules/dep1/modules_dep1.iml" filepath="$PROJECT_DIR$/modules/dep1/modules_dep1.iml" group="modules" />
+      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml" />
+    </modules>
   </component>
 </project>

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/project_with_custom_android_sdks/.idea/modules.xml.expected
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/project_with_custom_android_sdks/.idea/modules.xml.expected
@@ -2,9 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/modules/libA/modules_libA.iml" filepath="$PROJECT_DIR$/modules/libA/modules_libA.iml"  group="modules"  />
-      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml"  />
-
-   </modules>
+      <module fileurl="file://$PROJECT_DIR$/modules/libA/modules_libA.iml" filepath="$PROJECT_DIR$/modules/libA/modules_libA.iml" group="modules" />
+      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml" />
+    </modules>
   </component>
 </project>

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/project_with_custom_java_sdks/.idea/modules.xml.expected
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/project_with_custom_java_sdks/.idea/modules.xml.expected
@@ -2,10 +2,9 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/modules/libA/modules_libA.iml" filepath="$PROJECT_DIR$/modules/libA/modules_libA.iml"  group="modules"  />
-      <module fileurl="file://$PROJECT_DIR$/modules/libB/modules_libB.iml" filepath="$PROJECT_DIR$/modules/libB/modules_libB.iml"  group="modules"  />
-      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml"  />
-
-   </modules>
+      <module fileurl="file://$PROJECT_DIR$/modules/libA/modules_libA.iml" filepath="$PROJECT_DIR$/modules/libA/modules_libA.iml" group="modules" />
+      <module fileurl="file://$PROJECT_DIR$/modules/libB/modules_libB.iml" filepath="$PROJECT_DIR$/modules/libB/modules_libB.iml" group="modules" />
+      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml" />
+    </modules>
   </component>
 </project>


### PR DESCRIPTION
This pull request is to address various minor, but annoying, differences between buck generated IntelliJ project files and those generated by IntelliJ itself.

Our team commits buck generated IntelliJ project file artifacts into our repository.  However, the simple act of opening the project in IntelliJ results in IntelliJ making various minor (typically whitespace) changes to the project files resulting in spurious diffs with the committed artifacts.

I'll attempt to cover each one by one.

### ``ij-library.st``
The ``ij-library.st`` template is responsible for ``library_XXX.xml`` file generation.  Opening the project in IntelliJ and closing it again resulted in these differences compared to the buck generated version:
```xml
+    <JAVADOC />
+    <SOURCES />
   </library>
-</component>
+</component>
\ No newline at end of file
```
The ``ij-library.st`` template was modified with ``%else%`` conditionals to generate empty XML tags for javadoc and sources when not present.  Additionally, the newline at the end of the template was removed.

### ``ij-module-index.st``
The ``ij-module-index.st`` template is responsible for ``modules.xml`` file generation.  Opening the project in IntelliJ and closing it again resulted in these differences compared to the buck generated version:
```xml
-     <module fileurl="..." filepath="..."  group="modules"  />
+     <module fileurl="..." filepath="..." group="modules" />
-
     </modules>
```
The buck generated files contained:
* an additional whitespace character before the ``group`` attribute
* an additional whitespace character before the closing ``/>``
* an additional newline after the last module entry

IntelliJ strips these and updates the file when the project is opened, which creates a diff for every module in the ``modules.xml`` file (in our case, about 80 modules).

The ``ij-library.st`` template was modified to align the buck generated files to the format maintained by IntelliJ.  The removal of whitespace from the template makes it slightly less readable, but after studying the stringtemplate4 syntax I cannot come up with anything more readable.

### ``IjProjectTemplateDataPreparer.java``
When buck generates the ``modules.xml`` file it ordered the modules by the natural ordering of the module filepaths.  IntelliJ sorts the modules by an ordered depth first traversal of the filesystem represented by the module filepaths.

In other words, this is an example ordering based on a purely alphanumeric sort, as was previously done by buck:
```
proj/org.company.server.core.jobs.db/proj_org_company_server_core_jobs_db.iml
proj/org.company.server.core.jobs/proj_org_company_server_core_jobs.iml
proj/org.company.server.core/netld_org_company_server_core.iml
```
And here is the same based on an ordered depth first traversal of the projects, as is done by IntelliJ:
```
proj/org.company.server.core/netld_org_company_server_core.iml
proj/org.company.server.core.jobs/proj_org_company_server_core_jobs.iml
proj/org.company.server.core.jobs.db/proj_org_company_server_core_jobs_db.iml
```
You can see that it is basically inverted.  In an alphanumeric sort the ``.`` has higher precedence than ``/`` and therefore sorts first in contrast to the file system traversal.  This results in IntelliJ updating the ``module.xml`` with a different ordering (but same content) as that generating by buck:
```xml
-      <module fileurl="..." filepath="$PROJECT_DIR$/proj/org.company.server.core.jobs.db/proj_org_company_server_core_jobs_db.iml" group="modules" />
-      <module fileurl="..." filepath="$PROJECT_DIR$/proj/org.company.server.core.jobs/proj_org_company_server_core_jobs.iml" group="modules" />
       <module fileurl="..." filepath="$PROJECT_DIR$/proj/org.company.server.core/proj_org_company_server_core.iml" group="modules" />
+      <module fileurl="..." filepath="$PROJECT_DIR$/proj/org.company.server.core.jobs/proj_org_company_server_core_jobs.iml" group="modules" />
+      <module fileurl="..." filepath="$PROJECT_DIR$/proj/org.company.server.core.jobs.db/proj_org_company_server_core_jobs_db.iml" group="modules" />
```
The change to ``IjProjectTemplateDataPreparer.java`` alters the ``AbstractModuleIndexEntry`` implementation of the ``Comparable.compareTo()`` method to "demote" the path segment separator character for comparison purposes, with the resulting sorted module list matching an ordered depth first file system traversal.  Thus, the buck generated ``modules.xml`` file maintains the same order as IntelliJ and spurious diffs are not generated when opening/closing the project in the IDE.
