### PR TITLE
Add instructions on sharing macros to docs

### DIFF
--- a/docs/extending/macros.soy
+++ b/docs/extending/macros.soy
@@ -17,6 +17,8 @@ Because build files accept valid Python code, it is possible to define
 Python functions that have the side-effect of creating build rules.
 Such functions are called <strong>macros</strong>.
 
+<h3>Defining A Macro</h3>
+
 <p>
 
 <strong>Warning:</strong> Although build files are evaluated as Python
@@ -61,6 +63,8 @@ java_library_using_guava(
 )
 </pre>{/literal}
 
+<h3>Sharing Macros Within Your Project</h3>
+
 If you wish to include your macros in multiple BUCK files, you can 
 use <a href="/function/include_defs.html"><code>include_defs()</code></a>:
 {literal}<pre class="prettyprint lang-py">
@@ -77,6 +81,8 @@ include a <a href="/concept/buckconfig.html#buildfile.includes">buildfile.includ
   includes = //MACROS
 </pre>{/literal}
 
+
+<h3>Compound Build Rules</h3>
 
 You can also create more sophisticated macros that create multiple build
 rules. For example, you might want to create a single build rule that

--- a/docs/extending/macros.soy
+++ b/docs/extending/macros.soy
@@ -61,6 +61,23 @@ java_library_using_guava(
 )
 </pre>{/literal}
 
+If you wish to include your macros in multiple BUCK files, you can 
+use <a href="/function/include_defs.html"><code>include_defs()</code></a>:
+{literal}<pre class="prettyprint lang-py">
+include_defs("//MACROS")
+
+# This will call the `java_library_using_guava` macro defined in //MACROS.
+java_library_using_guava(...)
+</pre>{/literal}
+
+To include shared macros project-wide, edit your <code>.buckconfig</code> to
+include a <a href="/concept/buckconfig.html#buildfile.includes">buildfile.includes property</a>:
+{literal}<pre class="prettyprint lang-ini">
+[buildfile]
+  includes = //MACROS
+</pre>{/literal}
+
+
 You can also create more sophisticated macros that create multiple build
 rules. For example, you might want to create a single build rule that
 produces both debug and release versions of an APK:


### PR DESCRIPTION
I was recently trying to get some macros setup for a project and I couldn't remember how includes were supposed to work, and it would have been helpful if the page on macros was more instructive. This is just adding a section to introduce the concept of project includes so it's easier to come across/is in more than one place. 

Also add some section headers to break up the article.