### PR TITLE
Sort RDotTxtEntry such that styleable entries are kept together in R.txt

### DIFF
--- a/src/com/facebook/buck/android/aapt/RDotTxtEntry.java
+++ b/src/com/facebook/buck/android/aapt/RDotTxtEntry.java
@@ -216,10 +216,24 @@ public class RDotTxtEntry implements Comparable<RDotTxtEntry> {
       return 0;
     }
 
-    return ComparisonChain.start()
-        .compare(this.type, that.type)
-        .compare(this.name, that.name)
-        .result();
+    ComparisonChain comparisonChain = ComparisonChain.start().compare(this.type, that.type);
+
+    String [] thisNameParts = this.name.split("_");
+    String [] thatNameParts = that.name.split("_");
+
+    int index = 0;
+    while (index < thisNameParts.length && index < thatNameParts.length) {
+      comparisonChain = comparisonChain.compare(thisNameParts[index], thatNameParts[index]);
+      index++;
+    }
+
+    if (index < thisNameParts.length) {
+      comparisonChain = comparisonChain.compare(thisNameParts[index], "");
+    } else if (index < thatNameParts.length) {
+      comparisonChain = comparisonChain.compare("", thatNameParts[index]);
+    }
+
+    return comparisonChain.result();
   }
 
   @Override

--- a/src/com/facebook/buck/android/aapt/RDotTxtEntry.java
+++ b/src/com/facebook/buck/android/aapt/RDotTxtEntry.java
@@ -227,10 +227,8 @@ public class RDotTxtEntry implements Comparable<RDotTxtEntry> {
       index++;
     }
 
-    if (index < thisNameParts.length) {
-      comparisonChain = comparisonChain.compare(thisNameParts[index], "");
-    } else if (index < thatNameParts.length) {
-      comparisonChain = comparisonChain.compare("", thatNameParts[index]);
+    if (index < thisNameParts.length || index < thatNameParts.length) {
+      comparisonChain = comparisonChain.compare(thisNameParts.length, thatNameParts.length);
     }
 
     return comparisonChain.result();

--- a/test/com/facebook/buck/android/aapt/RDotTxtEntryTest.java
+++ b/test/com/facebook/buck/android/aapt/RDotTxtEntryTest.java
@@ -43,7 +43,6 @@ public class RDotTxtEntryTest {
     );
 
     assertEquals(
-        sortedEntries,
         ImmutableList.of(
             new RDotTxtEntry(IdType.INT_ARRAY, RType.STYLEABLE, "ActionBar", null),
             new RDotTxtEntry(IdType.INT, RType.STYLEABLE, "ActionBar_background", "2"),
@@ -51,7 +50,16 @@ public class RDotTxtEntryTest {
             new RDotTxtEntry(IdType.INT, RType.STYLEABLE, "ActionBar_contentInsetEnd", "0"),
             new RDotTxtEntry(IdType.INT_ARRAY, RType.STYLEABLE, "ActionBarLayout", "0x7f060008"),
             new RDotTxtEntry(IdType.INT, RType.STYLEABLE, "ActionBarLayout_android", "0")
-        )
+        ),
+        sortedEntries
     );
+  }
+
+  @Test
+  public void testRDotTxtEntryCompareToWithDifferentLengthStyleables() {
+    RDotTxtEntry entry1 = new RDotTxtEntry(IdType.INT, RType.STYLEABLE, "ActionBar_contentInsetEnd", "1");
+    RDotTxtEntry entry2 = new RDotTxtEntry(IdType.INT, RType.STYLEABLE, "ActionBar_contentInsetEnd__android", "0");
+
+    assertEquals(entry1.compareTo(entry2), -1);
   }
 }

