### PR TITLE
No objc interoperability by default

### DIFF
--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -91,7 +91,6 @@ class SwiftCompile
   private final CxxPlatform cxxPlatform;
   private final ImmutableSet<FrameworkPath> frameworks;
 
-  private final boolean enableObjcInterop;
   private final Optional<SourcePath> bridgingHeader;
   private final SwiftBuckConfig swiftBuckConfig;
 
@@ -108,7 +107,6 @@ class SwiftCompile
       Path outputPath,
       Iterable<SourcePath> srcs,
       ImmutableList<String> compilerFlags,
-      Optional<Boolean> enableObjcInterop,
       Optional<SourcePath> bridgingHeader) throws NoSuchBuildTargetException {
     super(params, resolver);
     this.cxxPlatform = cxxPlatform;
@@ -127,7 +125,6 @@ class SwiftCompile
 
     this.srcs = ImmutableSortedSet.copyOf(srcs);
     this.compilerFlags = compilerFlags;
-    this.enableObjcInterop = enableObjcInterop.orElse(true);
     this.bridgingHeader = bridgingHeader;
     performChecks(params);
   }
@@ -182,7 +179,6 @@ class SwiftCompile
     compilerCommand.add(
         "-enable-testing",
         "-c",
-        enableObjcInterop ? "-enable-objc-interop" : "",
         hasMainEntry ? "" : "-parse-as-library",
         "-module-name",
         moduleName,

--- a/src/com/facebook/buck/swift/SwiftDescriptions.java
+++ b/src/com/facebook/buck/swift/SwiftDescriptions.java
@@ -68,7 +68,6 @@ class SwiftDescriptions {
     output.supportedPlatformsRegex = args.supportedPlatformsRegex;
     output.moduleName =
         args.moduleName.map(Optional::of).orElse(Optional.of(buildTarget.getShortName()));
-    output.enableObjcInterop = Optional.of(true);
     output.bridgingHeader = args.bridgingHeader;
 
     boolean isCompanionTarget = buildTarget.getFlavors().contains(SWIFT_COMPANION_FLAVOR);

--- a/src/com/facebook/buck/swift/SwiftLibraryDescription.java
+++ b/src/com/facebook/buck/swift/SwiftLibraryDescription.java
@@ -251,7 +251,6 @@ public class SwiftLibraryDescription implements
               buildTarget, "%s"),
           args.srcs,
           args.compilerFlags,
-          args.enableObjcInterop,
           args.bridgingHeader);
     }
 
@@ -364,7 +363,6 @@ public class SwiftLibraryDescription implements
     public ImmutableList<String> compilerFlags = ImmutableList.of();
     public ImmutableSortedSet<FrameworkPath> frameworks = ImmutableSortedSet.of();
     public ImmutableSortedSet<FrameworkPath> libraries = ImmutableSortedSet.of();
-    public Optional<Boolean> enableObjcInterop;
     public Optional<Pattern> supportedPlatformsRegex;
     public Optional<String> soname;
     public Optional<SourcePath> bridgingHeader;

--- a/test/com/facebook/buck/swift/SwiftLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/swift/SwiftLibraryIntegrationTest.java
@@ -102,7 +102,6 @@ public class SwiftLibraryIntegrationTest {
     args.compilerFlags = ImmutableList.of();
     args.frameworks = ImmutableSortedSet.of();
     args.libraries = ImmutableSortedSet.of();
-    args.enableObjcInterop = Optional.empty();
     args.supportedPlatformsRegex = Optional.empty();
     args.bridgingHeader = Optional.empty();
 


### PR DESCRIPTION
At the moment enableObjcInterop flag was always try which can be simply achieved by having it in `.buckconfig` section or via `swift_compilerf_flags`.

Having this flag always on tides Swift compiler to always assume ObjC environment. See https://github.com/apple/swift/blob/bbecb33d13bf91696ea917f1b2a29f133168e67b/lib/Basic/LangOptions.cpp#L226-L229