### PR TITLE
Do not return empy annotation processor params if annotation processor deps are present

### DIFF
--- a/src/com/facebook/buck/jvm/java/JvmLibraryArg.java
+++ b/src/com/facebook/buck/jvm/java/JvmLibraryArg.java
@@ -56,7 +56,8 @@ public class JvmLibraryArg extends AbstractDescriptionArg {
       ProjectFilesystem filesystem,
       BuildRuleResolver resolver,
       Set<String> safeAnnotationProcessors) {
-    if (annotationProcessors.isEmpty() && plugins.isEmpty()) {
+    if (annotationProcessors.isEmpty() && plugins.isEmpty()
+        && annotationProcessorDeps.isEmpty()) {
       return AnnotationProcessingParams.EMPTY;
     }
 


### PR DESCRIPTION
Tools like [error-prone](https://github.com/google/error-prone) pickup custom error prone checks from the `-processorpath`. This change makes it so that annotation processor deps are always added to processor path if they exist regardless of the existence of annotation processors