### PR TITLE
Improved Kotlin support.

### DIFF
--- a/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
+++ b/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
@@ -217,7 +217,7 @@ public class DefaultJavaLibrary extends AbstractBuildRule
         classesToRemoveFromJar);
   }
 
-  private DefaultJavaLibrary(
+  protected DefaultJavaLibrary(
       BuildRuleParams params,
       final SourcePathResolver resolver,
       SourcePathRuleFinder ruleFinder,

--- a/src/com/facebook/buck/jvm/kotlin/BUCK.autodeps
+++ b/src/com/facebook/buck/jvm/kotlin/BUCK.autodeps
@@ -2,7 +2,9 @@
   "kotlin" : {
     "deps" : [
       "//src/com/facebook/buck/io:executable-finder",
-      "//src/com/facebook/buck/jvm/common:common"
+      "//src/com/facebook/buck/jvm/common:common",
+      "//src/com/facebook/buck/maven:util",
+      "//src/com/facebook/buck/util:exceptions"
     ],
     "exported_deps" : [
       "//src/com/facebook/buck/cli:config",

--- a/src/com/facebook/buck/jvm/kotlin/DefaultKotlinLibrary.java
+++ b/src/com/facebook/buck/jvm/kotlin/DefaultKotlinLibrary.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.jvm.kotlin;
+
+import com.facebook.buck.jvm.java.CompileToJarStepFactory;
+import com.facebook.buck.jvm.java.DefaultJavaLibrary;
+import com.facebook.buck.model.BuildTarget;
+import com.facebook.buck.rules.BuildRule;
+import com.facebook.buck.rules.BuildRuleParams;
+import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.buck.rules.SourcePathRuleFinder;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public class DefaultKotlinLibrary extends DefaultJavaLibrary {
+
+  public DefaultKotlinLibrary(
+      BuildRuleParams params,
+      final SourcePathResolver resolver,
+      SourcePathRuleFinder ruleFinder,
+      Set<? extends SourcePath> srcs,
+      Set<? extends SourcePath> resources,
+      Optional<Path> generatedSourceFolder,
+      Optional<SourcePath> proguardConfig,
+      ImmutableList<String> postprocessClassesCommands,
+      ImmutableSortedSet<BuildRule> exportedDeps,
+      ImmutableSortedSet<BuildRule> providedDeps,
+      BuildTarget abiJar,
+      ImmutableSortedSet<SourcePath> abiInputs,
+      final boolean trackClassUsage,
+      ImmutableSet<Path> additionalClasspathEntries,
+      CompileToJarStepFactory compileStepFactory,
+      Optional<Path> resourcesRoot,
+      Optional<SourcePath> manifestFile,
+      Optional<String> mavenCoords,
+      ImmutableSortedSet<BuildTarget> tests,
+      ImmutableSet<Pattern> classesToRemoveFromJar) {
+
+    super(
+        params,
+        resolver,
+        ruleFinder,
+        srcs,
+        resources,
+        generatedSourceFolder,
+        proguardConfig,
+        postprocessClassesCommands,
+        exportedDeps,
+        providedDeps,
+        abiJar,
+        abiInputs,
+        trackClassUsage,
+        additionalClasspathEntries,
+        compileStepFactory,
+        resourcesRoot,
+        manifestFile,
+        mavenCoords,
+        tests,
+        classesToRemoveFromJar);
+  }
+}

--- a/src/com/facebook/buck/jvm/kotlin/KotlinBuckConfig.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinBuckConfig.java
@@ -20,26 +20,119 @@ import com.facebook.buck.cli.BuckConfig;
 import com.facebook.buck.io.ExecutableFinder;
 import com.facebook.buck.rules.HashedFileTool;
 import com.facebook.buck.rules.Tool;
+import com.facebook.buck.util.HumanReadableException;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
 
 public class KotlinBuckConfig {
+  private static final String SECTION = "kotlin";
+
   private static final Path DEFAULT_KOTLIN_COMPILER = Paths.get("kotlinc");
 
   private final BuckConfig delegate;
+  private @Nullable Path kotlinHome;
 
   public KotlinBuckConfig(BuckConfig delegate) {
     this.delegate = delegate;
   }
 
+  /**
+   * Get the Tool instance for the Kotlin compiler.
+   * @return the Kotlin compiler Tool
+   */
   public Supplier<Tool> getKotlinCompiler() {
-    Path compilerPath = delegate.getPath("kotlin", "compiler").orElse(DEFAULT_KOTLIN_COMPILER);
+    Path compilerPath = getKotlinHome().resolve("kotlinc");
+    if (!Files.isExecutable(compilerPath)) {
+      compilerPath = getKotlinHome().resolve(Paths.get("bin", "kotlinc"));
+      if (!Files.isExecutable(compilerPath)) {
+        throw new HumanReadableException("Could not resolve kotlinc location.");
+      }
+    }
 
     Path compiler = new ExecutableFinder().getExecutable(compilerPath, delegate.getEnvironment());
-
     return Suppliers.ofInstance(new HashedFileTool(compiler));
+  }
+
+  /**
+   * Get the path to the Kotlin runtime jar.
+   * @return the Kotlin runtime jar path
+   */
+  public Path getPathToRuntimeJar() {
+    Optional<String> value = delegate.getValue(SECTION, "runtime_jar");
+    boolean isAbsolute = (value.isPresent() && Paths.get(value.get()).isAbsolute());
+
+    Path runtime = delegate.getPath(SECTION, "runtime_jar", !isAbsolute).orElse(null);
+    if (runtime != null) {
+      return runtime.normalize();
+    }
+
+    runtime = getKotlinHome().resolve("kotlin-runtime.jar");
+    if (Files.isRegularFile(runtime)) {
+      return runtime.normalize();
+    }
+
+    runtime = getKotlinHome().resolve(Paths.get("lib", "kotlin-runtime.jar"));
+    if (Files.isRegularFile(runtime)) {
+      return runtime.normalize();
+    }
+
+    throw new HumanReadableException("Could not resolve kotlin runtime JAR location.");
+  }
+
+  private Path getKotlinHome() {
+    if (kotlinHome != null) {
+      return kotlinHome;
+    }
+
+    try {
+      // Check the buck configuration for a specified kotlin compliler
+      Optional<String> value = delegate.getValue(SECTION, "compiler");
+      boolean isAbsolute = (value.isPresent() && Paths.get(value.get()).isAbsolute());
+      Optional<Path> compilerPath = delegate.getPath(SECTION, "compiler", !isAbsolute);
+      if (compilerPath.isPresent()) {
+        if (Files.isExecutable(compilerPath.get())) {
+          kotlinHome = compilerPath.get().toRealPath().getParent().normalize();
+          if (kotlinHome != null && kotlinHome.endsWith(Paths.get("bin"))) {
+            kotlinHome = kotlinHome.getParent().normalize();
+          }
+          return kotlinHome;
+        } else {
+          throw new HumanReadableException(
+              "Could not deduce kotlin home directory from path " + compilerPath.toString());
+        }
+      } else {
+        // If the KOTLIN_HOME environment variable is specified we trust it
+        String home = delegate.getEnvironment().get("KOTLIN_HOME");
+        if (home != null) {
+          kotlinHome = Paths.get(home).normalize();
+          return kotlinHome;
+        } else {
+          // Lastly, we try to resolve from the system PATH
+          Optional<Path> compiler = new ExecutableFinder()
+              .getOptionalExecutable(DEFAULT_KOTLIN_COMPILER, delegate.getEnvironment());
+          if (compiler.isPresent()) {
+            kotlinHome = compiler.get().toRealPath().getParent().normalize();
+            if (kotlinHome != null && kotlinHome.endsWith(Paths.get("bin"))) {
+              kotlinHome = kotlinHome.getParent().normalize();
+            }
+            return kotlinHome;
+          } else {
+            throw new HumanReadableException(
+                "Could not resolve kotlin home directory, Consider setting KOTLIN_HOME.");
+          }
+        }
+      }
+    } catch (IOException io) {
+      throw new HumanReadableException(
+          "Could not resolve kotlin home directory, Consider setting KOTLIN_HOME.", io);
+    }
   }
 }

--- a/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
@@ -19,10 +19,17 @@ package com.facebook.buck.jvm.kotlin;
 import static com.facebook.buck.jvm.common.ResourceValidator.validateResources;
 
 import com.facebook.buck.jvm.java.CalculateAbi;
-import com.facebook.buck.jvm.java.DefaultJavaLibrary;
+import com.facebook.buck.jvm.java.JavaLibrary;
+import com.facebook.buck.jvm.java.JavaLibraryDescription;
 import com.facebook.buck.jvm.java.JavaLibraryRules;
-import com.facebook.buck.jvm.java.JvmLibraryArg;
+import com.facebook.buck.jvm.java.JavaSourceJar;
+import com.facebook.buck.jvm.java.JavacOptions;
+import com.facebook.buck.jvm.java.JavacOptionsFactory;
+import com.facebook.buck.jvm.java.MavenUberJar;
+import com.facebook.buck.maven.AetherUtil;
 import com.facebook.buck.model.BuildTarget;
+import com.facebook.buck.model.Flavor;
+import com.facebook.buck.model.Flavored;
 import com.facebook.buck.parser.NoSuchBuildTargetException;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleParams;
@@ -30,11 +37,12 @@ import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.BuildRules;
 import com.facebook.buck.rules.BuildTargetSourcePath;
 import com.facebook.buck.rules.Description;
-import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.SourcePathRuleFinder;
 import com.facebook.buck.rules.TargetGraph;
 import com.facebook.infer.annotation.SuppressFieldNotInitialized;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
@@ -43,13 +51,28 @@ import com.google.common.collect.Iterables;
 import java.util.Optional;
 
 
-
-public class KotlinLibraryDescription implements Description<KotlinLibraryDescription.Arg> {
+public class KotlinLibraryDescription implements
+    Description<KotlinLibraryDescription.Arg>, Flavored {
 
   private final KotlinBuckConfig kotlinBuckConfig;
 
-  public KotlinLibraryDescription(KotlinBuckConfig kotlinBuckConfig) {
+  public static final ImmutableSet<Flavor> SUPPORTED_FLAVORS = ImmutableSet.of(
+      JavaLibrary.SRC_JAR,
+      JavaLibrary.MAVEN_JAR);
+
+  @VisibleForTesting
+  final JavacOptions defaultOptions;
+
+  public KotlinLibraryDescription(
+      KotlinBuckConfig kotlinBuckConfig,
+      JavacOptions templateOptions) {
     this.kotlinBuckConfig = kotlinBuckConfig;
+    this.defaultOptions = templateOptions;
+  }
+
+  @Override
+  public boolean hasFlavors(ImmutableSet<Flavor> flavors) {
+    return SUPPORTED_FLAVORS.containsAll(flavors);
   }
 
   @Override
@@ -63,10 +86,16 @@ public class KotlinLibraryDescription implements Description<KotlinLibraryDescri
       BuildRuleParams params,
       BuildRuleResolver resolver,
       A args) throws NoSuchBuildTargetException {
+
     SourcePathRuleFinder ruleFinder = new SourcePathRuleFinder(resolver);
     SourcePathResolver pathResolver = new SourcePathResolver(ruleFinder);
+    BuildTarget target = params.getBuildTarget();
 
-    if (params.getBuildTarget().getFlavors().contains(CalculateAbi.FLAVOR)) {
+    // We know that the flavour we're being asked to create is valid, since the check is done when
+    // creating the action graph from the target graph.
+    ImmutableSortedSet<Flavor> flavors = target.getFlavors();
+
+    if (flavors.contains(CalculateAbi.FLAVOR)) {
       BuildTarget libraryTarget = params.getBuildTarget().withoutFlavors(CalculateAbi.FLAVOR);
       resolver.requireRule(libraryTarget);
       return CalculateAbi.of(
@@ -77,52 +106,100 @@ public class KotlinLibraryDescription implements Description<KotlinLibraryDescri
           new BuildTargetSourcePath(libraryTarget));
     }
 
+    BuildRuleParams paramsWithMavenFlavor = null;
+    if (flavors.contains(JavaLibrary.MAVEN_JAR)) {
+      paramsWithMavenFlavor = params;
+
+      // Maven rules will depend upon their vanilla versions, so the latter have to be constructed
+      // without the maven flavor to prevent output-path conflict
+      params = params.copyWithBuildTarget(
+          params.getBuildTarget().withoutFlavors(ImmutableSet.of(JavaLibrary.MAVEN_JAR)));
+    }
+
+    if (flavors.contains(JavaLibrary.SRC_JAR)) {
+      args.mavenCoords = args.mavenCoords.map(input -> AetherUtil.addClassifier(
+          input,
+          AetherUtil.CLASSIFIER_SOURCES));
+
+      if (!flavors.contains(JavaLibrary.MAVEN_JAR)) {
+        return new JavaSourceJar(
+            params,
+            pathResolver,
+            args.srcs,
+            args.mavenCoords);
+      } else {
+        return MavenUberJar.SourceJar.create(
+            Preconditions.checkNotNull(paramsWithMavenFlavor),
+            pathResolver,
+            args.srcs,
+            args.mavenCoords,
+            args.mavenPomTemplate);
+      }
+    }
+
+    JavacOptions javacOptions = JavacOptionsFactory.create(
+        defaultOptions,
+        params,
+        resolver,
+        ruleFinder,
+        args);
+
     BuildTarget abiJarTarget = params.getBuildTarget().withAppendedFlavors(CalculateAbi.FLAVOR);
 
     ImmutableSortedSet<BuildRule> exportedDeps = resolver.getAllRules(args.exportedDeps);
     BuildRuleParams javaLibraryParams =
         params.appendExtraDeps(
-            BuildRules.getExportedRules(
-                Iterables.concat(
-                    params.getDeclaredDeps().get(),
-                    exportedDeps,
-                    resolver.getAllRules(args.providedDeps))));
-    return new DefaultJavaLibrary(
-        javaLibraryParams,
-        pathResolver,
-        ruleFinder,
-        args.srcs,
-        validateResources(
+            Iterables.concat(
+                BuildRules.getExportedRules(
+                    Iterables.concat(
+                        params.getDeclaredDeps().get(),
+                        exportedDeps,
+                        resolver.getAllRules(args.providedDeps))),
+                ruleFinder.filterBuildRuleInputs(
+                    javacOptions.getInputs(ruleFinder))));
+    DefaultKotlinLibrary defaultKotlinLibrary =
+        new DefaultKotlinLibrary(
+            javaLibraryParams,
             pathResolver,
-            params.getProjectFilesystem(),
-            args.resources),
-        Optional.empty(),
-        Optional.empty(),
-        ImmutableList.of(),
-        exportedDeps,
-        resolver.getAllRules(args.providedDeps),
-        abiJarTarget,
-        JavaLibraryRules.getAbiInputs(resolver, javaLibraryParams.getDeps()),
-        /* trackClassUsage */ false,
-        /* additionalClasspathEntries */ ImmutableSet.of(),
-        new KotlincToJarStepFactory(
-            kotlinBuckConfig.getKotlinCompiler().get(),
-            args.extraKotlincArguments),
-        Optional.empty(),
-        /* manifest file */ Optional.empty(),
-        Optional.empty(),
-        ImmutableSortedSet.of(),
-        /* classesToRemoveFromJar */ ImmutableSet.of());
+            ruleFinder,
+            args.srcs,
+            validateResources(
+                pathResolver,
+                params.getProjectFilesystem(),
+                args.resources),
+            Optional.empty(),
+            Optional.empty(),
+            ImmutableList.of(),
+            exportedDeps,
+            resolver.getAllRules(args.providedDeps),
+            abiJarTarget,
+            JavaLibraryRules.getAbiInputs(resolver, javaLibraryParams.getDeps()),
+            false,
+            ImmutableSet.of(),
+            new KotlincToJarStepFactory(
+                kotlinBuckConfig.getKotlinCompiler().get(),
+                args.extraKotlincArguments),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            ImmutableSortedSet.of(),
+            ImmutableSet.of());
+
+    if (!flavors.contains(JavaLibrary.MAVEN_JAR)) {
+      return defaultKotlinLibrary;
+    } else {
+      return MavenUberJar.create(
+          defaultKotlinLibrary,
+          Preconditions.checkNotNull(paramsWithMavenFlavor),
+          pathResolver,
+          args.mavenCoords,
+          args.mavenPomTemplate);
+    }
   }
 
 
   @SuppressFieldNotInitialized
-  public static class Arg extends JvmLibraryArg {
-    public ImmutableSortedSet<SourcePath> srcs = ImmutableSortedSet.of();
-    public ImmutableSortedSet<SourcePath> resources = ImmutableSortedSet.of();
+  public static class Arg extends JavaLibraryDescription.Arg {
     public ImmutableList<String> extraKotlincArguments = ImmutableList.of();
-    public ImmutableSortedSet<BuildTarget> providedDeps = ImmutableSortedSet.of();
-    public ImmutableSortedSet<BuildTarget> exportedDeps = ImmutableSortedSet.of();
-    public ImmutableSortedSet<BuildTarget> deps = ImmutableSortedSet.of();
   }
 }

--- a/src/com/facebook/buck/jvm/kotlin/KotlinTest.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.jvm.kotlin;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.logging.Level;
+
+import com.facebook.buck.jvm.java.ForkMode;
+import com.facebook.buck.jvm.java.JavaLibrary;
+import com.facebook.buck.jvm.java.JavaRuntimeLauncher;
+import com.facebook.buck.jvm.java.JavaTest;
+import com.facebook.buck.jvm.java.TestType;
+import com.facebook.buck.rules.BuildRuleParams;
+import com.facebook.buck.rules.Label;
+import com.facebook.buck.rules.SourcePathResolver;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+@SuppressWarnings("PMD.TestClassWithoutTestCases")
+public class KotlinTest extends JavaTest {
+
+  public KotlinTest(
+      BuildRuleParams params,
+      SourcePathResolver resolver,
+      JavaLibrary compiledTestsLibrary,
+      ImmutableSet<Path> additionalClasspathEntries,
+      Set<Label> labels,
+      Set<String> contacts,
+      TestType testType,
+      JavaRuntimeLauncher javaRuntimeLauncher,
+      List<String> vmArgs,
+      Map<String, String> nativeLibsEnvironment,
+      Optional<Long> testRuleTimeoutMs,
+      Optional<Long> testCaseTimeoutMs,
+      ImmutableMap<String, String> env,
+      boolean runTestSeparately,
+      ForkMode forkMode,
+      Optional<Level> stdOutLogLevel,
+      Optional<Level> stdErrLogLevel) {
+
+    super(
+        params,
+        resolver,
+        compiledTestsLibrary,
+        additionalClasspathEntries,
+        labels,
+        contacts,
+        testType,
+        javaRuntimeLauncher,
+        vmArgs,
+        nativeLibsEnvironment,
+        testRuleTimeoutMs,
+        testCaseTimeoutMs,
+        env,
+        runTestSeparately,
+        forkMode,
+        stdOutLogLevel,
+        stdErrLogLevel);
+  }
+
+}

--- a/src/com/facebook/buck/jvm/kotlin/KotlinTestDescription.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinTestDescription.java
@@ -18,13 +18,13 @@ package com.facebook.buck.jvm.kotlin;
 
 import com.facebook.buck.jvm.common.ResourceValidator;
 import com.facebook.buck.jvm.java.CalculateAbi;
-import com.facebook.buck.jvm.java.DefaultJavaLibrary;
 import com.facebook.buck.jvm.java.ForkMode;
 import com.facebook.buck.jvm.java.JavaLibrary;
 import com.facebook.buck.jvm.java.JavaLibraryRules;
 import com.facebook.buck.jvm.java.JavaOptions;
 import com.facebook.buck.jvm.java.JavaTest;
 import com.facebook.buck.jvm.java.JavacOptions;
+import com.facebook.buck.jvm.java.JavacOptionsFactory;
 import com.facebook.buck.jvm.java.TestType;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.parser.NoSuchBuildTargetException;
@@ -46,6 +46,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.logging.Level;
 
@@ -53,17 +54,17 @@ public class KotlinTestDescription implements Description<KotlinTestDescription.
 
   private final KotlinBuckConfig kotlinBuckConfig;
   private final JavaOptions javaOptions;
-  private final JavacOptions defaultJavacOptions;
+  private final JavacOptions templateJavacOptions;
   private final Optional<Long> defaultTestRuleTimeoutMs;
 
   public KotlinTestDescription(
       KotlinBuckConfig kotlinBuckConfig,
       JavaOptions javaOptions,
-      JavacOptions defaultJavacOptions,
+      JavacOptions templateOptions,
       Optional<Long> defaultTestRuleTimeoutMs) {
     this.kotlinBuckConfig = kotlinBuckConfig;
     this.javaOptions = javaOptions;
-    this.defaultJavacOptions = defaultJavacOptions;
+    this.templateJavacOptions = templateOptions;
     this.defaultTestRuleTimeoutMs = defaultTestRuleTimeoutMs;
   }
 
@@ -92,28 +93,39 @@ public class KotlinTestDescription implements Description<KotlinTestDescription.
           new BuildTargetSourcePath(testTarget));
     }
 
-    BuildTarget abiJarTarget =
-        BuildTarget.builder(params.getBuildTarget())
-            .addFlavors(CalculateAbi.FLAVOR)
-            .build();
+    JavacOptions javacOptions =
+        JavacOptionsFactory.create(
+            templateJavacOptions,
+            params,
+            resolver,
+            ruleFinder,
+            args
+        );
+
+    BuildTarget abiJarTarget = params.getBuildTarget().withAppendedFlavors(CalculateAbi.FLAVOR);
 
     KotlincToJarStepFactory stepFactory = new KotlincToJarStepFactory(
         kotlinBuckConfig.getKotlinCompiler().get(),
         args.extraKotlincArguments);
 
-    BuildRuleParams testsLibraryParams =
-        params.appendExtraDeps(
-            Iterables.concat(
-                BuildRules.getExportedRules(
+    BuildRuleParams testsLibraryParams = params.copyWithDeps(
+        Suppliers.ofInstance(
+            ImmutableSortedSet.<BuildRule>naturalOrder()
+                .addAll(params.getDeclaredDeps().get())
+                .addAll(BuildRules.getExportedRules(
                     Iterables.concat(
                         params.getDeclaredDeps().get(),
-                        resolver.getAllRules(args.providedDeps))),
-                ruleFinder.filterBuildRuleInputs(
-                    defaultJavacOptions.getInputs(ruleFinder))))
-            .withFlavor(JavaTest.COMPILED_TESTS_LIBRARY_FLAVOR);
-    JavaLibrary testsLibrary =
+                        resolver.getAllRules(args.providedDeps))))
+                .addAll(ruleFinder.filterBuildRuleInputs(
+                    javacOptions.getInputs(ruleFinder)))
+                .build()
+            ),
+            params.getExtraDeps())
+         .withFlavor(JavaTest.COMPILED_TESTS_LIBRARY_FLAVOR);
+
+        JavaLibrary testsLibrary =
         resolver.addToIndex(
-            new DefaultJavaLibrary(
+            new DefaultKotlinLibrary(
                 testsLibraryParams,
                 pathResolver,
                 ruleFinder,
@@ -122,36 +134,36 @@ public class KotlinTestDescription implements Description<KotlinTestDescription.
                     pathResolver,
                     params.getProjectFilesystem(),
                     args.resources),
-                defaultJavacOptions.getGeneratedSourceFolderName(),
-                /* proguardConfig */ Optional.empty(),
-                /* postprocessClassesCommands */ ImmutableList.of(),
-                /* exportDeps */ ImmutableSortedSet.of(),
-                /* providedDeps */ ImmutableSortedSet.of(),
+                templateJavacOptions.getGeneratedSourceFolderName(),
+                Optional.empty(),        /* proguardConfig */
+                ImmutableList.of(),      /* postprocessClassesCommands */
+                ImmutableSortedSet.of(), /* exportedDeps */
+                ImmutableSortedSet.of(), /* providedDeps */
                 abiJarTarget,
                 JavaLibraryRules.getAbiInputs(resolver, testsLibraryParams.getDeps()),
-                /* trackClassUsage */ false,
-                /* additionalClasspathEntries */ ImmutableSet.of(),
+                false,                   /* trackClassUsage */
+                ImmutableSet.of(),       /* additionalClasspathEntries */
                 stepFactory,
-                /* resourcesRoot */ Optional.empty(),
-                /* manifest file */ Optional.empty(),
-                /* mavenCoords */ Optional.empty(),
-                /* tests */ ImmutableSortedSet.of(),
-                /* classesToRemoveFromJar */ ImmutableSet.of()
+                args.resourcesRoot,
+                args.manifestFile,
+                args.mavenCoords,
+                ImmutableSortedSet.of(), /* tests */
+                ImmutableSet.of()        /* classesToRemoveFromJar */
             ));
 
-    return new JavaTest(
+    return new KotlinTest(
         params.copyWithDeps(
             Suppliers.ofInstance(ImmutableSortedSet.of(testsLibrary)),
             Suppliers.ofInstance(ImmutableSortedSet.of())),
         pathResolver,
         testsLibrary,
-        /* additionalClasspathEntries */ ImmutableSet.of(),
+        ImmutableSet.<Path>of(kotlinBuckConfig.getPathToRuntimeJar()),
         args.labels,
         args.contacts,
         args.testType.orElse(TestType.JUNIT),
         javaOptions.getJavaRuntimeLauncher(),
         args.vmArgs,
-        /* nativeLibsEnvironment */ ImmutableMap.of(),
+        ImmutableMap.of(), /* nativeLibsEnvironment */
         args.testRuleTimeoutMs.map(Optional::of).orElse(defaultTestRuleTimeoutMs),
         args.testCaseTimeoutMs,
         args.env,

--- a/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
+++ b/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
@@ -737,8 +737,7 @@ public class KnownBuildRuleTypes {
             defaultTestRuleTimeoutMs,
             defaultCxxPlatform));
     builder.register(new KeystoreDescription());
-    builder.register(
-        new KotlinLibraryDescription(kotlinBuckConfig));
+    builder.register(new KotlinLibraryDescription(kotlinBuckConfig, defaultJavacOptions));
     builder.register(
         new KotlinTestDescription(
             kotlinBuckConfig,

--- a/test/com/facebook/buck/jvm/kotlin/BUCK.autodeps
+++ b/test/com/facebook/buck/jvm/kotlin/BUCK.autodeps
@@ -1,11 +1,16 @@
 {
   "kotlin" : {
     "deps" : [
+      "//src/com/facebook/buck/io:io",
       "//src/com/facebook/buck/jvm/kotlin:kotlin",
+      "//src/com/facebook/buck/model:model",
       "//src/com/facebook/buck/util:exceptions",
       "//test/com/facebook/buck/cli:FakeBuckConfig",
       "//test/com/facebook/buck/jvm/kotlin:testutil",
+      "//test/com/facebook/buck/model:testutil",
       "//test/com/facebook/buck/testutil/integration:util",
+      "//third-party/java/guava:guava",
+      "//third-party/java/hamcrest:java-hamcrest",
       "//third-party/java/junit:junit"
     ],
     "exported_deps" : [ ]
@@ -14,6 +19,7 @@
     "deps" : [
       "//src/com/facebook/buck/jvm/kotlin:kotlin",
       "//src/com/facebook/buck/util:exceptions",
+      "//src/com/facebook/buck/util/environment:platform",
       "//test/com/facebook/buck/cli:FakeBuckConfig",
       "//third-party/java/junit:junit"
     ],

--- a/test/com/facebook/buck/jvm/kotlin/KotlinBuckConfigTest.java
+++ b/test/com/facebook/buck/jvm/kotlin/KotlinBuckConfigTest.java
@@ -15,23 +15,172 @@
  */
 package com.facebook.buck.jvm.kotlin;
 
-import com.facebook.buck.cli.FakeBuckConfig;
-import com.facebook.buck.util.HumanReadableException;
+import static java.io.File.pathSeparator;
+import static org.junit.Assert.assertEquals;
 
-import org.junit.Before;
-import org.junit.Test;
+import com.facebook.buck.cli.BuckConfig;
+import com.facebook.buck.cli.FakeBuckConfig;
+import com.facebook.buck.io.MoreFiles;
+import com.facebook.buck.io.ProjectFilesystem;
+import com.facebook.buck.testutil.integration.ProjectWorkspace;
+import com.facebook.buck.testutil.integration.TemporaryPaths;
+import com.facebook.buck.testutil.integration.TestDataHelper;
+import com.facebook.buck.util.HumanReadableException;
+import com.google.common.collect.ImmutableMap;
 
 import java.io.IOException;
+import java.nio.file.Path;
+
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 public class KotlinBuckConfigTest {
 
+  @Rule
+  public TemporaryPaths tmp = new TemporaryPaths();
+
+  private ProjectWorkspace workspace;
+
   @Before
   public void setUp() throws InterruptedException, IOException {
-    KotlinTestAssumptions.assumeCompilerAvailable();
+    KotlinTestAssumptions.assumeUnixLike();
+
+    workspace = TestDataHelper.createProjectWorkspaceForScenario(
+        this, "kotlin_compiler_test", tmp);
+    workspace.setUp();
   }
 
   @Test
-  public void testFindsKotlinCompiler() throws HumanReadableException {
-    new KotlinBuckConfig(FakeBuckConfig.builder().build()).getKotlinCompiler();
+  public void testFindsKotlinCompilerInPath() throws HumanReadableException, IOException {
+    // Get faux kotlinc binary location in project
+    Path kotlinPath = workspace.resolve("bin");
+    Path kotlinCompiler = kotlinPath.resolve("kotlinc");
+    MoreFiles.makeExecutable(kotlinCompiler);
+
+    BuckConfig buckConfig = FakeBuckConfig.builder()
+      .setEnvironment(
+        ImmutableMap.of("PATH",
+            kotlinPath.toString() + pathSeparator +
+            System.getenv("PATH")))
+      .build();
+
+    KotlinBuckConfig kotlinBuckConfig = new KotlinBuckConfig(buckConfig);
+    String command = kotlinBuckConfig.getKotlinCompiler().get().getCommandPrefix(null).get(0);
+    assertEquals(command, kotlinCompiler.toString());
+  }
+
+  @Test
+  public void testFindsKotlinCompilerInHome() throws HumanReadableException, IOException {
+    // Get faux kotlinc binary location in project
+    Path kotlinCompiler = workspace.resolve("bin").resolve("kotlinc");
+    MoreFiles.makeExecutable(kotlinCompiler);
+
+    BuckConfig buckConfig = FakeBuckConfig.builder()
+        .setEnvironment(
+          ImmutableMap.of("KOTLIN_HOME", workspace.getPath(".").normalize().toString()))
+        .build();
+
+    KotlinBuckConfig kotlinBuckConfig = new KotlinBuckConfig(buckConfig);
+    String command = kotlinBuckConfig.getKotlinCompiler().get().getCommandPrefix(null).get(0);
+    assertEquals(command, kotlinCompiler.toString());
+  }
+
+  @Test
+  public void testFindsKotlinCompilerInConfigWithAbsolutePath()
+      throws HumanReadableException, IOException {
+    // Get faux kotlinc binary location in project
+    Path kotlinCompiler = workspace.resolve("bin").resolve("kotlinc");
+    MoreFiles.makeExecutable(kotlinCompiler);
+
+    BuckConfig buckConfig = FakeBuckConfig.builder()
+        .setSections(ImmutableMap.of(
+            "kotlin",
+            ImmutableMap.of("compiler", kotlinCompiler.toString())))
+        .build();
+
+    KotlinBuckConfig kotlinBuckConfig = new KotlinBuckConfig(buckConfig);
+    String command = kotlinBuckConfig.getKotlinCompiler().get().getCommandPrefix(null).get(0);
+    assertEquals(command, kotlinCompiler.toString());
+  }
+
+  @Test
+  public void testFindsKotlinCompilerInConfigWithRelativePath()
+      throws HumanReadableException, IOException {
+    // Get faux kotlinc binary location in project
+    Path kotlinCompiler = workspace.resolve("bin").resolve("kotlinc");
+    MoreFiles.makeExecutable(kotlinCompiler);
+
+    ProjectFilesystem filesystem = new ProjectFilesystem(workspace.resolve("."));
+    BuckConfig buckConfig = FakeBuckConfig.builder()
+        .setFilesystem(filesystem)
+        .setSections(ImmutableMap.of("kotlin", ImmutableMap.of("compiler", "bin/kotlinc")))
+        .build();
+
+    KotlinBuckConfig kotlinBuckConfig = new KotlinBuckConfig(buckConfig);
+    String command = kotlinBuckConfig.getKotlinCompiler().get().getCommandPrefix(null).get(0);
+    assertEquals(command, kotlinCompiler.toString());
+  }
+
+  @Test
+  public void testFindsKotlinRuntimeLibraryInPath() throws IOException {
+    // Get faux kotlinc binary location in project
+    Path kotlinPath = workspace.resolve("bin");
+    Path kotlinCompiler = kotlinPath.resolve("kotlinc");
+    MoreFiles.makeExecutable(kotlinCompiler);
+
+    BuckConfig buckConfig = FakeBuckConfig.builder()
+      .setEnvironment(
+        ImmutableMap.of("PATH",
+            kotlinPath.toString() + pathSeparator +
+            System.getenv("PATH")))
+      .build();
+
+    KotlinBuckConfig kotlinBuckConfig = new KotlinBuckConfig(buckConfig);
+    Path runtimeJar = kotlinBuckConfig.getPathToRuntimeJar();
+    Assert.assertThat(runtimeJar.toString(),
+                      Matchers.containsString(workspace.getPath(".").normalize().toString()));
+  }
+
+  @Test
+  public void testFindsKotlinRuntimeInConfigWithAbsolutePath()
+      throws HumanReadableException, IOException {
+
+    Path kotlinRuntime = workspace.resolve("lib").resolve("kotlin-runtime.jar");
+
+    BuckConfig buckConfig = FakeBuckConfig.builder()
+        .setSections(ImmutableMap.of(
+            "kotlin",
+            ImmutableMap.of("runtime_jar", kotlinRuntime.toString())))
+        .setEnvironment(
+            ImmutableMap.of("KOTLIN_HOME", workspace.getPath(".").normalize().toString()))
+        .build();
+
+    KotlinBuckConfig kotlinBuckConfig = new KotlinBuckConfig(buckConfig);
+    Path runtimeJar = kotlinBuckConfig.getPathToRuntimeJar();
+    assertEquals(runtimeJar.toString(), kotlinRuntime.toString());
+  }
+
+  @Test
+  public void testFindsKotlinRuntimeInConfigWithRelativePath()
+      throws HumanReadableException, IOException {
+
+    Path kotlinRuntime = workspace.resolve("lib").resolve("kotlin-runtime.jar");
+
+    ProjectFilesystem filesystem = new ProjectFilesystem(workspace.resolve("."));
+    BuckConfig buckConfig = FakeBuckConfig.builder()
+        .setFilesystem(filesystem)
+        .setSections(ImmutableMap.of(
+            "kotlin",
+            ImmutableMap.of("runtime_jar", "lib/kotlin-runtime.jar")))
+        .setEnvironment(
+            ImmutableMap.of("KOTLIN_HOME", workspace.getPath(".").normalize().toString()))
+        .build();
+
+    KotlinBuckConfig kotlinBuckConfig = new KotlinBuckConfig(buckConfig);
+    Path runtimeJar = kotlinBuckConfig.getPathToRuntimeJar();
+    assertEquals(runtimeJar.toString(), kotlinRuntime.toString());
   }
 }

--- a/test/com/facebook/buck/jvm/kotlin/KotlinTestAssumptions.java
+++ b/test/com/facebook/buck/jvm/kotlin/KotlinTestAssumptions.java
@@ -17,13 +17,19 @@
 package com.facebook.buck.jvm.kotlin;
 
 import static org.junit.Assume.assumeNoException;
+import static org.junit.Assume.assumeTrue;
 
 import com.facebook.buck.cli.FakeBuckConfig;
 import com.facebook.buck.util.HumanReadableException;
+import com.facebook.buck.util.environment.Platform;
 
 import java.io.IOException;
 
 public abstract class KotlinTestAssumptions {
+  public static void assumeUnixLike() {
+    assumeTrue(Platform.detect() != Platform.WINDOWS);
+  }
+
   public static void assumeCompilerAvailable() throws IOException {
     Throwable exception = null;
     try {

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_compiler_test/bin/kotlinc
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_compiler_test/bin/kotlinc
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "Hello, Kotlin." > kotlin.out

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_compiler_test/environment/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_compiler_test/environment/BUCK.fixture
@@ -1,0 +1,7 @@
+kotlin_library(
+  name = 'simple',
+  srcs = ['Simple.kt'],
+  visibility = [
+    'PUBLIC',
+  ]
+)

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_compiler_test/environment/Simple.kt
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_compiler_test/environment/Simple.kt
@@ -1,0 +1,5 @@
+package environment
+
+fun main(args: Array<String>) {
+    println("Hello, world")
+}

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_compiler_test/lib/kotlin-runtime.jar
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_compiler_test/lib/kotlin-runtime.jar
@@ -1,0 +1,1 @@
+This is not really a jar.

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_test_description/com/example/empty_test/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_test_description/com/example/empty_test/BUCK.fixture
@@ -1,7 +1,3 @@
 kotlin_test(
   name = 'test',
-  deps = [
-    '//:junit',
-    '//:kotlin-runtime',
-  ],
 )


### PR DESCRIPTION
kotlin_test execution now implicitly includes Kotlin runtime.

Kotlin-specific classes introduced which extend their Java peers rather than referencing
the Java implementations directly, for semantic separation and preparation for first-class
native (in VM) compilation, abi, and autodeps support.