### PR TITLE
Do not link to the internal API at the top of the page

### DIFF
--- a/docs/__common.soy
+++ b/docs/__common.soy
@@ -127,7 +127,6 @@ src="https://www.facebook.com/tr?id=1637165926500152&ev=PageView&noscript=1"
       </li>
         <li><a href='{ROOT}setup/getting_started.html'>Getting Started</a>
         <li><a href='https://groups.google.com/forum/#!forum/buck-build'>Group</a>
-        <li><a href='{ROOT}javadoc/'>API</a>
         <li><a href='https://github.com/facebook/buck'>GitHub</a>
       </ul>
 	</nav></header>

--- a/docs/extending/rules.soy
+++ b/docs/extending/rules.soy
@@ -18,7 +18,9 @@
 As of the writing of this document, the only official way to add rules
 to Buck is to fork the project and modify the source. We will, at some
 point, construct a beautiful and elegant extensions API. Until
-then....
+then, you'll want to have the documentation of our internal{sp}
+<a href='{ROOT}javadoc/'>API</a> handy, and then...
+
 
 <p>
 


### PR DESCRIPTION
This isn't important for 99.9% of the people viewing the website.

Test Plan:
Loaded http://localhost:9811/extending/rules.html