### PR TITLE
Redirect template

### DIFF
--- a/docs/__common.soy
+++ b/docs/__common.soy
@@ -1287,3 +1287,17 @@ sudo ln -s ${lb}PWD{rb}/bin/buck /usr/bin/buck
 {/if}
 </pre>
 {/template}
+
+/**
+ * @param newURL
+ */
+{template .redirectTo}
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting...</title>
+<link rel=canonical href="{$newURL}">
+<meta http-equiv=refresh content="0; url={$newURL}">
+<h1>Redirecting...</h1>
+<a href="{$newURL}">Click here if you are not redirected.</a>
+<script>location="{$newURL}"</script>
+{/template}

--- a/docs/setup/install.soy
+++ b/docs/setup/install.soy
@@ -1,0 +1,8 @@
+{namespace buck.install}
+
+/***/
+{template .soyweb}
+{call buck.redirectTo }
+  {param newURL: 'https://buckbuild.com/setup/getting_started.html' /}
+{/call}
+{/template}


### PR DESCRIPTION
We removed `install.html` when we combined the getting started page.
So let's have a redirect template that we can use for important (or all)
pages that we remove.

Add back `install.soy` with a call to the redirect template.

Test:

redirect worked locally