### PR TITLE
Add support for kotlin and java mixed sources.

### DIFF
--- a/src/com/facebook/buck/android/DefaultAndroidLibraryCompilerFactory.java
+++ b/src/com/facebook/buck/android/DefaultAndroidLibraryCompilerFactory.java
@@ -41,7 +41,7 @@ public class DefaultAndroidLibraryCompilerFactory implements AndroidLibraryCompi
       case SCALA:
         return new ScalaAndroidLibraryCompiler(scalaConfig);
       case KOTLIN:
-        return new KotlinAndroidLibraryCompiler(kotlinBuckConfig);
+        return new KotlinAndroidLibraryCompiler(kotlinBuckConfig, javaConfig);
     }
     throw new HumanReadableException("Unsupported `language` parameter value: %s", language);
   }

--- a/src/com/facebook/buck/android/KotlinAndroidLibraryCompiler.java
+++ b/src/com/facebook/buck/android/KotlinAndroidLibraryCompiler.java
@@ -17,19 +17,25 @@
 package com.facebook.buck.android;
 
 import com.facebook.buck.jvm.java.CompileToJarStepFactory;
+import com.facebook.buck.jvm.java.JavaBuckConfig;
+import com.facebook.buck.jvm.java.Javac;
+import com.facebook.buck.jvm.java.JavacFactory;
 import com.facebook.buck.jvm.java.JavacOptions;
 import com.facebook.buck.jvm.kotlin.KotlinBuckConfig;
 import com.facebook.buck.jvm.kotlin.KotlincToJarStepFactory;
 import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.SourcePathRuleFinder;
 import com.google.common.collect.ImmutableList;
 
 public class KotlinAndroidLibraryCompiler extends AndroidLibraryCompiler {
 
   private final KotlinBuckConfig kotlinBuckConfig;
+  private final JavaBuckConfig javaBuckConfig;
 
-  public KotlinAndroidLibraryCompiler(KotlinBuckConfig kotlinBuckConfig) {
+  public KotlinAndroidLibraryCompiler(KotlinBuckConfig kotlinBuckConfig, JavaBuckConfig javaBuckConfig) {
     super();
     this.kotlinBuckConfig = kotlinBuckConfig;
+    this.javaBuckConfig = javaBuckConfig;
   }
 
   @Override
@@ -43,6 +49,15 @@ public class KotlinAndroidLibraryCompiler extends AndroidLibraryCompiler {
       JavacOptions javacOptions,
       BuildRuleResolver resolver) {
     return new KotlincToJarStepFactory(
-        kotlinBuckConfig.getKotlinc(), ImmutableList.of(), ANDROID_CLASSPATH_FROM_CONTEXT);
+        kotlinBuckConfig.getKotlinc(),
+        ImmutableList.of(),
+        ANDROID_CLASSPATH_FROM_CONTEXT,
+        getJavac(resolver, args),
+        javacOptions,
+        new BootClasspathAppender());
+  }
+
+  private Javac getJavac(BuildRuleResolver resolver, AndroidLibraryDescription.CoreArg arg) {
+    return JavacFactory.create(new SourcePathRuleFinder(resolver), javaBuckConfig, arg);
   }
 }

--- a/src/com/facebook/buck/jvm/java/BaseCompileToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/java/BaseCompileToJarStepFactory.java
@@ -142,7 +142,7 @@ public abstract class BaseCompileToJarStepFactory implements CompileToJarStepFac
    * @return the bootclasspath.
    */
   @SuppressWarnings("unused")
