### PR TITLE
Add res folder to library IML files for Android AARs

### DIFF
--- a/src/com/facebook/buck/android/UnzipAar.java
+++ b/src/com/facebook/buck/android/UnzipAar.java
@@ -52,6 +52,7 @@ import java.util.Optional;
 public class UnzipAar extends AbstractBuildRuleWithDeclaredAndExtraDeps
     implements InitializableFromDisk<UnzipAar.BuildOutput> {
 
+  private static final String AAR_UNZIP_PATH_FORMAT = "__unpack_%s__";
   private static final String METADATA_KEY_FOR_R_DOT_JAVA_PACKAGE = "R_DOT_JAVA_PACKAGE";
 
   @AddToRuleKey private final SourcePath aarFile;
@@ -70,7 +71,7 @@ public class UnzipAar extends AbstractBuildRuleWithDeclaredAndExtraDeps
     super(buildTarget, projectFilesystem, buildRuleParams);
     this.aarFile = aarFile;
     this.unpackDirectory =
-        BuildTargets.getScratchPath(getProjectFilesystem(), buildTarget, "__unpack_%s__");
+        BuildTargets.getScratchPath(getProjectFilesystem(), buildTarget, AAR_UNZIP_PATH_FORMAT);
     this.uberClassesJar =
         BuildTargets.getScratchPath(
             getProjectFilesystem(), buildTarget, "__uber_classes_%s__/classes.jar");
@@ -203,6 +204,10 @@ public class UnzipAar extends AbstractBuildRuleWithDeclaredAndExtraDeps
 
   public Path getPathToRDotJavaPackageFile() {
     return pathToRDotJavaPackageFile;
+  }
+
+  public static String getAarUnzipPathFormat() {
+    return AAR_UNZIP_PATH_FORMAT;
   }
 
   static class BuildOutput {

--- a/src/com/facebook/buck/ide/intellij/DefaultIjLibraryFactory.java
+++ b/src/com/facebook/buck/ide/intellij/DefaultIjLibraryFactory.java
@@ -18,17 +18,20 @@ package com.facebook.buck.ide.intellij;
 
 import com.facebook.buck.android.AndroidPrebuiltAarDescription;
 import com.facebook.buck.android.AndroidPrebuiltAarDescriptionArg;
+import com.facebook.buck.android.UnzipAar;
 import com.facebook.buck.ide.intellij.model.IjLibrary;
 import com.facebook.buck.ide.intellij.model.IjLibraryFactory;
 import com.facebook.buck.ide.intellij.model.IjLibraryFactoryResolver;
 import com.facebook.buck.jvm.java.PrebuiltJarDescription;
 import com.facebook.buck.jvm.java.PrebuiltJarDescriptionArg;
+import com.facebook.buck.model.BuildTargets;
 import com.facebook.buck.rules.Description;
 import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.TargetNode;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -154,6 +157,18 @@ class DefaultIjLibraryFactory extends IjLibraryFactory {
           .ifPresent(
               sourcePath -> library.addSourceJars(libraryFactoryResolver.getPath(sourcePath)));
       arg.getJavadocUrl().ifPresent(library::addJavadocUrls);
+
+      Path aarUnpackPath =
+          BuildTargets.getScratchPath(
+              targetNode.getFilesystem(),
+              targetNode
+                  .getBuildTarget()
+                  .withFlavors(AndroidPrebuiltAarDescription.AAR_UNZIP_FLAVOR),
+              UnzipAar.getAarUnzipPathFormat());
+
+      // Based on https://developer.android.com/studio/projects/android-library.html#aar-contents,
+      // the AAR library is required to have a resources folder.
+      library.addClassPaths(Paths.get(aarUnpackPath.toString(), "res"));
     }
   }
 

--- a/src/com/facebook/buck/ide/intellij/model/AbstractIjLibrary.java
+++ b/src/com/facebook/buck/ide/intellij/model/AbstractIjLibrary.java
@@ -48,7 +48,12 @@ abstract class AbstractIjLibrary implements IjProjectElement {
 
   @Value.Check
   protected void eitherBinaryJarOrClassPathPresent() {
-    Preconditions.checkArgument(!getBinaryJars().isEmpty() ^ !getClassPaths().isEmpty());
+    // IntelliJ library should have a binary jar or classpath, but we also allow it to have an
+    // optional res folder so that resources can be loaded properly.
+    boolean hasClasspathsWithoutRes =
+        getClassPaths().stream().anyMatch(input -> !input.endsWith("res"));
+
+    Preconditions.checkArgument(!getBinaryJars().isEmpty() ^ hasClasspathsWithoutRes);
   }
 
   @Override

--- a/test/com/facebook/buck/ide/intellij/DefaultIjLibraryFactoryTest.java
+++ b/test/com/facebook/buck/ide/intellij/DefaultIjLibraryFactoryTest.java
@@ -49,6 +49,7 @@ public class DefaultIjLibraryFactoryTest {
   private IjLibrary guavaLibrary;
   private TargetNode<?, ?> androidSupport;
   private FakeSourcePath androidSupportBinaryPath;
+  private FakeSourcePath androidSupportResClassPath;
   private IjLibrary androidSupportLibrary;
   private IjLibrary baseLibrary;
   private TargetNode<?, ?> base;
@@ -85,6 +86,9 @@ public class DefaultIjLibraryFactoryTest {
             .build();
 
     androidSupportBinaryJarPath = new FakeSourcePath("buck_out/support.aar/classes.jar");
+    androidSupportResClassPath =
+        new FakeSourcePath(
+            "buck-out/bin/third_party/java/support/__unpack_support#aar_unzip__/res");
     baseOutputPath = new FakeSourcePath("buck-out/base.jar");
 
     libraryFactoryResolver =
@@ -128,6 +132,9 @@ public class DefaultIjLibraryFactoryTest {
         androidSupportLibrary.getBinaryJars());
     assertEquals(
         ImmutableSet.of(androidSupport.getBuildTarget()), androidSupportLibrary.getTargets());
+    assertEquals(
+        ImmutableSet.of(androidSupportResClassPath.getRelativePath()),
+        androidSupportLibrary.getClassPaths());
   }
 
   @Test


### PR DESCRIPTION
This diff adds a `res` folder classpath entry to AAR library modules so that IntelliJ's Android Support's Layout Preview knows where to find resources from unpacked AARs.