### PR TITLE
Allow `sh_test` to run without specifying a `test=` parameter.

### DIFF
--- a/src/com/facebook/buck/shell/RunShTestAndRecordResultStep.java
+++ b/src/com/facebook/buck/shell/RunShTestAndRecordResultStep.java
@@ -37,8 +37,7 @@ import java.util.function.Consumer;
 public class RunShTestAndRecordResultStep implements Step {
 
   private final ProjectFilesystem filesystem;
-  private final Path pathToShellScript;
-  private final ImmutableList<String> args;
+  private final ImmutableList<String> command;
   private final ImmutableMap<String, String> env;
   private final Path pathToTestResultFile;
   private final Optional<Long> testRuleTimeoutMs;
@@ -46,15 +45,13 @@ public class RunShTestAndRecordResultStep implements Step {
 
   public RunShTestAndRecordResultStep(
       ProjectFilesystem filesystem,
-      Path pathToShellScript,
-      ImmutableList<String> args,
+      ImmutableList<String> command,
       ImmutableMap<String, String> env,
       Optional<Long> testRuleTimeoutMs,
       String testCaseName,
       Path pathToTestResultFile) {
     this.filesystem = filesystem;
-    this.pathToShellScript = pathToShellScript;
-    this.args = args;
+    this.command = command;
     this.env = env;
     this.testRuleTimeoutMs = testRuleTimeoutMs;
     this.testCaseName = testCaseName;
@@ -63,12 +60,12 @@ public class RunShTestAndRecordResultStep implements Step {
 
   @Override
   public String getShortName() {
-    return pathToShellScript.toString();
+    return command.get(0);
   }
 
   @Override
   public String getDescription(ExecutionContext context) {
-    return pathToShellScript.toString();
+    return command.get(0);
   }
 
   @Override
@@ -94,15 +91,12 @@ public class RunShTestAndRecordResultStep implements Step {
 
             @Override
             public String getShortName() {
-              return pathToShellScript.toString();
+              return command.get(0);
             }
 
             @Override
             protected ImmutableList<String> getShellCommandInternal(ExecutionContext context) {
-              return ImmutableList.<String>builder()
-                  .add(pathToShellScript.toString())
-                  .addAll(args)
-                  .build();
+              return command;
             }
 
             @Override

--- a/src/com/facebook/buck/shell/ShTest.java
+++ b/src/com/facebook/buck/shell/ShTest.java
@@ -63,7 +63,6 @@ public class ShTest extends NoopBuildRule
     implements TestRule, HasRuntimeDeps, ExternalTestRunnerRule, BinaryBuildRule {
 
   private final SourcePathRuleFinder ruleFinder;
-  @AddToRuleKey private final SourcePath test;
   @AddToRuleKey private final ImmutableList<Arg> args;
   @AddToRuleKey private final ImmutableMap<String, Arg> env;
 
@@ -79,7 +78,6 @@ public class ShTest extends NoopBuildRule
   protected ShTest(
       BuildRuleParams params,
       SourcePathRuleFinder ruleFinder,
-      SourcePath test,
       ImmutableList<Arg> args,
       ImmutableMap<String, Arg> env,
       ImmutableSortedSet<? extends SourcePath> resources,
@@ -89,7 +87,6 @@ public class ShTest extends NoopBuildRule
       ImmutableSet<String> contacts) {
     super(params);
     this.ruleFinder = ruleFinder;
-    this.test = test;
     this.args = args;
     this.env = env;
     this.resources = resources;
@@ -121,7 +118,6 @@ public class ShTest extends NoopBuildRule
             // Return a single command that runs an .sh file with no arguments.
             new RunShTestAndRecordResultStep(
                 getProjectFilesystem(),
-                pathResolver.getAbsolutePath(test),
                 Arg.stringify(args, pathResolver),
                 Arg.stringify(env, pathResolver),
                 testRuleTimeoutMs,
@@ -181,7 +177,6 @@ public class ShTest extends NoopBuildRule
   public Tool getExecutableCommand() {
     CommandTool.Builder builder =
         new CommandTool.Builder()
-            .addArg(SourcePathArg.of(test))
             .addDeps(ruleFinder.filterBuildRuleInputs(resources));
 
     for (Arg arg : args) {
@@ -201,7 +196,6 @@ public class ShTest extends NoopBuildRule
     return ExternalTestRunnerTestSpec.builder()
         .setTarget(getBuildTarget())
         .setType("custom")
-        .addCommand(pathResolver.getAbsolutePath(test).toString())
         .addAllCommand(Arg.stringify(args, pathResolver))
         .setEnv(Arg.stringify(env, pathResolver))
         .addAllLabels(getLabels())

--- a/src/com/facebook/buck/shell/ShTest.java
+++ b/src/com/facebook/buck/shell/ShTest.java
@@ -33,7 +33,6 @@ import com.facebook.buck.rules.SourcePathRuleFinder;
 import com.facebook.buck.rules.TestRule;
 import com.facebook.buck.rules.Tool;
 import com.facebook.buck.rules.args.Arg;
-import com.facebook.buck.rules.args.SourcePathArg;
 import com.facebook.buck.step.ExecutionContext;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.fs.MakeCleanDirectoryStep;

--- a/test/com/facebook/buck/shell/ShTestTest.java
+++ b/test/com/facebook/buck/shell/ShTestTest.java
@@ -30,6 +30,7 @@ import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.SourcePathRuleFinder;
 import com.facebook.buck.rules.TargetGraph;
+import com.facebook.buck.rules.args.SourcePathArg;
 import com.facebook.buck.util.MoreCollectors;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -66,8 +67,7 @@ public class ShTestTest extends EasyMockSupport {
                 .setExtraDeps(ImmutableSortedSet.of(extraDep))
                 .build(),
             ruleFinder,
-            new FakeSourcePath("run_test.sh"),
-            /* args */ ImmutableList.of(),
+            /* args */ ImmutableList.of(SourcePathArg.of(new FakeSourcePath("run_test.sh"))),
             /* env */ ImmutableMap.of(),
             /* resources */ ImmutableSortedSet.of(),
             Optional.empty(),


### PR DESCRIPTION
So the first argument of the command can be, e.g. `java`.