### PR TITLE
Add snapshot_reference_images_path to apple_test

### DIFF
--- a/src/com/facebook/buck/apple/AppleTest.java
+++ b/src/com/facebook/buck/apple/AppleTest.java
@@ -108,6 +108,9 @@ public class AppleTest
   private final Path testOutputPath;
   private final Path testLogsPath;
 
+  @AddToRuleKey
+  private final Optional<SourcePath> snapshotReferenceImagePath;
+
   private Optional<Long> testRuleTimeoutMs;
 
   private Optional<AppleTestXctoolStdoutReader> xctoolStdoutReader;
@@ -194,7 +197,8 @@ public class AppleTest
       String testLogLevelEnvironmentVariable,
       String testLogLevel,
       Optional<Long> testRuleTimeoutMs,
-      boolean isUiTest) {
+      boolean isUiTest,
+      Optional<SourcePath> snapshotReferenceImagePath) {
     super(params, resolver);
     this.xctool = xctool;
     this.xctoolStutterTimeout = xctoolStutterTimeout;
@@ -219,6 +223,7 @@ public class AppleTest
     this.testLogLevelEnvironmentVariable = testLogLevelEnvironmentVariable;
     this.testLogLevel = testLogLevel;
     this.isUiTest = isUiTest;
+    this.snapshotReferenceImagePath = snapshotReferenceImagePath;
   }
 
   @Override
@@ -316,7 +321,8 @@ public class AppleTest
               Optional.of(resolvedTestLogsPath),
               Optional.of(testLogLevelEnvironmentVariable),
               Optional.of(testLogLevel),
-              testRuleTimeoutMs);
+              testRuleTimeoutMs,
+              this.snapshotReferenceImagePath.map(getResolver()::getAbsolutePath));
       steps.add(xctoolStep);
       externalSpec.setType("xctool-" + (testHostApp.isPresent() ? "application" : "logic"));
       externalSpec.setCommand(xctoolStep.getCommand());

--- a/src/com/facebook/buck/apple/AppleTestDescription.java
+++ b/src/com/facebook/buck/apple/AppleTestDescription.java
@@ -295,7 +295,8 @@ public class AppleTestDescription implements
         appleConfig.getTestLogLevelEnvironmentVariable(),
         appleConfig.getTestLogLevel(),
         args.testRuleTimeoutMs.map(Optional::of).orElse(defaultTestRuleTimeoutMs),
