### PR TITLE
Let robolectric_manifest be specified as output of another rule

### DIFF
--- a/src/com/facebook/buck/android/RobolectricTest.java
+++ b/src/com/facebook/buck/android/RobolectricTest.java
@@ -190,7 +190,7 @@ public class RobolectricTest extends JavaTest {
     // Force robolectric to only use local dependency resolution.
     vmArgsBuilder.add("-Drobolectric.offline=true");
     robolectricManifest.ifPresent(s -> vmArgsBuilder.add(String.format(
-        "-D%s=%s", ROBOLECTRIC_MANIFEST, s)));
+        "-D%s=%s", ROBOLECTRIC_MANIFEST, pathResolver.getAbsolutePath(s))));
     robolectricRuntimeDependency.ifPresent(s -> vmArgsBuilder.add(String.format(
         "-D%s=%s", ROBOLECTRIC_DEPENDENCY_DIR, s)));
   }


### PR DESCRIPTION
This lets the `robolectric_manifest` be set to the output of another rule like an `export_file` etc. similar to how `android_manifest` allows in the `skeleton` parameter