### PR TITLE
[swift] Allow bridging header import headers under current module

### DIFF
--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -25,8 +25,10 @@ import com.facebook.buck.cxx.CxxHeaders;
 import com.facebook.buck.cxx.CxxPlatform;
 import com.facebook.buck.cxx.CxxPreprocessables;
 import com.facebook.buck.cxx.CxxPreprocessorInput;
+import com.facebook.buck.cxx.HeaderVisibility;
 import com.facebook.buck.cxx.LinkerMapMode;
 import com.facebook.buck.io.ProjectFilesystem;
+import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.parser.NoSuchBuildTargetException;
 import com.facebook.buck.rules.AbstractBuildRuleWithResolver;
 import com.facebook.buck.rules.AddToRuleKey;
@@ -248,6 +250,18 @@ class SwiftCompile
           headerMaps.add(resolver.getAbsolutePath(headerMap.get()).toString());
         }
         roots.add(resolver.getAbsolutePath(cxxHeaders.getIncludeRoot()).toString());
+      }
+    }
+
+    if (bridgingHeader.isPresent()) {
+      for (HeaderVisibility headerVisibility : HeaderVisibility.values()) {
+        Path headerPath = CxxDescriptionEnhancer.getHeaderSymlinkTreePath(
+            getProjectFilesystem(),
+            BuildTarget.builder(getBuildTarget().getUnflavoredBuildTarget()).build(),
+            cxxPlatform.getFlavor(),
+            headerVisibility);
+
+        headerMaps.add(headerPath.toString());
       }
     }
 

--- a/test/com/facebook/buck/apple/AppleLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/apple/AppleLibraryIntegrationTest.java
@@ -686,6 +686,22 @@ public class AppleLibraryIntegrationTest {
         containsString("libswiftCore.dylib"));
   }
 
+  @Test
+  public void testBuildAppleLibraryUsingBridingHeaderAndSwiftDotH() throws Exception {
+    assumeTrue(Platform.detect() == Platform.MACOS);
+
+    ProjectWorkspace workspace = TestDataHelper.createProjectWorkspaceForScenario(
+        this,
+        "import_current_module_via_bridging_header",
+        tmp);
+    workspace.setUp();
+    BuildTarget target = workspace.newBuildTarget("//:Greeter");
+    ProjectWorkspace.ProcessResult result = workspace.runBuckCommand(
+        "build",
+        target.getFullyQualifiedName());
+    result.assertSuccess();
+  }
+
   private static void assertIsSymbolicLink(
       Path link,
       Path target) throws IOException {

--- a/test/com/facebook/buck/apple/testdata/import_current_module_via_bridging_header/.buckconfig
+++ b/test/com/facebook/buck/apple/testdata/import_current_module_via_bridging_header/.buckconfig
@@ -1,0 +1,2 @@
+[cxx]
+    default_platform = macosx-x86_64

--- a/test/com/facebook/buck/apple/testdata/import_current_module_via_bridging_header/BUCK.fixture
+++ b/test/com/facebook/buck/apple/testdata/import_current_module_via_bridging_header/BUCK.fixture
@@ -1,0 +1,14 @@
+apple_library(
+    name = 'Greeter',
+    bridging_header = 'bridging-header.h',
+    headers = glob([
+        '*.h',
+    ]),
+    srcs = glob([
+        '*.m',
+        '*.swift',
+    ]),
+    frameworks = [
+        '$SDKROOT/System/Library/Frameworks/Foundation.framework'
+    ],
+)

--- a/test/com/facebook/buck/apple/testdata/import_current_module_via_bridging_header/Greeter.h
+++ b/test/com/facebook/buck/apple/testdata/import_current_module_via_bridging_header/Greeter.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface Greeter : NSObject
++ (void)sayHello:(NSString *)name;
+@end

--- a/test/com/facebook/buck/apple/testdata/import_current_module_via_bridging_header/Greeter.m
+++ b/test/com/facebook/buck/apple/testdata/import_current_module_via_bridging_header/Greeter.m
@@ -1,0 +1,7 @@
+#import "Greeter.h"
+
+@implementation Greeter
++ (void)sayHello:(NSString *)name {
+  printf("Hello %s\n", [name cStringUsingEncoding:NSUTF8StringEncoding]);
+}
+@end

--- a/test/com/facebook/buck/apple/testdata/import_current_module_via_bridging_header/bridging-header.h
+++ b/test/com/facebook/buck/apple/testdata/import_current_module_via_bridging_header/bridging-header.h
@@ -1,0 +1,1 @@
+#import <Greeter/Greeter.h>

--- a/test/com/facebook/buck/apple/testdata/import_current_module_via_bridging_header/hello.swift
+++ b/test/com/facebook/buck/apple/testdata/import_current_module_via_bridging_header/hello.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+@objc public class Hello : NSObject {
+    public class func sayHello(name: String) {
+        Greeter.sayHello(name)
+    }
+}

--- a/test/com/facebook/buck/swift/SwiftLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/swift/SwiftLibraryIntegrationTest.java
@@ -104,6 +104,7 @@ public class SwiftLibraryIntegrationTest {
     args.libraries = ImmutableSortedSet.of();
     args.enableObjcInterop = Optional.empty();
     args.supportedPlatformsRegex = Optional.empty();
+    args.bridgingHeader = Optional.empty();
 
     SwiftCompile buildRule = (SwiftCompile) FakeAppleRuleDescriptions.SWIFT_LIBRARY_DESCRIPTION
         .createBuildRule(TargetGraph.EMPTY, params, resolver, args);


### PR DESCRIPTION
Right now when buck building swift with bridging header, it is not able to import header files when it reference from current library.

For example, in build rule with this setup

```
apple_library(
    name = 'Greeter',
    bridging_header = 'bridging-header.h',
    headers = glob([
        '*.h',
    ]),
    srcs = glob([
        '*.m',
        '*.swift',
    ]),
    frameworks = [
        '$SDKROOT/System/Library/Frameworks/Foundation.framework'
    ],
)
```

We can not do `#import <Greeter/Greeter.h>` in bridging header.

After investigation, I figure its due to buck didn't include the header map generated for current library in SwiftCompile.

This PR is to improve buck so it can support above use case.

**Testing**
And a new test case and verify it with `buck test --all`