### PR TITLE
Xcode project generator expands location macros in linker flags

### DIFF
--- a/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
+++ b/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
@@ -113,9 +113,8 @@ import com.facebook.buck.rules.TargetNode;
 import com.facebook.buck.rules.args.StringWithMacrosArg;
 import com.facebook.buck.rules.coercer.FrameworkPath;
 import com.facebook.buck.rules.coercer.SourceList;
-import com.facebook.buck.rules.macros.AbstractMacroExpander;
 import com.facebook.buck.rules.macros.LocationMacro;
-import com.facebook.buck.rules.macros.Macro;
+import com.facebook.buck.rules.macros.LocationMacroExpander;
 import com.facebook.buck.rules.macros.StringWithMacros;
 import com.facebook.buck.shell.AbstractGenruleDescription;
 import com.facebook.buck.shell.ExportFileDescriptionArg;
@@ -310,7 +309,7 @@ public class ProjectGenerator {
     this.defaultCxxPlatform = defaultCxxPlatform;
     this.buildRuleResolverForNode = buildRuleResolverForNode;
     this.defaultBuildRuleResolver =
-        new BuildRuleResolver(TargetGraph.EMPTY, new DefaultTargetNodeToBuildRuleTransformer());
+        new BuildRuleResolver(targetGraph, new DefaultTargetNodeToBuildRuleTransformer());
     this.defaultPathResolver =
         new SourcePathResolver(new SourcePathRuleFinder(this.defaultBuildRuleResolver));
     this.buckEventBus = buckEventBus;
@@ -853,12 +852,38 @@ public class ProjectGenerator {
 
   private ImmutableList<String> convertStringWithMacros(
       TargetNode<?, ?> node, Iterable<StringWithMacros> flags) {
+
+    LocationMacroExpander locationMacroExpander = new LocationMacroExpander() {
+      @Override
+      public String expandFrom(
+          BuildTarget target,
+          CellPathResolver cellNames,
+          BuildRuleResolver resolver,
+          LocationMacro input) throws MacroException {
+        BuildTarget locationMacroTarget = input.getTarget();
+
+        try {
+          resolver.requireRule(locationMacroTarget);
+        } catch (NoSuchBuildTargetException | TargetGraph.NoSuchNodeException e) {
+          throw new MacroException(
+              String.format("couldn't find rule referenced by location macro: %s", e.getMessage()),
+              e);
+        }
+
+        requiredBuildTargetsBuilder.add(locationMacroTarget);
+        return super.expandFrom(target, cellNames, resolver, input);
+      }
+    };
+
     ImmutableList.Builder<String> result = new ImmutableList.Builder<>();
-    ImmutableList<? extends AbstractMacroExpander<? extends Macro>> expanders =
-        ImmutableList.of(new AsIsLocationMacroExpander());
     for (StringWithMacros flag : flags) {
-      StringWithMacrosArg.of(
-              flag, expanders, node.getBuildTarget(), node.getCellNames(), defaultBuildRuleResolver)
+      StringWithMacrosArg
+          .of(
+              flag,
+              ImmutableList.of(locationMacroExpander),
+              node.getBuildTarget(),
+              node.getCellNames(),
+              defaultBuildRuleResolver)
           .appendToCommandLine(result, defaultPathResolver);
     }
     return result.build();
@@ -2664,31 +2689,5 @@ public class ProjectGenerator {
 
   private Path getPathToMergedHeaderMap() {
     return getPathToHeaderMapsRoot().resolve("pub-hmap");
-  }
-
-  /** An expander for the location macro which leaves it as-is. */
-  private static class AsIsLocationMacroExpander extends AbstractMacroExpander<LocationMacro> {
-
-    @Override
-    public Class<LocationMacro> getInputClass() {
-      return LocationMacro.class;
-    }
-
-    @Override
-    protected LocationMacro parse(
-        BuildTarget target, CellPathResolver cellNames, ImmutableList<String> input)
-        throws MacroException {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public String expandFrom(
-        BuildTarget target,
-        CellPathResolver cellNames,
-        BuildRuleResolver resolver,
-        LocationMacro input)
-        throws MacroException {
-      return String.format("$(location %s)", input.getTarget());
-    }
   }
 }

--- a/test/com/facebook/buck/apple/project_generator/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/apple/project_generator/ProjectGeneratorTest.java
@@ -96,12 +96,15 @@ import com.facebook.buck.rules.DefaultTargetNodeToBuildRuleTransformer;
 import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.PathSourcePath;
 import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.buck.rules.SourcePathRuleFinder;
 import com.facebook.buck.rules.SourceWithFlags;
 import com.facebook.buck.rules.TargetGraph;
 import com.facebook.buck.rules.TargetNode;
 import com.facebook.buck.rules.TestCellBuilder;
 import com.facebook.buck.rules.coercer.FrameworkPath;
 import com.facebook.buck.rules.coercer.PatternMatchedCollection;
+import com.facebook.buck.rules.macros.LocationMacro;
 import com.facebook.buck.rules.macros.StringWithMacros;
 import com.facebook.buck.rules.macros.StringWithMacrosUtils;
 import com.facebook.buck.shell.ExportFileBuilder;
@@ -1698,6 +1701,48 @@ public class ProjectGeneratorTest {
 
     ImmutableMap<String, String> settings = getBuildSettings(buildTarget, target, "Debug");
     assertEquals("$(inherited) -Xlinker -lhello", settings.get("OTHER_LDFLAGS"));
+  }
+
+  @Test
+  public void testAppleLibraryLinkerFlagsWithLocationMacrosAreExpanded() throws IOException {
+    BuildTarget genruleTarget = BuildTarget.builder(rootPath, "//foo", "genrulelib").build();
+    TargetNode<?, ?> genruleNode = GenruleBuilder
+        .newGenruleBuilder(genruleTarget)
+        .setCmd("touch $OUT")
+        .setOut("libGenruleLib.a")
+        .build();
+
+    BuildTarget buildTarget = BuildTarget.builder(rootPath, "//foo", "lib").build();
+    TargetNode<?, ?> node = AppleLibraryBuilder
+        .createBuilder(buildTarget)
+        .setConfigs(
+            ImmutableSortedMap.of(
+                "Debug",
+                ImmutableMap.of()))
+        .setLinkerFlags(
+            ImmutableList.of(
+                StringWithMacrosUtils.format("-force_load"),
+                StringWithMacrosUtils.format("%s", LocationMacro.of(genruleTarget))))
+        .build();
+
+    Path generatedLibraryPath = getAbsoluteOutputForNode(
+        genruleNode,
+        ImmutableSet.of(genruleNode, node));
+
+    ProjectGenerator projectGenerator = createProjectGeneratorForCombinedProject(
+        ImmutableSet.of(node, genruleNode), ImmutableSet.of());
+
+    projectGenerator.createXcodeProjects();
+
+    PBXTarget target = assertTargetExistsAndReturnTarget(
+        projectGenerator.getGeneratedProject(),
+        "//foo:lib");
+
+    assertThat(projectGenerator.getRequiredBuildTargets(), equalTo(ImmutableSet.of(genruleTarget)));
+
+    ImmutableMap<String, String> settings = getBuildSettings(buildTarget, target, "Debug");
+    assertEquals("$(inherited) -force_load " + generatedLibraryPath.toString(),
+        settings.get("OTHER_LDFLAGS"));
   }
 
   @Test
@@ -4617,5 +4662,15 @@ public class ProjectGeneratorTest {
     assertHasConfigurations(target, config);
     return ProjectGeneratorTestUtils.getBuildSettings(
         projectFilesystem, buildTarget, target, config);
+  }
+
+  private Path getAbsoluteOutputForNode(
+      TargetNode<?, ?> node, ImmutableSet<TargetNode<?, ?>> nodes) {
+    TargetGraph targetGraph = TargetGraphFactory.newInstance(nodes);
+    BuildRuleResolver ruleResolver = getBuildRuleResolverNodeFunction(targetGraph).apply(node);
+    SourcePath nodeOutput = ruleResolver.getRule(node.getBuildTarget()).getSourcePathToOutput();
+    SourcePathRuleFinder ruleFinder = new SourcePathRuleFinder(ruleResolver);
+    SourcePathResolver sourcePathResolver = new SourcePathResolver(ruleFinder);
+    return sourcePathResolver.getAbsolutePath(nodeOutput);
   }
 }


### PR DESCRIPTION
### background ###
Previously, `ProjectGenerator` did not expand location macros used in linker flags.  As a result, buck builds for targets with linker flags using location macros would succeed but building a project generated from the same target would fail.

### change ###
`ProjectGenerator` now expands location macros to their absolute path and adds the macro's build target to the `ProjectGenerator`'s list of required targets.

### verification ###
- [x] add `ProjectGeneratorTest.testAppleLibraryLinkerFlagsWithLocationMacrosAreExpanded`
- [x] `buck test test/com/facebook/buck/apple/project_generator:project_generator`
- [x] verify that `buck project` generates a project with linker flag location macros correctly expanded, and that the targets of those macros were built as part of project generation
