### PR TITLE
Add the ability to link to specific arguments of a build rule

### DIFF
--- a/docs/__common.soy
+++ b/docs/__common.soy
@@ -667,18 +667,24 @@ docsearch({
  * @param desc Prose description of the argument.
  */
 {template .arg}
-  <li class="{css arg}"><code>{$name}</code>
-
-  {sp}
-  {if isNonnull($default)}
-    (defaults to <code>{$default}</code>)
-  {else}
-    (required)
-  {/if}
-  {sp}
-
-  {$desc|noAutoescape}
-
+<li id="{$name}" class="arg">
+  <h3>
+    <code class="argName">{$name}</code>
+    {sp}
+    <span class="argDefault">
+      {if isNonnull($default)}
+        (defaults to <code>{$default}</code>)
+      {else}
+        (required)
+      {/if}
+    </span>
+    {sp}
+    <a class="inline-link" href="#{$name}">#</a>
+  </h3>
+  <p>
+    {$desc|noAutoescape}
+  </p>
+</li>
 {/template}
 
 

--- a/docs/static/buck.css
+++ b/docs/static/buck.css
@@ -321,6 +321,12 @@ footer {
   list-style-type: square;
   margin-bottom: 0.5em;
 }
+.arg code.argName {
+  font-weight: bolder;
+}
+.arg span.argDefault {
+  font-size: smaller;
+}
 
 .build_target_ex {
   font-size: 36px;


### PR DESCRIPTION
This fixes https://github.com/facebook/buck/issues/979

Test Plan:
Loaded http://localhost:9811/rule/export_file.html and made sure I could
link to specific arguments (just like the .buckconfig page).