### PR TITLE
actool uses correct value for '--minimum-deployment-target' flag

### DIFF
--- a/src/com/facebook/buck/apple/ActoolStep.java
+++ b/src/com/facebook/buck/apple/ActoolStep.java
@@ -29,6 +29,7 @@ import java.util.SortedSet;
 class ActoolStep extends ShellStep {
 
   private final String applePlatformName;
+  private final String targetSDKVersion;
   private final ImmutableMap<String, String> environment;
   private final ImmutableList<String> actoolCommand;
   private final SortedSet<Path> assetCatalogDirs;
@@ -41,6 +42,7 @@ class ActoolStep extends ShellStep {
   public ActoolStep(
       Path workingDirectory,
       String applePlatformName,
+      String targetSDKVersion,
       ImmutableMap<String, String> environment,
       List<String> actoolCommand,
       SortedSet<Path> assetCatalogDirs,
@@ -51,6 +53,7 @@ class ActoolStep extends ShellStep {
       AppleAssetCatalogDescription.Optimization optimization) {
     super(workingDirectory);
     this.applePlatformName = applePlatformName;
+    this.targetSDKVersion = targetSDKVersion;
     this.environment = environment;
     this.actoolCommand = ImmutableList.copyOf(actoolCommand);
     this.assetCatalogDirs = assetCatalogDirs;
@@ -65,9 +68,6 @@ class ActoolStep extends ShellStep {
   protected ImmutableList<String> getShellCommandInternal(ExecutionContext context) {
     ImmutableList.Builder<String> commandBuilder = ImmutableList.builder();
 
-    //TODO(jakubzika): Let apps select their minimum target.
-    String target = "7.0";
-
     commandBuilder.addAll(actoolCommand);
     commandBuilder.add(
         "--output-format",
@@ -78,7 +78,7 @@ class ActoolStep extends ShellStep {
         "--platform",
         applePlatformName,
         "--minimum-deployment-target",
-        target,
+        targetSDKVersion,
         "--compress-pngs",
         "--compile",
         output.toString(),

--- a/src/com/facebook/buck/apple/AppleAssetCatalog.java
+++ b/src/com/facebook/buck/apple/AppleAssetCatalog.java
@@ -44,6 +44,8 @@ public class AppleAssetCatalog extends AbstractBuildRule {
 
   @AddToRuleKey private final String applePlatformName;
 
+  @AddToRuleKey private final String targetSDKVersion;
+
   @AddToRuleKey private final Tool actool;
 
   @AddToRuleKey private final ImmutableSortedSet<SourcePath> assetCatalogDirs;
@@ -62,6 +64,7 @@ public class AppleAssetCatalog extends AbstractBuildRule {
   AppleAssetCatalog(
       BuildRuleParams params,
       String applePlatformName,
+      String targetSDKVersion,
       Tool actool,
       SortedSet<SourcePath> assetCatalogDirs,
       Optional<String> appIcon,
@@ -70,6 +73,7 @@ public class AppleAssetCatalog extends AbstractBuildRule {
       String bundleName) {
     super(params);
     this.applePlatformName = applePlatformName;
+    this.targetSDKVersion = targetSDKVersion;
     this.actool = actool;
     this.assetCatalogDirs = ImmutableSortedSet.copyOf(assetCatalogDirs);
     this.outputDir =
@@ -96,6 +100,7 @@ public class AppleAssetCatalog extends AbstractBuildRule {
         new ActoolStep(
             getProjectFilesystem().getRootPath(),
             applePlatformName,
+            targetSDKVersion,
             actool.getEnvironment(context.getSourcePathResolver()),
             actool.getCommandPrefix(context.getSourcePathResolver()),
             absoluteAssetCatalogDirs,

--- a/src/com/facebook/buck/apple/AppleDescriptions.java
+++ b/src/com/facebook/buck/apple/AppleDescriptions.java
@@ -299,6 +299,7 @@ public class AppleDescriptions {
       BuildRuleParams params,
       SourcePathResolver sourcePathResolver,
       ApplePlatform applePlatform,
+      String targetSDKVersion,
       Tool actool) {
     TargetNode<?, ?> targetNode = targetGraph.get(params.getBuildTarget());
 
@@ -376,6 +377,7 @@ public class AppleDescriptions {
         new AppleAssetCatalog(
             assetCatalogParams,
             applePlatform.getName(),
+            targetSDKVersion,
             actool,
             assetCatalogDirs,
             appIcon,
@@ -652,6 +654,7 @@ public class AppleDescriptions {
             paramsWithoutBundleSpecificFlavors,
             sourcePathResolver,
             appleCxxPlatform.getAppleSdk().getApplePlatform(),
+            appleCxxPlatform.getMinVersion(),
             appleCxxPlatform.getActool());
     addToIndex(resolver, assetCatalog);
 


### PR DESCRIPTION
### background ###

Previously, the `actool` command to compile asset catalogs passed a hard-coded `7.0` to the `--minimum-deployment-target` flag.


### change ###

Now the correct value, taken from `AppleCxxPlatform#getMinVersion`, is passed to the `--minimum-deployment-target` flag.


### verification ###

- [x] `AppleBundleIntegrationTest#appleAssetCatalogsAreIncludedInBundle` passes
- [x] `buck build` project with deployment target of 9.0 and verify that the `Assets.car` file is correct