### PR TITLE
Make kotlinc always compile against full jars instead of abi

### DIFF
--- a/src/com/facebook/buck/jvm/kotlin/KotlinLibraryBuilder.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinLibraryBuilder.java
@@ -43,6 +43,7 @@ public class KotlinLibraryBuilder extends DefaultJavaLibraryBuilder {
       JavaBuckConfig javaBuckConfig) {
     super(targetGraph, params, buildRuleResolver, cellRoots, javaBuckConfig);
     this.kotlinBuckConfig = kotlinBuckConfig;
+    setCompileAgainstAbis(false);
   }
 
   @Override


### PR DESCRIPTION
Workaround for #1386