### PR TITLE
Fix exopackage installer timeout issues

### DIFF
--- a/src/com/facebook/buck/android/exopackage/RealExopackageDevice.java
+++ b/src/com/facebook/buck/android/exopackage/RealExopackageDevice.java
@@ -229,7 +229,7 @@ public class RealExopackageDevice implements ExopackageDevice {
               if (!startedPayload && getOutput().length() >= AgentUtil.TEXT_SECRET_KEY_SIZE) {
                 LOG.verbose("Got key: %s", getOutput().split("[\\r\\n]", 1)[0]);
                 startedPayload = true;
-                Socket clientSocket = new Socket("localhost", agentPort);
+                Socket clientSocket = new Socket("127.0.0.1", agentPort);
                 closer.register(clientSocket);
                 LOG.verbose("Connected");
                 outToDevice = clientSocket.getOutputStream();


### PR DESCRIPTION
Fixes #1374, #1369

It seems latest versions of adb in platform tools switched to use `localhost` instead of hardcoded `127.0.0.1` to ipv6 compatibility. However this makes ports forwarded via `adb forward` unavailable for anyone trying to connect via `localhost` if they are on a VPN.

This workaround changes the hardcoded usage of `localhost` to be set to `127.0.0.1` for exopackage installs to proceed correctly.

Note: This is the only hardcoded usage of `localhost` in src/com/facebook/buck/android`