### PR TITLE
Fix broken showcase page

### DIFF
--- a/docs/about/showcase.soy
+++ b/docs/about/showcase.soy
@@ -108,8 +108,8 @@
   {param items}
     {call .item}
       {param name: 'Sudoku' /}
-        {param imgSrc: 'https://http://brainiumstudios.com/icons/sudoku.png' /}
-        {param moreInfo: quoteKeysIfJs([
+        {param imgSrc: 'https://lh6.ggpht.com/m92klrf80HKcoOW10p565ooRzYsP7ktAgDLGT6QnK2KrfMxgcxsfgqJ1LwE08J8z7_br=w100' /}
+        {param links: quoteKeysIfJs([
             'iOS/Android':
               'http://www.brainiumstudios.com/site/sudoku.html',
               ]) /}
@@ -117,8 +117,8 @@
 
       {call .item}
         {param name: 'Blackjack' /}
-        {param imgSrc: 'https://http://brainiumstudios.com/icons/blackjack.png' /}
-        {param moreInfo: quoteKeysIfJs([
+        {param imgSrc: 'https://lh4.ggpht.com/9n8paiE9nfV380CK45QjdgRZ4xCVOx_LH8Ic3t-ITwjVVlCtrUOaQOv19CLFBnHCbb8=w100' /}
+        {param links: quoteKeysIfJs([
             'iOS/Android':
               'http://www.brainiumstudios.com/site/blackjack.html',
               ]) /}
@@ -126,8 +126,8 @@
 
       {call .item}
         {param name: 'Freecell' /}
-        {param imgSrc: 'https://http://brainiumstudios.com/icons/freecell.png' /}
-        {param moreInfo: quoteKeysIfJs([
+        {param imgSrc: 'https://lh3.ggpht.com/c0l_lmDA-LB0meyB6tVik1gdi_i0z42_RPYjhYHZAiJDSZetuCxWDcqJl3INzI_iyz0=w100' /}
+        {param links: quoteKeysIfJs([
             'iOS/Android':
               'http://www.brainiumstudios.com/site/freecell.html',
               ]) /}
@@ -135,8 +135,8 @@
 
       {call .item}
         {param name: 'Jumbline 2' /}
-        {param imgSrc: 'https://http://brainiumstudios.com/icons/jumbline.png' /}
-        {param moreInfo: quoteKeysIfJs([
+        {param imgSrc: 'https://lh3.ggpht.com/QZSc3YEppWF7VDjms6X1vCBs5mW3r03pcqPmtTj_86PX9fUDkTh9PXBqxIvdGVE1FJou=w100' /}
+        {param links: quoteKeysIfJs([
             'iOS/Android':
               'http://www.brainiumstudios.com/site/jumbline.html',
               ]) /}
@@ -144,19 +144,10 @@
 
       {call .item}
         {param name: 'Spider' /}
-        {param imgSrc: 'https://http://brainiumstudios.com/icons/spider.png' /}
-        {param moreInfo: quoteKeysIfJs([
+        {param imgSrc: 'https://lh5.ggpht.com/KfdGhIv4Cp9ysjb67avoNLWAgVjjbBGjTtEw1EM6L_s00Oj_UeXJun-tj2ynxWwCZA=w100' /}
+        {param links: quoteKeysIfJs([
             'iOS/Android':
               'http://www.brainiumstudios.com/site/spider.html',
-              ]) /}
-      {/call}
-
-      {call .item}
-        {param name: 'Word Search Star' /}
-        {param imgSrc: 'https://http://brainiumstudios.com/icons/wordsearch.png' /}
-        {param moreInfo: quoteKeysIfJs([
-            'iOS/Android':
-              'http://www.brainiumstudios.com/site/wordsearch.html',
               ]) /}
       {/call}
   {/param}


### PR DESCRIPTION
https://github.com/facebook/buck/pull/1239 was a little broken:
1) Image links weren't right, so they didn't render on the page
2) The code used the old `moreInfo` instead of `links` in the map,
   causing the links to not render

This change fixes that.  It also removes "Word Search Star" because
there is no HTTPS image available from the iTunes store, and it is
not published in the Play store.

Test Plan:
`.\docs\soyweb-local.ps1` and then loaded
http://localhost:9811/about/showcase.html