### PR TITLE
Turn off msbuild integration for appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,8 @@ install:
   - cmd: python --version
   - cmd: java -version
   - cmd: ant -version
-
+  
+build: off
 
 build_script:
   - "bin\\buck build buck"


### PR DESCRIPTION
This was potentially the cause of `Specify a project or solution file. The directory does not contain a project or solution file.`

See:

* http://help.appveyor.com/discussions/problems/4585-specify-a-project-or-solution-file-the-directory-does-not-contain-a-project-or-solution-file

Other possible causes are a webhook failing:
* http://help.appveyor.com/discussions/problems/4294-all-builds-say-specify-a-project-or-solution-file-the-directory-does-not-contain-a-project-or-solution-file