### PR TITLE
Cache the ndk and sdk artifacts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,10 @@ before_install:
 
 # https://docs.travis-ci.com/user/caching#Things-not-to-cache
 # https://docs.travis-ci.com/user/caching#Explicitly-disabling-caching
-cache: false
+cache:
+  directories:
+    - $HOME/ndk_cache
+    - $HOME/sdk_cache
 
 notifications:
     slack: buckbuild:TnJN80RxFaSAuCGswsnWLdoj

--- a/scripts/travisci_install_android_ndk.sh
+++ b/scripts/travisci_install_android_ndk.sh
@@ -1,15 +1,25 @@
 #!/bin/bash
 set -x
 
-# Because we cache NDK_HOME in Travis, we cannot test for the existence of the
-# directory; it always gets created before we run.  Instead, check for the
-# release text file, and if it doesn't exist, download the NDK.
-if [ ! -f ${NDK_HOME}/RELEASE.TXT ]; then
-  wget https://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin
-  chmod a+x android-ndk-r10e-linux-x86_64.bin
-  # Suppress the output to not spam the logs.
-  ./android-ndk-r10e-linux-x86_64.bin > /dev/null
-  rm android-ndk-r10e-linux-x86_64.bin
-  rm -rf ${NDK_HOME}
-  mv android-ndk-r10e ${NDK_HOME}
+export NDK_VERSION_STRING="android-ndk-r10e"
+export NDK_FILENAME="$NDK_VERSION_STRING-linux-x86_64.bin"
+
+export CACHED_PATH="${HOME}/ndk_cache/$NDK_FILENAME"
+
+if [ ! -f "$CACHED_PATH" ]; then
+  echo "Downloading NDK."
+  wget "https://dl.google.com/android/ndk/$NDK_FILENAME"
+else
+  echo "Using cached NDK."
+  mv "$CACHED_PATH" .
 fi
+
+# Uncpack the ndk.
+chmod a+x "$NDK_FILENAME"
+# Suppress the output to not spam the logs.
+"./$NDK_FILENAME" > /dev/null
+rm "$NDK_FILENAME";
+
+# Move ndk into the proper place.
+rm -rf ${NDK_HOME}
+mv android-ndk-r10e ${NDK_HOME}

--- a/scripts/travisci_install_android_sdk.sh
+++ b/scripts/travisci_install_android_sdk.sh
@@ -1,18 +1,26 @@
 #!/bin/bash
 set -x
 
-export ANDROID_TOOL=${ANDROID_HOME}/tools/android
+export SDK_FILENAME="android-sdk_r23-linux.tgz"
+export CACHED_PATH="${HOME}/sdk_cache/$SDK_FILENAME"
 
-# Because we cache ANDROID_HOME in Travis, we cannot test for the existence of
-# the directory; it always gets created before we run.  Instead, check for the
-# tool we care about, and if it doesn't exist, download the SDK.
-if [ ! -x ${ANDROID_TOOL} ]; then
-  wget https://dl.google.com/android/android-sdk_r23-linux.tgz
-  tar -zxf android-sdk_r23-linux.tgz
-  rm android-sdk_r23-linux.tgz
-  rm -rf ${ANDROID_HOME}
-  mv android-sdk-linux ${ANDROID_HOME}
+if [ ! -x "$CACHED_PATH" ]; then
+  echo "Downloading SDK."
+  wget "https://dl.google.com/android/$SDK_FILENAME"
+else
+  echo "Using cached SDK."
+  mv "$CACHED_PATH" .
 fi
+
+# Unzip the sdk.
+tar -zxf "$SDK_FILENAME"
+rm "$SDK_FILENAME"
+
+# Move it into our expected place.
+rm -rf ${ANDROID_HOME}
+mv android-sdk-linux ${ANDROID_HOME}
+
+export ANDROID_TOOL=${ANDROID_HOME}/tools/android
 
 function android_update_sdk() {
   (


### PR DESCRIPTION
Previously we were trying to cache the unzipped sdk and ndk, but it took
so long to tar them in the caching phase that it never worked (for an example see https://travis-ci.org/facebook/buck/builds/227525120).

Because Travis explicitly says to not cache android stuff (https://docs.travis-ci.com/user/caching/#Things-not-to-cache) I removed caching in a previous diff. Sadly, builds are still failing because sometimes we hit a slow mirror.

This turns caching back on, but only caches the compressed artifacts. Travis'
caching step should be materially faster (as it is only tarring one compressed file) and the cache should work.

If caching still times out, we can bump the limit...but I don't think we'll need to do so.