### PR TITLE
Enhance post process classes commands with additional env vars

### DIFF
--- a/src/com/facebook/buck/jvm/java/JavacToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/java/JavacToJarStepFactory.java
@@ -87,6 +87,11 @@ public class JavacToJarStepFactory extends BaseCompileToJarStepFactory {
   }
 
   @Override
+  Optional<String> getBootClasspath() {
+    return javacOptions.getBootclasspath();
+  }
+
+  @Override
   public void createCompileToJarStep(
       BuildContext context,
       ImmutableSortedSet<Path> sourceFilePaths,


### PR DESCRIPTION
This makes the `classpath` and `bootclasspath` (if available) of a jvm target available to `postProcessClassesCommands`. This is very useful to be able to do bytecode manipulation of the output classes with tools like retrolamdba etc.