### PR TITLE
Allow not setting `exe` for worker_tools

### DIFF
--- a/src/com/facebook/buck/cxx/CxxToolFlags.java
+++ b/src/com/facebook/buck/cxx/CxxToolFlags.java
@@ -20,6 +20,7 @@ import com.facebook.buck.util.immutables.BuckStyleImmutable;
 import com.facebook.buck.util.immutables.BuckStyleTuple;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+
 import org.immutables.value.Value;
 
 /**

--- a/src/com/facebook/buck/js/CoreReactNativeLibraryArg.java
+++ b/src/com/facebook/buck/js/CoreReactNativeLibraryArg.java
@@ -16,10 +16,13 @@
 
 package com.facebook.buck.js;
 
+import com.facebook.buck.model.Either;
 import com.facebook.buck.rules.CommonDescriptionArg;
 import com.facebook.buck.rules.HasDeclaredDeps;
 import com.facebook.buck.rules.HasSrcs;
 import com.facebook.buck.rules.SourcePath;
+import com.google.common.collect.ImmutableList;
+
 import java.util.Optional;
 
 // Immutables get really angry if you try to inherit from other Immutables. So we need to extract
@@ -29,5 +32,5 @@ public interface CoreReactNativeLibraryArg extends CommonDescriptionArg, HasDecl
 
   String getBundleName();
 
-  Optional<String> getPackagerFlags();
+  Optional<Either<String, ImmutableList<String>>> getPackagerFlags();
 }

--- a/src/com/facebook/buck/js/JsUtil.java
+++ b/src/com/facebook/buck/js/JsUtil.java
@@ -59,7 +59,6 @@ public class JsUtil {
             WorkerProcessParams.of(
                 worker.getTempDir(),
                 tool.getCommandPrefix(sourcePathResolver),
-                worker.getArgs(sourcePathResolver),
                 tool.getEnvironment(sourcePathResolver),
                 worker.getMaxWorkers(),
                 worker.isPersistent()

--- a/src/com/facebook/buck/js/ReactNativeBundle.java
+++ b/src/com/facebook/buck/js/ReactNativeBundle.java
@@ -37,9 +37,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Maps;
+
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Optional;
 import java.util.function.Predicate;
 
 /**
@@ -71,7 +71,7 @@ public class ReactNativeBundle extends AbstractBuildRule
 
   @AddToRuleKey private final String bundleName;
 
-  @AddToRuleKey private final Optional<String> packagerFlags;
+  @AddToRuleKey private final ImmutableList<String> packagerFlags;
 
   private final Path jsOutputDir;
   private final Path resource;
@@ -86,7 +86,7 @@ public class ReactNativeBundle extends AbstractBuildRule
       boolean isDevMode,
       boolean exposeSourceMap,
       String bundleName,
-      Optional<String> packagerFlags,
+      ImmutableList<String> packagerFlags,
       Tool jsPackager,
       ReactNativePlatform platform) {
     super(ruleParams);

--- a/src/com/facebook/buck/js/ReactNativeBundleWorkerStep.java
+++ b/src/com/facebook/buck/js/ReactNativeBundleWorkerStep.java
@@ -23,6 +23,7 @@ import com.facebook.buck.shell.WorkerProcessPoolFactory;
 import com.facebook.buck.shell.WorkerShellStep;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -32,7 +33,7 @@ public class ReactNativeBundleWorkerStep extends WorkerShellStep {
       ProjectFilesystem filesystem,
       Path tmpDir,
       ImmutableList<String> jsPackagerCommand,
-      Optional<String> additionalPackagerFlags,
+      ImmutableList<String> additionalPackagerFlags,
       ReactNativePlatform platform,
       boolean isUnbundle,
       boolean isIndexedUnbundle,
@@ -57,13 +58,11 @@ public class ReactNativeBundleWorkerStep extends WorkerShellStep {
                     sourceMapFile.toString()),
                 WorkerProcessParams.of(
                     filesystem.resolve(tmpDir),
-                    jsPackagerCommand,
-                    String.format(
-                        "--platform %s%s",
-                        platform.toString(),
-                        additionalPackagerFlags.isPresent()
-                            ? " " + additionalPackagerFlags.get()
-                            : ""),
+                    ImmutableList.<String>builder()
+                        .addAll(jsPackagerCommand)
+                        .add("--platform", platform.toString())
+                        .addAll(additionalPackagerFlags)
+                        .build(),
                     ImmutableMap.of(),
                     1,
                     Optional.empty()))),

--- a/src/com/facebook/buck/js/ReactNativeDepsWorkerStep.java
+++ b/src/com/facebook/buck/js/ReactNativeDepsWorkerStep.java
@@ -23,6 +23,7 @@ import com.facebook.buck.shell.WorkerProcessPoolFactory;
 import com.facebook.buck.shell.WorkerShellStep;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -32,7 +33,7 @@ public class ReactNativeDepsWorkerStep extends WorkerShellStep {
       ProjectFilesystem filesystem,
       Path tmpDir,
       ImmutableList<String> jsPackagerCommand,
-      Optional<String> additionalPackagerFlags,
+      ImmutableList<String> additionalPackagerFlags,
       ReactNativePlatform platform,
       Path entryFile,
       Path outputFile) {
@@ -44,13 +45,11 @@ public class ReactNativeDepsWorkerStep extends WorkerShellStep {
                     platform.toString(), entryFile.toString(), outputFile.toString()),
                 WorkerProcessParams.of(
                     filesystem.resolve(tmpDir),
-                    jsPackagerCommand,
-                    String.format(
-                        "--platform %s%s",
-                        platform.toString(),
-                        additionalPackagerFlags.isPresent()
-                            ? " " + additionalPackagerFlags.get()
-                            : ""),
+                    ImmutableList.<String>builder()
+                        .addAll(jsPackagerCommand)
+                        .add("--platform", platform.toString())
+                        .addAll(additionalPackagerFlags)
+                        .build(),
                     ImmutableMap.of(),
                     1,
                     Optional.empty()))),

--- a/src/com/facebook/buck/js/ReactNativeLibraryGraphEnhancer.java
+++ b/src/com/facebook/buck/js/ReactNativeLibraryGraphEnhancer.java
@@ -53,6 +53,18 @@ public class ReactNativeLibraryGraphEnhancer {
       CoreReactNativeLibraryArg args,
       ReactNativePlatform platform) {
     Tool jsPackager = buckConfig.getPackager(resolver);
+
+    ImmutableList<String> packagerFlags;
+    if (args.getPackagerFlags().isPresent()) {
+      if (args.getPackagerFlags().get().isLeft()) {
+        packagerFlags = ImmutableList.copyOf(args.getPackagerFlags().get().getLeft().split("\\s+"));
+      } else {
+        packagerFlags = args.getPackagerFlags().get().getRight();
+      }
+    } else {
+      packagerFlags = ImmutableList.of();
+    }
+
     return new ReactNativeBundle(
         baseParams
             .withBuildTarget(target)
@@ -71,7 +83,7 @@ public class ReactNativeLibraryGraphEnhancer {
         ReactNativeFlavors.isDevMode(baseParams.getBuildTarget()),
         ReactNativeFlavors.exposeSourceMap(baseParams.getBuildTarget()),
         args.getBundleName(),
-        args.getPackagerFlags(),
+        packagerFlags,
         jsPackager,
         platform);
   }

--- a/src/com/facebook/buck/rules/args/ProxyArg.java
+++ b/src/com/facebook/buck/rules/args/ProxyArg.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.facebook.buck.rules.args;
 
 import com.facebook.buck.rules.BuildRule;

--- a/src/com/facebook/buck/rules/args/ProxyArg.java
+++ b/src/com/facebook/buck/rules/args/ProxyArg.java
@@ -1,0 +1,56 @@
+package com.facebook.buck.rules.args;
+
+import com.facebook.buck.rules.BuildRule;
+import com.facebook.buck.rules.RuleKeyObjectSink;
+import com.facebook.buck.rules.SourcePath;
+import com.facebook.buck.rules.SourcePathResolver;
+import com.facebook.buck.rules.SourcePathRuleFinder;
+import com.google.common.collect.ImmutableCollection;
+
+/**
+ * An {@link Arg} implementation that delegates to another arg. Could be useful for overriding
+ * one of the functions of the underlying Arg.
+ */
+public class ProxyArg implements Arg {
+  protected final Arg arg;
+
+  public ProxyArg(Arg arg) {
+    this.arg = arg;
+  }
+
+  @Override
+  public void appendToRuleKey(RuleKeyObjectSink sink) {
+    arg.appendToRuleKey(sink);
+  }
+
+  @Override
+  public ImmutableCollection<BuildRule> getDeps(SourcePathRuleFinder ruleFinder) {
+    return arg.getDeps(ruleFinder);
+  }
+
+  @Override
+  public ImmutableCollection<SourcePath> getInputs() {
+    return arg.getInputs();
+  }
+
+  @Override
+  public void appendToCommandLine(
+      ImmutableCollection.Builder<String> builder, SourcePathResolver pathResolver) {
+    arg.appendToCommandLine(builder, pathResolver);
+  }
+
+  @Override
+  public String toString() {
+    return arg.toString();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return arg.equals(other) && getClass().equals(other.getClass());
+  }
+
+  @Override
+  public int hashCode() {
+    return arg.hashCode();
+  }
+}

