### PR TITLE
Fix race condition on Swift build

### DIFF
--- a/src/com/facebook/buck/apple/AppleLibraryDescription.java
+++ b/src/com/facebook/buck/apple/AppleLibraryDescription.java
@@ -25,6 +25,8 @@ import com.facebook.buck.cxx.CxxLibraryDescription;
 import com.facebook.buck.cxx.CxxPlatform;
 import com.facebook.buck.cxx.CxxStrip;
 import com.facebook.buck.cxx.FrameworkDependencies;
+import com.facebook.buck.cxx.HeaderSymlinkTree;
+import com.facebook.buck.cxx.HeaderVisibility;
 import com.facebook.buck.cxx.Linker;
 import com.facebook.buck.cxx.LinkerMapMode;
 import com.facebook.buck.cxx.ProvidesLinkedBinaryDeps;
@@ -57,12 +59,14 @@ import com.facebook.infer.annotation.SuppressFieldNotInitialized;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -93,7 +97,7 @@ public class AppleLibraryDescription implements
       LinkerMapMode.NO_LINKER_MAP.getFlavor(),
       ImmutableFlavor.of("default"));
 
-  private enum Type implements FlavorConvertible {
+  public enum Type implements FlavorConvertible {
     HEADERS(CxxDescriptionEnhancer.HEADER_SYMLINK_TREE_FLAVOR),
     EXPORTED_HEADERS(CxxDescriptionEnhancer.EXPORTED_HEADER_SYMLINK_TREE_FLAVOR),
     SANDBOX(CxxDescriptionEnhancer.SANDBOX_TREE_FLAVOR),
@@ -257,6 +261,8 @@ public class AppleLibraryDescription implements
       Optional<Linker.LinkableDepType> linkableDepType,
       Optional<SourcePath> bundleLoader,
       ImmutableSet<BuildTarget> blacklist) throws NoSuchBuildTargetException {
+    params = params.appendExtraDeps(requireHeaderSymlinkTree(params, resolver, args));
+
     Optional<BuildRule> swiftCompanionBuildRule = swiftDelegate.createCompanionBuildRule(
         targetGraph, params, resolver, args);
     if (swiftCompanionBuildRule.isPresent()) {
@@ -367,6 +373,55 @@ public class AppleLibraryDescription implements
           blacklist,
           pathResolver);
     }
+  }
+
+  private <A extends AppleNativeTargetDescriptionArg> ImmutableList<HeaderSymlinkTree>
+  requireHeaderSymlinkTree(
+      BuildRuleParams params,
+      BuildRuleResolver resolver,
+      A args
+  ) {
+    SourcePathResolver pathResolver = new SourcePathResolver(new SourcePathRuleFinder(resolver));
+    CxxLibraryDescription.Arg cxxDelegateArgs = CxxLibraryDescription.createEmptyConstructorArg();
+    AppleDescriptions.populateCxxLibraryDescriptionArg(
+        pathResolver,
+        cxxDelegateArgs,
+        args,
+        params.getBuildTarget());
+
+    ImmutableMap<Path, SourcePath> publicHeaders =  CxxDescriptionEnhancer.parseExportedHeaders(
+        params.getBuildTarget(),
+        pathResolver,
+        Optional.of(defaultCxxPlatform),
+        cxxDelegateArgs);
+    ImmutableMap<Path, SourcePath> privateHeaders =  CxxDescriptionEnhancer.parseHeaders(
+        params.getBuildTarget(),
+        pathResolver,
+        Optional.of(defaultCxxPlatform),
+        cxxDelegateArgs);
+
+    BuildRuleParams untypedParams = params
+        .withoutFlavor(SwiftLibraryDescription.SWIFT_COMPILE_FLAVOR)
+        .withoutFlavor(SwiftLibraryDescription.SWIFT_COMPILE_FLAVOR);
+
+    HeaderSymlinkTree publicHeaderSymlinkTree = CxxDescriptionEnhancer.requireHeaderSymlinkTree(
+        untypedParams,
+        resolver,
+        defaultCxxPlatform,
+        publicHeaders,
+        HeaderVisibility.PUBLIC,
+        true
+    );
+    HeaderSymlinkTree privateHeaderSymlinkTree = CxxDescriptionEnhancer.requireHeaderSymlinkTree(
+        untypedParams,
+        resolver,
+        defaultCxxPlatform,
+        privateHeaders,
+        HeaderVisibility.PRIVATE,
+        true
+    );
+
+    return ImmutableList.of(publicHeaderSymlinkTree, privateHeaderSymlinkTree);
   }
 
   private <A extends AppleNativeTargetDescriptionArg> BuildRule


### PR DESCRIPTION
In PR https://github.com/facebook/buck/pull/1164, we introduce the logic to allow `SwiftCompile` use the header maps to built bridging headers.
However, we encounter race condition issue when we building with this logic.

The headers maps, is generated by `CxxLibraryDescription`, and `SwiftCompile` step is generated by `SwiftLibraryDescription`. These two build rules are running in parallel, so its not guarantee that header maps are ready when we running `SwiftCpmile`.

To fix this issue, I am making changes to:
1. call `CxxDescriptionEnhancer.requireHeaderSymlinkTree ` to create the header symlink tree BuildRule
2. let `SwiftLibraryDescription` depends on the symlink tree BuildRule, also make changes to not filter out BuildRules if its building for headers

@ryu2 could you help to take a look on this? Thanks!