--- a/test/com/facebook/buck/android/aapt/RDotTxtEntryTest.java
+++ b/test/com/facebook/buck/android/aapt/RDotTxtEntryTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.android.aapt;
+
+import static org.junit.Assert.assertEquals;
+
+import com.facebook.buck.android.aapt.RDotTxtEntry.IdType;
+import com.facebook.buck.android.aapt.RDotTxtEntry.RType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Ordering;
+
+import org.junit.Test;
+
+public class RDotTxtEntryTest {
+
+  @Test
+  public void testRDotTxtEntryCompareTo() {
+    ImmutableList<RDotTxtEntry> entries = ImmutableList.of(
+        new RDotTxtEntry(IdType.INT_ARRAY, RType.STYLEABLE, "ActionBar", null),
+        new RDotTxtEntry(IdType.INT_ARRAY, RType.STYLEABLE, "ActionBarLayout", "0x7f060008"),
+        new RDotTxtEntry(IdType.INT, RType.STYLEABLE, "ActionBar_background", "2"),
+        new RDotTxtEntry(IdType.INT, RType.STYLEABLE, "ActionBar_contentInsetEnd", "0"),
+        new RDotTxtEntry(IdType.INT, RType.STYLEABLE, "ActionBarLayout_android", "0"),
+        new RDotTxtEntry(IdType.INT, RType.STYLEABLE, "ActionBar_backgroundStack", "1")
+    );
+
+    ImmutableList<RDotTxtEntry> sortedEntries = ImmutableList.copyOf(
+        Ordering.natural().sortedCopy(entries)
+    );
+
+    assertEquals(
+        sortedEntries,
+        ImmutableList.of(
+            new RDotTxtEntry(IdType.INT_ARRAY, RType.STYLEABLE, "ActionBar", null),
+            new RDotTxtEntry(IdType.INT, RType.STYLEABLE, "ActionBar_background", "2"),
+            new RDotTxtEntry(IdType.INT, RType.STYLEABLE, "ActionBar_backgroundStack", "1"),
+            new RDotTxtEntry(IdType.INT, RType.STYLEABLE, "ActionBar_contentInsetEnd", "0"),
+            new RDotTxtEntry(IdType.INT_ARRAY, RType.STYLEABLE, "ActionBarLayout", "0x7f060008"),
+            new RDotTxtEntry(IdType.INT, RType.STYLEABLE, "ActionBarLayout_android", "0")
+        )
+    );
+  }
+}

--- a/test/com/facebook/buck/android/aapt/RDotTxtEntryTest.java
+++ b/test/com/facebook/buck/android/aapt/RDotTxtEntryTest.java
@@ -57,8 +57,10 @@ public class RDotTxtEntryTest {
 
   @Test
   public void testRDotTxtEntryCompareToWithDifferentLengthStyleables() {
-    RDotTxtEntry entry1 = new RDotTxtEntry(IdType.INT, RType.STYLEABLE, "ActionBar_contentInsetEnd", "1");
-    RDotTxtEntry entry2 = new RDotTxtEntry(IdType.INT, RType.STYLEABLE, "ActionBar_contentInsetEnd__android", "0");
+    RDotTxtEntry entry1 = new RDotTxtEntry(
+        IdType.INT, RType.STYLEABLE, "ActionBar_contentInsetEnd", "1");
+    RDotTxtEntry entry2 = new RDotTxtEntry(
+        IdType.INT, RType.STYLEABLE, "ActionBar_contentInsetEnd__android", "0");
 
     assertEquals(entry1.compareTo(entry2), -1);
   }


### PR DESCRIPTION
Correct Sorting:
```
int[] styleable ActionBar {  }
int styleable ActionBar_background 10
int styleable ActionBar_backgroundSplit 12
int styleable ActionBar_backgroundStacked 11
int styleable ActionBar_contentInsetEnd 21
...
int[] styleable ActionBarLayout { 0x7f060008 }
int styleable ActionBarLayout_android_layout_gravity 0
```

Incorrect Sorting
```
int[] styleable ActionBar {  }
int[] styleable ActionBarLayout { 0x7f060008 }
int styleable ActionBarLayout_android_layout_gravity 0
int styleable ActionBar_background 10
int styleable ActionBar_backgroundSplit 12
int styleable ActionBar_backgroundStacked 11
int styleable ActionBar_contentInsetEnd 21
...
```