### PR TITLE
Add kotlin support to robolectric_test rules

### DIFF
--- a/src/com/facebook/buck/android/RobolectricTestDescription.java
+++ b/src/com/facebook/buck/android/RobolectricTestDescription.java
@@ -73,18 +73,21 @@ public class RobolectricTestDescription
   private final JavacOptions templateOptions;
   private final Optional<Long> defaultTestRuleTimeoutMs;
   private final CxxPlatform cxxPlatform;
+  private final AndroidLibraryCompilerFactory compilerFactory;
 
   public RobolectricTestDescription(
       JavaBuckConfig javaBuckConfig,
       JavaOptions javaOptions,
       JavacOptions templateOptions,
       Optional<Long> defaultTestRuleTimeoutMs,
-      CxxPlatform cxxPlatform) {
+      CxxPlatform cxxPlatform,
+      AndroidLibraryCompilerFactory compilerFactory) {
     this.javaBuckConfig = javaBuckConfig;
     this.javaOptions = javaOptions;
     this.templateOptions = templateOptions;
     this.defaultTestRuleTimeoutMs = defaultTestRuleTimeoutMs;
     this.cxxPlatform = cxxPlatform;
+    this.compilerFactory = compilerFactory;
   }
 
   @Override
@@ -173,6 +176,9 @@ public class RobolectricTestDescription
                     cellRoots,
                     javaBuckConfig)
                 .setArgs(args)
+                .setCompileStepFactory(compilerFactory.getCompiler(
+                    args.getLanguage().orElse(AndroidLibraryDescription.JvmLanguage.JAVA))
+                  .compileToJar(args, Preconditions.checkNotNull(javacOptions), resolver))
                 .setJavacOptions(javacOptions)
                 .setJavacOptionsAmender(new BootClasspathAppender())
                 .setTrackClassUsage(javacOptions.trackClassUsage())
@@ -227,6 +233,8 @@ public class RobolectricTestDescription
     Optional<String> getRobolectricRuntimeDependency();
 
     Optional<SourcePath> getRobolectricManifest();
+
+    Optional<AndroidLibraryDescription.JvmLanguage> getLanguage();
 
     @Value.Default
     default boolean isUseOldStyleableFormat() {

--- a/src/com/facebook/buck/jvm/java/DefaultJavaLibraryBuilder.java
+++ b/src/com/facebook/buck/jvm/java/DefaultJavaLibraryBuilder.java
@@ -73,6 +73,7 @@ public class DefaultJavaLibraryBuilder {
   protected boolean sourceAbisAllowed = true;
   @Nullable protected JavacOptions javacOptions = null;
   @Nullable private JavaLibraryDescription.CoreArg args = null;
+  @Nullable private CompileToJarStepFactory compileStepFactory;
 
   protected DefaultJavaLibraryBuilder(
       TargetGraph targetGraph,
@@ -214,6 +215,12 @@ public class DefaultJavaLibraryBuilder {
     return this;
   }
 
+  public DefaultJavaLibraryBuilder setCompileStepFactory(
+      @Nullable CompileToJarStepFactory compileStepFactory) {
+    this.compileStepFactory = compileStepFactory;
+    return this;
+  }
+
   protected DefaultJavaLibraryBuilder setCompileAgainstAbis(boolean compileAgainstAbis) {
     this.compileAgainstAbis = compileAgainstAbis;
     return this;
@@ -239,7 +246,6 @@ public class DefaultJavaLibraryBuilder {
     @Nullable private ImmutableSortedSet<BuildRule> compileTimeClasspathFullDeps;
     @Nullable private ImmutableSortedSet<BuildRule> compileTimeClasspathAbiDeps;
     @Nullable private ZipArchiveDependencySupplier abiClasspath;
-    @Nullable private CompileToJarStepFactory compileStepFactory;
     @Nullable private JarBuildStepsFactory jarBuildStepsFactory;
     @Nullable private BuildTarget abiJar;
 

--- a/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
+++ b/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
@@ -24,6 +24,7 @@ import com.facebook.buck.android.AndroidBuildConfigDescription;
 import com.facebook.buck.android.AndroidDirectoryResolver;
 import com.facebook.buck.android.AndroidInstrumentationApkDescription;
 import com.facebook.buck.android.AndroidInstrumentationTestDescription;
+import com.facebook.buck.android.AndroidLibraryCompilerFactory;
 import com.facebook.buck.android.AndroidLibraryDescription;
 import com.facebook.buck.android.AndroidManifestDescription;
 import com.facebook.buck.android.AndroidPrebuiltAarDescription;
@@ -522,6 +523,9 @@ public class KnownBuildRuleTypes {
                             .orElse(SmartDexingStep.determineOptimalThreadCount())),
                 new CommandThreadFactory("SmartDexing")));
 
+    AndroidLibraryCompilerFactory defaultAndroidCompilerFactory =
+        new DefaultAndroidLibraryCompilerFactory(javaConfig, scalaConfig, kotlinBuckConfig);
+
     builder.register(
         new AndroidAarDescription(
             new AndroidManifestDescription(),
@@ -557,7 +561,7 @@ public class KnownBuildRuleTypes {
         new AndroidLibraryDescription(
             javaConfig,
             defaultJavacOptions,
-            new DefaultAndroidLibraryCompilerFactory(javaConfig, scalaConfig, kotlinBuckConfig)));
+            defaultAndroidCompilerFactory));
     builder.register(new AndroidManifestDescription());
     builder.register(new AndroidPrebuiltAarDescription(javaConfig, defaultJavacOptions));
     builder.register(new AndroidReactNativeLibraryDescription(reactNativeBuckConfig));
@@ -686,7 +690,8 @@ public class KnownBuildRuleTypes {
             defaultJavaOptionsForTests,
             defaultJavacOptions,
             defaultTestRuleTimeoutMs,
-            defaultCxxPlatform));
+            defaultCxxPlatform,
+            defaultAndroidCompilerFactory));
     builder.register(new RustBinaryDescription(rustBuckConfig, cxxPlatforms, defaultCxxPlatform));
     builder.register(new RustLibraryDescription(rustBuckConfig, cxxPlatforms, defaultCxxPlatform));
     builder.register(new RustTestDescription(rustBuckConfig, cxxPlatforms, defaultCxxPlatform));

