### PR TITLE
Use JvmLibraryArg instead of AndroidLibraryDescriptionArg.

### DIFF
--- a/src/com/facebook/buck/android/AndroidLibraryCompiler.java
+++ b/src/com/facebook/buck/android/AndroidLibraryCompiler.java
@@ -19,6 +19,7 @@ package com.facebook.buck.android;
 import com.facebook.buck.android.AndroidLibraryDescription.JvmLanguage;
 import com.facebook.buck.jvm.java.CompileToJarStepFactory;
 import com.facebook.buck.jvm.java.JavacOptions;
+import com.facebook.buck.jvm.java.JvmLibraryArg;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.rules.BuildContext;
 import com.facebook.buck.rules.BuildRuleResolver;
@@ -34,13 +35,13 @@ import java.nio.file.Path;
  * different compilers for different {@link JvmLanguage}.
  */
 public abstract class AndroidLibraryCompiler
-    implements ImplicitDepsInferringDescription<AndroidLibraryDescription.CoreArg> {
+    implements ImplicitDepsInferringDescription<JvmLibraryArg> {
 
   public static final Function<BuildContext, Iterable<Path>> ANDROID_CLASSPATH_FROM_CONTEXT =
       context -> context.getAndroidPlatformTargetSupplier().get().getBootclasspathEntries();
 
   public abstract CompileToJarStepFactory compileToJar(
-      AndroidLibraryDescription.CoreArg args,
+      JvmLibraryArg args,
       JavacOptions javacOptions,
       BuildRuleResolver resolver);
 
@@ -52,7 +53,7 @@ public abstract class AndroidLibraryCompiler
   public void findDepsForTargetFromConstructorArgs(
       BuildTarget buildTarget,
       CellPathResolver cellRoots,
-      AndroidLibraryDescription.CoreArg constructorArg,
+      JvmLibraryArg constructorArg,
       ImmutableCollection.Builder<BuildTarget> extraDepsBuilder,
       ImmutableCollection.Builder<BuildTarget> targetGraphOnlyDepsBuilder) {}
 }

--- a/src/com/facebook/buck/android/JavaAndroidLibraryCompiler.java
+++ b/src/com/facebook/buck/android/JavaAndroidLibraryCompiler.java
@@ -22,6 +22,7 @@ import com.facebook.buck.jvm.java.Javac;
 import com.facebook.buck.jvm.java.JavacFactory;
 import com.facebook.buck.jvm.java.JavacOptions;
 import com.facebook.buck.jvm.java.JavacToJarStepFactory;
+import com.facebook.buck.jvm.java.JvmLibraryArg;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.SourcePathRuleFinder;
 
@@ -34,7 +35,7 @@ public class JavaAndroidLibraryCompiler extends AndroidLibraryCompiler {
 
   @Override
   public CompileToJarStepFactory compileToJar(
-      AndroidLibraryDescription.CoreArg arg,
+      JvmLibraryArg arg,
       JavacOptions javacOptions,
       BuildRuleResolver resolver) {
 
@@ -42,7 +43,7 @@ public class JavaAndroidLibraryCompiler extends AndroidLibraryCompiler {
         getJavac(resolver, arg), javacOptions, new BootClasspathAppender());
   }
 
-  private Javac getJavac(BuildRuleResolver resolver, AndroidLibraryDescription.CoreArg arg) {
+  private Javac getJavac(BuildRuleResolver resolver, JvmLibraryArg arg) {
     return JavacFactory.create(new SourcePathRuleFinder(resolver), javaBuckConfig, arg);
   }
 }

--- a/src/com/facebook/buck/android/KotlinAndroidLibraryCompiler.java
+++ b/src/com/facebook/buck/android/KotlinAndroidLibraryCompiler.java
@@ -18,6 +18,7 @@ package com.facebook.buck.android;
 
 import com.facebook.buck.jvm.java.CompileToJarStepFactory;
 import com.facebook.buck.jvm.java.JavacOptions;
+import com.facebook.buck.jvm.java.JvmLibraryArg;
 import com.facebook.buck.jvm.kotlin.KotlinBuckConfig;
 import com.facebook.buck.jvm.kotlin.KotlincToJarStepFactory;
 import com.facebook.buck.rules.BuildRuleResolver;
@@ -39,7 +40,7 @@ public class KotlinAndroidLibraryCompiler extends AndroidLibraryCompiler {
 
   @Override
   public CompileToJarStepFactory compileToJar(
-      AndroidLibraryDescription.CoreArg args,
+      JvmLibraryArg args,
       JavacOptions javacOptions,
       BuildRuleResolver resolver) {
     return new KotlincToJarStepFactory(

--- a/src/com/facebook/buck/android/ScalaAndroidLibraryCompiler.java
+++ b/src/com/facebook/buck/android/ScalaAndroidLibraryCompiler.java
@@ -18,6 +18,7 @@ package com.facebook.buck.android;
 
 import com.facebook.buck.jvm.java.CompileToJarStepFactory;
 import com.facebook.buck.jvm.java.JavacOptions;
+import com.facebook.buck.jvm.java.JvmLibraryArg;
 import com.facebook.buck.jvm.scala.ScalaBuckConfig;
 import com.facebook.buck.jvm.scala.ScalacToJarStepFactory;
 import com.facebook.buck.model.BuildTarget;
@@ -50,7 +51,7 @@ public class ScalaAndroidLibraryCompiler extends AndroidLibraryCompiler {
 
   @Override
   public CompileToJarStepFactory compileToJar(
-      AndroidLibraryDescription.CoreArg arg,
+      JvmLibraryArg arg,
       JavacOptions javacOptions,
       BuildRuleResolver resolver) {
 
@@ -67,7 +68,7 @@ public class ScalaAndroidLibraryCompiler extends AndroidLibraryCompiler {
   public void findDepsForTargetFromConstructorArgs(
       BuildTarget buildTarget,
       CellPathResolver cellRoots,
-      AndroidLibraryDescription.CoreArg constructorArg,
+      JvmLibraryArg constructorArg,
       ImmutableCollection.Builder<BuildTarget> extraDepsBuilder,
       ImmutableCollection.Builder<BuildTarget> targetGraphOnlyDepsBuilder) {
 


### PR DESCRIPTION
Prefer abstractions over concrete implementations.

This makes it easier to re-use the AndroidLibraryCompiler in other
places like RobolectricTest.

https://github.com/facebook/buck/issues/1349