### PR TITLE
Fix persistent worker process bug when a process dies.

### DIFF
--- a/src/com/facebook/buck/shell/BUCK
+++ b/src/com/facebook/buck/shell/BUCK
@@ -205,6 +205,7 @@ java_immutables_library(
         "//src/com/facebook/buck/util:exceptions",
         "//src/com/facebook/buck/util:process_executor",
         "//src/com/facebook/buck/util:util",
+        "//src/com/facebook/buck/util/concurrent:concurrent",
         "//third-party/java/gson:gson",
     ],
 )

--- a/src/com/facebook/buck/shell/WorkerShellStep.java
+++ b/src/com/facebook/buck/shell/WorkerShellStep.java
@@ -70,6 +70,9 @@ public class WorkerShellStep implements Step {
       pool = factory.getWorkerProcessPool(context, paramsToUse);
       process = pool.borrowWorkerProcess();
       WorkerJobResult result = process.submitAndWaitForJob(getExpandedJobArgs(context));
+      pool.returnWorkerProcess(process);
+      process = null;  // to avoid finally below
+
       Verbosity verbosity = context.getVerbosity();
       if (result.getStdout().isPresent() && !result.getStdout().get().isEmpty() &&
           verbosity.shouldPrintOutput()) {
@@ -88,7 +91,7 @@ public class WorkerShellStep implements Step {
       throw new HumanReadableException(e, "Error communicating with external process.");
     } finally {
       if (pool != null && process != null) {
-        pool.returnWorkerProcess(process);
+        pool.destroyWorkerProcess(process);
       }
     }
   }

--- a/src/com/facebook/buck/util/ProcessExecutor.java
+++ b/src/com/facebook/buck/util/ProcessExecutor.java
@@ -124,6 +124,7 @@ public interface ProcessExecutor {
    * Represents a running process returned by {@link #launchProcess(ProcessExecutorParams)}.
    */
   public interface LaunchedProcess {
+    boolean isAlive();
     OutputStream getOutputStream();
     InputStream getInputStream();
     InputStream getErrorStream();
@@ -139,6 +140,11 @@ public interface ProcessExecutor {
 
     public LaunchedProcessImpl(Process process) {
       this.process = process;
+    }
+
+    @Override
+    public boolean isAlive() {
+      return process.isAlive();
     }
 
     @Override

--- a/test/com/facebook/buck/message_ipc/ConnectionTest.java
+++ b/test/com/facebook/buck/message_ipc/ConnectionTest.java
@@ -51,6 +51,7 @@ public class ConnectionTest {
                 0,
                 Optional.of("{\"type\":\"ReturnResultMessage\",\"value\":42}"),
                 Optional.empty())));
+    workerProcess.ensureLaunchAndHandshake();
     MessageTransport messageTransport = new MessageTransport(workerProcess, messageSerializer);
 
     try (Connection<RemoteInterface> connection = new Connection<>(messageTransport)) {
@@ -74,6 +75,7 @@ public class ConnectionTest {
                 0,
                 Optional.of("{\"type\":\"ReturnResultMessage\",\"value\":false}"),
                 Optional.empty())));
+    workerProcess.ensureLaunchAndHandshake();
     MessageTransport messageTransport = new MessageTransport(workerProcess, messageSerializer);
 
     try (Connection<RemoteInterface> connection = new Connection<>(messageTransport)) {
@@ -94,6 +96,7 @@ public class ConnectionTest {
                 0,
                 Optional.of("{\"type\":\"ReturnResultMessage\",\"value\":true}"),
                 Optional.empty())));
+    workerProcess.ensureLaunchAndHandshake();
     MessageTransport messageTransport = new MessageTransport(workerProcess, messageSerializer);
 
     try (Connection<RemoteInterface> connection = new Connection<>(messageTransport)) {

--- a/test/com/facebook/buck/shell/WorkerProcessPoolTest.java
+++ b/test/com/facebook/buck/shell/WorkerProcessPoolTest.java
@@ -129,7 +129,62 @@ public class WorkerProcessPoolTest {
     assertThat(
         new HashSet<>(usedWorkers.values()).size(),
         Matchers.allOf(Matchers.greaterThan(0), Matchers.lessThanOrEqualTo(numThreads)));
+  }
 
+  @Test
+  public void destroysProcessOnFailure() throws InterruptedException {
+    final WorkerProcessPool pool = createPool(1);
+    final ConcurrentHashMap<Runnable, WorkerProcess> usedWorkers = new ConcurrentHashMap<>();
+    Thread t = new Thread(new BorrowAndReturnWorkerProcess(pool, usedWorkers));
+    t.start();
+    t.join();
+    assertThat(usedWorkers.size(), Matchers.is(1));
+
+    t = new Thread(new BorrowAndKillWorkerProcess(pool, usedWorkers));
+    t.start();
+    t.join();
+
+    t = new Thread(new BorrowAndReturnWorkerProcess(pool, usedWorkers));
+    t.start();
+    t.join();
+
+    assertThat(usedWorkers.size(), Matchers.is(3));
+    assertThat(
+        new HashSet<>(usedWorkers.values()).size(),
+        Matchers.is(2));
+  }
+
+  @Test
+  public void returnAndDestroyDoNotInterrupt() throws InterruptedException, IOException {
+    final WorkerProcessPool pool = createPool(1);
+    final WorkerProcess process = pool.borrowWorkerProcess();
+    process.ensureLaunchAndHandshake();
+
+    Thread.currentThread().interrupt();
+    pool.returnWorkerProcess(process);
+    assertThat(Thread.interrupted(), Matchers.is(true));
+
+    final WorkerProcess process2 = pool.borrowWorkerProcess();
+    process2.ensureLaunchAndHandshake();
+    assertThat(process2, Matchers.is(process));
+
+    Thread.currentThread().interrupt();
+    pool.destroyWorkerProcess(process2);
+    assertThat(Thread.interrupted(), Matchers.is(true));
+  }
+
+  @Test
+  public void cleansUpDeadProcesses() throws InterruptedException, IOException {
+    final WorkerProcessPool pool = createPool(1);
+    final WorkerProcess process = pool.borrowWorkerProcess();
+    process.ensureLaunchAndHandshake();
+    pool.returnWorkerProcess(process);
+    process.close();
+
+    final WorkerProcess process2 = pool.borrowWorkerProcess();
+    process2.ensureLaunchAndHandshake();
+    assertThat(process2, Matchers.not(process));
+    pool.returnWorkerProcess(process2);
   }
 
   private static WorkerProcessPool createPool(int maxWorkers) {
@@ -171,7 +226,9 @@ public class WorkerProcessPoolTest {
 
     @Override
     public void runUnsafe() throws Exception {
-      createdWorkers.add(pool.borrowWorkerProcess());
+      WorkerProcess process = pool.borrowWorkerProcess();
+      process.ensureLaunchAndHandshake();
+      createdWorkers.add(process);
     }
   }
 
@@ -190,7 +247,28 @@ public class WorkerProcessPoolTest {
     public void runUnsafe() throws Exception {
       WorkerProcess workerProcess = pool.borrowWorkerProcess();
       usedWorkers.put(this, workerProcess);
+      workerProcess.ensureLaunchAndHandshake();
       pool.returnWorkerProcess(workerProcess);
+    }
+  }
+
+  class BorrowAndKillWorkerProcess extends Runnable {
+    private final WorkerProcessPool pool;
+    private final Map<Runnable, WorkerProcess> usedWorkers;
+
+    public BorrowAndKillWorkerProcess(
+        WorkerProcessPool pool,
+        Map<Runnable, WorkerProcess> usedWorkers) {
+      this.pool = pool;
+      this.usedWorkers = usedWorkers;
+    }
+
+    @Override
+    public void runUnsafe() throws Exception {
+      WorkerProcess workerProcess = pool.borrowWorkerProcess();
+      usedWorkers.put(this, workerProcess);
+      workerProcess.ensureLaunchAndHandshake();
+      pool.destroyWorkerProcess(workerProcess);
     }
   }
 }


### PR DESCRIPTION
When a build is canceled, a SIGINT is sent to Buck's entire process tree. This kills any persistent workers. Unfortunately, this also hung the `WorkerShellStep`s for the next build.

This PR fixes the particular problem, but not the core issue of persistent worker death. I'm not sure how to tackle the core issue without either:
 - Adding a new message type to the protocol. (i.e. "ping")
 - Adding some amount of retries with persistent workers per step (that is >= the number of workers in the pool).

This PR solves the particular issue above (SIGINT & clean death) by killing workers that get interrupted in the middle of a build step. It also improves logging so worker tool debugging is a bit easier.