### PR TITLE
Add swift compilerflags from buckconfig to rulekey

### DIFF
--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -126,8 +126,8 @@ class SwiftCompile
 
     this.srcs = ImmutableSortedSet.copyOf(srcs);
     ImmutableList.Builder<String> compilerFlagsBuilder = ImmutableList.builder();
-    compilerFlagsBuilder.addAll(compilerFlags);
     compilerFlagsBuilder.addAll(swiftBuckConfig.getFlags().orElse(ImmutableSet.of()));
+    compilerFlagsBuilder.addAll(compilerFlags);
     this.compilerFlags = compilerFlagsBuilder.build();
     this.enableObjcInterop = enableObjcInterop.orElse(true);
     this.bridgingHeader = bridgingHeader;


### PR DESCRIPTION
Fix rebuilding when swift compiler flags are updated in the buckconfig. Also marks the bridging header for rulekey.

Any suggestions for test are welcome.