### PR TITLE
Fix default value in docs for `allow_symlinks`

### DIFF
--- a/docs/concept/buckconfig.soy
+++ b/docs/concept/buckconfig.soy
@@ -2226,7 +2226,7 @@ your <code>.buckjavaargs</code> file</a>:
     will silently ignore symlinks.
     </p>
     <p>
-    The default value is <code>allow</code>.
+    The default value is <code>warn</code>.
     </p>
   {/param}
 {/call}


### PR DESCRIPTION
As per https://github.com/facebook/buck/blob/5faa80d0a10e252b79274aa59edead8e0e4e0d20/src/com/facebook/buck/parser/AbstractParserConfig.java#L136