-  Optional<String> getBootClasspath(BuildContext context) {
+  protected Optional<String> getBootClasspath(BuildContext context) {
     return Optional.empty();
   }
 

--- a/src/com/facebook/buck/jvm/java/JavacToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/java/JavacToJarStepFactory.java
@@ -138,7 +138,7 @@ public class JavacToJarStepFactory extends BaseCompileToJarStepFactory {
   }
 
   @Override
-  Optional<String> getBootClasspath(BuildContext context) {
+  protected Optional<String> getBootClasspath(BuildContext context) {
     JavacOptions buildTimeOptions = amender.amend(javacOptions, context);
     return buildTimeOptions.getBootclasspath();
   }

--- a/src/com/facebook/buck/jvm/kotlin/BUCK
+++ b/src/com/facebook/buck/jvm/kotlin/BUCK
@@ -12,6 +12,7 @@ java_immutables_library(
         "//src/com/facebook/buck/io:executable-finder",
         "//src/com/facebook/buck/io:io",
         "//src/com/facebook/buck/jvm/core:classhash",
+        "//src/com/facebook/buck/jvm/java:config",
         "//src/com/facebook/buck/jvm/java:rules",
         "//src/com/facebook/buck/jvm/java:steps",
         "//src/com/facebook/buck/jvm/java:support",

--- a/src/com/facebook/buck/jvm/kotlin/KotlinLibraryBuilder.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinLibraryBuilder.java
@@ -20,7 +20,9 @@ import static com.facebook.buck.jvm.java.BaseCompileToJarStepFactory.EMPTY_EXTRA
 
 import com.facebook.buck.jvm.java.CompileToJarStepFactory;
 import com.facebook.buck.jvm.java.DefaultJavaLibraryBuilder;
+import com.facebook.buck.jvm.java.JavaBuckConfig;
 import com.facebook.buck.jvm.java.JavaLibraryDescription;
+import com.facebook.buck.jvm.java.JavacOptions;
 import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.CellPathResolver;
@@ -37,8 +39,9 @@ public class KotlinLibraryBuilder extends DefaultJavaLibraryBuilder {
       BuildRuleParams params,
       BuildRuleResolver buildRuleResolver,
       CellPathResolver cellRoots,
-      KotlinBuckConfig kotlinBuckConfig) {
-    super(targetGraph, params, buildRuleResolver, cellRoots);
+      KotlinBuckConfig kotlinBuckConfig,
+      JavaBuckConfig javaBuckConfig) {
+    super(targetGraph, params, buildRuleResolver, cellRoots, javaBuckConfig);
     this.kotlinBuckConfig = kotlinBuckConfig;
   }
 
@@ -48,6 +51,12 @@ public class KotlinLibraryBuilder extends DefaultJavaLibraryBuilder {
 
     KotlinLibraryDescription.CoreArg kotlinArgs = (KotlinLibraryDescription.CoreArg) args;
     extraKotlincArguments = kotlinArgs.getExtraKotlincArguments();
+    return this;
+  }
+
+  @Override
+  public KotlinLibraryBuilder setJavacOptions(JavacOptions javacOptions) {
+    this.javacOptions = javacOptions;
     return this;
   }
 
@@ -62,7 +71,10 @@ public class KotlinLibraryBuilder extends DefaultJavaLibraryBuilder {
       return new KotlincToJarStepFactory(
           Preconditions.checkNotNull(kotlinBuckConfig).getKotlinc(),
           extraKotlincArguments,
-          EMPTY_EXTRA_CLASSPATH);
+          EMPTY_EXTRA_CLASSPATH,
+          getJavac(),
+          Preconditions.checkNotNull(javacOptions),
+          javacOptionsAmender);
     }
   }
 }

--- a/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
@@ -18,9 +18,12 @@ package com.facebook.buck.jvm.kotlin;
 
 import com.facebook.buck.jvm.java.DefaultJavaLibrary;
 import com.facebook.buck.jvm.java.HasJavaAbi;
+import com.facebook.buck.jvm.java.JavaBuckConfig;
 import com.facebook.buck.jvm.java.JavaLibrary;
 import com.facebook.buck.jvm.java.JavaLibraryDescription;
 import com.facebook.buck.jvm.java.JavaSourceJar;
+import com.facebook.buck.jvm.java.JavacOptions;
+import com.facebook.buck.jvm.java.JavacOptionsFactory;
 import com.facebook.buck.jvm.java.MavenUberJar;
 import com.facebook.buck.maven.AetherUtil;
 import com.facebook.buck.model.BuildTarget;
