### PR TITLE
Add missing build from source for Java

### DIFF
--- a/docs/setup/getting_started.soy
+++ b/docs/setup/getting_started.soy
@@ -219,7 +219,7 @@ brew install ant python git watchman
 
 <span><block class="mac ios" /></span>
 {call .active_developer_path /}
-<span><block class="mac ios android other" /></span>
+<span><block class="mac ios java android other" /></span>
 
 <h3>Build</h3>
 


### PR DESCRIPTION
Left of Java for building from source, so it is currently not in the docs.