### PR TITLE
No logical change: reformat implemented interfaces for DefaultJavaLibrary

### DIFF
--- a/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
+++ b/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
@@ -85,10 +85,15 @@ import javax.annotation.Nullable;
  * Then this would compile {@code FeedStoryRenderer.java} against Guava and the classes generated
  * from the {@code //src/com/facebook/feed/model:model} rule.
  */
-public class DefaultJavaLibrary extends AbstractBuildRuleWithResolver
-    implements JavaLibrary, HasClasspathEntries, ExportDependencies,
-    InitializableFromDisk<JavaLibrary.Data>, AndroidPackageable,
-    SupportsInputBasedRuleKey, SupportsDependencyFileRuleKey, JavaLibraryWithTests {
+public class DefaultJavaLibrary extends AbstractBuildRuleWithResolver implements
+    AndroidPackageable,
+    ExportDependencies,
+    HasClasspathEntries,
+    InitializableFromDisk<JavaLibrary.Data>,
+    JavaLibrary,
+    JavaLibraryWithTests,
+    SupportsDependencyFileRuleKey,
+    SupportsInputBasedRuleKey {
 
   private static final BuildableProperties OUTPUT_TYPE = new BuildableProperties(LIBRARY);
   private static final Path METADATA_DIR = Paths.get("META-INF");


### PR DESCRIPTION
This class appears to be attempting to implement
every interface that Buck has, so make it simple
to read them all (nb: clarity is the real reason
for this diff.