### PR TITLE
Update broken Homebrew instructions for iOS/Mac

### DIFF
--- a/docs/setup/getting_started.soy
+++ b/docs/setup/getting_started.soy
@@ -134,9 +134,8 @@ You can find a more detailed explanation about each step in the development proc
 # already be installed.
 xcode-select --install
 # Install Java - this installs the JDK, a superset of the JRE
-brew update
 brew tap caskroom/cask
-brew install java
+brew cask install java
 </pre>{/literal}
 
 <span><block class="mac ios" /></span>
@@ -150,7 +149,6 @@ brew install java
 </p>
 
 {literal}<pre>
-brew update
 brew tap facebook/fb
 brew install buck
 </pre>


### PR DESCRIPTION
As per #1230, the docs have been fixed.