### PR TITLE
Use filelist for swift output dynamic library and object files

### DIFF
--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -275,8 +275,8 @@ class SwiftCompile extends AbstractBuildRule {
     return args.build();
   }
 
-  ImmutableSet<Arg> getAstLinkArgs() {
-    return ImmutableSet.<Arg>builder()
+  ImmutableList<Arg> getAstLinkArgs() {
+    return ImmutableList.<Arg>builder()
         .addAll(StringArg.from("-Xlinker", "-add_ast_path"))
         .add(SourcePathArg.of(new ExplicitBuildTargetSourcePath(getBuildTarget(), modulePath)))
         .build();

--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -41,6 +41,7 @@ import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.Tool;
 import com.facebook.buck.rules.args.Arg;
+import com.facebook.buck.rules.args.FileListableLinkerInputArg;
 import com.facebook.buck.rules.args.SourcePathArg;
 import com.facebook.buck.rules.args.StringArg;
 import com.facebook.buck.rules.coercer.FrameworkPath;
@@ -274,11 +275,15 @@ class SwiftCompile extends AbstractBuildRule {
     return args.build();
   }
 
-  ImmutableSet<Arg> getLinkArgs() {
+  ImmutableSet<Arg> getAstLinkArgs() {
     return ImmutableSet.<Arg>builder()
         .addAll(StringArg.from("-Xlinker", "-add_ast_path"))
         .add(SourcePathArg.of(new ExplicitBuildTargetSourcePath(getBuildTarget(), modulePath)))
-        .add(SourcePathArg.of(new ExplicitBuildTargetSourcePath(getBuildTarget(), objectPath)))
         .build();
+  }
+
+  Arg getFileListLinkArg() {
+    return FileListableLinkerInputArg.withSourcePathArg(
+        SourcePathArg.of(new ExplicitBuildTargetSourcePath(getBuildTarget(), objectPath)));
   }
 }

--- a/src/com/facebook/buck/swift/SwiftLibraryDescription.java
+++ b/src/com/facebook/buck/swift/SwiftLibraryDescription.java
@@ -292,15 +292,18 @@ public class SwiftLibraryDescription implements
     SwiftRuntimeNativeLinkable swiftRuntimeLinkable =
         new SwiftRuntimeNativeLinkable(swiftPlatform);
 
-    NativeLinkableInput.Builder inputBuilder = NativeLinkableInput.builder()
-        .from(swiftRuntimeLinkable.getNativeLinkableInput(
-                cxxPlatform, Linker.LinkableDepType.SHARED));
     BuildTarget requiredBuildTarget = buildTarget
         .withoutFlavors(CxxDescriptionEnhancer.SHARED_FLAVOR)
         .withoutFlavors(LinkerMapMode.FLAVOR_DOMAIN.getFlavors())
         .withAppendedFlavors(SWIFT_COMPILE_FLAVOR);
     SwiftCompile rule = (SwiftCompile) resolver.requireRule(requiredBuildTarget);
-    inputBuilder.addAllArgs(rule.getLinkArgs());
+
+    NativeLinkableInput.Builder inputBuilder = NativeLinkableInput.builder()
+        .from(swiftRuntimeLinkable.getNativeLinkableInput(
+            cxxPlatform,
+            Linker.LinkableDepType.SHARED))
+        .addAllArgs(rule.getAstLinkArgs())
+        .addArgs(rule.getFileListLinkArg());
     return resolver.addToIndex(CxxLinkableEnhancer.createCxxLinkableBuildRule(
         cxxBuckConfig,
         cxxPlatform,

--- a/test/com/facebook/buck/swift/SwiftLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/swift/SwiftLibraryIntegrationTest.java
@@ -19,29 +19,40 @@ package com.facebook.buck.swift;
 import static org.junit.Assert.assertThat;
 
 import com.facebook.buck.apple.FakeAppleRuleDescriptions;
+import com.facebook.buck.cxx.CxxDescriptionEnhancer;
+import com.facebook.buck.cxx.CxxLink;
 import com.facebook.buck.cxx.FakeCxxLibrary;
 import com.facebook.buck.cxx.HeaderSymlinkTreeWithHeaderMap;
 import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.model.BuildTargets;
+import com.facebook.buck.parser.NoSuchBuildTargetException;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.DefaultTargetNodeToBuildRuleTransformer;
+import com.facebook.buck.rules.ExplicitBuildTargetSourcePath;
 import com.facebook.buck.rules.FakeBuildRule;
 import com.facebook.buck.rules.FakeBuildRuleParamsBuilder;
+import com.facebook.buck.rules.FakeTargetNodeBuilder;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.SourcePathRuleFinder;
 import com.facebook.buck.rules.TargetGraph;
+import com.facebook.buck.rules.args.Arg;
+import com.facebook.buck.rules.args.FileListableLinkerInputArg;
+import com.facebook.buck.rules.args.SourcePathArg;
+import com.facebook.buck.rules.args.StringArg;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
+import com.facebook.buck.testutil.TargetGraphFactory;
 import com.facebook.buck.testutil.integration.TemporaryPaths;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
 
 import org.hamcrest.Matchers;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -53,13 +64,20 @@ public class SwiftLibraryIntegrationTest {
   @Rule
   public final TemporaryPaths tmpDir = new TemporaryPaths();
 
+  private BuildRuleResolver resolver;
+  private SourcePathResolver pathResolver;
+  private SourcePathRuleFinder ruleFinder;
+
+  @Before
+  public void setUp() {
+    resolver =
+        new BuildRuleResolver(TargetGraph.EMPTY, new DefaultTargetNodeToBuildRuleTransformer());
+    ruleFinder = new SourcePathRuleFinder(resolver);
+    pathResolver = new SourcePathResolver(ruleFinder);
+  }
+
   @Test
   public void headersOfDependentTargetsAreIncluded() throws Exception {
-    BuildRuleResolver resolver =
-        new BuildRuleResolver(TargetGraph.EMPTY, new DefaultTargetNodeToBuildRuleTransformer());
-    SourcePathRuleFinder ruleFinder = new SourcePathRuleFinder(resolver);
-    SourcePathResolver pathResolver = new SourcePathResolver(ruleFinder);
-
     // The output path used by the buildable for the link tree.
     BuildTarget symlinkTarget = BuildTargetFactory.newInstance("//:symlink");
     ProjectFilesystem projectFilesystem = new FakeProjectFilesystem(tmpDir.getRoot());
@@ -96,16 +114,7 @@ public class SwiftLibraryIntegrationTest {
         .setDeclaredDeps(ImmutableSortedSet.of(depRule))
         .build();
 
-    SwiftLibraryDescription.Arg args =
-        FakeAppleRuleDescriptions.SWIFT_LIBRARY_DESCRIPTION.createUnpopulatedConstructorArg();
-    args.moduleName = Optional.empty();
-    args.srcs = ImmutableSortedSet.of();
-    args.compilerFlags = ImmutableList.of();
-    args.frameworks = ImmutableSortedSet.of();
-    args.libraries = ImmutableSortedSet.of();
-    args.enableObjcInterop = Optional.empty();
-    args.supportedPlatformsRegex = Optional.empty();
-    args.bridgingHeader = Optional.empty();
+    SwiftLibraryDescription.Arg args = createDummySwiftArg();
 
     SwiftCompile buildRule = (SwiftCompile) FakeAppleRuleDescriptions.SWIFT_LIBRARY_DESCRIPTION
         .createBuildRule(TargetGraph.EMPTY, params, resolver, args);
@@ -117,4 +126,70 @@ public class SwiftLibraryIntegrationTest {
     assertThat(swiftIncludeArgs.get(0), Matchers.endsWith("symlink.hmap"));
   }
 
+  @Test
+  public void testSwiftCompileAndLinkArgs() throws NoSuchBuildTargetException {
+    BuildTarget buildTarget = BuildTargetFactory.newInstance("//foo:bar#iphoneos-x86_64");
+    BuildTarget swiftCompileTarget = buildTarget.withAppendedFlavors(
+        SwiftLibraryDescription.SWIFT_COMPILE_FLAVOR);
+    BuildRuleParams params = new FakeBuildRuleParamsBuilder(swiftCompileTarget).build();
+
+    SwiftLibraryDescription.Arg args = createDummySwiftArg();
+    SwiftCompile buildRule = (SwiftCompile) FakeAppleRuleDescriptions.SWIFT_LIBRARY_DESCRIPTION
+        .createBuildRule(
+            TargetGraph.EMPTY,
+            params,
+            resolver,
+            args);
+    resolver.addToIndex(buildRule);
+
+    ImmutableList<Arg> astArgs = buildRule.getAstLinkArgs();
+    assertThat(astArgs, Matchers.hasSize(3));
+    assertThat(astArgs.get(0), Matchers.equalTo(StringArg.of("-Xlinker")));
+    assertThat(astArgs.get(1), Matchers.equalTo(StringArg.of("-add_ast_path")));
+
+    assertThat(astArgs.get(2), Matchers.instanceOf(SourcePathArg.class));
+    SourcePathArg sourcePathArg = (SourcePathArg) astArgs.get(2);
+    assertThat(sourcePathArg.getPath(), Matchers.equalTo(
+        new ExplicitBuildTargetSourcePath(swiftCompileTarget,
+            pathResolver.getRelativePath(
+                buildRule.getSourcePathToOutput())
+                .resolve("bar.swiftmodule"))));
+
+    Arg objArg = buildRule.getFileListLinkArg();
+    assertThat(objArg, Matchers.instanceOf(FileListableLinkerInputArg.class));
+    FileListableLinkerInputArg fileListArg = (FileListableLinkerInputArg) objArg;
+    ExplicitBuildTargetSourcePath fileListSourcePath = new ExplicitBuildTargetSourcePath(
+        swiftCompileTarget,
+        pathResolver.getRelativePath(buildRule.getSourcePathToOutput()).resolve("bar.o"));
+    assertThat(fileListArg.getPath(), Matchers.equalTo(fileListSourcePath));
+
+    BuildTarget linkTarget = buildTarget.withAppendedFlavors(CxxDescriptionEnhancer.SHARED_FLAVOR);
+    CxxLink linkRule = (CxxLink) FakeAppleRuleDescriptions.SWIFT_LIBRARY_DESCRIPTION
+        .createBuildRule(
+            TargetGraphFactory.newInstance(FakeTargetNodeBuilder.build(buildRule)),
+            params.copyWithBuildTarget(linkTarget),
+            resolver,
+            args);
+
+    assertThat(linkRule.getArgs(), Matchers.hasItem(objArg));
+    assertThat(linkRule.getArgs(),
+        Matchers.not(
+            Matchers.hasItem(SourcePathArg.of(fileListSourcePath))));
+  }
+
+  private SwiftLibraryDescription.Arg createDummySwiftArg() {
+    SwiftLibraryDescription.Arg args =
+        FakeAppleRuleDescriptions.SWIFT_LIBRARY_DESCRIPTION.createUnpopulatedConstructorArg();
+    args.soname = Optional.empty();
+    args.moduleName = Optional.empty();
+    args.srcs = ImmutableSortedSet.of();
+    args.compilerFlags = ImmutableList.of();
+    args.frameworks = ImmutableSortedSet.of();
+    args.libraries = ImmutableSortedSet.of();
+    args.enableObjcInterop = Optional.empty();
+    args.supportedPlatformsRegex = Optional.empty();
+    args.bridgingHeader = Optional.empty();
+    args.preferredLinkage = Optional.empty();
+    return args;
+  }
 }


### PR DESCRIPTION
Pull out from https://github.com/facebook/buck/pull/917

Before this PR:
* Swift object files stay in the link command of any parent target.
* Swift dylib files are in the link command of any parent target, along with object files from the same swift target. This is wrong because object files should only be used for static linking.

After:
* Swift object files will stay in an filelist, along with other object files from cxx rules. If the target is a shared target, only its dylib output file will be used for linking (not its object files)
* Swift dylib files stay in an output filelist of the link command.

This also helps to remove duplication of swift object files in a link command.


**Sample**:
Input: A depends on B (swift)

A link command:
```
...
-Xlinker -add_ast_path
/path/to/B.swiftmodule
/path/to/B.o
...
```

will change to 
```
-Xlinker -add_ast_path
/path/to/B.swiftmodule
...
-filelist
/path/to/B_filelist.txt <--- /path/to/B.o is in here
```