### PR TITLE
Provide better documentation for `cxx_test` using `gtest`

### DIFF
--- a/docs/__buckconfig_common.soy
+++ b/docs/__buckconfig_common.soy
@@ -152,6 +152,14 @@
 {/template}
 
 /***/
+{template .cxx_gtest_dep}
+{call .entry_link}
+  {param section: 'cxx' /}
+  {param entry: 'gtest_dep' /}
+{/call}
+{/template}
+
+/***/
 {template .lua_cxx_library}
 {call .entry_link}
     {param section: 'lua' /}

--- a/docs/concept/buckconfig.soy
+++ b/docs/concept/buckconfig.soy
@@ -1355,6 +1355,50 @@ $ buck targets --resolve-alias app#src_jar
 
 {call buckconfig.entry}
   {param section: 'cxx' /}
+  {param name: 'gtest_dep' /}
+  {param example_value: '//third-party/gtest:gtest' /}
+  {param description}
+    The {call buck.build_rule /} to compile the <a href="https://github.com/google/googletest" target="_blank">Google Test</a> framework.
+  {/param}
+  {param raw_example}
+    <p>
+      If you had your Google Test code in <code>third-party/gtest/</code>, the {call buck.build_file /} in that directory would look something like this:
+    </p>
+    <pre class="prettyprint lang-py">
+{literal}
+cxx_library(
+  name = 'gtest',
+  srcs = subdir_glob([
+    'googletest/src/gtest-all.cc',
+    'googlemock/src/gmock-all.cc',
+    'googlemock/src/gmock_main.cc',
+  ]),
+  header_namespace = '',
+  exported_headers = subdir_glob([
+    ('googletest/include', '**/*.h'),
+    ('googlemock/include', '**/*.h'),
+  ]),
+  headers = subdir_glob([
+    ('googletest', 'src/*.cc'),
+    ('googletest', 'src/*.h'),
+    ('googlemock', 'src/*.cc'),
+    ('googlemock', 'src/*.h'),
+  ]),
+  platform_linker_flags = [
+    ('android', []),
+    ('', ['-lpthread']),
+  ],
+  visibility = [
+    '//test/...',
+  ],
+)
+{/literal}
+    </pre>
+  {/param}
+{/call}
+
+{call buckconfig.entry}
+  {param section: 'cxx' /}
   {param name: 'untracked_headers' /}
   {param example_value: 'error' /}
   {param description}

--- a/docs/rule/cxx_test.soy
+++ b/docs/rule/cxx_test.soy
@@ -15,7 +15,7 @@
 {param status: 'UNFROZEN' /}
 {param overview}
 A cxx_test() rule builds a C/C++ binary against a C/C++ testing framework and runs
-it as part of <code>buck test</code>.
+it as part of {call buck.cmd_test /}.
 {/param}
 
 {param args}
@@ -45,8 +45,12 @@ it as part of <code>buck test</code>.
   {param name: 'framework' /}
   {param default : '"gtest"' /}
   {param desc}
-  The testing framework to build against and run with.
-  We currently support <a href="https://code.google.com/p/googletest/"><code>gtest</code></a> and <a href="http://www.boost.org/doc/libs/1_57_0/libs/test/doc/html/index.html"><code>boost</code></a>.
+  <p>
+    The testing framework to build against and run with.  We currently support <a href="https://github.com/google/googletest"><code>gtest</code></a> and <a href="http://www.boost.org/doc/libs/1_57_0/libs/test/doc/html/index.html"><code>boost</code></a>.
+  </p>
+  <p>
+    When set to <code>gtest</code>, you must also set {call buckconfig.cxx_gtest_dep /}.
+  </p>
   {/param}
 {/call}
 


### PR DESCRIPTION
This incorporates the changes suggested by @milch into the docs.

Closes https://github.com/facebook/buck/issues/448

Test Plan:
Loaded these pages:
* http://localhost:9811/rule/cxx_test.html
* http://localhost:9811/concept/buckconfig.html#cxx.gtest_dep