-        args.isUiTest());
+        args.isUiTest(),
+        args.snapshotReferenceImagesPath);
   }
 
   private Optional<SourcePath> getXctool(
@@ -468,6 +469,9 @@ public class AppleTestDescription implements
     public Optional<Boolean> runTestSeparately;
     public Optional<Boolean> isUiTest;
     public Optional<BuildTarget> testHostApp;
+
+    // for use with FBSnapshotTestcase, injects the path as FB_REFERENCE_IMAGE_DIR
+    public Optional<SourcePath> snapshotReferenceImagesPath;
 
     // Bundle related fields.
     public SourcePath infoPlist;

--- a/src/com/facebook/buck/apple/XctoolRunTestsStep.java
+++ b/src/com/facebook/buck/apple/XctoolRunTestsStep.java
@@ -74,6 +74,7 @@ class XctoolRunTestsStep implements Step {
   private static final ScheduledExecutorService stutterTimeoutExecutorService =
       Executors.newSingleThreadScheduledExecutor();
   private static final String XCTOOL_ENV_VARIABLE_PREFIX = "XCTOOL_TEST_ENV_";
+  private static final String FB_REFERENCE_IMAGE_DIR = "FB_REFERENCE_IMAGE_DIR";
 
   private final ProjectFilesystem filesystem;
 
@@ -95,6 +96,7 @@ class XctoolRunTestsStep implements Step {
   private final Optional<String> logLevelEnvironmentVariable;
   private final Optional<String> logLevel;
   private final Optional<Long> timeoutInMs;
+  private final Optional<Path> snapshotReferenceImagePath;
 
   // Helper class to parse the output of `xctool -listTestsOnly` then
   // store it in a multimap of {target: [testDesc1, testDesc2, ...], ... } pairs.
@@ -171,7 +173,8 @@ class XctoolRunTestsStep implements Step {
       Optional<Path> logDirectory,
       Optional<String> logLevelEnvironmentVariable,
       Optional<String> logLevel,
-      Optional<Long> timeoutInMs) {
+      Optional<Long> timeoutInMs,
+      Optional<Path> snapshotReferenceImagePath) {
     Preconditions.checkArgument(
         !(logicTestBundlePaths.isEmpty() &&
           appTestBundleToHostAppPaths.isEmpty()),
@@ -198,6 +201,7 @@ class XctoolRunTestsStep implements Step {
     this.logLevelEnvironmentVariable = logLevelEnvironmentVariable;
     this.logLevel = logLevel;
     this.timeoutInMs = timeoutInMs;
+    this.snapshotReferenceImagePath = snapshotReferenceImagePath;
   }
 
   @Override
@@ -226,6 +230,11 @@ class XctoolRunTestsStep implements Step {
       environment.put(
           XCTOOL_ENV_VARIABLE_PREFIX + logLevelEnvironmentVariable.get(),
           logLevel.get());
+    }
+    if (snapshotReferenceImagePath.isPresent()) {
+      environment.put(
+          XCTOOL_ENV_VARIABLE_PREFIX + FB_REFERENCE_IMAGE_DIR,
+          snapshotReferenceImagePath.get().toString());
     }
 
     environment.putAll(this.environmentOverrides);

--- a/test/com/facebook/buck/apple/XctoolRunTestsStepTest.java
+++ b/test/com/facebook/buck/apple/XctoolRunTestsStepTest.java
@@ -74,6 +74,7 @@ public class XctoolRunTestsStepTest {
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
+        Optional.empty(),
         Optional.empty()
         );
     ProcessExecutorParams xctoolParams =
@@ -120,6 +121,7 @@ public class XctoolRunTestsStepTest {
         Optional.empty(),
         Suppliers.ofInstance(Optional.of(Paths.get("/path/to/developer/dir"))),
         TestSelectorList.EMPTY,
+        Optional.empty(),
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
@@ -180,6 +182,7 @@ public class XctoolRunTestsStepTest {
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
+        Optional.empty(),
         Optional.empty());
 
     ProcessExecutorParams xctoolParams =
@@ -231,6 +234,7 @@ public class XctoolRunTestsStepTest {
         Optional.empty(),
         Suppliers.ofInstance(Optional.of(Paths.get("/path/to/developer/dir"))),
         TestSelectorList.EMPTY,
+        Optional.empty(),
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
@@ -289,6 +293,7 @@ public class XctoolRunTestsStepTest {
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
+        Optional.empty(),
         Optional.empty());
 
     ProcessExecutorParams xctoolParams =
@@ -341,6 +346,7 @@ public class XctoolRunTestsStepTest {
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
+        Optional.empty(),
         Optional.empty());
 
     ProcessExecutorParams xctoolParams =
@@ -389,6 +395,7 @@ public class XctoolRunTestsStepTest {
         TestSelectorList.builder()
             .addRawSelectors("#.*Magic.*")
             .build(),
+        Optional.empty(),
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
@@ -484,6 +491,7 @@ public class XctoolRunTestsStepTest {
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
+        Optional.empty(),
         Optional.empty());
 
     ProcessExecutorParams xctoolListOnlyParams =
@@ -544,6 +552,7 @@ public class XctoolRunTestsStepTest {
         TestSelectorList.builder()
             .addRawSelectors("Blargh#Xyzzy")
             .build(),
+        Optional.empty(),
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
@@ -610,7 +619,8 @@ public class XctoolRunTestsStepTest {
         Optional.of(Paths.get("/path/to/test-logs")),
         Optional.of("TEST_LOG_LEVEL"),
         Optional.of("verbose"),
-        Optional.empty());
+        Optional.empty(),
+        Optional.of(Paths.get("/path/to/snapshotimages")));
     ProcessExecutorParams xctoolParams =
         ProcessExecutorParams.builder()
             .setCommand(
@@ -629,7 +639,8 @@ public class XctoolRunTestsStepTest {
                 ImmutableMap.of(
                     "DEVELOPER_DIR", "/path/to/developer/dir",
                     "XCTOOL_TEST_ENV_TEST_LOG_PATH", "/path/to/test-logs",
-                    "XCTOOL_TEST_ENV_TEST_LOG_LEVEL", "verbose"))
+                    "XCTOOL_TEST_ENV_TEST_LOG_LEVEL", "verbose",
+                    "XCTOOL_TEST_ENV_FB_REFERENCE_IMAGE_DIR", "/path/to/snapshotimages"))
             .setDirectory(projectFilesystem.getRootPath().toAbsolutePath())
             .setRedirectOutput(ProcessBuilder.Redirect.PIPE)
             .build();


### PR DESCRIPTION
For usage with the https://github.com/facebook/ios-snapshot-test-case repo.

Snapshot test reference image paths are controlled by an environment variable that is set on the test run process. Currently though it is not possible to add an environment variable to a specific test target. This commit allows indivudual apple_test rules to reference different paths for snapshot test reference images.

This is a specific field instead of a more general thing like `test_environment_variables`, to allow the value to be a SourcePath so it can be combined with the `export_file` rule.