### PR TITLE
Corrects clang flags for x86_64 NDK builds

### DIFF
--- a/src/com/facebook/buck/android/NdkCxxPlatforms.java
+++ b/src/com/facebook/buck/android/NdkCxxPlatforms.java
@@ -466,7 +466,7 @@ public class NdkCxxPlatforms {
             .putCompilerFlags(
                 NdkCxxPlatformCompiler.Type.CLANG,
                 ImmutableList.of(
-                    "-target", "i686-none-linux-android",
+                    "-target", "x86_64-none-linux-android",
                     "-O2"))
             .putLinkerFlags(
                 NdkCxxPlatformCompiler.Type.GCC,
@@ -474,7 +474,7 @@ public class NdkCxxPlatforms {
             .putLinkerFlags(
                 NdkCxxPlatformCompiler.Type.CLANG,
                 ImmutableList.of(
-                    "-target", "i686-none-linux-android"))
+                    "-target", "x86_64-none-linux-android"))
             .build();
       case MIPS:
         break;


### PR DESCRIPTION
The flags seems to have been copied from the x86 version, which is incorrect.