### PR TITLE
Handle race conditions in Buck project constructor.

### DIFF
--- a/programs/buck_project.py
+++ b/programs/buck_project.py
@@ -25,6 +25,7 @@ def write_contents_to_file(path, contents):
         with open(path, 'w') as output_file:
             output_file.write(str(contents))
 
+
 def makedirs(path):
     try:
         os.makedirs(path)
@@ -36,6 +37,7 @@ def makedirs(path):
         # Python 3.
         if e.errno != errno.EEXIST and os.path.isdir(path):
             raise
+
 
 class BuckProject:
 

--- a/programs/buck_project.py
+++ b/programs/buck_project.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import errno
 import os
 import tempfile
 import textwrap
@@ -24,6 +25,17 @@ def write_contents_to_file(path, contents):
         with open(path, 'w') as output_file:
             output_file.write(str(contents))
 
+def makedirs(path):
+    try:
+        os.makedirs(path)
+    except OSError, e:
+        # Potentially the case that multiple processes are running in parallel
+        # (e.g. a series of linters running buck query without buckd), so we
+        # should just swallow the error.
+        # This is mostly equivalent to os.makedirs(path, exist_ok=True) in
+        # Python 3.
+        if e.errno != errno.EEXIST and os.path.isdir(path):
+            raise
 
 class BuckProject:
 
@@ -31,11 +43,9 @@ class BuckProject:
         self.root = root
         self._buck_out = os.path.join(root, "buck-out")
         buck_out_tmp = os.path.join(self._buck_out, "tmp")
-        if not os.path.exists(buck_out_tmp):
-            os.makedirs(buck_out_tmp)
+        makedirs(buck_out_tmp)
         self._buck_out_log = os.path.join(self._buck_out, "log")
-        if not os.path.exists(self._buck_out_log):
-            os.makedirs(self._buck_out_log)
+        makedirs(self._buck_out_log)
         self.tmp_dir = tempfile.mkdtemp(prefix="buck_run.", dir=buck_out_tmp)
 
         # Only created if buckd is used.
@@ -94,8 +104,7 @@ class BuckProject:
         if self.buckd_tmp_dir is not None:
             return self.buckd_tmp_dir
         tmp_dir_parent = os.path.join(self.buckd_dir, "tmp")
-        if not os.path.exists(tmp_dir_parent):
-            os.makedirs(tmp_dir_parent)
+        makedirs(tmp_dir_parent)
         self.buckd_tmp_dir = tempfile.mkdtemp(prefix="buck_run.",
                                               dir=tmp_dir_parent)
         return self.buckd_tmp_dir


### PR DESCRIPTION
There are some cases where running 2 buck processes in parallel will
result in fatal errors as they race to create the temp directory.

There's another case in buck_program.py that does a similar `if !dir: mkdir` check but I don't know if I need to check that too - my failure case hasn't gotten that far.

cc @sdwilsh 