--- a/test/com/facebook/buck/android/RobolectricTestBuilder.java
+++ b/test/com/facebook/buck/android/RobolectricTestBuilder.java
@@ -20,8 +20,11 @@ import static com.facebook.buck.jvm.java.JavaCompilationConstants.ANDROID_JAVAC_
 import static com.facebook.buck.jvm.java.JavaCompilationConstants.DEFAULT_JAVA_CONFIG;
 import static com.facebook.buck.jvm.java.JavaCompilationConstants.DEFAULT_JAVA_OPTIONS;
 
+import com.facebook.buck.cli.FakeBuckConfig;
 import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.jvm.java.JavaBuckConfig;
+import com.facebook.buck.jvm.kotlin.KotlinBuckConfig;
+import com.facebook.buck.jvm.scala.ScalaBuckConfig;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.rules.AbstractNodeBuilder;
 import java.util.Optional;
@@ -31,6 +34,11 @@ public class RobolectricTestBuilder
         RobolectricTestDescriptionArg.Builder, RobolectricTestDescriptionArg,
         RobolectricTestDescription, RobolectricTest> {
 
+  public static final AndroidLibraryCompilerFactory DEFAULT_ANDROID_COMPILER_FACTORY =
+      new DefaultAndroidLibraryCompilerFactory(DEFAULT_JAVA_CONFIG,
+          new ScalaBuckConfig(FakeBuckConfig.builder().build()),
+          new KotlinBuckConfig(FakeBuckConfig.builder().build()));
+
   private RobolectricTestBuilder(BuildTarget target, JavaBuckConfig javaBuckConfig) {
     super(
         new RobolectricTestDescription(
@@ -38,7 +46,8 @@ public class RobolectricTestBuilder
             DEFAULT_JAVA_OPTIONS,
             ANDROID_JAVAC_OPTIONS,
             /* testRuleTimeoutMs */ Optional.empty(),
-            null),
+            null,
+            DEFAULT_ANDROID_COMPILER_FACTORY),
         target);
   }
 
@@ -49,7 +58,8 @@ public class RobolectricTestBuilder
             DEFAULT_JAVA_OPTIONS,
             ANDROID_JAVAC_OPTIONS,
             /* testRuleTimeoutMs */ Optional.empty(),
-            null),
+            null,
+            DEFAULT_ANDROID_COMPILER_FACTORY),
         target,
         filesystem);
   }

--- a/test/com/facebook/buck/android/testdata/android_project/kotlin/com/sample/lib/BUCK.fixture
+++ b/test/com/facebook/buck/android/testdata/android_project/kotlin/com/sample/lib/BUCK.fixture
@@ -42,3 +42,26 @@ android_library(
     'PUBLIC',
   ],
 )
+
+robolectric_test(
+  name = 'test',
+  srcs = glob(['Activity.kt', 'Sample.kt', 'Sample2.kt']),
+  language = 'KOTLIN',
+  deps = [
+    '//res/com/sample/title:title',
+    '//res/com/sample/top:top',
+    '//res/com/sample/asset_only:asset_only',
+  ],
+  visibility = [
+    'PUBLIC',
+  ],
+)
+
+robolectric_test(
+  name = 'test_mixed_sources',
+  srcs = glob(['*.kt', 'JavaClass.java']),
+  language = 'KOTLIN',
+  visibility = [
+    'PUBLIC',
+  ],
+)


### PR DESCRIPTION
This adds a `language` parameter to `robolectric_test` rules that allows one to use kotlin (and java mixed if needed) to write their robolectric tests.

Fixes #1349