### PR TITLE
Add NDK cxx_runtime_type to link static C++ runtime

### DIFF
--- a/src/com/facebook/buck/android/AndroidBuckConfig.java
+++ b/src/com/facebook/buck/android/AndroidBuckConfig.java
@@ -17,6 +17,7 @@
 package com.facebook.buck.android;
 
 import com.facebook.buck.cli.BuckConfig;
+import com.facebook.buck.cxx.Linker;
 import com.facebook.buck.util.environment.Platform;
 import com.google.common.collect.ImmutableSet;
 
@@ -69,6 +70,10 @@ public class AndroidBuckConfig {
 
   public Optional<NdkCxxPlatforms.CxxRuntime> getNdkCxxRuntime() {
     return delegate.getEnum("ndk", "cxx_runtime", NdkCxxPlatforms.CxxRuntime.class);
+  }
+
+  public Optional<Linker.CxxRuntimeType> getNdkCxxRuntimeType() {
+    return delegate.getEnum("ndk", "cxx_runtime_type", Linker.CxxRuntimeType.class);
   }
 
   /**

--- a/src/com/facebook/buck/android/NdkCxxPlatforms.java
+++ b/src/com/facebook/buck/android/NdkCxxPlatforms.java
@@ -83,6 +83,8 @@ public class NdkCxxPlatforms {
       ImmutableSet.of("arm", "armv7", "x86");
   public static final NdkCxxPlatforms.CxxRuntime DEFAULT_CXX_RUNTIME =
       NdkCxxPlatforms.CxxRuntime.GNUSTL;
+  public static final Linker.CxxRuntimeType DEFAULT_CXX_RUNTIME_TYPE =
+      Linker.CxxRuntimeType.DYNAMIC;
 
   private static final ImmutableMap<Platform, Host> BUILD_PLATFORMS =
       ImmutableMap.of(
@@ -134,6 +136,7 @@ public class NdkCxxPlatforms {
       Path ndkRoot,
       NdkCxxPlatformCompiler compiler,
       CxxRuntime cxxRuntime,
+      Linker.CxxRuntimeType cxxRuntimeType,
       String androidPlatform,
       Set<String> cpuAbis,
       Platform platform) {
@@ -143,6 +146,7 @@ public class NdkCxxPlatforms {
         ndkRoot,
         compiler,
         cxxRuntime,
+        cxxRuntimeType,
         androidPlatform,
         cpuAbis,
         platform,
@@ -159,6 +163,7 @@ public class NdkCxxPlatforms {
       Path ndkRoot,
       NdkCxxPlatformCompiler compiler,
       CxxRuntime cxxRuntime,
+      Linker.CxxRuntimeType cxxRuntimeType,
       String androidPlatform,
       Set<String> cpuAbis,
       Platform platform,
@@ -182,6 +187,7 @@ public class NdkCxxPlatforms {
               ndkRoot,
               targetConfiguration,
               cxxRuntime,
+              cxxRuntimeType,
               executableFinder,
               strictToolchainPaths);
       ndkCxxPlatformBuilder.put(TargetCpuType.ARM, armeabi);
@@ -202,6 +208,7 @@ public class NdkCxxPlatforms {
               ndkRoot,
               targetConfiguration,
               cxxRuntime,
+              cxxRuntimeType,
               executableFinder,
               strictToolchainPaths);
       ndkCxxPlatformBuilder.put(TargetCpuType.ARMV7, armeabiv7);
@@ -222,6 +229,7 @@ public class NdkCxxPlatforms {
               ndkRoot,
               targetConfiguration,
               cxxRuntime,
+              cxxRuntimeType,
               executableFinder,
               strictToolchainPaths);
       ndkCxxPlatformBuilder.put(TargetCpuType.ARM64, arm64);
@@ -242,6 +250,7 @@ public class NdkCxxPlatforms {
               ndkRoot,
               targetConfiguration,
               cxxRuntime,
+              cxxRuntimeType,
               executableFinder,
               strictToolchainPaths);
       ndkCxxPlatformBuilder.put(TargetCpuType.X86, x86);
@@ -265,6 +274,7 @@ public class NdkCxxPlatforms {
               ndkRoot,
               targetConfiguration,
               cxxRuntime,
+              cxxRuntimeType,
               executableFinder,
               strictToolchainPaths);
       ndkCxxPlatformBuilder.put(TargetCpuType.X86_64, x86_64);
@@ -484,6 +494,7 @@ public class NdkCxxPlatforms {
       Path ndkRoot,
       NdkCxxPlatformTargetConfiguration targetConfiguration,
       CxxRuntime cxxRuntime,
+      Linker.CxxRuntimeType cxxRuntimeType,
       ExecutableFinder executableFinder,
       boolean strictToolchainPaths) {
     // Create a version string to use when generating rule keys via the NDK tools we'll generate
@@ -631,7 +642,10 @@ public class NdkCxxPlatforms {
 
     if (cxxRuntime != CxxRuntime.SYSTEM) {
       cxxPlatformBuilder.putRuntimeLdflags(
-          Linker.LinkableDepType.SHARED, "-l" + cxxRuntime.getSharedName());
+          Linker.LinkableDepType.SHARED, "-l" +
+              (cxxRuntimeType == Linker.CxxRuntimeType.DYNAMIC ?
+                  cxxRuntime.getSharedName() :
+                  cxxRuntime.getStaticName()));
       cxxPlatformBuilder.putRuntimeLdflags(
           Linker.LinkableDepType.STATIC, "-l" + cxxRuntime.getStaticName());
     }

--- a/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
+++ b/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
@@ -385,6 +385,7 @@ public class KnownBuildRuleTypes {
               ndkRoot.get(),
               compiler,
               androidConfig.getNdkCxxRuntime().orElse(NdkCxxPlatforms.DEFAULT_CXX_RUNTIME),
+              androidConfig.getNdkCxxRuntimeType().orElse(NdkCxxPlatforms.DEFAULT_CXX_RUNTIME_TYPE),
               androidConfig.getNdkAppPlatform().orElse(NdkCxxPlatforms.DEFAULT_TARGET_APP_PLATFORM),
               androidConfig.getNdkCpuAbis().orElse(NdkCxxPlatforms.DEFAULT_CPU_ABIS),
               platform));

--- a/test/com/facebook/buck/android/AndroidBinaryIntegrationTest.java
+++ b/test/com/facebook/buck/android/AndroidBinaryIntegrationTest.java
@@ -334,6 +334,32 @@ public class AndroidBinaryIntegrationTest {
   }
 
   @Test
+  public void testCxxLibraryDepClangStatic() throws IOException {
+    String target = "//apps/sample:app_cxx_lib_dep_static";
+    ProjectWorkspace.ProcessResult result =
+        workspace.runBuckCommand(
+            "build",
+            "-c", "ndk.compiler=clang",
+            "-c", "ndk.cxx_runtime=libcxx",
+            "-c", "ndk.cxx_runtime_type=static",
+            target);
+    result.assertSuccess();
+
+    ZipInspector zipInspector = new ZipInspector(
+        workspace.getPath(
+            BuildTargets.getGenPath(
+                filesystem,
+                BuildTargetFactory.newInstance(target),
+                "%s.apk")));
+    zipInspector.assertFileExists("lib/armeabi/libnative_cxx_lib.so");
+    zipInspector.assertFileDoesNotExist("lib/armeabi/libc++_shared.so");
+    zipInspector.assertFileExists("lib/armeabi-v7a/libnative_cxx_lib.so");
+    zipInspector.assertFileDoesNotExist("lib/armeabi-v7a/libc++_shared.so");
+    zipInspector.assertFileExists("lib/x86/libnative_cxx_lib.so");
+    zipInspector.assertFileDoesNotExist("lib/x86/libc++_shared.so");
+  }
+
+  @Test
   public void testCxxLibraryDepWithNoFilters() throws IOException {
     String target = "//apps/sample:app_cxx_lib_dep_no_filters";
     workspace.runBuckCommand("build", target).assertSuccess();
@@ -619,6 +645,7 @@ public class AndroidBinaryIntegrationTest {
             .setGccVersion(gccVersion)
             .build(),
         NdkCxxPlatforms.DEFAULT_CXX_RUNTIME,
+        NdkCxxPlatforms.DEFAULT_CXX_RUNTIME_TYPE,
         NdkCxxPlatforms.DEFAULT_TARGET_APP_PLATFORM,
         NdkCxxPlatforms.DEFAULT_CPU_ABIS,
         Platform.detect()).values();

--- a/test/com/facebook/buck/android/NdkCxxPlatformTest.java
+++ b/test/com/facebook/buck/android/NdkCxxPlatformTest.java
@@ -228,6 +228,7 @@ public class NdkCxxPlatformTest {
                       .setGccVersion("clang-version")
                       .build(),
                   NdkCxxPlatforms.CxxRuntime.GNUSTL,
+                  NdkCxxPlatforms.DEFAULT_CXX_RUNTIME_TYPE,
                   "target-app-platform",
                   ImmutableSet.of("x86"),
                   platform,

--- a/test/com/facebook/buck/android/testdata/android_project/apps/sample/BUCK.fixture
+++ b/test/com/facebook/buck/android/testdata/android_project/apps/sample/BUCK.fixture
@@ -133,6 +133,21 @@ android_binary(
 )
 
 android_binary(
+  name = 'app_cxx_lib_dep_static',
+  manifest = 'AndroidManifest.xml',
+  keystore = '//keystores:debug',
+  cpu_filters = [
+    'arm',
+    'armv7',
+    'x86',
+  ],
+  deps = [
+    '//res/com/sample/base:base',
+    '//native/cxx:lib',
+  ],
+)
+
+android_binary(
   name = 'app_cxx_lib_dep_modular',
   manifest = 'AndroidManifest.xml',
   application_module_targets = [

--- a/test/com/facebook/buck/cxx/CxxSharedLibraryInterfaceIntegrationTest.java
+++ b/test/com/facebook/buck/cxx/CxxSharedLibraryInterfaceIntegrationTest.java
@@ -83,6 +83,7 @@ public class CxxSharedLibraryInterfaceIntegrationTest {
             ndkDir.get(),
             compiler,
             NdkCxxPlatforms.DEFAULT_CXX_RUNTIME,
+            NdkCxxPlatforms.DEFAULT_CXX_RUNTIME_TYPE,
             NdkCxxPlatforms.DEFAULT_TARGET_APP_PLATFORM,
             NdkCxxPlatforms.DEFAULT_CPU_ABIS,
             Platform.detect());


### PR DESCRIPTION
Fix #741

Example:

    [ndk]
      ndk_version = r10e
      app_platform = android-21
      compiler = clang
      cxx_runtime = libcxx
      cxx_runtime_type = static
