### PR TITLE
Extend zip external attributes to indicate files are files

### DIFF
--- a/src/com/facebook/buck/io/MoreFiles.java
+++ b/src/com/facebook/buck/io/MoreFiles.java
@@ -57,6 +57,8 @@ public final class MoreFiles {
   @SuppressWarnings("PMD.AvoidUsingOctalValues")
   public static final long S_IFDIR = 0040000;
   @SuppressWarnings("PMD.AvoidUsingOctalValues")
+  public static final long S_IFREG = 0100000;
+  @SuppressWarnings("PMD.AvoidUsingOctalValues")
   public static final long S_IFLNK = 0120000;
 
   public enum DeleteRecursivelyOptions {

--- a/src/com/facebook/buck/io/ProjectFilesystem.java
+++ b/src/com/facebook/buck/io/ProjectFilesystem.java
@@ -1082,6 +1082,8 @@ public class ProjectFilesystem {
 
     if (isDirectory(path)) {
       mode |= MoreFiles.S_IFDIR;
+    } else if (isFile(path)) {
+      mode |= MoreFiles.S_IFREG;
     }
 
     // Propagate any additional permissions

--- a/test/com/facebook/buck/rules/CachingBuildEngineTest.java
+++ b/test/com/facebook/buck/rules/CachingBuildEngineTest.java
@@ -1440,6 +1440,7 @@ public class CachingBuildEngineTest {
       assertEquals(
           new ZipInspector(artifact).getZipFileEntries(),
           new ZipInspector(fetchedArtifact).getZipFileEntries());
+
       MoreAsserts.assertContentsEqual(artifact, fetchedArtifact);
     }
 
@@ -3333,7 +3334,7 @@ public class CachingBuildEngineTest {
         entry.setTime(ZipConstants.getFakeTime());
         // We set the external attributes to this magic value which seems to match the attributes
         // of entries created by {@link InMemoryArtifactCache}.
-        entry.setExternalAttributes(420 << 16);
+        entry.setExternalAttributes(33188L << 16);
         zip.putNextEntry(entry);
         zip.write(mapEntry.getValue().getBytes());
         zip.closeEntry();


### PR DESCRIPTION
Without this, node's zip-decompress library has no idea what
kind of file it's dealing with and gets grumpy with us. That
can't be a Good Thing, so just indicate that files are files
as we build the zip.