### PR TITLE
HasConsecutiveItemsMatcher: Make it compile with JDK 9

### DIFF
--- a/test/com/facebook/buck/testutil/HasConsecutiveItemsMatcher.java
+++ b/test/com/facebook/buck/testutil/HasConsecutiveItemsMatcher.java
@@ -83,7 +83,7 @@ public class HasConsecutiveItemsMatcher<T>
   @SafeVarargs
   public static <T> Matcher<Collection<? extends T>> hasConsecutiveItems(
       Matcher<? super T>... matchers) {
-    return hasConsecutiveItems(Arrays.asList(matchers));
+    return hasConsecutiveItems(Arrays.<Matcher<? super T>>asList(matchers));
   }
 
   public static <T> Matcher<Collection<? extends T>> hasConsecutiveItems(


### PR DESCRIPTION
This problem is probably related to: [1].

Test Plan:

Apply this PR https://github.com/facebook/buck/pull/1047 and run:

  buck build --config java.error_prone_javac=true \
test/com/facebook/buck/testutil:testutil

[1] https://bugs.openjdk.java.net/browse/JDK-8039214