### PR TITLE
Prevent an exception when generating intellij projects

### DIFF
--- a/src/com/facebook/buck/jvm/java/intellij/IjProject.java
+++ b/src/com/facebook/buck/jvm/java/intellij/IjProject.java
@@ -146,8 +146,11 @@ public class IjProject {
           public Optional<Path> getLibraryAndroidManifestPath(
               TargetNode<AndroidLibraryDescription.Arg, ?> targetNode) {
             Optional<SourcePath> manifestPath = targetNode.getConstructorArg().manifest;
-            return manifestPath.map(sourcePathResolver::getAbsolutePath).map(Optional::of).orElse(
-                intellijConfig.getAndroidManifest());
+            Optional<Path> defaultAndroidManifestPath = intellijConfig.getAndroidManifest()
+                .map(Path::toAbsolutePath);
+            return manifestPath.map(sourcePathResolver::getAbsolutePath)
+                .map(Optional::of)
+                .orElse(defaultAndroidManifestPath);
           }
 
           @Override

--- a/test/com/facebook/buck/jvm/java/intellij/ProjectIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/java/intellij/ProjectIntegrationTest.java
@@ -576,6 +576,11 @@ public class ProjectIntegrationTest {
   }
 
   @Test
+  public void testAndroidLibraryProject() throws IOException {
+    runBuckProjectAndVerify("android_library");
+  }
+
+  @Test
   public void testVersion2BuckProject() throws IOException {
     runBuckProjectAndVerify("experimental_project1");
   }

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/android_library/.buckconfig
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/android_library/.buckconfig
@@ -1,0 +1,2 @@
+[intellij]
+    default_android_manifest_path = src/main/AndroidManifest.xml

--- a/test/com/facebook/buck/jvm/java/intellij/testdata/android_library/lib/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/java/intellij/testdata/android_library/lib/BUCK.fixture
@@ -1,0 +1,3 @@
+android_library(
+    name = 'src_release'
+)


### PR DESCRIPTION
This exception was observed on an `android_library` target that did not have a `manifest` set, thus, the `manifest` fell back to our `.buckconfig[intellij].default_android_manifest_path` which was a relative path.  This fix ensures that the default android manifest path is an absolute path to avoid this exception.

```
java.lang.IllegalArgumentException: 'other' is different type of Path
	at sun.nio.fs.UnixPath.relativize(UnixPath.java:416)
	at sun.nio.fs.UnixPath.relativize(UnixPath.java:43)
	at com.facebook.buck.jvm.java.intellij.IjProjectTemplateDataPreparer.addAndroidManifestPath(IjProjectTemplateDataPreparer.java:458)
	at com.facebook.buck.jvm.java.intellij.IjProjectTemplateDataPreparer.getAndroidProperties(IjProjectTemplateDataPreparer.java:389)
	at com.facebook.buck.jvm.java.intellij.IjProjectWriter.writeModule(IjProjectWriter.java:121)
	at com.facebook.buck.jvm.java.intellij.IjProjectWriter.write(IjProjectWriter.java:87)
	at com.facebook.buck.jvm.java.intellij.IjProject.write(IjProject.java:219)
	at com.facebook.buck.cli.ProjectCommand.writeProjectAndGetRequiredBuildTargets(ProjectCommand.java:646)
	at com.facebook.buck.cli.ProjectCommand.runIntellijProjectGenerator(ProjectCommand.java:600)
	at com.facebook.buck.cli.ProjectCommand.runIntellijProjectGenerator(ProjectCommand.java:785)
	at com.facebook.buck.cli.ProjectCommand.runWithoutHelp(ProjectCommand.java:507)
	at com.facebook.buck.cli.AbstractCommand.run(AbstractCommand.java:198)
	at com.facebook.buck.cli.BuckCommand.run(BuckCommand.java:91)
	at com.facebook.buck.cli.Main.runMainWithExitCode(Main.java:1257)
	at com.facebook.buck.cli.Main.runMainThenExit(Main.java:700)
	at com.facebook.buck.cli.Main.nailMain(Main.java:1937)
```

