### PR TITLE
Introduce rules for compiling closure javascript

### DIFF
--- a/src/com/facebook/buck/rules/BUCK
+++ b/src/com/facebook/buck/rules/BUCK
@@ -103,6 +103,7 @@ java_immutables_library(
         "//src/com/facebook/buck/util/environment:platform",
         "//src/com/facebook/buck/versions:versions",
         "//src/com/facebook/buck/zip:rules",
+        "//src/org/openqa/selenium/buck/javascript:javascript",
     ],
 )
 

--- a/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
+++ b/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
@@ -166,6 +166,11 @@ import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 
+import org.openqa.selenium.buck.javascript.ClosureBinaryDescription;
+import org.openqa.selenium.buck.javascript.ClosureFragmentDescription;
+import org.openqa.selenium.buck.javascript.ClosureLibraryDescription;
+import org.openqa.selenium.buck.javascript.JavascriptConfig;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -425,6 +430,8 @@ public class KnownBuildRuleTypes {
 
     DxConfig dxConfig = new DxConfig(config);
 
+    JavascriptConfig jsConfig = new JavascriptConfig(config);
+
     PythonBuckConfig pyConfig = new PythonBuckConfig(config, executableFinder);
     ImmutableList<PythonPlatform> pythonPlatformsList =
         pyConfig.getPythonPlatforms(processExecutor);
@@ -621,6 +628,9 @@ public class KnownBuildRuleTypes {
             appleConfig.getAppleDeveloperDirectorySupplierForTests(processExecutor),
             defaultTestRuleTimeoutMs));
     builder.register(new CoreDataModelDescription());
+    builder.register(new ClosureBinaryDescription(jsConfig));
+    builder.register(new ClosureFragmentDescription(jsConfig));
+    builder.register(new ClosureLibraryDescription());
     builder.register(new CsharpLibraryDescription());
     builder.register(cxxBinaryDescription);
     builder.register(cxxLibraryDescription);

--- a/src/org/openqa/selenium/buck/javascript/BUCK
+++ b/src/org/openqa/selenium/buck/javascript/BUCK
@@ -1,0 +1,27 @@
+
+java_library(name = 'javascript',
+  srcs = glob(['*.java']),
+  deps = [
+    '//src/com/facebook/buck/cli:config',
+    '//src/com/facebook/buck/graph:graph',
+    '//src/com/facebook/buck/io:io',
+    '//src/com/facebook/buck/model:model',
+    '//src/com/facebook/buck/parser:rule_pattern',
+    '//src/com/facebook/buck/rules:build_rule',
+    '//src/com/facebook/buck/rules:interfaces',
+    '//src/com/facebook/buck/rules:rules',
+    '//src/com/facebook/buck/shell:steps',
+    '//src/com/facebook/buck/step/fs:fs',
+    '//src/com/facebook/buck/step:step',
+    '//src/com/facebook/buck/util:constants',
+    '//src/com/facebook/buck/util:exceptions',
+    '//src/com/facebook/buck/util:util',
+    '//third-party/java/guava:guava',
+    '//third-party/java/jackson:jackson-core',
+    '//third-party/java/jackson:jackson-databind',
+    '//third-party/java/jsr:jsr305',
+  ],
+  visibility = [
+    '//src/com/facebook/buck/rules:types',
+  ],
+)