@@ -45,12 +48,17 @@ public class KotlinLibraryDescription
     implements Description<KotlinLibraryDescriptionArg>, Flavored {
 
   private final KotlinBuckConfig kotlinBuckConfig;
+  private final JavaBuckConfig javaBuckConfig;
+  private final JavacOptions defaultOptions;
 
   public static final ImmutableSet<Flavor> SUPPORTED_FLAVORS =
       ImmutableSet.of(JavaLibrary.SRC_JAR, JavaLibrary.MAVEN_JAR);
 
-  public KotlinLibraryDescription(KotlinBuckConfig kotlinBuckConfig) {
+  public KotlinLibraryDescription(KotlinBuckConfig kotlinBuckConfig, JavaBuckConfig javaBuckConfig,
+      JavacOptions defaultOptions) {
     this.kotlinBuckConfig = kotlinBuckConfig;
+    this.javaBuckConfig = javaBuckConfig;
+    this.defaultOptions = defaultOptions;
   }
 
   @Override
@@ -100,9 +108,12 @@ public class KotlinLibraryDescription
             args.getMavenPomTemplate());
       }
     }
+    JavacOptions javacOptions = JavacOptionsFactory.create(defaultOptions, params, resolver, args);
 
     KotlinLibraryBuilder defaultKotlinLibraryBuilder =
-        new KotlinLibraryBuilder(targetGraph, params, resolver, cellRoots, kotlinBuckConfig)
+        new KotlinLibraryBuilder(targetGraph, params, resolver, cellRoots, kotlinBuckConfig,
+            javaBuckConfig)
+            .setJavacOptions(javacOptions)
             .setArgs(args);
 
     // We know that the flavour we're being asked to create is valid, since the check is done when

--- a/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
@@ -16,9 +16,14 @@
 
 package com.facebook.buck.jvm.kotlin;
 
+import com.facebook.buck.io.PathOrGlobMatcher;
 import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.jvm.java.BaseCompileToJarStepFactory;
 import com.facebook.buck.jvm.java.ClassUsageFileWriter;
+import com.facebook.buck.jvm.java.Javac;
+import com.facebook.buck.jvm.java.JavacOptions;
+import com.facebook.buck.jvm.java.JavacOptionsAmender;
+import com.facebook.buck.jvm.java.JavacToJarStepFactory;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.rules.BuildContext;
 import com.facebook.buck.rules.BuildableContext;
@@ -28,24 +33,38 @@ import com.facebook.buck.rules.SourcePathRuleFinder;
 import com.facebook.buck.rules.Tool;
 import com.facebook.buck.step.Step;
 import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
+
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class KotlincToJarStepFactory extends BaseCompileToJarStepFactory {
+
+  private static final PathOrGlobMatcher JAVA_PATH_MATCHER = new PathOrGlobMatcher("**.java");
 
   private final Kotlinc kotlinc;
   private final ImmutableList<String> extraArguments;
   private final Function<BuildContext, Iterable<Path>> extraClassPath;
+  private final Javac javac;
+  private final JavacOptions javacOptions;
+  private final JavacOptionsAmender amender;
 
   public KotlincToJarStepFactory(
       Kotlinc kotlinc,
       ImmutableList<String> extraArguments,
-      Function<BuildContext, Iterable<Path>> extraClassPath) {
+      Function<BuildContext, Iterable<Path>> extraClassPath,
+      Javac javac,
+      JavacOptions javacOptions,
+      JavacOptionsAmender amender) {
     this.kotlinc = kotlinc;
     this.extraArguments = extraArguments;
     this.extraClassPath = extraClassPath;
+    this.javac = javac;
+    this.javacOptions = Preconditions.checkNotNull(javacOptions);
+    this.amender = amender;
   }
 
   @Override
@@ -80,6 +99,43 @@ public class KotlincToJarStepFactory extends BaseCompileToJarStepFactory {
             kotlinc,
             extraArguments,
             filesystem));
