### PR TITLE
Plumb java bootclasspath to genrules.

### DIFF
--- a/src/com/facebook/buck/shell/Genrule.java
+++ b/src/com/facebook/buck/shell/Genrule.java
@@ -191,6 +191,7 @@ public class Genrule extends AbstractBuildRule
         "GEN_DIR",
         getProjectFilesystem().resolve(getProjectFilesystem().getBuckPaths().getGenDir())
             .toString());
+    environmentVariablesBuilder.put("BOOT_CLASSPATH", System.getProperty("sun.boot.class.path"));
     environmentVariablesBuilder.put("SRCDIR", absolutePathToSrcDirectory.toString());
     environmentVariablesBuilder.put("TMP", absolutePathToTmpDirectory.toString());
 


### PR DESCRIPTION
The plumbs the java bootclasspath so genrules can properly build source using the base java libraries. Like java.util.concurrent.

http://docs.oracle.com/javase/7/docs/technotes/tools/findingclasses.html
