### PR TITLE
Add apple test's host app as a target dependency in generated xcode project

### DIFF
--- a/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
+++ b/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
@@ -264,7 +264,6 @@ public class ProjectGenerator {
    */
   private final ImmutableSet.Builder<String> targetConfigNamesBuilder;
 
-  private final Map<String, String> gidsToTargetNames;
   private final HalideBuckConfig halideBuckConfig;
   private final CxxBuckConfig cxxBuckConfig;
   private final SwiftBuckConfig swiftBuckConfig;
@@ -336,7 +335,6 @@ public class ProjectGenerator {
                 });
 
     targetConfigNamesBuilder = ImmutableSet.builder();
-    gidsToTargetNames = new HashMap<>();
     this.halideBuckConfig = halideBuckConfig;
     this.cxxBuckConfig = cxxBuckConfig;
     this.swiftBuckConfig = swiftBuckConfig;
@@ -2009,9 +2007,7 @@ public class ProjectGenerator {
 
   /** Create the project bundle structure and write {@code project.pbxproj}. */
   private void writeProjectFile(PBXProject project) throws IOException {
-    XcodeprojSerializer serializer =
-        new XcodeprojSerializer(
-            new GidGenerator(ImmutableSet.copyOf(gidsToTargetNames.keySet())), project);
+    XcodeprojSerializer serializer = new XcodeprojSerializer(new GidGenerator(), project);
     NSDictionary rootObject = serializer.toPlist();
     Path xcodeprojDir = outputDirectory.resolve(projectName + ".xcodeproj");
     projectFilesystem.mkdirs(xcodeprojDir);

--- a/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
+++ b/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
@@ -51,6 +51,7 @@ import com.facebook.buck.apple.xcode.XcodeprojSerializer;
 import com.facebook.buck.apple.xcode.xcodeproj.CopyFilePhaseDestinationSpec;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXBuildFile;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXBuildPhase;
+import com.facebook.buck.apple.xcode.xcodeproj.PBXContainerItemProxy;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXCopyFilesBuildPhase;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXFileReference;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXGroup;
@@ -59,6 +60,7 @@ import com.facebook.buck.apple.xcode.xcodeproj.PBXProject;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXReference;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXShellScriptBuildPhase;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXTarget;
+import com.facebook.buck.apple.xcode.xcodeproj.PBXTargetDependency;
 import com.facebook.buck.apple.xcode.xcodeproj.ProductType;
 import com.facebook.buck.apple.xcode.xcodeproj.SourceTreePath;
 import com.facebook.buck.apple.xcode.xcodeproj.XCBuildConfiguration;
@@ -264,6 +266,7 @@ public class ProjectGenerator {
    */
   private final ImmutableSet.Builder<String> targetConfigNamesBuilder;
 
+  private final GidGenerator gidGenerator;
   private final HalideBuckConfig halideBuckConfig;
   private final CxxBuckConfig cxxBuckConfig;
   private final SwiftBuckConfig swiftBuckConfig;
@@ -339,6 +342,8 @@ public class ProjectGenerator {
     this.cxxBuckConfig = cxxBuckConfig;
     this.swiftBuckConfig = swiftBuckConfig;
     this.focusModules = focusModules;
+
+    gidGenerator = new GidGenerator();
   }
 
   @VisibleForTesting
@@ -994,6 +999,7 @@ public class ProjectGenerator {
         if (bundleLoaderNode.isPresent()) {
           BuildTarget testTarget = bundleLoaderNode.get().getBuildTarget();
           extraSettingsBuilder.put("TEST_TARGET_NAME", getXcodeTargetName(testTarget));
+          addPBXTargetDependency(target, testTarget);
         } else {
           throw new HumanReadableException(
               "The test rule '%s' is configured with 'is_ui_test' but has no test_host_app",
@@ -1057,6 +1063,8 @@ public class ProjectGenerator {
             .put(bundleLoaderOutputPathDeepSetting, bundleLoaderOutputPathDeepValue)
             .put("BUNDLE_LOADER", bundleLoaderOutputPathValue)
             .put("TEST_HOST", "$(BUNDLE_LOADER)");
+
+        addPBXTargetDependency(target, bundleLoader.getBuildTarget());
       }
       if (infoPlistOptional.isPresent()) {
         Path infoPlistPath = pathRelativizer.outputDirToRootRelative(infoPlistOptional.get());
@@ -1269,6 +1277,31 @@ public class ProjectGenerator {
     }
 
     return target;
+  }
+
+  private void addPBXTargetDependency(PBXNativeTarget pbxTarget, BuildTarget dependency) {
+    // Xcode appears to only support target dependencies if both targets are within the same project.
+    // If the desired target dependency is not in the same project, then just ignore it.
+    if (!isBuiltByCurrentProject(dependency)) {
+      return;
+    }
+
+    targetNodeToProjectTarget
+        .getUnchecked(targetGraph.get(dependency))
+        .ifPresent(dependencyPBXTarget -> {
+          if (project.getGlobalID() == null) {
+            project.setGlobalID(project.generateGid(gidGenerator));
+          }
+          if (dependencyPBXTarget.getGlobalID() == null) {
+            dependencyPBXTarget.setGlobalID(dependencyPBXTarget.generateGid(gidGenerator));
+          }
+          PBXContainerItemProxy dependencyProxy = new PBXContainerItemProxy(
+              project,
+              dependencyPBXTarget.getGlobalID(),
+              PBXContainerItemProxy.ProxyType.TARGET_REFERENCE);
+
+          pbxTarget.getDependencies().add(new PBXTargetDependency(dependencyProxy));
+        });
   }
 
   private ImmutableMap<String, String> getFrameworkAndLibrarySearchPathConfigs(
@@ -2007,7 +2040,7 @@ public class ProjectGenerator {
 
   /** Create the project bundle structure and write {@code project.pbxproj}. */
   private void writeProjectFile(PBXProject project) throws IOException {
-    XcodeprojSerializer serializer = new XcodeprojSerializer(new GidGenerator(), project);
+    XcodeprojSerializer serializer = new XcodeprojSerializer(gidGenerator, project);
     NSDictionary rootObject = serializer.toPlist();
     Path xcodeprojDir = outputDirectory.resolve(projectName + ".xcodeproj");
     projectFilesystem.mkdirs(xcodeprojDir);

--- a/src/com/facebook/buck/apple/xcode/GidGenerator.java
+++ b/src/com/facebook/buck/apple/xcode/GidGenerator.java
@@ -27,8 +27,8 @@ import java.util.Set;
 public class GidGenerator {
   private final Set<String> generatedAndReservedIds;
 
-  public GidGenerator(Set<String> reservedIds) {
-    generatedAndReservedIds = Sets.newHashSet(reservedIds);
+  public GidGenerator() {
+    generatedAndReservedIds = Sets.newHashSet();
   }
 
   /**

--- a/src/com/facebook/buck/apple/xcode/xcodeproj/PBXContainerItemProxy.java
+++ b/src/com/facebook/buck/apple/xcode/xcodeproj/PBXContainerItemProxy.java
@@ -38,18 +38,18 @@ public class PBXContainerItemProxy extends PBXContainerItem {
     }
   }
 
-  private final PBXFileReference containerPortal;
+  private final PBXObject containerPortal;
   private final String remoteGlobalIDString;
   private final ProxyType proxyType;
 
   public PBXContainerItemProxy(
-      PBXFileReference containerPortal, String remoteGlobalIDString, ProxyType proxyType) {
+      PBXObject containerPortal, String remoteGlobalIDString, ProxyType proxyType) {
     this.containerPortal = containerPortal;
     this.remoteGlobalIDString = remoteGlobalIDString;
     this.proxyType = proxyType;
   }
 
-  public PBXFileReference getContainerPortal() {
+  public PBXObject getContainerPortal() {
     return containerPortal;
   }
 
@@ -75,7 +75,7 @@ public class PBXContainerItemProxy extends PBXContainerItem {
   public void serializeInto(XcodeprojSerializer s) {
     super.serializeInto(s);
 
-    s.addField("containerPortal", containerPortal);
+    s.addField("containerPortal", containerPortal.getGlobalID());
     s.addField("remoteGlobalIDString", remoteGlobalIDString);
     s.addField("proxyType", proxyType.getIntValue());
   }

--- a/test/com/facebook/buck/apple/project_generator/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/apple/project_generator/ProjectGeneratorTest.java
@@ -52,6 +52,7 @@ import com.facebook.buck.apple.clang.HeaderMap;
 import com.facebook.buck.apple.xcode.xcodeproj.CopyFilePhaseDestinationSpec;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXBuildFile;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXBuildPhase;
+import com.facebook.buck.apple.xcode.xcodeproj.PBXContainerItemProxy;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXCopyFilesBuildPhase;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXFileReference;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXGroup;
@@ -3533,6 +3534,8 @@ public class ProjectGeneratorTest {
 
     PBXTarget testPBXTarget =
         assertTargetExistsAndReturnTarget(projectGenerator.getGeneratedProject(), "//foo:AppTest");
+    assertPBXTargetHasDependency(
+        projectGenerator.getGeneratedProject(), testPBXTarget, "//foo:HostApp");
 
     ImmutableMap<String, String> settings = getBuildSettings(testTarget, testPBXTarget, "Debug");
     // Check starts with as the remainder depends on the bundle style at build time.
@@ -3573,6 +3576,8 @@ public class ProjectGeneratorTest {
     PBXTarget testPBXTarget =
         assertTargetExistsAndReturnTarget(projectGenerator.getGeneratedProject(), "//foo:AppTest");
     assertEquals(testPBXTarget.getProductType(), ProductType.UI_TEST);
+    assertPBXTargetHasDependency(
+        projectGenerator.getGeneratedProject(), testPBXTarget, "//foo:HostApp");
 
     ImmutableMap<String, String> settings = getBuildSettings(testTarget, testPBXTarget, "Debug");
     // Check starts with as the remainder depends on the bundle style at build time.
@@ -4617,5 +4622,18 @@ public class ProjectGeneratorTest {
     assertHasConfigurations(target, config);
     return ProjectGeneratorTestUtils.getBuildSettings(
         projectFilesystem, buildTarget, target, config);
+  }
+
+  private void assertPBXTargetHasDependency(
+      PBXProject project,
+      PBXTarget pbxTarget,
+      String dependencyTargetName) {
+
+    assertEquals(pbxTarget.getDependencies().size(), 1);
+    PBXContainerItemProxy dependencyProxy = pbxTarget.getDependencies().get(0).getTargetProxy();
+
+    PBXTarget dependency = assertTargetExistsAndReturnTarget(project, dependencyTargetName);
+    assertEquals(dependencyProxy.getRemoteGlobalIDString(), dependency.getGlobalID());
+    assertEquals(dependencyProxy.getContainerPortal(), project);
   }
 }

--- a/test/com/facebook/buck/apple/xcode/GidGeneratorTest.java
+++ b/test/com/facebook/buck/apple/xcode/GidGeneratorTest.java
@@ -21,13 +21,12 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 
 public class GidGeneratorTest {
   @Test
   public void testTrivialGidGeneration() {
-    GidGenerator generator = new GidGenerator(ImmutableSet.of());
+    GidGenerator generator = new GidGenerator();
     String gid = generator.generateGid("foo", 0);
     assertFalse("GID should be non-empty", gid.isEmpty());
     assertTrue("GID should be hexadecimal", gid.matches("^[0-9A-F]+$"));
@@ -39,7 +38,7 @@ public class GidGeneratorTest {
 
   @Test
   public void testTwoGidsWithSameClassNameAndHashDiffer() {
-    GidGenerator generator = new GidGenerator(ImmutableSet.of());
+    GidGenerator generator = new GidGenerator();
     String gid = generator.generateGid("foo", 0);
     String gid1 = generator.generateGid("foo", 0);
     assertNotEquals("The GID generator should avoid collisions", gid, gid1);

--- a/test/com/facebook/buck/apple/xcode/XcodeprojSerializerTest.java
+++ b/test/com/facebook/buck/apple/xcode/XcodeprojSerializerTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 import com.dd.plist.NSDictionary;
 import com.dd.plist.NSString;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXProject;
+
 import org.junit.Test;
 
 public class XcodeprojSerializerTest {

--- a/test/com/facebook/buck/apple/xcode/XcodeprojSerializerTest.java
+++ b/test/com/facebook/buck/apple/xcode/XcodeprojSerializerTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertTrue;
 import com.dd.plist.NSDictionary;
 import com.dd.plist.NSString;
 import com.facebook.buck.apple.xcode.xcodeproj.PBXProject;
-import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 
 public class XcodeprojSerializerTest {
@@ -31,7 +30,7 @@ public class XcodeprojSerializerTest {
   public void testEmptyProject() {
     PBXProject project = new PBXProject("TestProject");
     XcodeprojSerializer xcodeprojSerializer =
-        new XcodeprojSerializer(new GidGenerator(ImmutableSet.of()), project);
+        new XcodeprojSerializer(new GidGenerator(), project);
     NSDictionary rootObject = xcodeprojSerializer.toPlist();
 
     assertEquals(project.getGlobalID(), ((NSString) rootObject.get("rootObject")).getContent());


### PR DESCRIPTION
### background ###

Previously, the generated xcode project for `apple_test`s that specified a host app, did not add the app under the test's "Target Dependencies" build phase.  As a result, these tests failed to build if the host app hadn't already been built.

### change ###

Adds the host app under the test target's "Target Dependencies" build phase.

### verification ###

- [x] verify that the host app is a target dependency for unit tests with a specified host app
- [x] verify that the host app is a target dependency for UI tests
- [x] verify that logic tests without host apps continue to be generated correctly
- [x] verify that tests with host apps in a different project don't add the app as a target dependency
- [x] update `ProjectGeneratorTest`