+
+    ImmutableSortedSet<Path> javaSourceFiles = ImmutableSortedSet.copyOf(
+        sourceFilePaths
+            .stream()
+            .filter(JAVA_PATH_MATCHER::matches)
+            .collect(Collectors.toSet()));
+
+    // Don't invoke javac if we don't have any java files.
+    if (!javaSourceFiles.isEmpty()) {
+      new JavacToJarStepFactory(javac, javacOptions, amender)
+          .createCompileStep(
+              buildContext,
+              javaSourceFiles,
+              invokingRule,
+              resolver,
+              ruleFinder,
+              filesystem,
+              // We need to add the kotlin class files to the classpath. (outputDirectory).
+              ImmutableSortedSet.<Path>naturalOrder()
+                  .add(outputDirectory)
+                  .addAll(Optional.ofNullable(extraClassPath.apply(buildContext))
+                      .orElse(ImmutableList.of()))
+                  .addAll(declaredClasspathEntries)
+                  .build(),
+              outputDirectory,
+              workingDirectory,
+              pathToSrcsList,
+              usedClassesFileWriter,
+              steps,
+              buildableContext);
+    }
+  }
+
+  @Override
+  protected Optional<String> getBootClasspath(BuildContext context) {
+    JavacOptions buildTimeOptions = amender.amend(javacOptions, context);
+    return buildTimeOptions.getBootclasspath();
   }
 
   @Override

