### PR TITLE
Error prone fixes

### DIFF
--- a/src/com/facebook/buck/cli/MachOAbstractCommand.java
+++ b/src/com/facebook/buck/cli/MachOAbstractCommand.java
@@ -84,7 +84,7 @@ public abstract class MachOAbstractCommand extends AbstractCommand {
     Preconditions.checkNotNull(output, OUTPUT_OPTION + " must be set");
     Preconditions.checkNotNull(oldCompDir, OLD_COMPDIR_OPTION + " must be set");
     Preconditions.checkNotNull(updatedCompDir, NEW_COMPDIR_OPTION + " must be set");
-    Preconditions.checkNotNull(
+    Preconditions.checkState(
         !binary.equals(output),
         BINARY_OPTION + " must be different from " + OUTPUT_OPTION);
     Preconditions.checkArgument(

--- a/src/com/facebook/buck/cxx/PrebuiltCxxLibraryDescription.java
+++ b/src/com/facebook/buck/cxx/PrebuiltCxxLibraryDescription.java
@@ -621,7 +621,7 @@ public class PrebuiltCxxLibraryDescription implements
 
         switch (headerVisibility) {
           case PUBLIC:
-            if (Preconditions.checkNotNull(hasHeaders(cxxPlatform))) {
+            if (hasHeaders(cxxPlatform)) {
               CxxPreprocessables.addHeaderSymlinkTree(
                   builder,
                   getBuildTarget(),

--- a/src/com/facebook/buck/jvm/java/AccumulateClassNamesStep.java
+++ b/src/com/facebook/buck/jvm/java/AccumulateClassNamesStep.java
@@ -151,7 +151,7 @@ public class AccumulateClassNamesStep implements Step {
             HashCode existing = classNames.putIfAbsent(key, value);
             if (existing != null && !existing.equals(value)) {
               throw new IllegalArgumentException(String.format(
-                  "Multiple entries with same key but differing values: %1$s=%s and %1$s=%s",
+                  "Multiple entries with same key but differing values: %1$s=%2$s and %1$s=%3$s",
                   key, value, existing));
             }
           }
@@ -181,7 +181,7 @@ public class AccumulateClassNamesStep implements Step {
       HashCode existing = classNames.putIfAbsent(key, value);
       if (existing != null && !existing.equals(value)) {
         throw new IllegalArgumentException(String.format(
-            "Multiple entries with same key but differing values: %1$s=%s and %1$s=%s",
+            "Multiple entries with same key but differing values: %1$s=%2$s and %1$s=%3$s",
             key, value, existing));
       }
     }

--- a/src/com/facebook/buck/test/selectors/SimpleTestSelector.java
+++ b/src/com/facebook/buck/test/selectors/SimpleTestSelector.java
@@ -39,7 +39,7 @@ public class SimpleTestSelector implements TestSelector {
 
   @Override
   public String getExplanation() {
-    return String.format("%s class:%s method:%s",
+    return String.format("class:%s method:%s",
         isMatchAnyClass() ? "<any>" : className,
         isMatchAnyMethod() ? "<any>" : methodName);
   }

--- a/src/com/facebook/buck/testrunner/SameThreadFailOnTimeout.java
+++ b/src/com/facebook/buck/testrunner/SameThreadFailOnTimeout.java
@@ -65,7 +65,7 @@ class SameThreadFailOnTimeout extends Statement {
       System.err.printf("Dumping threads for timed-out test %s:%n", testName);
       for (Map.Entry<Thread, StackTraceElement[]> t : Thread.getAllStackTraces().entrySet()) {
         Thread thread = t.getKey();
-        System.err.printf("\"%s\" #%d%n", thread.getName(), thread.getId(), thread.getId());
+        System.err.printf("\"%s\" #%d%n", thread.getName(), thread.getId());
         System.err.printf("\tjava.lang.Thread.State: %s%n", thread.getState());
         for (StackTraceElement element : t.getValue()) {
           System.err.printf("\t\t at %s%n", element);

--- a/src/com/facebook/buck/util/Escaper.java
+++ b/src/com/facebook/buck/util/Escaper.java
@@ -409,7 +409,7 @@ public final class Escaper {
       char c = 0;
       boolean valid = false;
       for (int i = 0; i < maxCodeLength && pos < escaped.length(); i++) {
-        final char digit = (char) table.indexOf(Character.toLowerCase(escaped.charAt(pos)));
+        final int digit = table.indexOf(Character.toLowerCase(escaped.charAt(pos)));
         if (digit == -1 || digit >= base) {
           break;
         }

--- a/src/com/facebook/buck/util/concurrent/ResourcePool.java
+++ b/src/com/facebook/buck/util/concurrent/ResourcePool.java
@@ -230,7 +230,7 @@ public class ResourcePool<R extends AutoCloseable> implements AutoCloseable {
   }
 
   @Nullable
-  public ListenableFuture<Void> getShutdownFullyCompleteFuture() {
+  public synchronized ListenableFuture<Void> getShutdownFullyCompleteFuture() {
     Preconditions.checkState(
         closing.get(),
         "This method should not be called before the .close() method is called.");


### PR DESCRIPTION
Activate error prone on Buck by adding these lines to .buckconfig:

```
[tools]
  javac_jar = third-party/error_prone_ant-2.0.15.jar
  compiler_class_name = com.google.errorprone.ErrorProneJavaCompiler
[java]
  extra_arguments = "-Xep:OptionalEquality:OFF"
```

Put `error_prone_ant-2.0.15.jar` to `third-party` directory, run `buck build buck`
and fix the problem flagged by error prone.