--- a/src/com/facebook/buck/rules/args/WorkerMacroArg.java
+++ b/src/com/facebook/buck/rules/args/WorkerMacroArg.java
@@ -99,10 +99,6 @@ public class WorkerMacroArg extends MacroArg {
     return workerTool.getTempDir();
   }
 
-  public String getStartupArgs(SourcePathResolver pathResolver) {
-    return workerTool.getArgs(pathResolver);
-  }
-
   public Optional<String> getPersistentWorkerKey() {
     if (workerTool.isPersistent()) {
       return Optional.of(buildTarget.getCellPath().toString() + buildTarget.toString());

--- a/src/com/facebook/buck/shell/AbstractWorkerProcessParams.java
+++ b/src/com/facebook/buck/shell/AbstractWorkerProcessParams.java
@@ -40,13 +40,6 @@ interface AbstractWorkerProcessParams {
    */
   ImmutableList<String> getStartupCommand();
 
-  /**
-   * All args combined into single string and separated with a white space, e.g. if tool is expected
-   * to compute hashes on the fly you may pass something like "--compute-hashes". This string will
-   * be escaped for you using Escaper#SHELL_ESCAPER.
-   */
-  String getStartupArgs();
-
   /** Environment that will be used to start the worker tool. */
   ImmutableMap<String, String> getStartupEnvironment();
 

--- a/src/com/facebook/buck/shell/Genrule.java
+++ b/src/com/facebook/buck/shell/Genrule.java
@@ -282,9 +282,9 @@ public class Genrule extends AbstractBuildRule implements HasOutputName, Support
 
   public WorkerShellStep createWorkerShellStep(BuildContext context) {
     return new WorkerShellStep(
-        convertToWorkerJobParams(cmd, context.getSourcePathResolver()),
-        convertToWorkerJobParams(bash, context.getSourcePathResolver()),
-        convertToWorkerJobParams(cmdExe, context.getSourcePathResolver()),
+        convertToWorkerJobParams(cmd),
+        convertToWorkerJobParams(bash),
+        convertToWorkerJobParams(cmdExe),
         new WorkerProcessPoolFactory(getProjectFilesystem())) {
       @Override
       protected ImmutableMap<String, String> getEnvironmentVariables(
@@ -298,7 +298,7 @@ public class Genrule extends AbstractBuildRule implements HasOutputName, Support
   }
 
   private static Optional<WorkerJobParams> convertToWorkerJobParams(
-      Optional<Arg> arg, SourcePathResolver pathResolver) {
+      Optional<Arg> arg) {
     return arg.map(
         arg1 -> {
           WorkerMacroArg workerMacroArg = (WorkerMacroArg) arg1;
@@ -307,7 +307,6 @@ public class Genrule extends AbstractBuildRule implements HasOutputName, Support
               WorkerProcessParams.of(
                   workerMacroArg.getTempDir(),
                   workerMacroArg.getStartupCommand(),
-                  workerMacroArg.getStartupArgs(pathResolver),
                   workerMacroArg.getEnvironment(),
                   workerMacroArg.getMaxWorkers(),
                   workerMacroArg.getPersistentWorkerKey().isPresent()

--- a/src/com/facebook/buck/shell/WorkerProcessPoolFactory.java
+++ b/src/com/facebook/buck/shell/WorkerProcessPoolFactory.java
@@ -24,18 +24,19 @@ import com.facebook.buck.util.ProcessExecutorParams;
 import com.facebook.buck.util.environment.Platform;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 /**
  * WorkerProcessPoolFactory class is designed to provide you an instance of WorkerProcessPool based
@@ -139,11 +140,10 @@ public class WorkerProcessPoolFactory {
 
     return ImmutableList.<String>builder()
         .addAll(executionArgs)
-        .add(
-            FluentIterable.from(paramsToUse.getStartupCommand())
-                .transform(Escaper.SHELL_ESCAPER)
-                .append(paramsToUse.getStartupArgs())
-                .join(Joiner.on(' ')))
+        .add(paramsToUse.getStartupCommand()
+            .stream()
+            .map(Escaper::escapeAsShellString)
+            .collect(Collectors.joining(" ")))
         .build();
   }
 

--- a/src/com/facebook/buck/shell/WorkerTool.java
+++ b/src/com/facebook/buck/shell/WorkerTool.java
@@ -16,15 +16,13 @@
 
 package com.facebook.buck.shell;
 
-import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.Tool;
 import com.google.common.hash.HashCode;
+
 import java.nio.file.Path;
 
 public interface WorkerTool {
   Tool getTool();
-
-  String getArgs(SourcePathResolver pathResolver);
 
   Path getTempDir();
 

--- a/src/com/facebook/buck/shell/WorkerToolDescription.java
+++ b/src/com/facebook/buck/shell/WorkerToolDescription.java
@@ -26,11 +26,14 @@ import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.CellPathResolver;
+import com.facebook.buck.rules.CommandTool;
 import com.facebook.buck.rules.CommonDescriptionArg;
 import com.facebook.buck.rules.Description;
 import com.facebook.buck.rules.ImplicitDepsInferringDescription;
+import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.TargetGraph;
 import com.facebook.buck.rules.args.MacroArg;
+import com.facebook.buck.rules.args.ProxyArg;
 import com.facebook.buck.rules.macros.ClasspathMacroExpander;
 import com.facebook.buck.rules.macros.ExecutableMacroExpander;
 import com.facebook.buck.rules.macros.LocationMacroExpander;
@@ -43,9 +46,11 @@ import com.google.common.base.Function;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+
+import org.immutables.value.Value;
+
 import java.util.Map;
 import java.util.Optional;
-import org.immutables.value.Value;
 
 public class WorkerToolDescription
     implements Description<WorkerToolDescriptionArg>,
@@ -82,34 +87,59 @@ public class WorkerToolDescription
       WorkerToolDescriptionArg args)
       throws NoSuchBuildTargetException {
 
-    BuildRule rule = resolver.requireRule(args.getExe());
-    if (!(rule instanceof BinaryBuildRule)) {
-      throw new HumanReadableException(
-          "The 'exe' argument of %s, %s, needs to correspond to a "
-              + "binary rule, such as sh_binary().",
-          params.getBuildTarget(), args.getExe().getFullyQualifiedName());
+    CommandTool.Builder builder;
+    if (args.getExe().isPresent()) {
+      BuildRule rule = resolver.requireRule(args.getExe().get());
+      if (!(rule instanceof BinaryBuildRule)) {
+        throw new HumanReadableException(
+            "The 'exe' argument of %s, %s, needs to correspond to a "
+                + "binary rule, such as sh_binary().",
+            params.getBuildTarget(), args.getExe().get().getFullyQualifiedName());
+      }
+
+      builder = new CommandTool.Builder(((BinaryBuildRule) rule).getExecutableCommand());
+    } else {
+      builder = new CommandTool.Builder();
     }
+
+    builder.addInputs(
+        params.getBuildDeps()
+            .stream()
+            .map(BuildRule::getSourcePathToOutput)
+            .collect(MoreCollectors.toImmutableList()));
 
     Function<String, com.facebook.buck.rules.args.Arg> toArg =
         MacroArg.toMacroArgFunction(MACRO_HANDLER, params.getBuildTarget(), cellRoots, resolver);
-    final ImmutableList<com.facebook.buck.rules.args.Arg> workerToolArgs =
-        args.getStartupArgs().stream().map(toArg::apply).collect(MoreCollectors.toImmutableList());
 
-    ImmutableMap<String, com.facebook.buck.rules.args.Arg> unexpandedEnv =
-        args.getEnv()
-            .entrySet()
-            .stream()
-            .collect(
-                MoreCollectors.toImmutableMap(Map.Entry::getKey, e -> toArg.apply(e.getValue())));
+    if (args.getArgs().isLeft()) {
+      builder.addArg(new ProxyArg(toArg.apply(args.getArgs().getLeft())) {
+        @Override
+        public void appendToCommandLine(
+            ImmutableCollection.Builder<String> builder, SourcePathResolver pathResolver) {
+          ImmutableList.Builder<String> subBuilder = ImmutableList.builder();
+          super.appendToCommandLine(subBuilder, pathResolver);
+          for (String arg : subBuilder.build()) {
+            for (String splitArg : arg.split("\\s+")) {
+              builder.add(splitArg);
+            }
+          }
+        }
+      });
+    } else {
+      for (String arg : args.getArgs().getRight()) {
+        builder.addArg(toArg.apply(arg));
+      }
+    }
+    for (Map.Entry<String, String> e : args.getEnv().entrySet()) {
+      builder.addEnv(e.getKey(), toArg.apply(e.getValue()));
+    }
 
     // negative or zero: unlimited number of worker processes
     int maxWorkers = args.getMaxWorkers() < 1 ? Integer.MAX_VALUE : args.getMaxWorkers();
 
     return new DefaultWorkerTool(
         params,
-        (BinaryBuildRule) rule,
-        workerToolArgs,
-        unexpandedEnv,
+        builder.build(),
         maxWorkers,
         args.getPersistent()
             .orElse(buckConfig.getBooleanValue(CONFIG_SECTION, CONFIG_PERSISTENT_KEY, false)));
@@ -123,9 +153,14 @@ public class WorkerToolDescription
       ImmutableCollection.Builder<BuildTarget> extraDepsBuilder,
       ImmutableCollection.Builder<BuildTarget> targetGraphOnlyDepsBuilder) {
     try {
-      for (String arg : constructorArg.getStartupArgs()) {
+      if (constructorArg.getArgs().isLeft()) {
         MACRO_HANDLER.extractParseTimeDeps(
-            buildTarget, cellRoots, arg, extraDepsBuilder, targetGraphOnlyDepsBuilder);
+            buildTarget, cellRoots, constructorArg.getArgs().getLeft(), extraDepsBuilder, targetGraphOnlyDepsBuilder);
+      } else {
+        for (String arg : constructorArg.getArgs().getRight()) {
+          MACRO_HANDLER.extractParseTimeDeps(
+              buildTarget, cellRoots, arg, extraDepsBuilder, targetGraphOnlyDepsBuilder);
+        }
       }
       for (Map.Entry<String, String> env : constructorArg.getEnv().entrySet()) {
         MACRO_HANDLER.extractParseTimeDeps(
@@ -139,15 +174,6 @@ public class WorkerToolDescription
   @BuckStyleImmutable
   @Value.Immutable
   interface AbstractWorkerToolDescriptionArg extends CommonDescriptionArg {
-    @Value.Derived
-    default ImmutableList<String> getStartupArgs() {
-      if (getArgs().isLeft()) {
-        return ImmutableList.of(getArgs().getLeft());
-      } else {
-        return getArgs().getRight();
-      }
-    }
-
     ImmutableMap<String, String> getEnv();
 
     @Value.Default
@@ -155,7 +181,7 @@ public class WorkerToolDescription
       return Either.ofRight(ImmutableList.of());
     }
 
-    BuildTarget getExe();
+    Optional<BuildTarget> getExe();
 
     @Value.Default
     default int getMaxWorkers() {

--- a/test/com/facebook/buck/rules/args/WorkerMacroArgTest.java
+++ b/test/com/facebook/buck/rules/args/WorkerMacroArgTest.java
@@ -37,6 +37,7 @@ import com.facebook.buck.rules.macros.WorkerMacroExpander;
 import com.facebook.buck.shell.ShBinaryBuilder;
 import com.facebook.buck.shell.WorkerToolBuilder;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -46,7 +47,6 @@ public class WorkerMacroArgTest {
   public void testWorkerMacroArgConstruction() throws MacroException, NoSuchBuildTargetException {
     BuildRuleResolver resolver =
         new BuildRuleResolver(TargetGraph.EMPTY, new DefaultTargetNodeToBuildRuleTransformer());
-    SourcePathResolver pathResolver = new SourcePathResolver(new SourcePathRuleFinder(resolver));
 
     BuildRule shBinaryRule =
         new ShBinaryBuilder(BuildTargetFactory.newInstance("//:my_exe"))
@@ -75,7 +75,8 @@ public class WorkerMacroArgTest {
             resolver,
             "$(worker //:worker_rule) " + jobArgs);
     assertThat(arg.getJobArgs(), Matchers.equalTo(jobArgs));
-    assertThat(arg.getStartupArgs(pathResolver), Matchers.equalTo(startupArgs));
+    assertThat(arg.getStartupCommand().subList(1, 2), Matchers.equalTo(
+        ImmutableList.<String>builder().add(startupArgs).build()));
     assertThat(arg.getMaxWorkers(), Matchers.equalTo(maxWorkers));
   }
 

--- a/test/com/facebook/buck/shell/FakeWorkerBuilder.java
+++ b/test/com/facebook/buck/shell/FakeWorkerBuilder.java
@@ -69,11 +69,6 @@ public class FakeWorkerBuilder
     }
 
     @Override
-    public String getArgs(SourcePathResolver pathResolver) {
-      return "";
-    }
-
-    @Override
     public Path getTempDir() {
       return Paths.get("");
     }

--- a/test/com/facebook/buck/shell/WorkerShellStepTest.java
+++ b/test/com/facebook/buck/shell/WorkerShellStepTest.java
@@ -58,13 +58,13 @@ import org.junit.Test;
 public class WorkerShellStepTest {
 
   private static final String startupCommand = "startupCommand";
-  private static final String startupArgs = "startupArgs";
-  private static final String persistentStartupArgs = "persistentStartupArgs";
+  private static final String startupArg = "startupArg";
+  private static final String persistentStartupArg = "persistentStartupArg";
   private static final String persistentWorkerKey = "//:my-persistent-worker";
   private static final String fakeWorkerStartupCommand =
-      String.format("/bin/bash -e -c %s %s", startupCommand, startupArgs);
+      String.format("/bin/bash -e -c %s %s", startupCommand, startupArg);
   private static final String fakePersistentWorkerStartupCommand =
-      String.format("/bin/bash -e -c %s %s", startupCommand, persistentStartupArgs);
+      String.format("/bin/bash -e -c %s %s", startupCommand, persistentStartupArg);
 
   private WorkerShellStep createWorkerShellStep(
       @Nullable WorkerJobParams cmdParams,
@@ -78,30 +78,27 @@ public class WorkerShellStepTest {
   }
 
   private WorkerJobParams createJobParams() {
-    return createJobParams(ImmutableList.of(), "", ImmutableMap.of(), "");
+    return createJobParams(ImmutableList.of(), ImmutableMap.of(), "");
   }
 
   private WorkerJobParams createJobParams(
       ImmutableList<String> startupCommand,
-      String startupArgs,
       ImmutableMap<String, String> startupEnv,
       String jobArgs) {
-    return createJobParams(startupCommand, startupArgs, startupEnv, jobArgs, 1);
+    return createJobParams(startupCommand, startupEnv, jobArgs, 1);
   }
 
   private WorkerJobParams createJobParams(
       ImmutableList<String> startupCommand,
-      String startupArgs,
       ImmutableMap<String, String> startupEnv,
       String jobArgs,
       int maxWorkers) {
     return createJobParams(
-        startupCommand, startupArgs, startupEnv, jobArgs, maxWorkers, null, null);
+        startupCommand, startupEnv, jobArgs, maxWorkers, null, null);
   }
 
   private WorkerJobParams createJobParams(
       ImmutableList<String> startupCommand,
-      String startupArgs,
       ImmutableMap<String, String> startupEnv,
       String jobArgs,
       int maxWorkers,
@@ -112,7 +109,6 @@ public class WorkerShellStepTest {
         WorkerProcessParams.of(
             Paths.get("tmp").toAbsolutePath().normalize(),
             startupCommand,
-            startupArgs,
             startupEnv,
             maxWorkers,
             persistentWorkerKey == null || workerHash == null
@@ -221,10 +217,10 @@ public class WorkerShellStepTest {
   public void testGetCommand() {
     WorkerJobParams cmdParams =
         createJobParams(
-            ImmutableList.of("command"), "--platform unix-like", ImmutableMap.of(), "job params");
+            ImmutableList.of("command", "--platform", "unix-like"), ImmutableMap.of(), "job params");
     WorkerJobParams cmdExeParams =
         createJobParams(
-            ImmutableList.of("command"), "--platform windows", ImmutableMap.of(), "job params");
+            ImmutableList.of("command", "--platform", "windows"), ImmutableMap.of(), "job params");
 
     WorkerShellStep step = createWorkerShellStep(cmdParams, null, cmdExeParams);
     assertThat(
@@ -254,7 +250,7 @@ public class WorkerShellStepTest {
     WorkerShellStep step =
         createWorkerShellStep(
             createJobParams(
-                ImmutableList.of(startupCommand), startupArgs, ImmutableMap.of(), "myJobArgs"),
+                ImmutableList.of(startupCommand, startupArg), ImmutableMap.of(), "myJobArgs"),
             null,
             null);
 
@@ -282,8 +278,7 @@ public class WorkerShellStepTest {
     WorkerShellStep step =
         createWorkerShellStep(
             createJobParams(
-                ImmutableList.of(startupCommand),
-                persistentStartupArgs,
+                ImmutableList.of(startupCommand, persistentStartupArg),
                 ImmutableMap.of(),
                 "myJobArgs",
                 1,
@@ -309,7 +304,7 @@ public class WorkerShellStepTest {
 
     WorkerJobParams params =
         createJobParams(
-            ImmutableList.of(startupCommand), startupArgs, ImmutableMap.of(), jobArgs1, 1);
+            ImmutableList.of(startupCommand, startupArg), ImmutableMap.of(), jobArgs1, 1);
 
     WorkerShellStep step1 = createWorkerShellStep(params, null, null);
     final WorkerShellStep step2 = createWorkerShellStep(params.withJobArgs(jobArgs2), null, null);
@@ -337,7 +332,7 @@ public class WorkerShellStepTest {
     WorkerShellStep step =
         createWorkerShellStep(
             createJobParams(
-                ImmutableList.of(startupCommand), startupArgs, ImmutableMap.of(), "myJobArgs"),
+                ImmutableList.of(startupCommand, startupArg), ImmutableMap.of(), "myJobArgs"),
             null,
             null);
 
@@ -361,7 +356,6 @@ public class WorkerShellStepTest {
             Optional.of(
                 createJobParams(
                     ImmutableList.of(),
-                    "",
                     ImmutableMap.of("BAK", "chicken"),
                     "$FOO $BAR $BAZ $BAK")),
             Optional.empty(),
@@ -442,7 +436,7 @@ public class WorkerShellStepTest {
 
     WorkerJobParams jobParamsA =
         createJobParams(
-            ImmutableList.of(startupCommand), startupArgs, ImmutableMap.of(), jobArgsA, 2);
+            ImmutableList.of(startupCommand, startupArg), ImmutableMap.of(), jobArgsA, 2);
     WorkerShellStep stepA = new WorkerShellStepWithFakeProcesses(jobParamsA);
     WorkerShellStep stepB = new WorkerShellStepWithFakeProcesses(jobParamsA.withJobArgs(jobArgsB));
 
@@ -481,8 +475,7 @@ public class WorkerShellStepTest {
 
     WorkerJobParams params =
         createJobParams(
-            ImmutableList.of(startupCommand),
-            startupArgs,
+            ImmutableList.of(startupCommand, startupArg),
             ImmutableMap.of(),
             "jobArgs",
             stepPoolSize);

--- a/test/com/facebook/buck/shell/WorkerToolRuleIntegrationTest.java
+++ b/test/com/facebook/buck/shell/WorkerToolRuleIntegrationTest.java
@@ -28,12 +28,14 @@ import com.facebook.buck.testutil.integration.TemporaryPaths;
 import com.facebook.buck.testutil.integration.TestDataHelper;
 import com.facebook.buck.util.environment.Platform;
 import com.google.common.collect.ImmutableSet;
-import java.io.IOException;
-import java.nio.file.Paths;
+
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Paths;
 
 public class WorkerToolRuleIntegrationTest {
 

--- a/test/com/facebook/buck/shell/WorkerToolTest.java
+++ b/test/com/facebook/buck/shell/WorkerToolTest.java
@@ -31,6 +31,8 @@ import com.facebook.buck.rules.SourcePathRuleFinder;
 import com.facebook.buck.rules.TargetGraph;
 import com.facebook.buck.util.HumanReadableException;
 import com.facebook.buck.util.MoreCollectors;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -56,8 +58,8 @@ public class WorkerToolTest {
 
     assertThat(
         "getArgs should return the args string supplied in the definition.",
-        "arg1 arg2",
-        Matchers.is(((WorkerTool) workerRule).getArgs(pathResolver)));
+        ImmutableList.of("arg1", "arg2"),
+        Matchers.is(((WorkerTool) workerRule).getTool().getCommandPrefix(pathResolver).subList(1, 3)));
   }
 
   @Test
@@ -112,7 +114,7 @@ public class WorkerToolTest {
         workerTool.getRuntimeDeps().collect(MoreCollectors.toImmutableSet()),
         Matchers.hasItems(shBinaryRule.getBuildTarget(), exportFileRule.getBuildTarget()));
     assertThat(
-        workerTool.getArgs(pathResolver),
+        Joiner.on(' ').join(workerTool.getTool().getCommandPrefix(pathResolver)),
         Matchers.containsString(
             pathResolver.getAbsolutePath(exportFileRule.getSourcePathToOutput()).toString()));
   }

--- a/test/com/facebook/buck/shell/testdata/worker_tool_test/BUCK.fixture
+++ b/test/com/facebook/buck/shell/testdata/worker_tool_test/BUCK.fixture
@@ -5,7 +5,7 @@ sh_binary(
 
 worker_tool(
   name = 'worker1',
-  args = ['--num-jobs 2'],
+  args = ['--num-jobs', '2'],
   exe = ':external_tool',
 )
 
@@ -17,7 +17,7 @@ worker_tool(
 
 worker_tool(
   name = 'worker3',
-  args = ['--num-jobs 2'],
+  args = ['--num-jobs', '2'],
   exe = ':concurrent_tool',
   persistent = True,
 )
@@ -30,13 +30,13 @@ worker_tool(
 
 worker_tool(
   name = 'worker_location_args_list',
-  args = ['--num-jobs 2', '--loc $(location :external_tool)'],
+  args = ['--num-jobs', '2', '--loc', '$(location :external_tool)'],
   exe = ':external_tool',
 )
 
 worker_tool(
   name = 'worker_crash_on_start',
-  args = ['--num-jobs 2', '--loc /doesnotexsist'],
+  args = ['--num-jobs', '2', '--loc', '/doesnotexsist'],
   exe = ':external_tool',
 )
 


### PR DESCRIPTION
This assumes the arguments will come via `args`, so you can have the first arg be e.g. `java`.

The only downside is folks that were previously abusing the `args` to pass multiple arguments in one entry will have their arguments properly quoted. Similarly for the react native worker rules w.r.t packager arguments.