### PR TITLE
Fix cache key inconsistency in kotlin library rules

### DIFF
--- a/src/com/facebook/buck/cli/BuckConfig.java
+++ b/src/com/facebook/buck/cli/BuckConfig.java
@@ -355,6 +355,18 @@ public class BuckConfig implements ConfigPathGetter {
   }
 
   /**
+   * @return a {@link SourcePath} identified by a {@link Path}.
+   */
+  public SourcePath getSourcePath(Path path) {
+    if (path == null) {
+      return null;
+    }
+    return new PathSourcePath(
+            projectFilesystem,
+            checkPathExists(path.toString(),"path not found: "));
+  }
+
+  /**
    * @return a {@link Tool} identified by a @{link BuildTarget} or {@link Path} reference by the
    *     given section:field, if set.
    */

--- a/src/com/facebook/buck/jvm/kotlin/KotlinBuckConfig.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinBuckConfig.java
@@ -18,6 +18,7 @@ package com.facebook.buck.jvm.kotlin;
 
 import com.facebook.buck.cli.BuckConfig;
 import com.facebook.buck.io.ExecutableFinder;
+import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.util.HumanReadableException;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
@@ -43,8 +44,9 @@ public class KotlinBuckConfig {
     if (isExternalCompilation()) {
       return new ExternalKotlinc(getPathToCompilerBinary());
     } else {
-      ImmutableSet<Path> classpathEntries =
-          ImmutableSet.of(getPathToStdlibJar(), getPathToCompilerJar());
+      ImmutableSet<SourcePath> classpathEntries =
+          ImmutableSet.of(delegate.getSourcePath(getPathToStdlibJar()),
+              delegate.getSourcePath(getPathToCompilerJar()));
 
       return new JarBackedReflectedKotlinc(classpathEntries);
     }


### PR DESCRIPTION
Fixes #1392

Verified the rulekeys and target hashes are the same after this fix on two copies of the same codebase

Also verified that kotlin library rules can still build