--- a/src/org/openqa/selenium/buck/javascript/ClosureBinaryDescription.java
+++ b/src/org/openqa/selenium/buck/javascript/ClosureBinaryDescription.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2013-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.openqa.selenium.buck.javascript;
+
+import com.facebook.buck.model.BuildTarget;
+import com.facebook.buck.parser.NoSuchBuildTargetException;
+import com.facebook.buck.rules.AbstractDescriptionArg;
+import com.facebook.buck.rules.BuildRule;
+import com.facebook.buck.rules.BuildRuleParams;
+import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.BuildTargetSourcePath;
+import com.facebook.buck.rules.CellPathResolver;
+import com.facebook.buck.rules.Description;
+import com.facebook.buck.rules.ImplicitDepsInferringDescription;
+import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.buck.rules.SourcePathRuleFinder;
+import com.facebook.buck.rules.TargetGraph;
+import com.facebook.buck.util.MoreCollectors;
+import com.facebook.buck.util.RichStream;
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
+
+import java.util.Optional;
+
+public class ClosureBinaryDescription implements
+    Description<ClosureBinaryDescription.Arg>,
+    ImplicitDepsInferringDescription<ClosureBinaryDescription.Arg> {
+
+  private final JavascriptConfig config;
+
+  public ClosureBinaryDescription(JavascriptConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public Arg createUnpopulatedConstructorArg() {
+    return new Arg();
+  }
+
+  @Override
+  public <A extends Arg> BuildRule createBuildRule(
+      TargetGraph targetGraph,
+      BuildRuleParams params,
+      BuildRuleResolver resolver,
+      CellPathResolver cellRoots,
+      A args) throws NoSuchBuildTargetException {
+    SourcePathRuleFinder finder = new SourcePathRuleFinder(resolver);
+    SourcePathResolver pathResolver = new SourcePathResolver(finder);
+    return new JsBinary(
+        params,
+        config.getClosureCompiler(args.compiler, pathResolver, finder),
+        params.getDeclaredDeps(),
+        args.srcs,
+        args.defines,
+        args.flags,
+        args.externs,
+        args.noFormat);
+  }
+
+  @Override
+  public void findDepsForTargetFromConstructorArgs(
+      BuildTarget buildTarget,
+      CellPathResolver cellRoots,
+      Arg constructorArg,
+      ImmutableCollection.Builder<BuildTarget> extraDepsBuilder,
+      ImmutableCollection.Builder<BuildTarget> targetGraphOnlyDepsBuilder) {
+    extraDepsBuilder.addAll(
+        RichStream.of(config.getClosureCompilerSourcePath(constructorArg.compiler))
+            .filter(BuildTargetSourcePath.class)
+            .map(BuildTargetSourcePath::getTarget)
+            .collect(MoreCollectors.toImmutableList()));
+  }
+
+  public static class Arg extends AbstractDescriptionArg {
+    public ImmutableList<String> defines = ImmutableList.of();
+    public ImmutableList<SourcePath> externs = ImmutableList.of();
+    public ImmutableList<String> flags = ImmutableList.of();
+    public Optional<Boolean> noFormat;
+    public ImmutableSortedSet<SourcePath> srcs = ImmutableSortedSet.of();
+    public Optional<SourcePath> compiler;
+
+    public ImmutableSortedSet<BuildTarget> deps = ImmutableSortedSet.of();
+  }
+}

--- a/src/org/openqa/selenium/buck/javascript/ClosureCompilerStep.java
+++ b/src/org/openqa/selenium/buck/javascript/ClosureCompilerStep.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2014-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.openqa.selenium.buck.javascript;
+
+
+import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.buck.rules.Tool;
+import com.facebook.buck.shell.ShellStep;
+import com.facebook.buck.step.ExecutionContext;
+import com.facebook.buck.step.StepExecutionResult;
+import com.facebook.buck.util.HumanReadableException;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class ClosureCompilerStep extends ShellStep {
+
+  private final Path output;
+  private final ImmutableList<String> cmd;
+
+  private ClosureCompilerStep(Path workingDirectory, Path output, ImmutableList<String> cmd) {
+    super(workingDirectory);
+    this.output = Preconditions.checkNotNull(output);
+    this.cmd = cmd;
+  }
+
+  @Override
+  protected ImmutableList<String> getShellCommandInternal(ExecutionContext context) {
+    return cmd;
+  }
+
+  @Override
+  public String getShortName() {
+    return "closure compiler";
+  }
+
+  @Override
+  public StepExecutionResult execute(ExecutionContext context)
+      throws InterruptedException, IOException {
+    StepExecutionResult exitCode = super.execute(context);
+
+    if (exitCode.isSuccess()) {
+      return exitCode;
+    }
+    File file = output.toFile();
+    if (file.exists() && !file.delete()) {
+      throw new HumanReadableException(
+          "Unable to delete output, which may lead to incorrect builds: " + output);
+    }
+    return exitCode;
+  }
+
+  public static Builder builder(
+      Path workingDirectory,
+      SourcePathResolver resolver,
+      Tool jsCompiler) {
+    return new Builder(workingDirectory, resolver, jsCompiler);
+  }
+
+  public static class Builder {
+
+    private final Path workingDirectory;
+    private final SourcePathResolver resolver;
+    private ImmutableList.Builder<String> cmd = ImmutableList.builder();
+    private Path output;
+
+    public Builder(Path workingDirectory, SourcePathResolver resolver, Tool compiler) {
+      this.workingDirectory = Preconditions.checkNotNull(workingDirectory);
+      this.resolver = resolver;
+
+      cmd.addAll(compiler.getCommandPrefix(resolver));
+    }
+
+    public Builder defines(ImmutableList<String> defines) {
+      for (String define : defines) {
+        cmd.add("--define=" + define);
+      }
+      return this;
+    }
+
+    public Builder externs(ImmutableList<SourcePath> externs) {
+      for (SourcePath path : externs) {
+        cmd.add("--externs='" + resolver.getAbsolutePath(path) + "'");
+      }
+      return this;
+    }
+
+    public Builder flags(ImmutableList<String> flags) {
+      for (String flag : flags) {
+        cmd.add(flag);
+      }
+      return this;
+    }
+
+    public Builder prettyPrint() {
+      cmd.add("--formatting=PRETTY_PRINT");
+      return this;
+    }
+
+    public Builder prettyPrint(boolean isPretty) {
+      if (isPretty) {
+        prettyPrint();
+      }
+      return this;
+    }
+
+    public Builder sources(Iterable<Path> paths) {
+      for (Path path : paths) {
+        cmd.add("--js='" + path + "'");
+      }
+      return this;
+    }
+
+    public Builder output(Path out) {
+      this.output = out;
+      cmd.add("--js_output_file=" + out);
+      return this;
+    }
+
+    public ClosureCompilerStep build() {
+      return new ClosureCompilerStep(workingDirectory, output, cmd.build());
+    }
+  }
+}

--- a/src/org/openqa/selenium/buck/javascript/ClosureFragmentDescription.java
+++ b/src/org/openqa/selenium/buck/javascript/ClosureFragmentDescription.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2014-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.openqa.selenium.buck.javascript;
+
+
+import static java.lang.Boolean.FALSE;
+
+import com.facebook.buck.model.BuildTarget;
+import com.facebook.buck.parser.NoSuchBuildTargetException;
+import com.facebook.buck.rules.AbstractDescriptionArg;
+import com.facebook.buck.rules.BuildRule;
+import com.facebook.buck.rules.BuildRuleParams;
+import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.BuildTargetSourcePath;
+import com.facebook.buck.rules.CellPathResolver;
+import com.facebook.buck.rules.Description;
+import com.facebook.buck.rules.ImplicitDepsInferringDescription;
+import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.buck.rules.SourcePathRuleFinder;
+import com.facebook.buck.rules.TargetGraph;
+import com.facebook.buck.util.MoreCollectors;
+import com.facebook.buck.util.RichStream;
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
+
+import java.util.Optional;
+
+public class ClosureFragmentDescription implements
+    Description<ClosureFragmentDescription.Arg>,
+    ImplicitDepsInferringDescription<ClosureFragmentDescription.Arg> {
+
+  private final JavascriptConfig config;
+
+  public ClosureFragmentDescription(JavascriptConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public Arg createUnpopulatedConstructorArg() {
+    return new Arg();
+  }
+
+  @Override
+  public <A extends Arg> BuildRule createBuildRule(
+      TargetGraph targetGraph,
+      BuildRuleParams params,
+      BuildRuleResolver resolver,
+      CellPathResolver cellRoots,
+      A args) throws NoSuchBuildTargetException {
+    SourcePathRuleFinder finder = new SourcePathRuleFinder(resolver);
+    SourcePathResolver pathResolver = new SourcePathResolver(finder);
+    return new JsFragment(
+        params,
+        config.getClosureCompiler(args.compiler, pathResolver, finder),
+        params.getBuildDeps(),
+        args.module,
+        args.function,
+        args.defines,
+        args.prettyPrint.orElse(FALSE));
+  }
+
+  @Override
+  public void findDepsForTargetFromConstructorArgs(
+      BuildTarget buildTarget,
+      CellPathResolver cellRoots,
+      ClosureFragmentDescription.Arg constructorArg,
+      ImmutableCollection.Builder<BuildTarget> extraDepsBuilder,
+      ImmutableCollection.Builder<BuildTarget> targetGraphOnlyDepsBuilder) {
+    extraDepsBuilder.addAll(
+        RichStream.of(config.getClosureCompilerSourcePath(constructorArg.compiler))
+            .filter(BuildTargetSourcePath.class)
+            .map(BuildTargetSourcePath::getTarget)
+            .collect(MoreCollectors.toImmutableList()));
+  }
+
+  public static class Arg extends AbstractDescriptionArg {
+    public String function;
+    public String module;
+    public Optional<Boolean> prettyPrint;
+    public ImmutableList<String> defines = ImmutableList.of();
+    public Optional<SourcePath> compiler;
+
+    public ImmutableSortedSet<BuildTarget> deps = ImmutableSortedSet.of();
+  }
+}

--- a/src/org/openqa/selenium/buck/javascript/ClosureLibraryDescription.java
+++ b/src/org/openqa/selenium/buck/javascript/ClosureLibraryDescription.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2013-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.openqa.selenium.buck.javascript;
+
+import com.facebook.buck.model.BuildTarget;
+import com.facebook.buck.parser.NoSuchBuildTargetException;
+import com.facebook.buck.rules.AbstractDescriptionArg;
+import com.facebook.buck.rules.BuildRule;
+import com.facebook.buck.rules.BuildRuleParams;
+import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.CellPathResolver;
+import com.facebook.buck.rules.Description;
+import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.rules.TargetGraph;
+import com.google.common.collect.ImmutableSortedSet;
+
+public class ClosureLibraryDescription implements Description<ClosureLibraryDescription.Arg> {
+
+  @Override
+  public Arg createUnpopulatedConstructorArg() {
+    return new Arg();
+  }
+
+  @Override
+  public <A extends Arg> BuildRule createBuildRule(
+      TargetGraph targetGraph,
+      BuildRuleParams params,
+      BuildRuleResolver resolver,
+      CellPathResolver cellRoots,
+      A args) throws NoSuchBuildTargetException {
+    return new JsLibrary(
+        params,
+        params.getDeclaredDeps().get(),
+        args.srcs);
+  }
+
+  public static class Arg extends AbstractDescriptionArg {
+    public ImmutableSortedSet<SourcePath> srcs;
+    public ImmutableSortedSet<BuildTarget> deps = ImmutableSortedSet.of();
+  }
+}

--- a/src/org/openqa/selenium/buck/javascript/HasJavascriptDependencies.java
+++ b/src/org/openqa/selenium/buck/javascript/HasJavascriptDependencies.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2014-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.openqa.selenium.buck.javascript;
+
+interface HasJavascriptDependencies {
+  JavascriptDependencies getBundleOfJoy();
+}

--- a/src/org/openqa/selenium/buck/javascript/JavascriptConfig.java
+++ b/src/org/openqa/selenium/buck/javascript/JavascriptConfig.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.openqa.selenium.buck.javascript;
+
+import com.facebook.buck.cli.BuckConfig;
+import com.facebook.buck.rules.BinaryBuildRule;
+import com.facebook.buck.rules.BuildRule;
+import com.facebook.buck.rules.HashedFileTool;
+import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.buck.rules.SourcePathRuleFinder;
+import com.facebook.buck.rules.Tool;
+import com.facebook.buck.util.HumanReadableException;
+import com.google.common.base.Preconditions;
+
+import java.util.Optional;
+
+public class JavascriptConfig {
+
+  private final BuckConfig delegate;
+
+  public JavascriptConfig(BuckConfig delegate) {
+    this.delegate = delegate;
+  }
+
+  public Tool getClosureCompiler(
+      Optional<SourcePath> compilerPath,
+      SourcePathResolver resolver,
+      SourcePathRuleFinder finder) {
+    SourcePath path = getClosureCompilerSourcePath(compilerPath);
+    Optional<BuildRule> rule = finder.getRule(path);
+    if (rule.isPresent()) {
+      Preconditions.checkState(
+          rule.get() instanceof BinaryBuildRule,
+          "Closure compiler must be a binary build rule");
+      return ((BinaryBuildRule) rule.get()).getExecutableCommand();
+    }
+
+    return new HashedFileTool(resolver.getAbsolutePath(path));
+  }
+
+  public SourcePath getClosureCompilerSourcePath(Optional<SourcePath> compilerPath) {
+    Optional<SourcePath> path = delegate.getSourcePath("tools", "closure_compiler");
+    if (!path.isPresent()) {
+      throw new HumanReadableException("Unable to determine closure compiler to use");
+    }
+    return compilerPath.orElse(path.get());
+  }
+}
+

--- a/src/org/openqa/selenium/buck/javascript/JavascriptDependencies.java
+++ b/src/org/openqa/selenium/buck/javascript/JavascriptDependencies.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2014-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.openqa.selenium.buck.javascript;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+
+class JavascriptDependencies {
+
+  private Map<String, JavascriptSource> provide2Source = Maps.newHashMap();
+
+  public void add(JavascriptSource source) {
+    Preconditions.checkNotNull(source);
+
+    for (String provide : source.getProvides()) {
+      provide2Source.put(provide, source);
+    }
+  }
+
+  public void addAll(Set<JavascriptSource> sources) {
+    for (JavascriptSource source : sources) {
+      add(source);
+    }
+  }
+
+  public void amendGraph(JavascriptDependencyGraph graph, String dep) {
+    Preconditions.checkNotNull(dep);
+
+    Set<JavascriptSource> allDeps = getDeps(dep);
+    for (JavascriptSource source : allDeps) {
+      graph.amendGraph(source);
+    }
+  }
+
+  @VisibleForTesting
+  Set<JavascriptSource> getDeps(String required) {
+    ImmutableSet.Builder<JavascriptSource> deps = ImmutableSet.builder();
+
+    Queue<String> toFind = new ArrayDeque<>();
+    Set<String> seen = Sets.newHashSet();
+    toFind.add(required);
+    while (!toFind.isEmpty()) {
+      String dep = toFind.remove();
+      if (seen.contains(dep)) {
+        continue;
+      }
+      seen.add(dep);
+      JavascriptSource source = provide2Source.get(dep);
+      if (source == null) {
+        continue;
+      }
+      deps.add(source);
+      toFind.addAll(source.getRequires());
+    }
+
+    return deps.build();
+  }
+
+  @Override
+  public String toString() {
+    return "BundleOfJoy{provide2Source=" + provide2Source + '}';
+  }
+
+  public void writeTo(Writer writer) {
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      SimpleModule module = new SimpleModule();
+      module.addSerializer(Path.class, new Serializer());
+      mapper.registerModule(module);
+      mapper.writeValue(writer, provide2Source.values());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  public static JavascriptDependencies buildFrom(String raw) {
+    JavascriptDependencies joy = new JavascriptDependencies();
+
+    try {
+      Set<?> allSources = new ObjectMapper().readValue(raw, Set.class);
+
+      for (Object source : allSources) {
+        Map<String, ?> srcMap = (Map<String, ?>) source;
+        JavascriptSource jsSource = new JavascriptSource(
+            (String) srcMap.get("path"),
+            (Collection<String>) srcMap.get("provides"),
+            (Collection<String>) srcMap.get("requires"));
+        joy.add(jsSource);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    return joy;
+  }
+
+  private static class Serializer extends JsonSerializer<Path> {
+    @Override
+    public void serialize(
+        Path path,
+        JsonGenerator generator,
+        SerializerProvider serializerProvider) throws IOException {
+      generator.writeString(path.toString());
+    }
+  }
+}

--- a/src/org/openqa/selenium/buck/javascript/JavascriptDependencyGraph.java
+++ b/src/org/openqa/selenium/buck/javascript/JavascriptDependencyGraph.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2013-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.openqa.selenium.buck.javascript;
+
+import com.facebook.buck.graph.MutableDirectedGraph;
+import com.facebook.buck.graph.TopologicalSort;
+import com.facebook.buck.util.HumanReadableException;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Set;
+
+public class JavascriptDependencyGraph {
+
+  private static final Path BASE_JS = Paths.get("third_party/closure/goog/base.js");
+  private Set<JavascriptSource> sources = Sets.newHashSet();
+  private Map<String, Path> depToPath = Maps.newHashMap();
+
+  public void amendGraph(JavascriptSource source) {
+    sources.add(source);
+    for (String provide : source.getProvides()) {
+      depToPath.put(provide, source.getPath());
+    }
+  }
+
+  public void amendGraph(Iterable<JavascriptSource> allSources) {
+    for (JavascriptSource source : allSources) {
+      sources.add(source);
+      for (String provide : source.getProvides()) {
+        depToPath.put(provide, source.getPath());
+      }
+    }
+  }
+
+  public ImmutableSet<Path> sortSources() {
+    MutableDirectedGraph<String> graph = new MutableDirectedGraph<>();
+
+    for (JavascriptSource source : sources) {
+      for (String provide : source.getProvides()) {
+        graph.addNode(provide);
+
+        for (String require : source.getRequires()) {
+          graph.addNode(require);
+          graph.addEdge(provide, require);
+        }
+      }
+    }
+
+    // Final step, topo sort the graph of deps and map back to files.
+    ImmutableList<String> sorted = TopologicalSort.sort(graph);
+    ImmutableSet.Builder<Path> builder = ImmutableSet.builder();
+    builder.add(BASE_JS);
+
+    for (String dep : sorted) {
+      Path element = depToPath.get(dep);
+
+      if (element == null) {
+        throw new HumanReadableException("Missing dependency for: %s in", dep, sorted);
+      }
+
+      builder.add(element);
+    }
+
+    return builder.build();
+  }
+
+  @Override
+  public String toString() {
+    return sources.toString();
+  }
+}

--- a/src/org/openqa/selenium/buck/javascript/JavascriptFragmentStep.java
+++ b/src/org/openqa/selenium/buck/javascript/JavascriptFragmentStep.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2014-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.openqa.selenium.buck.javascript;
+
+import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.buck.rules.Tool;
+import com.facebook.buck.shell.ShellStep;
+import com.facebook.buck.step.ExecutionContext;
+import com.google.common.collect.ImmutableList;
+
+import java.nio.file.Path;
+
+class JavascriptFragmentStep extends ShellStep {
+
+  private final SourcePathResolver resolver;
+  private final Tool compiler;
+  private final Iterable<Path> jsDeps;
+  private final Path temp;
+  private final Path output;
+  private final ImmutableList<String> flags;
+
+  public JavascriptFragmentStep(
+      Path workingDirectory,
+      SourcePathResolver resolver,
+      Tool compiler,
+      ImmutableList<String> flags,
+      Path temp,
+      Path output,
+      Iterable<Path> jsDeps) {
+    super(workingDirectory);
+    this.resolver = resolver;
+    this.compiler = compiler;
+    this.flags = flags;
+    this.temp = temp;
+    this.output = output;
+    this.jsDeps = jsDeps;
+  }
+
+  @Override
+  protected ImmutableList<String> getShellCommandInternal(ExecutionContext context) {
+    ImmutableList.Builder<String> cmd = ImmutableList.builder();
+
+    String wrapper = "function(){%output%; return this._.apply(null,arguments);}";
+    wrapper = String.format(
+        "function(){return %s.apply({" +
+            "navigator:typeof window!='undefined'?window.navigator:null," +
+            "document:typeof window!='undefined'?window.document:null" +
+            "}, arguments);}", wrapper);
+
+    cmd.addAll(compiler.getCommandPrefix(resolver));
+    cmd.add(
+        String.format("--js_output_file='%s'", output),
+        String.format("--output_wrapper='%s'", wrapper),
+        "--compilation_level=ADVANCED_OPTIMIZATIONS",
+        "--define=goog.NATIVE_ARRAY_PROTOTYPES=false",
+        "--define=bot.json.NATIVE_JSON=false");
+    cmd.addAll(flags);
+    cmd.add(
+        "--jscomp_off=unknownDefines",
+        "--jscomp_off=deprecated",
+        "--jscomp_error=accessControls",
+        "--jscomp_error=ambiguousFunctionDecl",
+        "--jscomp_error=checkDebuggerStatement",
+        "--jscomp_error=checkRegExp",
+        "--jscomp_error=checkTypes",
+        "--jscomp_error=checkVars",
+        "--jscomp_error=const",
+        "--jscomp_error=constantProperty",
+        "--jscomp_error=duplicate",
+        "--jscomp_error=duplicateMessage",
+        "--jscomp_error=externsValidation",
+        "--jscomp_error=fileoverviewTags",
+        "--jscomp_error=globalThis",
+        "--jscomp_error=internetExplorerChecks",
+        "--jscomp_error=invalidCasts",
+        "--jscomp_error=missingProperties",
+        "--jscomp_error=nonStandardJsDocs",
+        "--jscomp_error=strictModuleDepCheck",
+        "--jscomp_error=typeInvalidation",
+        "--jscomp_error=undefinedNames",
+        "--jscomp_error=undefinedVars",
+        "--jscomp_error=uselessCode",
+        "--jscomp_error=visibility"
+    );
+
+    for (Path dep : jsDeps) {
+      cmd.add("--js='" + dep + "'");
+      if (dep.endsWith("closure/goog/base.js")) {
+        // Always load closure's deps.js first to "forward declare" all of the Closure types. This
+        // prevents type errors when a symbol is referenced in a file's type annotation, but not
+        // actually needed in the compiled output.
+        cmd.add("--js='third_party/closure/goog/deps.js'");
+      }
+    }
+    cmd.add("--js='" + temp + "'");
+
+    return cmd.build();
+  }
+
+  @Override
+  public String getShortName() {
+    return "compile js fragment";
+  }
+}

--- a/src/org/openqa/selenium/buck/javascript/JavascriptSource.java
+++ b/src/org/openqa/selenium/buck/javascript/JavascriptSource.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2013-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.openqa.selenium.buck.javascript;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSortedSet;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class JavascriptSource {
+
+//  private static final Pattern ADD_DEP = Pattern.compile(
+//    Joiner.on("").join(
+//        "^goog.addDependency\\s*\\(\\s*",
+//        "['\"]([^'\"]+)['\"]",     // Relative path from Closure's base.js
+//        "\\s*,\\s*",
+//        "\\[([^\\]]+)?\\]",        // Provided symbols
+//        "\\s*,\\s*",
+//        "\\[([^\\]]+)?\\]",        // Required symbols
+//        "\\s*",
+//        "(?:,\\s*(true|false))?",  // Module flag.
+//        "\\s*\\)"
+//    ));
+
+  private static final Pattern MODULE = Pattern.compile(
+      "^goog\\.module\\s*\\(\\s*['\"]([^'\"]+)['\"]\\s*\\)");
+
+  // goog.require statement may have a LHS assignment if inside a goog.module
+  // file. This is a simplified version of:
+  // https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/deps/JsFileParser.java#L41
+  @SuppressWarnings("checkstyle:linelength")
+  private static final Pattern REQUIRE = Pattern.compile(
+      "^\\s*(?:(?:var|let|const)\\s+[a-zA-Z_$][a-zA-Z0-9$_]*\\s*=\\s*)?goog\\.require\\s*\\(\\s*['\"]([^'\"]+)['\"]\\s*\\)");
+  private static final Pattern PROVIDE = Pattern.compile(
+      "^goog\\.provide\\s*\\(\\s*['\"]([^'\"]+)['\"]\\s*\\)");
+
+
+  private final Path path;
+  private final ImmutableSortedSet<String> provides;
+  private final ImmutableSortedSet<String> requires;
+
+  public JavascriptSource(Path path) {
+    this.path = Preconditions.checkNotNull(path);
+
+    ImmutableSortedSet.Builder<String> toProvide = ImmutableSortedSet.naturalOrder();
+    ImmutableSortedSet.Builder<String> toRequire = ImmutableSortedSet.naturalOrder();
+
+    try {
+      for (String line : Files.readAllLines(path, StandardCharsets.UTF_8)) {
+        Matcher moduleMatcher = MODULE.matcher(line);
+        if (moduleMatcher.find()) {
+          toProvide.add(moduleMatcher.group(1));
+        }
+
+        Matcher requireMatcher = REQUIRE.matcher(line);
+        if (requireMatcher.find()) {
+          toRequire.add(requireMatcher.group(1));
+        }
+
+        Matcher provideMatcher = PROVIDE.matcher(line);
+        if (provideMatcher.find()) {
+          toProvide.add(provideMatcher.group(1));
+        }
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    this.provides = toProvide.build();
+    this.requires = toRequire.build();
+  }
+
+  JavascriptSource(String path, Iterable<String> provides, Iterable<String> requires) {
+    this.path = Paths.get(path);
+    this.provides = ImmutableSortedSet.copyOf(provides);
+    this.requires = ImmutableSortedSet.copyOf(requires);
+  }
+
+  public Path getPath() {
+    return path;
+  }
+
+  public ImmutableSortedSet<String> getProvides() {
+    return provides;
+  }
+
+  public ImmutableSortedSet<String> getRequires() {
+    return requires;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s -> provide: %s  + require: %s", path, provides, requires);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    JavascriptSource that = (JavascriptSource) o;
+
+    return path.equals(that.path) &&
+        provides.equals(that.provides) &&
+        requires.equals(that.requires);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = path.hashCode();
+    result = 31 * result + provides.hashCode();
+    result = 31 * result + requires.hashCode();
+    return result;
+  }
+}

--- a/src/org/openqa/selenium/buck/javascript/JsBinary.java
+++ b/src/org/openqa/selenium/buck/javascript/JsBinary.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2013-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.openqa.selenium.buck.javascript;
+
+import com.facebook.buck.model.BuildTargets;
+import com.facebook.buck.rules.AbstractBuildRule;
+import com.facebook.buck.rules.AddToRuleKey;
+import com.facebook.buck.rules.BuildContext;
+import com.facebook.buck.rules.BuildOutputInitializer;
+import com.facebook.buck.rules.BuildRule;
+import com.facebook.buck.rules.BuildRuleParams;
+import com.facebook.buck.rules.BuildableContext;
+import com.facebook.buck.rules.InitializableFromDisk;
+import com.facebook.buck.rules.OnDiskBuildInfo;
+import com.facebook.buck.rules.PathSourcePath;
+import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.rules.Tool;
+import com.facebook.buck.step.Step;
+import com.facebook.buck.step.fs.MkdirStep;
+import com.facebook.buck.step.fs.WriteFileStep;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Sets;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public class JsBinary extends AbstractBuildRule implements
+    InitializableFromDisk<JavascriptDependencies>, HasJavascriptDependencies {
+
+  private final Path joyPath;
+  private final Path output;
+  @AddToRuleKey
+  private final Tool compiler;
+  @AddToRuleKey
+  private final com.google.common.base.Supplier<ImmutableSortedSet<BuildRule>> deps;
+  @AddToRuleKey
+  private final ImmutableSortedSet<SourcePath> srcs;
+  @AddToRuleKey
+  private final ImmutableList<String> defines;
+  @AddToRuleKey
+  private final ImmutableList<SourcePath> externs;
+  @AddToRuleKey
+  private final ImmutableList<String> flags;
+  @AddToRuleKey
+  private final boolean prettyPrint;
+  private JavascriptDependencies joy;
+  private final BuildOutputInitializer<JavascriptDependencies> buildOutputInitializer;
+
+  public JsBinary(
+      BuildRuleParams params,
+      Tool compiler,
+      com.google.common.base.Supplier<ImmutableSortedSet<BuildRule>> deps,
+      ImmutableSortedSet<SourcePath> srcs,
+      ImmutableList<String> defines,
+      ImmutableList<String> flags,
+      ImmutableList<SourcePath> externs,
+      Optional<Boolean> noFormat) {
+    super(params);
+
+    this.compiler = compiler;
+
+    this.deps = Preconditions.checkNotNull(deps);
+    this.srcs = Preconditions.checkNotNull(srcs);
+    this.defines = Preconditions.checkNotNull(defines);
+    this.externs = Preconditions.checkNotNull(externs);
+    this.flags = Preconditions.checkNotNull(flags);
+    this.prettyPrint = !noFormat.orElse(Boolean.FALSE);  // Bloody double negatives
+
+    this.output = BuildTargets.getGenPath(getProjectFilesystem(), getBuildTarget(), "%s.js");
+    this.joyPath = BuildTargets.getGenPath(getProjectFilesystem(), getBuildTarget(), "%s.deps");
+
+    buildOutputInitializer = new BuildOutputInitializer<>(getBuildTarget(), this);
+  }
+
+  @Override
+  public ImmutableList<Step> getBuildSteps(
+      BuildContext context,
+      BuildableContext buildableContext) {
+    ImmutableList.Builder<Step> steps = ImmutableList.builder();
+
+    JavascriptDependencyGraph graph = new JavascriptDependencyGraph();
+
+    // Iterate over deps and build a bundle of joy
+    JavascriptDependencies smidgen = new JavascriptDependencies();
+
+    Set<String> jsDeps = Sets.newHashSet();
+    Set<JavascriptSource> jsSources = Sets.newHashSet();
+    // Do the magic with the sources, as if we're a js_library
+    for (SourcePath src : srcs) {
+      Path resolved = context.getSourcePathResolver().getAbsolutePath(src);
+      JavascriptSource jsSource = new JavascriptSource(resolved);
+      jsSources.add(jsSource);
+
+      graph.amendGraph(jsSource);
+      smidgen.add(jsSource);
+      jsDeps.addAll(jsSource.getRequires());
+    }
+
+    Set<String> seen = Sets.newHashSet();
+    for (BuildRule dep : deps.get()) {
+      if (!(dep instanceof HasJavascriptDependencies)) {
+        continue;
+      }
+
+      JavascriptDependencies moreJoy = ((HasJavascriptDependencies) dep).getBundleOfJoy();
+
+      for (String require : jsDeps) {
+        Set<JavascriptSource> sources = moreJoy.getDeps(require);
+        if (!seen.contains(require) && !sources.isEmpty()) {
+          smidgen.addAll(sources);
+          graph.amendGraph(sources);
+          seen.add(require);
+        }
+      }
+    }
+
+    // Now ask that mess of data for the things we need.
+    for (String dep : jsDeps) {
+      smidgen.amendGraph(graph, dep);
+    }
+
+    // If the srcs don't goog.provide anything, they won't be included in the sources. Which is an
+    // oversight.
+    LinkedHashSet<Path> requiredSources = new LinkedHashSet<>();
+    requiredSources.addAll(graph.sortSources());
+    for (JavascriptSource jsSource : jsSources) {
+      if (jsSource.getProvides().isEmpty()) {
+        requiredSources.add(jsSource.getPath());
+      }
+    }
+
+    ClosureCompilerStep compileStep =
+        ClosureCompilerStep.builder(getProjectFilesystem().getRootPath(), context.getSourcePathResolver(), compiler)
+            .defines(defines)
+            .externs(externs)
+            .flags(flags)
+            .prettyPrint(prettyPrint)
+            .sources(requiredSources)
+            .output(output)
+            .build();
+
+    StringWriter writer = new StringWriter();
+    smidgen.writeTo(writer);
+
+    steps.add(MkdirStep.of(getProjectFilesystem(), joyPath.getParent()));
+    steps.add(new WriteFileStep(getProjectFilesystem(), writer.toString(), joyPath, false));
+    steps.add(MkdirStep.of(getProjectFilesystem(), output.getParent()));
+    steps.add(compileStep);
+
+    buildableContext.recordArtifact(output);
+
+    return steps.build();
+  }
+
+  @Override
+  public SourcePath getSourcePathToOutput() {
+    return new PathSourcePath(getProjectFilesystem(), output);
+  }
+
+  @Override
+  public JavascriptDependencies initializeFromDisk(OnDiskBuildInfo onDiskBuildInfo) {
+    try {
+      List<String> allLines = onDiskBuildInfo.getOutputFileContentsByLine(joyPath);
+      joy = JavascriptDependencies.buildFrom(Joiner.on("\n").join(allLines));
+      return joy;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public BuildOutputInitializer<JavascriptDependencies> getBuildOutputInitializer() {
+    return buildOutputInitializer;
+  }
+
+  @Override
+  public JavascriptDependencies getBundleOfJoy() {
+    return joy;
+  }
+}

--- a/src/org/openqa/selenium/buck/javascript/JsFragment.java
+++ b/src/org/openqa/selenium/buck/javascript/JsFragment.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2014-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.openqa.selenium.buck.javascript;
+
+import com.facebook.buck.model.BuildTargets;
+import com.facebook.buck.rules.AbstractBuildRule;
+import com.facebook.buck.rules.AddToRuleKey;
+import com.facebook.buck.rules.BuildContext;
+import com.facebook.buck.rules.BuildRule;
+import com.facebook.buck.rules.BuildRuleParams;
+import com.facebook.buck.rules.BuildableContext;
+import com.facebook.buck.rules.PathSourcePath;
+import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.rules.Tool;
+import com.facebook.buck.step.Step;
+import com.facebook.buck.step.fs.MkdirStep;
+import com.facebook.buck.step.fs.WriteFileStep;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+public class JsFragment extends AbstractBuildRule {
+
+  private final Path output;
+  private final Path temp;
+  @AddToRuleKey
+  private final Tool compiler;
+  @AddToRuleKey
+  private final ImmutableSortedSet<BuildRule> deps;
+  @AddToRuleKey
+  private final String module;
+  @AddToRuleKey
+  private final String function;
+  @AddToRuleKey
+  private final ImmutableList<String> defines;
+  @AddToRuleKey
+  private final boolean prettyPrint;
+
+  public JsFragment(
+      BuildRuleParams params,
+      Tool compiler,
+      ImmutableSortedSet<BuildRule> deps,
+      String module,
+      String function,
+      ImmutableList<String> defines,
+      boolean prettyPrint) {
+    super(params);
+
+    this.deps = deps;
+    this.module = module;
+    this.function = function;
+    this.output = BuildTargets.getGenPath(getProjectFilesystem(), getBuildTarget(), "%s.js");
+    this.temp = BuildTargets.getScratchPath(getProjectFilesystem(), getBuildTarget(), "%s-temp.js");
+    this.compiler = compiler;
+    this.defines = defines;
+    this.prettyPrint = prettyPrint;
+  }
+
+  @Override
+  public ImmutableList<Step> getBuildSteps(
+      BuildContext context,
+      BuildableContext buildableContext) {
+    ImmutableList.Builder<Step> steps = ImmutableList.builder();
+
+    JavascriptDependencyGraph graph = new JavascriptDependencyGraph();
+
+    for (BuildRule dep : deps) {
+      if (!(dep instanceof JsLibrary)) {
+        continue;
+      }
+
+      Set<JavascriptSource> allDeps = ((JsLibrary) dep).getBundleOfJoy().getDeps(module);
+      if (!allDeps.isEmpty()) {
+        graph.amendGraph(allDeps);
+        break;
+      }
+    }
+
+    steps.add(MkdirStep.of(getProjectFilesystem(), temp.getParent()));
+    steps.add(
+        new WriteFileStep(
+            getProjectFilesystem(),
+            String.format("goog.require('%s'); goog.exportSymbol('_', %s);", module, function),
+            temp,
+            /* executable */ false));
+    steps.add(MkdirStep.of(getProjectFilesystem(), output.getParent()));
+
+    List<String> flags = defines.stream()
+        .map(define -> "--define=" + define)
+        .collect(Collectors.toList());
+
+    if (prettyPrint) {
+      flags.add("--formatting=PRETTY_PRINT");
+    }
+    steps.add(
+        new JavascriptFragmentStep(
+            getProjectFilesystem().getRootPath(),
+            context.getSourcePathResolver(),
+            compiler,
+            ImmutableList.copyOf(flags),
+            temp,
+            output,
+            graph.sortSources()));
+
+    buildableContext.recordArtifact(output);
+
+    return steps.build();
+  }
+
+  @Nullable
+  @Override
+  public SourcePath getSourcePathToOutput() {
+    return new PathSourcePath(getProjectFilesystem(), output);
+  }
+
+}

--- a/src/org/openqa/selenium/buck/javascript/JsLibrary.java
+++ b/src/org/openqa/selenium/buck/javascript/JsLibrary.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2013-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.openqa.selenium.buck.javascript;
+
+import com.facebook.buck.model.BuildTargets;
+import com.facebook.buck.rules.AbstractBuildRule;
+import com.facebook.buck.rules.AddToRuleKey;
+import com.facebook.buck.rules.BuildContext;
+import com.facebook.buck.rules.BuildOutputInitializer;
+import com.facebook.buck.rules.BuildRule;
+import com.facebook.buck.rules.BuildRuleParams;
+import com.facebook.buck.rules.BuildableContext;
+import com.facebook.buck.rules.InitializableFromDisk;
+import com.facebook.buck.rules.OnDiskBuildInfo;
+import com.facebook.buck.rules.PathSourcePath;
+import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.step.Step;
+import com.facebook.buck.step.fs.MkdirStep;
+import com.facebook.buck.step.fs.WriteFileStep;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Sets;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+public class JsLibrary extends AbstractBuildRule implements
+    InitializableFromDisk<JavascriptDependencies>, HasJavascriptDependencies {
+
+  private final Path output;
+  @AddToRuleKey
+  private final ImmutableSortedSet<BuildRule> deps;
+  @AddToRuleKey
+  private final ImmutableSortedSet<SourcePath> srcs;
+  private JavascriptDependencies joy;
+  private final BuildOutputInitializer<JavascriptDependencies> buildOutputInitializer;
+
+  public JsLibrary(
+      BuildRuleParams params,
+      ImmutableSortedSet<BuildRule> deps,
+      ImmutableSortedSet<SourcePath> srcs) {
+    super(params);
+    this.deps = Preconditions.checkNotNull(deps);
+    this.srcs = Preconditions.checkNotNull(srcs);
+
+    this.output = BuildTargets.getGenPath(
+        getProjectFilesystem(),
+        getBuildTarget(),
+        "%s-library.deps");
+
+    buildOutputInitializer = new BuildOutputInitializer<>(getBuildTarget(), this);
+  }
+
+  @Override
+  public ImmutableList<Step> getBuildSteps(
+      BuildContext context,
+      BuildableContext buildableContext) {
+    Set<String> allRequires = Sets.newHashSet();
+    Set<String> allProvides = Sets.newHashSet();
+    JavascriptDependencies smidgen = new JavascriptDependencies();
+    for (SourcePath src : srcs) {
+      Path path = context.getSourcePathResolver().getAbsolutePath(src);
+      JavascriptSource source = new JavascriptSource(path);
+      smidgen.add(source);
+      allRequires.addAll(source.getRequires());
+      allProvides.addAll(source.getProvides());
+    }
+
+    allRequires.removeAll(allProvides);
+
+    for (BuildRule dep : deps) {
+      Iterator<String> iterator = allRequires.iterator();
+
+      if (!(dep instanceof HasJavascriptDependencies)) {
+        continue;
+      }
+      JavascriptDependencies moreJoy = ((HasJavascriptDependencies) dep).getBundleOfJoy();
+
+      while (iterator.hasNext()) {
+        String require = iterator.next();
+
+        Set<JavascriptSource> sources = moreJoy.getDeps(require);
+        if (!sources.isEmpty()) {
+          smidgen.addAll(sources);
+          iterator.remove();
+        }
+      }
+    }
+
+    if (!allRequires.isEmpty()) {
+      throw new RuntimeException(
+          getBuildTarget() + " --- Missing dependencies for: " + allRequires);
+    }
+
+    StringWriter writer = new StringWriter();
+    smidgen.writeTo(writer);
+
+    ImmutableList.Builder<Step> builder = ImmutableList.builder();
+    builder.add(MkdirStep.of(getProjectFilesystem(), output.getParent()));
+    builder.add(new WriteFileStep(getProjectFilesystem(), writer.toString(), output, false));
+
+    buildableContext.recordArtifact(output);
+
+    return builder.build();
+  }
+
+  @Override
+  public JavascriptDependencies initializeFromDisk(OnDiskBuildInfo onDiskBuildInfo) {
+    try {
+      List<String> allLines = onDiskBuildInfo.getOutputFileContentsByLine(output);
+      joy = JavascriptDependencies.buildFrom(Joiner.on("\n").join(allLines));
+      return joy;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public BuildOutputInitializer<JavascriptDependencies> getBuildOutputInitializer() {
+    return buildOutputInitializer;
+  }
+
+  @Override
+  public SourcePath getSourcePathToOutput() {
+    return new PathSourcePath(getProjectFilesystem(), output);
+  }
+
+  @Override
+  public JavascriptDependencies getBundleOfJoy() {
+    return joy;
+  }
+}


### PR DESCRIPTION
This includes:

- `closure_library`: no concrete output, but a
  useful way of collecting functionality into
  modules.

- `closure_binary`: compile a set of
  `closure_library` instances into a single
  minified output.

- `closure_fragment`: takes a single method
  from a `closure_library` and exposes it as
  a minified set of JS, suitable for injeting
  into a web page.

The last rule is used extensively within Selenium
to implement shared functionality which is best
done using JS.