### PR TITLE
Add compilation task event mirror enum

### DIFF
--- a/src/com/facebook/buck/jvm/java/plugin/api/TaskEventMirror.java
+++ b/src/com/facebook/buck/jvm/java/plugin/api/TaskEventMirror.java
@@ -52,6 +52,14 @@ public final class TaskEventMirror {
      * For events relating to an individual annotation processing round.
      **/
     ANNOTATION_PROCESSING_ROUND,
+    /**
+     * Sent before parsing first source file, and after writing the last output file.
+     * This event is not sent when using {@code JavacTask#parse()},
+     * {@code JavacTask#analyze()} or {@code JavacTask#generate()}.
+     *
+     * @since 9
+     **/
+    COMPILATION,
   };
 
   private final Object original;

--- a/src/com/facebook/buck/jvm/java/tracing/TracingTaskListener.java
+++ b/src/com/facebook/buck/jvm/java/tracing/TracingTaskListener.java
@@ -67,6 +67,7 @@ public class TracingTaskListener implements BuckJavacTaskListener {
         tracing.beginGenerate(getFileName(e), getTypeName(e));
         break;
       case ANNOTATION_PROCESSING:
+      case COMPILATION:
       default:
         // The tracing doesn't care about these events
         break;
@@ -93,6 +94,7 @@ public class TracingTaskListener implements BuckJavacTaskListener {
         tracing.endGenerate();
         break;
       case ANNOTATION_PROCESSING:
+      case COMPILATION:
       default:
         // The tracing doesn't care about these events
         break;


### PR DESCRIPTION
Fixes compatibility with jdk 9 compilers. See https://github.com/facebook/buck/issues/1285#issuecomment-293146039