### PR TITLE
Add some more Facebook applications to the showcase

### DIFF
--- a/docs/about/showcase.soy
+++ b/docs/about/showcase.soy
@@ -88,6 +88,16 @@
         ] /}
     {/call}
     {call .item}
+      {param name: 'Workplace' /}
+      {param imgSrc: 'https://lh3.googleusercontent.com/D77zPWACCJG-AfXpzSsVJmM9Om2-Vj4ltstKINR22GFQBAv7zYhdzKQANWjLkrhvVw=w100' /}
+      {param links: [
+          'Android':
+            'https://play.google.com/store/apps/details?id=com.facebook.work',
+          'iOS':
+            'https://itunes.apple.com/us/app/workplace-by-facebook/id944921229',
+        ] /}
+    {/call}
+    {call .item}
       {param name: 'Instagram' /}
       {param imgSrc: 'https://lh3.googleusercontent.com/aYbdIM1abwyVSUZLDKoE0CDZGRhlkpsaPOg9tNnBktUQYsXflwknnOn2Ge1Yr7rImGk=w100' /}
       {param links: [
@@ -95,6 +105,26 @@
             'https://play.google.com/store/apps/details?id=com.instagram.android',
           'iOS':
             'https://itunes.apple.com/us/app/instagram/id389801252',
+        ] /}
+    {/call}
+    {call .item}
+      {param name: 'Ads Manager' /}
+      {param imgSrc: 'https://lh3.googleusercontent.com/ODKlFYm7BaNiLMEEDO2b4DOCU-hmS1-Fg3_x_lLUaJZ0ssFsxciSoX1dYERaWDJuEs8=w100' /}
+      {param links: [
+          'Android':
+            'https://play.google.com/store/apps/details?id=com.facebook.adsmanager',
+          'iOS':
+            'https://itunes.apple.com/us/app/facebook-ads-manager/id964397083',
+        ] /}
+    {/call}
+    {call .item}
+      {param name: 'Pages Manager' /}
+      {param imgSrc: 'https://lh4.ggpht.com/vcyZimfIRlWrLarEpIj7MMSuqgwIkF4bx5nArKhFWsEqGclnPTAeLLK4cFiQ5QscRIEc=w100' /}
+      {param links: [
+          'Android':
+            'https://play.google.com/store/apps/details?id=com.facebook.pages.app',
+          'iOS':
+            'https://itunes.apple.com/us/app/facebook-pages-manager/id514643583',
         ] /}
     {/call}
   {/param}


### PR DESCRIPTION
Now that it wouldn't completely dominate the page, we can
add a few more Facebook applications.

Test Plan:
`.\docs\soyweb-local.ps1` and then loaded
http://localhost:9811/about/showcase.html