### PR TITLE
Fix split_zip step exception

### DIFF
--- a/src/com/facebook/buck/android/APKModuleGraph.java
+++ b/src/com/facebook/buck/android/APKModuleGraph.java
@@ -35,6 +35,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -211,7 +212,7 @@ public class APKModuleGraph {
       final Function<String, String> translatorFunction,
       final ProjectFilesystem filesystem)
       throws IOException {
-    final ImmutableMultimap.Builder<APKModule, String> builder = ImmutableMultimap.builder();
+    final ImmutableMultimap.Builder<APKModule, String> builder = ImmutableSetMultimap.builder();
     if (!apkModuleToJarPathMap.isEmpty()) {
       for (final APKModule dexStore : apkModuleToJarPathMap.keySet()) {
         for (Path jarFilePath : apkModuleToJarPathMap.get(dexStore)) {


### PR DESCRIPTION
I am trying out release builds with buck and am seeing a weird issue during proguard.
Without obfuscation, everything works fine and dandy. With obfuscation, I see stuff like

 ```failed on step split_zip with an exception:
classpath android/support/v7/widget/ListPopupWindow$1 is contained in multiple dex stores:
```
It is usually some layout's anonymous inner classes.

Upon debugging further it seems like there are duplicate entries in the list of dex stores that cause the exception to be thrown unnecessarily.

<img width="905" alt="screen shot 2017-07-10 at 10 55 48 pm" src="https://user-images.githubusercontent.com/291148/28053763-04d669c8-65c7-11e7-8203-4ee9e3bc05da.png">

This change removes the source of the duplication without affecting the check. Verified that the `split_zip` step works correctly after this change when proguard obfuscation is enabled for a test build