### PR TITLE
Add delegate for getSystemService in ApplicationLike.

### DIFF
--- a/android/com/facebook/buck/android/support/exopackage/ApplicationLike.java
+++ b/android/com/facebook/buck/android/support/exopackage/ApplicationLike.java
@@ -53,4 +53,9 @@ public interface ApplicationLike {
    */
   void onConfigurationChanged(Configuration newConfig);
 
+  /**
+   * Same as {@link Application#getSystemService(String name)}.
+   */
+  Object getSystemService(String name);
+
 }

--- a/android/com/facebook/buck/android/support/exopackage/DefaultApplicationLike.java
+++ b/android/com/facebook/buck/android/support/exopackage/DefaultApplicationLike.java
@@ -42,4 +42,9 @@ public class DefaultApplicationLike implements ApplicationLike {
 
   @Override
   public void onConfigurationChanged(Configuration newConfig) {}
+
+  @Override
+  public Object getSystemService(String name) {
+    return null;
+  }
 }

--- a/android/com/facebook/buck/android/support/exopackage/ExopackageApplication.java
+++ b/android/com/facebook/buck/android/support/exopackage/ExopackageApplication.java
@@ -162,4 +162,15 @@ public abstract class ExopackageApplication<T extends ApplicationLike> extends A
       delegate.onConfigurationChanged(newConfig);
     }
   }
+
+  @Override
+  public Object getSystemService(String name) {
+    if (delegate != null) {
+      Object service = delegate.getSystemService(name);
+      if (service != null) {
+        return service;
+      }
+    }
+    return super.getSystemService(name);
+  }
 }


### PR DESCRIPTION
We have an application that delegates the `getSystemService` to a another service lookup similar to the pattern found here: https://github.com/square/mortar/blob/master/mortar-hellodagger2/src/main/java/com/example/hellodagger2/HelloDagger2Application.java

In order to use Exopackage, we need to be able to delegate our Application class to our service lookup.