### PR TITLE
Fix genrule documentation's escaping

### DIFF
--- a/docs/__genrule_common.soy
+++ b/docs/__genrule_common.soy
@@ -41,7 +41,7 @@
     {sp}<code>cmd</code>, using builtin {call buck.string_parameter_macros /}.
     This expansion takes two supported forms:
     <dl>
-      <dt><code>$(classpath /&#2F;path/to:target)</code></dt>
+      <dt><code>$(classpath /&#x2F;path/to:target)</code></dt>
       <dd>Expands a build rule for something that has a java classpath
       to the transitive classpath of that rule. If the rule does not
       have (or contribute to) a classpath, an exception will be thrown


### PR DESCRIPTION
The `genrule()` documentation had a typo in one of the locations where
it's trying to escape a double slash this caused a broken glyph to be
shown.  Fix it to be like all the others.