### PR TITLE
Don't set enable-testing by default

### DIFF
--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -176,7 +176,6 @@ class SwiftCompile extends AbstractBuildRule {
         .anyMatch(SwiftDescriptions.SWIFT_MAIN_FILENAME::equalsIgnoreCase);
 
     compilerCommand.add(
-        "-enable-testing",
         "-c",
         enableObjcInterop ? "-enable-objc-interop" : "",
         hasMainEntry ? "" : "-parse-as-library",

--- a/test/com/facebook/buck/swift/testdata/swift_test/.buckconfig
+++ b/test/com/facebook/buck/swift/testdata/swift_test/.buckconfig
@@ -1,0 +1,2 @@
+[swift]
+compiler_flags = -enable-testing


### PR DESCRIPTION
This should be configurable in the `buckconfig`, otherwise there is no way to disable it for release builds.