### PR TITLE
Minor fix to apt-get documentation

### DIFF
--- a/docs/setup/getting_started.soy
+++ b/docs/setup/getting_started.soy
@@ -313,7 +313,7 @@ choco install jdk8 ant python git
 
 {literal}<pre>
 sudo apt-get update
-apt-get install default-jdk ant python git
+sudo apt-get install default-jdk ant python git
 # install watchman as stated in the watchman prerequisite link above
 </pre>{/literal}
 


### PR DESCRIPTION
`apt-get install` needs root privileges, as such it should have a `sudo` prefix, much like the `sudo apt-get update` command which already had it