### PR TITLE
Signed binary if needed in Apple bundle

### DIFF
--- a/src/com/facebook/buck/apple/AppleBundle.java
+++ b/src/com/facebook/buck/apple/AppleBundle.java
@@ -547,6 +547,11 @@ public class AppleBundle
         };
       }
 
+      addBinarySigningStepIfNeeded(
+        context.getSourcePathResolver(),
+        codeSignIdentitySupplier,
+        stepsBuilder);
+
       addSwiftStdlibStepIfNeeded(
         context.getSourcePathResolver(),
         bundleRoot.resolve(Paths.get("Frameworks")),
@@ -763,6 +768,26 @@ public class AppleBundle
     }
 
     return keys.build();
+  }
+
+  public void addBinarySigningStepIfNeeded(
+      SourcePathResolver resolver,
+      Supplier<CodeSignIdentity> codeSignIdentitySupplier,
+      ImmutableList.Builder<Step> stepsBuilder) {
+    if (hasBinary) {
+      stepsBuilder.add(
+        new CodeSignStep(
+          getProjectFilesystem(),
+          resolver,
+          bundleBinaryPath,
+          Optional.empty(),
+          codeSignIdentitySupplier,
+          codesignAllocatePath,
+          dryRunCodeSigning ?
+            Optional.of(bundleBinaryPath.resolve(CODE_SIGN_DRY_RUN_ARGS_FILE)) :
+            Optional.empty())
+      );
+    }
   }
 
   public void addSwiftStdlibStepIfNeeded(


### PR DESCRIPTION
I was getting `Foo.app/Foo: code object is not signed at all` when I was running `buck install --emulator FooApp` where `FooApp` is an `apple_bundle`.

Testing:

After this change I'm able to launch the app but will appreciate direction on where and how to add tests :-)