### PR TITLE
Close test result output file properly

### DIFF
--- a/src/com/facebook/buck/testrunner/BaseRunner.java
+++ b/src/com/facebook/buck/testrunner/BaseRunner.java
@@ -157,9 +157,11 @@ public abstract class BaseRunner {
       testSelectorSuffix += ".dry_run";
     }
     OutputStream output;
+    FileOutputStream fileOutputStream = null;
     if (outputDirectory != null) {
       File outputFile = new File(outputDirectory, testClassName + testSelectorSuffix + ".xml");
-      output = new BufferedOutputStream(new FileOutputStream(outputFile));
+      fileOutputStream = new FileOutputStream(outputFile);
+      output = new BufferedOutputStream(fileOutputStream);
     } else {
       output = System.out;
     }
@@ -168,6 +170,9 @@ public abstract class BaseRunner {
     trans.transform(source, streamResult);
     if (outputDirectory != null) {
       output.close();
+      if (fileOutputStream != null) {
+        fileOutputStream.close();
+      }
     }
   }
 


### PR DESCRIPTION
Currently, the `BaseRunner` does not correctly close the underlying `FileOutputStream` when writing test results out. This is because the current `close()` call is only performed on `BufferedOutputStream` which simply class `flush()` on the underlying stream but never closes it. This leads to too many files open exception and the test run exiting prematurely when there are several test rules running on a machine at the same time. This change fixes that problem