### PR TITLE
Increase JVM startup timeout in nailgun python test.

### DIFF
--- a/third-party/nailgun/pynailgun/test_ng.py
+++ b/third-party/nailgun/pynailgun/test_ng.py
@@ -92,9 +92,9 @@ class TestNailgunConnection(unittest.TestCase):
         self.assertIsNone(self.ng_server_process.poll())
 
         # Give Java some time to create the listening socket.
-        for i in range(0, 300):
+        for i in range(0, 600):
             if not transport_exists(self.transport_file):
-                time.sleep(0.01)
+                time.sleep(0.1)
 
         self.assertTrue(transport_exists(self.transport_file))
 


### PR DESCRIPTION
Let's try a more drastic number.

Closes: #1364