### PR TITLE
Allow for a pageid to be passed in for navigation purposes

### DIFF
--- a/docs/__common.soy
+++ b/docs/__common.soy
@@ -4,14 +4,14 @@
  * @param title
  * @param? subtitle
  * @param content
- * @param? ishome
+ * @param? navid
  * @param? prettify true if https://code.google.com/p/google-code-prettify/
  *     should be used.
  * @param description the content of the og:description meta tag
  */
 {template .page}
   {call .header}
-    {param ishome: $ishome /}
+    {param navid: $navid /}
     {param title: $title /}
     {param subtitle: $subtitle /}
     {param prettify: $prettify /}
@@ -30,7 +30,7 @@
 /**
  * @param title
  * @param? subtitle
- * @param? ishome
+ * @param? navid
  * @param? prettify true if https://code.google.com/p/google-code-prettify/
  *     should be used.
  * @param description the content of the og:description meta tag
@@ -73,11 +73,12 @@ src="https://www.facebook.com/tr?id=1637165926500152&ev=PageView&noscript=1"
 
   // TODO(bolinfest): Pass $og_type in as a parameter.
   {let $og_type}
-    {if $ishome}
-      website
-    {else}
-      article
-    {/if}
+    {switch $navid}
+      {case 'home'}
+        website
+      {default}
+        article
+    {/switch}
   {/let}
 
   <meta property="og:locale" content="en_US">
@@ -122,7 +123,7 @@ src="https://www.facebook.com/tr?id=1637165926500152&ev=PageView&noscript=1"
       </ul>
 	</nav></header>
 
-{if $ishome}
+{if $navid == 'home'}
   <header class='hero'><div class='width'>
     <hgroup>
       <h1>
@@ -144,7 +145,7 @@ src="https://www.facebook.com/tr?id=1637165926500152&ev=PageView&noscript=1"
 
   <article>
 
-  {if not $ishome}
+  {if $navid != 'home'}
     <h1>{$title}{if $subtitle}:<div class="subtitle">{$subtitle}</div>{/if}</h1>
   {/if}
 

--- a/docs/index.soy
+++ b/docs/index.soy
@@ -3,7 +3,7 @@
 /***/
 {template .soyweb}
   {call buck.page}
-    {param ishome: true /}
+    {param navid: 'home' /}
     {param title: 'A fast build tool' /}
     {param description}
         Buck is a build system developed and used by Facebook.  It encourages the creation of small,


### PR DESCRIPTION
This largely just repurposes `ishome` to be more useful in a series of
future changes.