### PR TITLE
Rename "Getting Started" to "Docs" in header.

### DIFF
--- a/docs/__common.soy
+++ b/docs/__common.soy
@@ -125,7 +125,7 @@ src="https://www.facebook.com/tr?id=1637165926500152&ev=PageView&noscript=1"
       <li class="algolia-search-wrapper">
         <input id="algolia-doc-search" type="search" placeholder="Search docs..." />
       </li>
-        <li><a href='{ROOT}setup/getting_started.html'>Getting Started</a>
+        <li><a href='{ROOT}setup/getting_started.html'>Docs</a>
         <li><a href='https://groups.google.com/forum/#!forum/buck-build'>Group</a>
         <li><a href='https://github.com/facebook/buck'>GitHub</a>
       </ul>


### PR DESCRIPTION
We will still default to the Getting Started page, but Docs is more clear that one can see the Table of Contents of all the docs by clicking on it.

![screenshot 2017-01-11 13 31 18](https://cloud.githubusercontent.com/assets/3757713/21867264/48dc921c-d802-11e6-91e8-d63d00315455.png)
