### PR TITLE
Fix docs and don't escape literal braces

### DIFF
--- a/docs/function/get_cell_name.soy
+++ b/docs/function/get_cell_name.soy
@@ -18,6 +18,16 @@ The <code>get_cell_name()</code> function is used the canonical cell name of the
 from within a build file.
 {/param}
 
+{param args}
+
+{call buck.functionArg}
+  {param desc}
+  No arguments.
+  {/param}
+{/call}
+
+{/param}
+
 {/call} // buck.function
     {/param} // content
   {/call}

--- a/docs/learning/tutorial.soy
+++ b/docs/learning/tutorial.soy
@@ -28,7 +28,7 @@
 <h2>Path Setup</h2>
 
 <p>
-  Buck needs a way to reference this collection of resources, so we need to create a build file that defines an {call buck.android_resource /} rule:
+  Add Buck to your <code>$PATH</code> and set up <code><a href="{ROOT}command/buckd.html"></code>buckd</code></a>:
 </p>
 
 {literal}

--- a/docs/learning/tutorial.soy
+++ b/docs/learning/tutorial.soy
@@ -33,8 +33,8 @@
 
 {literal}
 <pre>
-sudo ln -s ${lb}PWD{rb}/bin/buck /usr/bin/buck
-sudo ln -s ${lb}PWD{rb}/bin/buckd /usr/bin/buckd
+sudo ln -s ${PWD}/bin/buck /usr/bin/buck
+sudo ln -s ${PWD}/bin/buckd /usr/bin/buckd
 </pre>
 {/literal}
 


### PR DESCRIPTION
`get_cell_name()`s documentation was missing the required `args` param
causing soy to error out and fail to build the documentation.

Add the param.


Escaped braces (eg `{lb}` and `{rb}`) should not be used within
`{literal}` blocks as that will literally print the strings "{lb}" or
"{rb}".

Fix the tutorial page.


When the Tutorial was split out of Getting Started in 71f8452,
the 'Path Setup' section was garbled with a copy-paste error from
a later section.

Fix tutorial's 'Path Setup' section