### PR TITLE
Coloured dot outputs for queries

### DIFF
--- a/src/com/facebook/buck/cli/AuditClasspathCommand.java
+++ b/src/com/facebook/buck/cli/AuditClasspathCommand.java
@@ -28,6 +28,7 @@ import com.facebook.buck.parser.NoSuchBuildTargetException;
 import com.facebook.buck.rules.ActionGraphCache;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.Description;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.SourcePathRuleFinder;
 import com.facebook.buck.rules.TargetGraph;
@@ -151,6 +152,7 @@ public class AuditClasspathCommand extends AbstractCommand {
         targetGraph,
         "target_graph",
         targetNode -> "\"" + targetNode.getBuildTarget().getFullyQualifiedName() + "\"",
+        targetNode -> Description.getBuildRuleType(targetNode.getDescription()).getName(),
         params.getConsole().getStdOut());
     try {
       dot.writeOutput();

--- a/src/com/facebook/buck/cli/QueryCommand.java
+++ b/src/com/facebook/buck/cli/QueryCommand.java
@@ -26,6 +26,7 @@ import com.facebook.buck.query.QueryBuildTarget;
 import com.facebook.buck.query.QueryException;
 import com.facebook.buck.query.QueryExpression;
 import com.facebook.buck.query.QueryTarget;
+import com.facebook.buck.rules.Description;
 import com.facebook.buck.rules.TargetNode;
 import com.facebook.buck.util.HumanReadableException;
 import com.facebook.buck.util.PatternsMatcher;
@@ -259,6 +260,7 @@ public class QueryCommand extends AbstractCommand {
         "result_graph",
         env.getNodesFromQueryTargets(queryResult),
         targetNode -> "\"" + targetNode.getBuildTarget().getFullyQualifiedName() + "\"",
+        targetNode -> Description.getBuildRuleType(targetNode.getDescription()).getName(),
         params.getConsole().getStdOut(),
         shouldGenerateBFSOutput());
   }

