### PR TITLE
add important JVM arguments for buck launched with NO_BUCKD

### DIFF
--- a/programs/buck_tool.py
+++ b/programs/buck_tool.py
@@ -210,7 +210,9 @@ class BuckTool(object):
 
             command = ["buck"]
             extra_default_options = [
-                "-Djava.io.tmpdir={0}".format(self._tmp_dir)
+                "-Djava.io.tmpdir={0}".format(self._tmp_dir),
+                "-XX:SoftRefLRUPolicyMSPerMB=0",
+                "-XX:+UseG1GC",
             ]
             command.extend(self._get_java_args(buck_version_uid, extra_default_options))
             command.append("com.facebook.buck.cli.bootstrapper.ClassLoaderBootstrapper")


### PR DESCRIPTION
Without `-XX:SoftRefLRUPolicyMSPerMB=0`, running Buck can have really bad performance with `NO_BUCKD`, as the JVM is not aggressive enough about clearing `SoftReference`s.  It seemed best to also enable the G1 GC in `NO_BUCKD` mode but this may not be as critical.  The other JVM args passed when using the Buck daemon seemed less relevant without the daemon.