### PR TITLE
Fix buckd on Debian/Ubuntu by using bash

### DIFF
--- a/bin/buckd
+++ b/bin/buckd
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Resolve symlinks if necessary, otherwise madness will follow.
 # On a GNU system, we could use "-f" to follow all symlinks. BSD based


### PR DESCRIPTION
The `buckd` script uses `bash` features (as opposed to generic bourne
shell `sh` features) like the `function` keyword and the `BASH_SOURCE`
array.

This is a problem if `/bin/sh` isn't just a symlink to `bash`, eg in
Debian/Ubuntu it points to `dash`.

Use `/bin/bash` explicitly (just as is already done in the main `buck`
script).