### PR TITLE
Fix nailgun test on Windows on AppVeyor

### DIFF
--- a/third-party/nailgun/pynailgun/test_ng.py
+++ b/third-party/nailgun/pynailgun/test_ng.py
@@ -92,7 +92,7 @@ class TestNailgunConnection(unittest.TestCase):
         self.assertIsNone(self.ng_server_process.poll())
 
         # Give Java some time to create the listening socket.
-        for i in range(0, 300):
+        for i in range(0, 600):
             if not transport_exists(self.transport_file):
                 time.sleep(0.01)
 


### PR DESCRIPTION
This test failed on the commit that introduced the test (https://github.com/facebook/buck/commit/5a79d2aeb14c87c1de8b8d17aee8f90009cfe76d) but passed on a subsequent commit (https://ci.appveyor.com/project/Facebook/buck/build/3554). It appears waiting for 3 seconds is not enough on AppVeyor (maybe due to noisy neighbors?), so let's double it.