### PR TITLE
Remove doc navigation from landing page + sticky footer

### DIFF
--- a/docs/__common.soy
+++ b/docs/__common.soy
@@ -613,14 +613,15 @@ src="https://www.facebook.com/tr?id=1637165926500152&ev=PageView&noscript=1"
  */
 {template .footer}
 
-</article>
-
 {if $navid != 'home'}
+  </article>
   <nav>
     {call buck.tableOfContents data="all"}
       {param navid: $navid /}
     {/call}
   </nav>
+{else}
+  </landing-page>
 {/if}
 
 </div></section>

--- a/docs/__common.soy
+++ b/docs/__common.soy
@@ -152,10 +152,11 @@ src="https://www.facebook.com/tr?id=1637165926500152&ev=PageView&noscript=1"
 
 	<section class='content'><div class='width'>
 
-  <article>
-
   {if $navid != 'home'}
+    <article>
     <h1>{$title}{if $subtitle}:<div class="subtitle">{$subtitle}</div>{/if}</h1>
+  {else}
+    <landing-page>
   {/if}
 
 {/template}
@@ -614,12 +615,13 @@ src="https://www.facebook.com/tr?id=1637165926500152&ev=PageView&noscript=1"
 
 </article>
 
+{if $navid != 'home'}
   <nav>
     {call buck.tableOfContents data="all"}
       {param navid: $navid /}
     {/call}
   </nav>
-
+{/if}
 
 </div></section>
 

--- a/docs/static/buck.css
+++ b/docs/static/buck.css
@@ -285,9 +285,14 @@ section.content nav ul li.navActiveItem a {
   color: white;
 }
 
+
 footer {
-  background: #000;
-  padding: 10px 0;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 1rem;
+  background-color: #000;
   color: #fff;
   border-top: 4px solid #fff;
 }
@@ -383,6 +388,11 @@ footer {
 
   section.content article {
     float: right;
+    width: 660px;
+  }
+
+  section.content landing-page {
+    float: left;
     width: 660px;
   }
 

--- a/docs/static/buck.css
+++ b/docs/static/buck.css
@@ -291,7 +291,7 @@ footer {
   bottom: 0;
   left: 0;
   right: 0;
-  padding: 1rem;
+  padding: 10px 0;
   background-color: #000;
   color: #fff;
   border-top: 4px solid #fff;

--- a/docs/static/buck.css
+++ b/docs/static/buck.css
@@ -229,7 +229,7 @@ section.content landing-page h2 {
 section.content article ul li,
 section.content article ol li,
 section.content landing-page ul li,
-section.content landing-page ol, li
+section.content landing-page ol li
  {
   margin: 1em 0;
 }

--- a/docs/static/buck.css
+++ b/docs/static/buck.css
@@ -210,40 +210,51 @@ section.content {
   padding: 30px 0;
 }
 
-section.content article img {
+section.content article img,
+section.content landing-page img {
   max-width: 100%;
 }
 
-section.content article h1 {
+section.content article h1,
+section.content landing-page h1 {
   font-weight: bold;
 }
 
-section.content article h2 {
+section.content article h2,
+section.content landing-page h2 {
   color: #888888;
   font-weight: bold;
 }
 
 section.content article ul li,
-section.content article ol li {
+section.content article ol li,
+section.content landing-page ul li,
+section.content landing-page ol, li
+ {
   margin: 1em 0;
 }
 
 section.content article ul.tight-list li,
-section.content article ol.tight-list li {
+section.content article ol.tight-list li,
+section.content landing-page ul.tight-list li,
+section.content landing-page ol.tight-list li {
   margin: 0;
 }
 
-section.content article blockquote {
+section.content article blockquote,
+section.content landing-page blockquote {
   padding: 0px 20px;
   margin: 0 0 20px;
   border-left: 5px solid #eee;
 }
 
-section.content article blockquote p {
+section.content article blockquote p,
+section.content landing-page blockquote p {
   font-style: italic;
 }
 
-section.content article blockquote small:before {
+section.content article blockquote small:before,
+section.content landing-page blockquote small:before {
   content: '\2014 \00A0';
 }
 


### PR DESCRIPTION
- Use landing page to market Buck without other distractions
  - This includes centering the text in the middle of the landing page now
- Keep footer sticky


![screenshot 2017-01-10 16 06 49](https://cloud.githubusercontent.com/assets/3757713/21830026/cf854aac-d74e-11e6-9dab-0ec3e2034e3c.png)