### PR TITLE
Fix Guava 20.0 migration

### DIFF
--- a/src/com/facebook/buck/rules/args/AbstractGlobArg.java
+++ b/src/com/facebook/buck/rules/args/AbstractGlobArg.java
@@ -23,7 +23,6 @@ import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.SourcePathRuleFinder;
 import com.facebook.buck.util.immutables.BuckStyleImmutable;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 
@@ -67,7 +66,6 @@ abstract class AbstractGlobArg extends Arg {
               getPathResolver().getRelativePath(getRoot()),
               matcher::matches));
     } catch (IOException e) {
-      Throwables.throwIfUnchecked(e);
       throw new RuntimeException(e);
     }
     builder.addAll(

--- a/test/com/facebook/buck/artifact_cache/InMemoryArtifactCache.java
+++ b/test/com/facebook/buck/artifact_cache/InMemoryArtifactCache.java
@@ -19,7 +19,6 @@ package com.facebook.buck.artifact_cache;
 import com.facebook.buck.io.BorrowablePath;
 import com.facebook.buck.io.LazyPath;
 import com.facebook.buck.rules.RuleKey;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.io.ByteStreams;
@@ -52,7 +51,7 @@ public class InMemoryArtifactCache implements ArtifactCache {
     try {
       Files.write(output.get(), artifact.data);
     } catch (IOException e) {
-      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
     }
     return CacheResult.hit("in-memory", artifact.metadata, artifact.data.length);
   }
@@ -75,7 +74,7 @@ public class InMemoryArtifactCache implements ArtifactCache {
     try (InputStream inputStream = Files.newInputStream(output.getPath())) {
       store(info, ByteStreams.toByteArray(inputStream));
     } catch (IOException e) {
-      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
     }
 
     return Futures.immediateFuture(null);

--- a/test/com/facebook/buck/dalvik/firstorder/FirstOrderTest.java
+++ b/test/com/facebook/buck/dalvik/firstorder/FirstOrderTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.facebook.buck.util.MoreCollectors;
-import com.google.common.base.Throwables;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -218,7 +217,6 @@ public class FirstOrderTest {
       reader.accept(node, ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
       return node;
     } catch (IOException e) {
-      Throwables.throwIfUnchecked(e);
       throw new RuntimeException(e);
     }
   }

--- a/test/com/facebook/buck/jvm/java/classes/ClasspathTraversalTest.java
+++ b/test/com/facebook/buck/jvm/java/classes/ClasspathTraversalTest.java
@@ -23,7 +23,6 @@ import com.facebook.buck.io.MorePaths;
 import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.util.MoreCollectors;
 import com.google.common.base.Charsets;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
@@ -61,7 +60,6 @@ public class ClasspathTraversalTest {
             try {
               contents = new FileLikeCharSource(fileLike).read();
             } catch (IOException e) {
-              Throwables.throwIfUnchecked(e);
               throw new RuntimeException(e);
             }
             completeList.put(fileLike, contents);

--- a/test/com/facebook/buck/rules/AbstractNodeBuilder.java
+++ b/test/com/facebook/buck/rules/AbstractNodeBuilder.java
@@ -25,7 +25,6 @@ import com.facebook.buck.rules.coercer.DefaultTypeCoercerFactory;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
 import com.facebook.buck.util.ObjectMappers;
 import com.facebook.buck.versions.Version;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
@@ -149,7 +148,6 @@ public abstract class AbstractNodeBuilder<
       }
       return node;
     } catch (NoSuchBuildTargetException e) {
-      Throwables.throwIfUnchecked(e);
       throw new RuntimeException(e);
     }
   }
@@ -217,7 +215,6 @@ public abstract class AbstractNodeBuilder<
               target,
               arg);
     } catch (ParamInfoException error) {
-      Throwables.throwIfUnchecked(error);
       throw new RuntimeException(error);
     }
   }

--- a/test/com/facebook/buck/testutil/integration/HttpdForTests.java
+++ b/test/com/facebook/buck/testutil/integration/HttpdForTests.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.server.Handler;
@@ -112,7 +111,6 @@ public class HttpdForTests implements AutoCloseable {
       return getUri("/");
     } catch (SocketException | URISyntaxException e) {
       // Should never happen
-      Throwables.throwIfUnchecked(e);
       throw new RuntimeException(e);
     }
   }


### PR DESCRIPTION
Some places were erroneously migrated to calling throwIfUnchecked(e)
even though the thrown exception was known to be a checked exception.