### PR TITLE
Make source based abi generation compatible with error prone

### DIFF
--- a/src/com/facebook/buck/jvm/java/abi/source/InterfaceValidator.java
+++ b/src/com/facebook/buck/jvm/java/abi/source/InterfaceValidator.java
@@ -19,7 +19,6 @@ package com.facebook.buck.jvm.java.abi.source;
 import com.facebook.buck.event.api.BuckTracing;
 import com.facebook.buck.jvm.java.abi.source.api.BootClasspathOracle;
 import com.sun.source.tree.CompilationUnitTree;
-import com.sun.source.util.JavacTask;
 import com.sun.source.util.TreePath;
 import com.sun.source.util.Trees;
 
@@ -34,8 +33,8 @@ import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.QualifiedNameable;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
-import javax.lang.model.util.Elements;
 import javax.tools.Diagnostic;
+import javax.tools.JavaCompiler;
 
 /**
  * Validates the type and compile-time-constant references in the non-private interface of classes
@@ -58,18 +57,16 @@ class InterfaceValidator {
   private static final BuckTracing BUCK_TRACING =
       BuckTracing.getInstance("ExpressionTreeResolutionValidator");
 
-  private final Elements elements;
   private final Diagnostic.Kind messageKind;
   private final Trees trees;
   private final BootClasspathOracle bootClasspathOracle;
 
   public InterfaceValidator(
       Diagnostic.Kind messageKind,
-      JavacTask task,
+      JavaCompiler.CompilationTask task,
       BootClasspathOracle bootClasspathOracle) {
     this.messageKind = messageKind;
     trees = Trees.instance(task);
-    elements = task.getElements();
     this.bootClasspathOracle = bootClasspathOracle;
   }
 
@@ -139,8 +136,7 @@ class InterfaceValidator {
             }
 
             private boolean isOnBootClasspath(TypeElement typeElement) {
-              return bootClasspathOracle.isOnBootClasspath(
-                  elements.getBinaryName(typeElement).toString());
+              return bootClasspathOracle.isOnBootClasspath(typeElement.getQualifiedName().toString());
             }
 
             private boolean referenceIsLegalForMissingTypes(

--- a/src/com/facebook/buck/jvm/java/abi/source/InterfaceValidator.java
+++ b/src/com/facebook/buck/jvm/java/abi/source/InterfaceValidator.java
@@ -21,6 +21,7 @@ import com.facebook.buck.jvm.java.abi.source.api.BootClasspathOracle;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.util.TreePath;
 import com.sun.source.util.Trees;
+import com.sun.tools.javac.code.Symbol;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -136,7 +137,8 @@ class InterfaceValidator {
             }
 
             private boolean isOnBootClasspath(TypeElement typeElement) {
-              return bootClasspathOracle.isOnBootClasspath(typeElement.getQualifiedName().toString());
+              return bootClasspathOracle.isOnBootClasspath(
+                  ((Symbol.TypeSymbol) typeElement).flatName().toString());
             }
 
             private boolean referenceIsLegalForMissingTypes(

--- a/src/com/facebook/buck/jvm/java/abi/source/ValidatingTaskListener.java
+++ b/src/com/facebook/buck/jvm/java/abi/source/ValidatingTaskListener.java
@@ -20,7 +20,6 @@ import com.facebook.buck.jvm.java.abi.source.api.BootClasspathOracle;
 import com.facebook.buck.util.liteinfersupport.Nullable;
 import com.facebook.buck.util.liteinfersupport.Preconditions;
 import com.sun.source.tree.CompilationUnitTree;
-import com.sun.source.util.JavacTask;
 import com.sun.source.util.TaskEvent;
 import com.sun.source.util.TaskListener;
 
@@ -36,7 +35,7 @@ import javax.tools.JavaCompiler;
  */
 public class ValidatingTaskListener
     implements TaskListener {
-  private final JavacTask javacTask;
+  private final JavaCompiler.CompilationTask javacTask;
   private final List<CompilationUnitTree> compilationUnits = new ArrayList<>();
   private final BootClasspathOracle bootClasspathOracle;
   private final Diagnostic.Kind messageKind;
@@ -50,7 +49,7 @@ public class ValidatingTaskListener
       JavaCompiler.CompilationTask task,
       BootClasspathOracle bootClasspathOracle,
       Diagnostic.Kind messageKind) {
-    this.javacTask = (JavacTask) task;
+    this.javacTask = task;
     this.bootClasspathOracle = bootClasspathOracle;
     this.messageKind = messageKind;
   }


### PR DESCRIPTION
This makes source based abi generation compatible with the error prone java compiler.

Key aspect is to not assume the `CompilationTask` will be an instance of `JavacTask` as that assumption is not really required. Without this change, compiling with error prone fails with

```
Could not load source-generated ABI validator. Your compiler might not support this. If it doesn't, you may need to disable source-based ABI generation.
com.facebook.buck.util.HumanReadableException: Could not load source-generated ABI validator. Your compiler might not support this. If it doesn't, you may need to disable source-based ABI generation.
	at com.facebook.buck.jvm.java.abi.SourceBasedAbiStubber.newValidatingTaskListener(SourceBasedAbiStubber.java:50)
	at com.facebook.buck.jvm.java.Jsr199Javac.buildWithClasspath(Jsr199Javac.java:260)
	at com.facebook.buck.jvm.java.Jsr199Javac.buildWithClasspath(Jsr199Javac.java:155)
	at com.facebook.buck.jvm.java.JavacStep.performBuild(JavacStep.java:194)
	at com.facebook.buck.jvm.java.JavacStep.tryBuildWithFirstOrderDeps(JavacStep.java:184)
	at com.facebook.buck.jvm.java.JavacStep.execute(JavacStep.java:145)
	at com.facebook.buck.jvm.java.JavacDirectToJarStep.execute(JavacDirectToJarStep.java:94)
	at com.facebook.buck.step.DefaultStepRunner.runStepForBuildTarget(DefaultStepRunner.java:47)
	at com.facebook.buck.rules.CachingBuildEngine.executeCommandsNowThatDepsAreBuilt(CachingBuildEngine.java:1507)
	at com.facebook.buck.rules.CachingBuildEngine.lambda$15(CachingBuildEngine.java:350)
	at com.facebook.buck.util.concurrent.WeightedListeningExecutorService.lambda$0(WeightedListeningExecutorService.java:81)
	at com.google.common.util.concurrent.AbstractTransformFuture$AsyncTransformFuture.doTransform(AbstractTransformFuture.java:211)
	at com.google.common.util.concurrent.AbstractTransformFuture$AsyncTransformFuture.doTransform(AbstractTransformFuture.java:200)
	at com.google.common.util.concurrent.AbstractTransformFuture.run(AbstractTransformFuture.java:130)
	at com.google.common.util.concurrent.MoreExecutors$5$1.run(MoreExecutors.java:988)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at com.facebook.buck.jvm.java.abi.SourceBasedAbiStubber.newValidatingTaskListener(SourceBasedAbiStubber.java:48)
	... 17 more
Caused by: java.lang.ClassCastException: com.google.errorprone.BaseErrorProneJavaCompiler$1 cannot be cast to com.sun.source.util.JavacTask
	at com.facebook.buck.jvm.java.abi.source.ValidatingTaskListener.<init>(ValidatingTaskListener.java:53)
	... 22 more
```

With this change, compilation proceeds as normal and shows abi from source generation migration warnings as expected