### PR TITLE
Fix groovy cross compile with empty options

### DIFF
--- a/src/com/facebook/buck/jvm/groovy/GroovycStep.java
+++ b/src/com/facebook/buck/jvm/groovy/GroovycStep.java
@@ -31,6 +31,7 @@ import com.facebook.buck.step.StepExecutionResult;
 import com.facebook.buck.util.ProcessExecutor;
 import com.facebook.buck.util.ProcessExecutorParams;
 import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
@@ -144,7 +145,9 @@ class GroovycStep implements Step {
               if (option.equals("sourcepath")) {
                 return;
               }
-              command.add("-J" + String.format("%s=%s", option, value));
+              if (!Strings.isNullOrEmpty(value)) {
+                command.add("-J" + String.format("%s=%s", option, value));
+              }
             }
 
             @Override


### PR DESCRIPTION
When there are annotation processor deps but no annotation processors, the groovy cross compile step fails with

```
stderr: org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
Compile error during compilation with javac.
warning: [options] bootstrap class path not set in conjunction with -source 1.7
error: Annotation processor '' not found
1 error
1 warning
```

This changes the behavior by only adding a cross compile option if it is non empty