### PR TITLE
Get resId value of an attribute from module’s styleable array if there is no explicit attribute entry.

### DIFF
--- a/src/com/facebook/buck/android/MergeAndroidResourcesStep.java
+++ b/src/com/facebook/buck/android/MergeAndroidResourcesStep.java
@@ -263,10 +263,10 @@ public class MergeAndroidResourcesStep implements Step {
 
         ImmutableList.Builder<String> customDrawablesBuilder = ImmutableList.builder();
         ImmutableList.Builder<String> grayscaleImagesBuilder = ImmutableList.builder();
-        RDotTxtEntry.RType lastType = null;
+        RType lastType = null;
 
         for (RDotTxtEntry res : packageToResources.get(rDotJavaPackage)) {
-          RDotTxtEntry.RType type = res.type;
+          RType type = res.type;
           if (!type.equals(lastType)) {
             // If the previous type needs to be closed, close it.
             if (lastType != null) {
@@ -287,10 +287,10 @@ public class MergeAndroidResourcesStep implements Step {
               res.name,
               res.idValue);
 
-          if (type == RDotTxtEntry.RType.DRAWABLE &&
+          if (type == RType.DRAWABLE &&
               res.customType == RDotTxtEntry.CustomDrawableType.CUSTOM) {
             customDrawablesBuilder.add(res.idValue);
-          } else if (type == RDotTxtEntry.RType.DRAWABLE &&
+          } else if (type == RType.DRAWABLE &&
               res.customType == RDotTxtEntry.CustomDrawableType.GRAYSCALE_IMAGE) {
             grayscaleImagesBuilder.add(res.idValue);
           }
@@ -355,9 +355,10 @@ public class MergeAndroidResourcesStep implements Step {
       List<String> linesInSymbolsFile;
       try {
         linesInSymbolsFile =
-            FluentIterable.from(filesystem.readLines(symbolsFile))
+            filesystem.readLines(symbolsFile)
+                .stream()
                 .filter(input -> !Strings.isNullOrEmpty(input))
-                .toList();
+                .collect(Collectors.toList());
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
@@ -530,10 +531,12 @@ public class MergeAndroidResourcesStep implements Step {
 
   @Override
   public String getDescription(ExecutionContext context) {
-    ImmutableList<String> resources =
-        FluentIterable.from(androidResourceDeps)
-            .transform(Object::toString)
-            .toSortedList(natural());
+    List<String> resources =
+        androidResourceDeps
+            .stream()
+            .map(Object::toString)
+            .sorted(natural())
+            .collect(Collectors.toList());
     return getShortName() + " " + Joiner.on(' ').join(resources);
   }
 
@@ -545,7 +548,7 @@ public class MergeAndroidResourcesStep implements Step {
   private static class IntEnumerator {
     private int value;
 
-    public IntEnumerator(int start) {
+    IntEnumerator(int start) {
       value = start;
     }
 

--- a/test/com/facebook/buck/android/MergeAndroidResourcesStepTest.java
+++ b/test/com/facebook/buck/android/MergeAndroidResourcesStepTest.java
@@ -111,7 +111,7 @@ public class MergeAndroidResourcesStepTest {
 
     Set<String> uniqueEntries = Sets.newHashSet();
     for (RDotTxtEntry resource : resources) {
-      if (!resource.type.equals(RDotTxtEntry.RType.STYLEABLE)) {
+      if (!resource.type.equals(STYLEABLE)) {
         assertFalse("Duplicate ids should be fixed by renumerate=true; duplicate was: " +
             resource.idValue, uniqueEntries.contains(resource.idValue));
         uniqueEntries.add(resource.idValue);
@@ -771,11 +771,11 @@ public class MergeAndroidResourcesStepTest {
     private final ImmutableMap.Builder<Path, String> filePathToPackageName =
         ImmutableMap.builder();
 
-    public RDotTxtEntryBuilder() {
+    RDotTxtEntryBuilder() {
       this(new FakeProjectFilesystem());
     }
 
-    public RDotTxtEntryBuilder(FakeProjectFilesystem filesystem) {
+    RDotTxtEntryBuilder(FakeProjectFilesystem filesystem) {
       this.filesystem = filesystem;
     }
 
@@ -784,7 +784,7 @@ public class MergeAndroidResourcesStepTest {
       filePathToPackageName.put(entry.filePath, entry.packageName);
     }
 
-    public Map<Path, String> buildFilePathToPackageNameSet() {
+    Map<Path, String> buildFilePathToPackageNameSet() {
       return filePathToPackageName.build();
     }
 
@@ -793,12 +793,13 @@ public class MergeAndroidResourcesStepTest {
     }
   }
 
-  private static class RDotTxtFile {
-    public String packageName;
-    public Path filePath;
+  static class RDotTxtFile {
     public ImmutableList<String> contents;
 
-    public RDotTxtFile(String packageName, String filePath, ImmutableList<String> contents) {
+    String packageName;
+    Path filePath;
+
+    RDotTxtFile(String packageName, String filePath, ImmutableList<String> contents) {
       this.packageName = packageName;
       this.filePath = Paths.get(filePath);
       this.contents = contents;


### PR DESCRIPTION
This applies for attributes which come from android sdk.

Correct Output
```
    public static int[] AlertDialog={ 0x010100f2,0x07f01074,0x07f010b3,0x07f010b4,0x07f010c0,0x07f010df };
    public static int AlertDialog_android_layout=0;
    public static int AlertDialog_buttonPanelSideLayout=1;
    public static int AlertDialog_listItemLayout=2;
    public static int AlertDialog_listLayout=3;
    public static int AlertDialog_multiChoiceItemLayout=4;
    public static int AlertDialog_singleChoiceItemLayout=5;
```

Previous Output
```
    public static int[] AlertDialog={ 0,0x07f01074,0x07f010b3,0x07f010b4,0x07f010c0,0x07f010df };
    public static int AlertDialog_android_layout=0;
    public static int AlertDialog_buttonPanelSideLayout=1;
    public static int AlertDialog_listItemLayout=2;
    public static int AlertDialog_listLayout=3;
    public static int AlertDialog_multiChoiceItemLayout=4;
    public static int AlertDialog_singleChoiceItemLayout=5;
```