--- a/src/com/facebook/buck/graph/Dot.java
+++ b/src/com/facebook/buck/graph/Dot.java
@@ -70,7 +70,7 @@ public class Dot<T> {
 
         try {
           output.append(String.format(
-              "  %s [style=filled,color=%s]\n",
+              "  %s [style=filled,color=%s];\n",
               source,
               Dot.colorFromType(sourceType)));
         } catch (IOException e) {
@@ -115,7 +115,7 @@ public class Dot<T> {
             String source = nodeToName.apply(node);
             String sourceType = nodeToTypeName.apply(node);
             builder.add(String.format(
-                "  %s [style=filled,color=%s]",
+                "  %s [style=filled,color=%s];\n",
                 source,
                 Dot.colorFromType(sourceType)));
             ImmutableSortedSet<T> nodes = ImmutableSortedSet.copyOf(
@@ -142,7 +142,7 @@ public class Dot<T> {
           String source = nodeToName.apply(node);
           String sourceType = nodeToTypeName.apply(node);
           sortedSetBuilder.add(String.format(
-              "  %s [style=filled,color=%s]\n",
+              "  %s [style=filled,color=%s];\n",
               source,
               Dot.colorFromType(sourceType)));
           for (T sink : Sets.filter(graph.getOutgoingNodesFor(node), nodesToFilter::contains)) {

--- a/src/com/facebook/buck/graph/Dot.java
+++ b/src/com/facebook/buck/graph/Dot.java
@@ -17,13 +17,12 @@
 package com.facebook.buck.graph;
 
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Sets;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 public class Dot<T> {
@@ -36,14 +35,14 @@ public class Dot<T> {
   private static final Map<String, String> typeColors;
 
   static {
-    HashMap<String, String> _typeColors = new HashMap<>();
-    _typeColors.put("android_aar", "springgreen2");
-    _typeColors.put("android_library", "springgreen3");
-    _typeColors.put("android_resource", "springgreen1");
-    _typeColors.put("android_prebuilt_aar", "olivedrab3");
-    _typeColors.put("java_library", "indianred1");
-    _typeColors.put("prebuilt_jar", "mediumpurple1");
-    typeColors = Collections.unmodifiableMap(_typeColors);
+    typeColors = new ImmutableMap.Builder<String, String>() {{
+      put("android_aar", "springgreen2");
+      put("android_library", "springgreen3");
+      put("android_resource", "springgreen1");
+      put("android_prebuilt_aar", "olivedrab3");
+      put("java_library", "indianred1");
+      put("prebuilt_jar", "mediumpurple1");
+    }}.build();
   }
 
   public Dot(

--- a/test/com/facebook/buck/cli/testdata/query_command/stdout-allpaths-deps-one-to-five-six.dot
+++ b/test/com/facebook/buck/cli/testdata/query_command/stdout-allpaths-deps-one-to-five-six.dot
@@ -1,9 +1,15 @@
 digraph result_graph {
   "//example:five" -> "//example:six";
+  "//example:five" [style=filled,color="#D6D3F5"];
   "//example:four" -> "//example:six";
+  "//example:four" [style=filled,color="#D6D3F5"];
   "//example:one" -> "//example:three";
   "//example:one" -> "//example:two";
+  "//example:one" [style=filled,color="#D6D3F5"];
+  "//example:six" [style=filled,color="#D6D3F5"];
   "//example:three" -> "//example:five";
   "//example:three" -> "//example:four";
+  "//example:three" [style=filled,color="#D6D3F5"];
   "//example:two" -> "//example:four";
+  "//example:two" [style=filled,color="#D6D3F5"];
 }

--- a/test/com/facebook/buck/cli/testdata/query_command/stdout-bfs-deps-one.dot
+++ b/test/com/facebook/buck/cli/testdata/query_command/stdout-bfs-deps-one.dot
@@ -1,9 +1,15 @@
 digraph result_graph {
+  "//example:one" [style=filled,color="#D6D3F5"];
   "//example:one" -> "//example:three";
   "//example:one" -> "//example:two";
+  "//example:three" [style=filled,color="#D6D3F5"];
   "//example:three" -> "//example:five";
   "//example:three" -> "//example:four";
+  "//example:two" [style=filled,color="#D6D3F5"];
   "//example:two" -> "//example:four";
+  "//example:five" [style=filled,color="#D6D3F5"];
   "//example:five" -> "//example:six";
+  "//example:four" [style=filled,color="#D6D3F5"];
   "//example:four" -> "//example:six";
+  "//example:six" [style=filled,color="#D6D3F5"];
 }

--- a/test/com/facebook/buck/cli/testdata/query_command/stdout-deps-one.dot
+++ b/test/com/facebook/buck/cli/testdata/query_command/stdout-deps-one.dot
@@ -1,9 +1,15 @@
 digraph result_graph {
   "//example:five" -> "//example:six";
+  "//example:five" [style=filled,color="#D6D3F5"];
   "//example:four" -> "//example:six";
+  "//example:four" [style=filled,color="#D6D3F5"];
   "//example:one" -> "//example:three";
   "//example:one" -> "//example:two";
+  "//example:one" [style=filled,color="#D6D3F5"];
+  "//example:six" [style=filled,color="#D6D3F5"];
   "//example:three" -> "//example:five";
   "//example:three" -> "//example:four";
+  "//example:three" [style=filled,color="#D6D3F5"];
   "//example:two" -> "//example:four";
+  "//example:two" [style=filled,color="#D6D3F5"];
 }

--- a/test/com/facebook/buck/graph/DotTest.java
+++ b/test/com/facebook/buck/graph/DotTest.java
@@ -43,7 +43,12 @@ public class DotTest {
     DirectedAcyclicGraph<String> graph = new DirectedAcyclicGraph<>(mutableGraph);
 
     StringBuilder output = new StringBuilder();
-    Dot<String> dot = new Dot<String>(graph, "the_graph", Functions.identity(), output);
+    Dot<String> dot = new Dot<String>(
+        graph,
+        "the_graph",
+        Functions.identity(),
+        Functions.identity(),
+        output);
     dot.writeOutput();
 
     String dotGraph = output.toString();
@@ -61,6 +66,37 @@ public class DotTest {
             "  C -> E;",
             "  D -> E;",
             "  A -> E;"));
+
+    assertEquals("}", lines.get(lines.size() - 1));
+  }
+
+  @Test
+  public void testGenerateDotOutputWithColors() throws IOException {
+    MutableDirectedGraph<String> mutableGraph = new MutableDirectedGraph<>();
+    mutableGraph.addEdge("A", "B");
+    DirectedAcyclicGraph<String> graph = new DirectedAcyclicGraph<>(mutableGraph);
+
+    StringBuilder output = new StringBuilder();
+    Dot<String> dot = new Dot<String>(
+        graph,
+        "the_graph",
+        Functions.identity(),
+        name -> name.equals("A") ? "android_library" : "java_library",
+        output);
+    dot.writeOutput();
+
+    String dotGraph = output.toString();
+    List<String> lines = ImmutableList.copyOf(Splitter.on('\n').omitEmptyStrings().split(dotGraph));
+
+    assertEquals("digraph the_graph {", lines.get(0));
+
+    Set<String> edges = ImmutableSet.copyOf(lines.subList(1, lines.size() - 1));
+    assertEquals(
+        edges,
+        ImmutableSet.of(
+            "  A -> B;",
+            "  A [style=filled,color=springgreen3]",
+            "  B [style=filled,color=indianred1]"));
 
     assertEquals("}", lines.get(lines.size() - 1));
   }

--- a/test/com/facebook/buck/graph/DotTest.java
+++ b/test/com/facebook/buck/graph/DotTest.java
@@ -65,7 +65,12 @@ public class DotTest {
             "  B -> D;",
             "  C -> E;",
             "  D -> E;",
-            "  A -> E;"));
+            "  A -> E;",
+            "  A [style=filled,color=\"#C1C1C0\"]",
+            "  B [style=filled,color=\"#C2C1C0\"]",
+            "  C [style=filled,color=\"#C3C1C0\"]",
+            "  D [style=filled,color=\"#C4C1C0\"]",
+            "  E [style=filled,color=\"#C5C1C0\"]"));
 
     assertEquals("}", lines.get(lines.size() - 1));
   }

--- a/test/com/facebook/buck/graph/DotTest.java
+++ b/test/com/facebook/buck/graph/DotTest.java
@@ -66,11 +66,11 @@ public class DotTest {
             "  C -> E;",
             "  D -> E;",
             "  A -> E;",
-            "  A [style=filled,color=\"#C1C1C0\"]",
-            "  B [style=filled,color=\"#C2C1C0\"]",
-            "  C [style=filled,color=\"#C3C1C0\"]",
-            "  D [style=filled,color=\"#C4C1C0\"]",
-            "  E [style=filled,color=\"#C5C1C0\"]"));
+            "  A [style=filled,color=\"#C1C1C0\"];",
+            "  B [style=filled,color=\"#C2C1C0\"];",
+            "  C [style=filled,color=\"#C3C1C0\"];",
+            "  D [style=filled,color=\"#C4C1C0\"];",
+            "  E [style=filled,color=\"#C5C1C0\"];"));
 
     assertEquals("}", lines.get(lines.size() - 1));
   }
@@ -100,8 +100,8 @@ public class DotTest {
         edges,
         ImmutableSet.of(
             "  A -> B;",
-            "  A [style=filled,color=springgreen3]",
-            "  B [style=filled,color=indianred1]"));
+            "  A [style=filled,color=springgreen3];",
+            "  B [style=filled,color=indianred1];"));
 
     assertEquals("}", lines.get(lines.size() - 1));
   }


### PR DESCRIPTION
Adds colors to the dot nodes when visualizing graphs. They are colored according to their types, on a random (but consistent basis). We reserve certain colors for the more common targets.  This list could be expanded.