### PR TITLE
Fix aapt2_compile across cells

### DIFF
--- a/src/com/facebook/buck/android/Aapt2Compile.java
+++ b/src/com/facebook/buck/android/Aapt2Compile.java
@@ -57,8 +57,7 @@ public class Aapt2Compile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
     steps.add(
         new Aapt2CompileStep(
             getProjectFilesystem().getRootPath(),
-            getProjectFilesystem().relativize(context
-                .getSourcePathResolver().getAbsolutePath(resDir)),
+            context.getSourcePathResolver().getAbsolutePath(resDir),
             getOutputPath()));
     steps.add(ZipScrubberStep.of(getProjectFilesystem().resolve(getOutputPath())));
     buildableContext.recordArtifact(getOutputPath());

--- a/src/com/facebook/buck/android/Aapt2Compile.java
+++ b/src/com/facebook/buck/android/Aapt2Compile.java
@@ -57,7 +57,8 @@ public class Aapt2Compile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
     steps.add(
         new Aapt2CompileStep(
             getProjectFilesystem().getRootPath(),
-            context.getSourcePathResolver().getRelativePath(resDir),
+            getProjectFilesystem().relativize(context
+                .getSourcePathResolver().getAbsolutePath(resDir)),
             getOutputPath()));
     steps.add(ZipScrubberStep.of(getProjectFilesystem().resolve(getOutputPath())));
     buildableContext.recordArtifact(getOutputPath());


### PR DESCRIPTION
When referencing resources in a different cell, aapt2 compile used to fail with "No such file or directory" because it would search within the `buck-out` folder of the current cell. This fixes that with the same methodology seen in https://github.com/facebook/buck/commit/e803c7f082

I'm not sure if this is the proper way to do this but my testing showed that it worked as expected with this change.

cc @dreiss 