--- a/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
+++ b/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
@@ -635,10 +635,11 @@ public class KnownBuildRuleTypes {
     builder.register(new JsBundleDescription());
     builder.register(new JsLibraryDescription());
     builder.register(new KeystoreDescription());
-    builder.register(new KotlinLibraryDescription(kotlinBuckConfig));
+    builder.register(new KotlinLibraryDescription(kotlinBuckConfig, javaConfig, defaultJavacOptions));
     builder.register(
         new KotlinTestDescription(
             kotlinBuckConfig,
+            javaConfig,
             defaultJavaOptionsForTests,
             defaultJavacOptions,
             defaultTestRuleTimeoutMs));

--- a/test/com/facebook/buck/android/AndroidLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/android/AndroidLibraryIntegrationTest.java
@@ -27,6 +27,7 @@ import com.facebook.buck.testutil.integration.TestDataHelper;
 import com.facebook.buck.util.HumanReadableException;
 import java.io.IOException;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -71,6 +72,15 @@ public class AndroidLibraryIntegrationTest extends AbiCompilationModeTest {
     KotlinTestAssumptions.assumeCompilerAvailable(workspace.asCell().getBuckConfig());
     ProcessResult result =
         workspace.runBuckBuild("//kotlin/com/sample/lib:lib_depending_on_main_lib");
+    result.assertSuccess();
+  }
+
+  @Test @Ignore("https://github.com/facebook/buck/issues/1371")
+  public void testAndroidKotlinLibraryMixedSourcesCompilation() throws Exception {
+    AssumeAndroidPlatform.assumeSdkIsAvailable();
+    KotlinTestAssumptions.assumeCompilerAvailable(workspace.asCell().getBuckConfig());
+    ProcessResult result =
+        workspace.runBuckBuild("//kotlin/com/sample/lib:lib_mixed_sources");
     result.assertSuccess();
   }
 

--- a/test/com/facebook/buck/android/testdata/android_project/kotlin/com/sample/lib/BUCK.fixture
+++ b/test/com/facebook/buck/android/testdata/android_project/kotlin/com/sample/lib/BUCK.fixture
@@ -1,6 +1,6 @@
 android_library(
   name = 'lib',
-  srcs = glob(['*.kt']),
+  srcs = glob(['Activity.kt', 'Sample.kt', 'Sample2.kt']),
   language = 'KOTLIN',
   deps = [
     '//res/com/sample/title:title',
@@ -14,7 +14,7 @@ android_library(
 
 android_library(
   name = 'lib_using_transitive_empty_res',
-  srcs = glob(['*.kt']),
+  srcs = glob(['Activity.kt', 'Sample.kt', 'Sample2.kt']),
   language = 'KOTLIN',
   deps = [
     '//res/com/sample/empty_res:empty_res',
@@ -29,6 +29,15 @@ android_library(
   deps = [
     ':lib',
   ],
+  visibility = [
+    'PUBLIC',
+  ],
+)
+
+android_library(
+  name = 'lib_mixed_sources',
+  srcs = glob(['*.kt', 'JavaClass.java']),
+  language = 'KOTLIN',
   visibility = [
     'PUBLIC',
   ],

--- a/test/com/facebook/buck/android/testdata/android_project/kotlin/com/sample/lib/Example.kt
+++ b/test/com/facebook/buck/android/testdata/android_project/kotlin/com/sample/lib/Example.kt
@@ -1,0 +1,10 @@
+package com.sample.lib
+
+fun main(args: Array<String>) {
+    println("Hello, world")
+    JavaClass()
+}
+
+fun out(num1: Int) : Float {
+    return num1 / .66f
+}

--- a/test/com/facebook/buck/android/testdata/android_project/kotlin/com/sample/lib/JavaClass.java
+++ b/test/com/facebook/buck/android/testdata/android_project/kotlin/com/sample/lib/JavaClass.java
@@ -1,0 +1,7 @@
+package com.sample.lib;
+
+class JavaClass {
+  void foo() {
+    ExampleKt.out(1)
+  }
+}

--- a/test/com/facebook/buck/jvm/kotlin/FauxKotlinLibraryBuilder.java
+++ b/test/com/facebook/buck/jvm/kotlin/FauxKotlinLibraryBuilder.java
@@ -33,9 +33,9 @@ public class FauxKotlinLibraryBuilder
 
   private final ProjectFilesystem projectFilesystem;
 
-  protected FauxKotlinLibraryBuilder(
+  private FauxKotlinLibraryBuilder(
       BuildTarget target, ProjectFilesystem projectFilesystem, HashCode hashCode) {
-    super(new KotlinLibraryDescription(null), target, projectFilesystem, hashCode);
+    super(new KotlinLibraryDescription(null, null, null), target, projectFilesystem, hashCode);
     this.projectFilesystem = projectFilesystem;
   }
 

--- a/test/com/facebook/buck/jvm/kotlin/KotlinLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/kotlin/KotlinLibraryIntegrationTest.java
@@ -23,6 +23,7 @@ import com.facebook.buck.testutil.integration.TestDataHelper;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -62,5 +63,12 @@ public class KotlinLibraryIntegrationTest {
     ProjectWorkspace.ProcessResult buildResult =
         workspace.runBuckCommand("build", "//com/example/bad:fail");
     buildResult.assertFailure();
+  }
+
+  @Test @Ignore("https://github.com/facebook/buck/issues/1371")
+  public void shouldCompileMixedJavaAndKotlinSources() throws Exception {
+    ProjectWorkspace.ProcessResult buildResult =
+        workspace.runBuckCommand("build", "//com/example/mixed:example");
+    buildResult.assertSuccess("Build should have succeeded.");
   }
 }

--- a/test/com/facebook/buck/jvm/kotlin/KotlinTestAssumptions.java
+++ b/test/com/facebook/buck/jvm/kotlin/KotlinTestAssumptions.java
@@ -23,6 +23,7 @@ import com.facebook.buck.cli.BuckConfig;
 import com.facebook.buck.cli.FakeBuckConfig;
 import com.facebook.buck.util.HumanReadableException;
 import com.facebook.buck.util.environment.Platform;
+
 import java.io.IOException;
 import javax.annotation.Nullable;
 

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/mixed/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/mixed/BUCK.fixture
@@ -1,0 +1,7 @@
+kotlin_library(
+  name = 'example',
+  srcs = ['Example.kt', 'JavaClass.java'],
+  visibility = [
+    'PUBLIC',
+  ]
+)

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/mixed/Example.kt
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/mixed/Example.kt
@@ -1,0 +1,10 @@
+package com.example.mixed
+
+fun main(args: Array<String>) {
+    println("Hello, world")
+    JavaClass()
+}
+
+fun out(num1: Int) : Float {
+    return num1 / .66f
+}

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/mixed/JavaClass.java
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/mixed/JavaClass.java
@@ -1,0 +1,7 @@
+package com.example.mixed;
+
+class JavaClass {
+  void foo() {
+    ExampleKt.out(1)
+  }
+}


### PR DESCRIPTION
This adds a javac step to the KotlincToJarStepFactory.
If any java files are found it will invoke javac, otherwise it won't do
anything.

This also adds java annotations processors to kotlin library rules.

This also fixes an issue where the bootclasspath was not being set properly for kotlin rules.

For now, this only works if the java annotation processors do not reference
kotlin code and the kotlin code does not rely on annotation processors.

This fixes #1037 

This probably isn't ready to merge yet until a stable version of kotlinc has support for passing java files directly to it. Currently you can use `1.1.3-eap-68` or newer to test this out.