### PR TITLE
Support creation of extra dependency modules for IntelliJ

### DIFF
--- a/docs/concept/buckconfig.soy
+++ b/docs/concept/buckconfig.soy
@@ -2078,8 +2078,9 @@ cxx_library(
   {param name: 'extra_compiler_output_modules_path' /}
   {param example_value: 'buck-out/extra-intellij-output' /}
   {param description}
-    This flag decides whether or not extra library modules will be generated for Android library
-    modules and specifies the root location of those extra modules.
+    This option specifies the location of additional modules for code generated outside of buck
+    graph. For example, it can be used to specify the location of R.java classes generated for
+    Android plugin to help Layout Preview with resolving references to resources.
   {/param}
 {/call}
 

--- a/docs/concept/buckconfig.soy
+++ b/docs/concept/buckconfig.soy
@@ -2073,6 +2073,16 @@ cxx_library(
   {/param}
 {/call}
 
+{call buckconfig.entry}
+  {param section: 'intellij' /}
+  {param name: 'extra_compiler_output_modules_path' /}
+  {param example_value: 'buck-out/extra-intellij-output' /}
+  {param description}
+    This flag decides whether or not extra library modules will be generated for Android library
+    modules and specifies the root location of those extra modules.
+  {/param}
+{/call}
+
 {call buckconfig.section}
   {param name: 'java' /}
   {param description}

--- a/src/com/facebook/buck/ide/intellij/DefaultIjModuleFactory.java
+++ b/src/com/facebook/buck/ide/intellij/DefaultIjModuleFactory.java
@@ -101,6 +101,7 @@ public class DefaultIjModuleFactory implements IjModuleFactory {
         .putAllDependencies(context.getDependencies())
         .setAndroidFacet(context.getAndroidFacet())
         .addAllExtraClassPathDependencies(context.getExtraClassPathDependencies())
+        .addAllExtraModuleDependencies(context.getExtraModuleDependencies())
         .addAllGeneratedSourceCodeFolders(context.getGeneratedSourceCodeFolders())
         .setLanguageLevel(context.getJavaLanguageLevel())
         .setModuleType(context.getModuleType())

--- a/src/com/facebook/buck/ide/intellij/IjModuleGraphFactory.java
+++ b/src/com/facebook/buck/ide/intellij/IjModuleGraphFactory.java
@@ -36,7 +36,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -307,7 +306,7 @@ public final class IjModuleGraphFactory {
           && !module.getExtraModuleDependencies().isEmpty()) {
         IjModule extraModule =
             createExtraModuleForCompilerOutput(
-                module, projectFilesystem, extraCompileOutputRootPath.get());
+                module, extraCompileOutputRootPath.get());
         moduleDeps.put(extraModule, DependencyType.PROD);
         depsBuilder.put(extraModule, ImmutableMap.of());
       }
@@ -329,21 +328,9 @@ public final class IjModuleGraphFactory {
 
   private static IjModule createExtraModuleForCompilerOutput(
       IjModule module,
-      ProjectFilesystem projectFilesystem,
       Path extraCompileOutputRootPath) {
-    Path extraModuleRelativePath = extraCompileOutputRootPath.resolve(module.getModuleBasePath());
-    if (!projectFilesystem.exists(extraModuleRelativePath)) {
-      try {
-        projectFilesystem.mkdirs(extraModuleRelativePath);
-      } catch (IOException e) {
-        throw new AssertionError(
-            "Could not make directories for extra module for compiler output module: "
-                + extraModuleRelativePath.toString());
-      }
-    }
-
     return IjModule.builder()
-        .setModuleBasePath(extraModuleRelativePath)
+        .setModuleBasePath(extraCompileOutputRootPath.resolve(module.getModuleBasePath()))
         .setTargets(ImmutableSet.of())
         .addAllFolders(ImmutableSet.of())
         .putAllDependencies(ImmutableMap.of())

--- a/src/com/facebook/buck/ide/intellij/IjModuleGraphFactory.java
+++ b/src/com/facebook/buck/ide/intellij/IjModuleGraphFactory.java
@@ -307,7 +307,7 @@ public final class IjModuleGraphFactory {
           && !module.getExtraModuleDependencies().isEmpty()) {
         IjModule extraModule =
             createExtraModuleForCompilerOutput(
-                module, projectConfig, projectFilesystem, extraCompileOutputRootPath.get());
+                module, projectFilesystem, extraCompileOutputRootPath.get());
         moduleDeps.put(extraModule, DependencyType.PROD);
         depsBuilder.put(extraModule, ImmutableMap.of());
       }
@@ -329,15 +329,9 @@ public final class IjModuleGraphFactory {
 
   private static IjModule createExtraModuleForCompilerOutput(
       IjModule module,
-      IjProjectConfig projectConfig,
       ProjectFilesystem projectFilesystem,
       Path extraCompileOutputRootPath) {
-    Path projectRootPath = Paths.get(projectConfig.getProjectRoot());
-    Path extraModuleBasePath =
-        Paths.get(projectRootPath.toString(), extraCompileOutputRootPath.toString())
-            .resolve(projectRootPath.relativize(module.getModuleBasePath()));
-
-    Path extraModuleRelativePath = projectRootPath.relativize(extraModuleBasePath.normalize());
+    Path extraModuleRelativePath = extraCompileOutputRootPath.resolve(module.getModuleBasePath());
     if (!projectFilesystem.exists(extraModuleRelativePath)) {
       try {
         projectFilesystem.mkdirs(extraModuleRelativePath);
@@ -349,7 +343,7 @@ public final class IjModuleGraphFactory {
     }
 
     return IjModule.builder()
-        .setModuleBasePath(extraModuleBasePath)
+        .setModuleBasePath(extraModuleRelativePath)
         .setTargets(ImmutableSet.of())
         .addAllFolders(ImmutableSet.of())
         .putAllDependencies(ImmutableMap.of())

--- a/src/com/facebook/buck/ide/intellij/IjModuleGraphFactory.java
+++ b/src/com/facebook/buck/ide/intellij/IjModuleGraphFactory.java
@@ -305,8 +305,7 @@ public final class IjModuleGraphFactory {
       if (extraCompileOutputRootPath.isPresent()
           && !module.getExtraModuleDependencies().isEmpty()) {
         IjModule extraModule =
-            createExtraModuleForCompilerOutput(
-                module, extraCompileOutputRootPath.get());
+            createExtraModuleForCompilerOutput(module, extraCompileOutputRootPath.get());
         moduleDeps.put(extraModule, DependencyType.PROD);
         depsBuilder.put(extraModule, ImmutableMap.of());
       }
@@ -327,8 +326,7 @@ public final class IjModuleGraphFactory {
   }
 
   private static IjModule createExtraModuleForCompilerOutput(
-      IjModule module,
-      Path extraCompileOutputRootPath) {
+      IjModule module, Path extraCompileOutputRootPath) {
     return IjModule.builder()
         .setModuleBasePath(extraCompileOutputRootPath.resolve(module.getModuleBasePath()))
         .setTargets(ImmutableSet.of())

--- a/src/com/facebook/buck/ide/intellij/IjProjectBuckConfig.java
+++ b/src/com/facebook/buck/ide/intellij/IjProjectBuckConfig.java
@@ -123,6 +123,9 @@ public class IjProjectBuckConfig {
                 INTELLIJ_BUCK_CONFIG_SECTION, "generate_android_manifest", false))
         .setOutputUrl(
             buckConfig.getValue(INTELLIJ_BUCK_CONFIG_SECTION, "project_compiler_output_url"))
+        .setExtraCompilerOutputModulesPath(
+            buckConfig.getPath(
+                INTELLIJ_BUCK_CONFIG_SECTION, "extra_compiler_output_modules_path", false))
         .build();
   }
 

--- a/src/com/facebook/buck/ide/intellij/IjProjectTemplateDataPreparer.java
+++ b/src/com/facebook/buck/ide/intellij/IjProjectTemplateDataPreparer.java
@@ -363,6 +363,16 @@ public class IjProjectTemplateDataPreparer {
 
     boolean isAndroidFacetPresent = androidFacetOptional.isPresent();
     androidProperties.put("enabled", isAndroidFacetPresent);
+
+    Path basePath = module.getModuleBasePath();
+
+    Optional<Path> extraCompilerOutputPath = projectConfig.getExtraCompilerOutputModulesPath();
+    if (isAndroidFacetPresent
+        || (extraCompilerOutputPath.isPresent()
+            && basePath.toString().contains(extraCompilerOutputPath.get().toString()))) {
+      addAndroidCompilerOutputPath(androidProperties, module, basePath);
+    }
+
     if (!isAndroidFacetPresent) {
       return androidProperties;
     }
@@ -376,8 +386,6 @@ public class IjProjectTemplateDataPreparer {
         "disallow_user_configuration",
         projectConfig.isAggregatingAndroidResourceModulesEnabled()
             && projectConfig.getAggregationMode() != AggregationMode.NONE);
-
-    Path basePath = module.getModuleBasePath();
 
     addAndroidApkPaths(androidProperties, module, basePath, androidFacet);
     addAndroidAssetPaths(androidProperties, module, androidFacet);

--- a/src/com/facebook/buck/ide/intellij/IjProjectTemplateDataPreparer.java
+++ b/src/com/facebook/buck/ide/intellij/IjProjectTemplateDataPreparer.java
@@ -225,6 +225,9 @@ public class IjProjectTemplateDataPreparer {
   public ImmutableCollection<IjFolder> createExcludes(final IjModule module) throws IOException {
     final ImmutableList.Builder<IjFolder> excludesBuilder = ImmutableList.builder();
     final Path moduleBasePath = module.getModuleBasePath();
+    if (!projectFilesystem.exists(moduleBasePath)) {
+      return ImmutableList.of();
+    }
     projectFilesystem.walkRelativeFileTree(
         moduleBasePath,
         new FileVisitor<Path>() {

--- a/src/com/facebook/buck/ide/intellij/IjProjectTemplateDataPreparer.java
+++ b/src/com/facebook/buck/ide/intellij/IjProjectTemplateDataPreparer.java
@@ -223,11 +223,11 @@ public class IjProjectTemplateDataPreparer {
   }
 
   public ImmutableCollection<IjFolder> createExcludes(final IjModule module) throws IOException {
-    final ImmutableList.Builder<IjFolder> excludesBuilder = ImmutableList.builder();
     final Path moduleBasePath = module.getModuleBasePath();
     if (!projectFilesystem.exists(moduleBasePath)) {
       return ImmutableList.of();
     }
+    final ImmutableList.Builder<IjFolder> excludesBuilder = ImmutableList.builder();
     projectFilesystem.walkRelativeFileTree(
         moduleBasePath,
         new FileVisitor<Path>() {

--- a/src/com/facebook/buck/ide/intellij/IjProjectTemplateDataPreparer.java
+++ b/src/com/facebook/buck/ide/intellij/IjProjectTemplateDataPreparer.java
@@ -393,7 +393,6 @@ public class IjProjectTemplateDataPreparer {
     addAndroidManifestPath(androidProperties, basePath, androidFacet);
     addAndroidProguardPath(androidProperties, androidFacet);
     addAndroidResourcePaths(androidProperties, module, androidFacet);
-    addAndroidCompilerOutputPath(androidProperties, module, basePath);
 
     return androidProperties;
   }

--- a/src/com/facebook/buck/ide/intellij/ModuleBuildContext.java
+++ b/src/com/facebook/buck/ide/intellij/ModuleBuildContext.java
@@ -44,6 +44,7 @@ public class ModuleBuildContext {
 
   private Optional<IjModuleAndroidFacet.Builder> androidFacetBuilder;
   private ImmutableSet.Builder<Path> extraClassPathDependenciesBuilder;
+  private ImmutableSet.Builder<Path> extraModuleDependenciesBuilder;
   private Map<Path, IjFolder> generatedSourceCodeFoldersMap = new HashMap<>();
   private Map<Path, IjFolder> sourceFoldersMergeMap;
   // See comment in getDependencies for these two member variables.
@@ -58,6 +59,7 @@ public class ModuleBuildContext {
     this.circularDependencyInducingTargets = circularDependencyInducingTargets;
     this.androidFacetBuilder = Optional.empty();
     this.extraClassPathDependenciesBuilder = new ImmutableSet.Builder<>();
+    this.extraModuleDependenciesBuilder = new ImmutableSet.Builder<>();
     this.sourceFoldersMergeMap = new HashMap<>();
     this.dependencyTypeMap = new HashMap<>();
     this.dependencyOriginMap = HashMultimap.create();
@@ -96,6 +98,14 @@ public class ModuleBuildContext {
 
   public ImmutableSet<Path> getExtraClassPathDependencies() {
     return extraClassPathDependenciesBuilder.build();
+  }
+
+  public void addExtraModuleDependency(Path path) {
+    extraModuleDependenciesBuilder.add(path);
+  }
+
+  public ImmutableSet<Path> getExtraModuleDependencies() {
+    return extraModuleDependenciesBuilder.build();
   }
 
   public void addGeneratedSourceCodeFolder(IjFolder generatedFolder) {

--- a/src/com/facebook/buck/ide/intellij/lang/android/AndroidLibraryModuleRule.java
+++ b/src/com/facebook/buck/ide/intellij/lang/android/AndroidLibraryModuleRule.java
@@ -53,6 +53,7 @@ public class AndroidLibraryModuleRule extends AndroidModuleRule<AndroidLibraryDe
     Optional<Path> dummyRDotJavaClassPath = moduleFactoryResolver.getDummyRDotJavaPath(target);
     if (dummyRDotJavaClassPath.isPresent()) {
       context.addExtraClassPathDependency(dummyRDotJavaClassPath.get());
+      context.addExtraModuleDependency(dummyRDotJavaClassPath.get());
     }
 
     context.setJavaLanguageLevel(JavaLibraryRuleHelper.getLanguageLevel(projectConfig, target));

--- a/src/com/facebook/buck/ide/intellij/lang/android/AndroidResourceModuleRule.java
+++ b/src/com/facebook/buck/ide/intellij/lang/android/AndroidResourceModuleRule.java
@@ -85,6 +85,7 @@ public class AndroidResourceModuleRule extends AndroidModuleRule<AndroidResource
     Optional<Path> dummyRDotJavaClassPath = moduleFactoryResolver.getDummyRDotJavaPath(target);
     if (dummyRDotJavaClassPath.isPresent()) {
       context.addExtraClassPathDependency(dummyRDotJavaClassPath.get());
+      context.addExtraModuleDependency(dummyRDotJavaClassPath.get());
     }
 
     context.addDeps(resourceFolders, target.getBuildDeps(), DependencyType.PROD);

--- a/src/com/facebook/buck/ide/intellij/model/AbstractIjModule.java
+++ b/src/com/facebook/buck/ide/intellij/model/AbstractIjModule.java
@@ -65,6 +65,9 @@ abstract class AbstractIjModule implements IjProjectElement {
   /** @return a set of classpaths that the module requires to index correctly. */
   public abstract ImmutableSet<Path> getExtraClassPathDependencies();
 
+  /** @return a set of module paths that the module requires to index correctly. */
+  public abstract ImmutableSet<Path> getExtraModuleDependencies();
+
   /** @return Folders which contain the generated source code. */
   public abstract ImmutableList<IjFolder> getGeneratedSourceCodeFolders();
 

--- a/src/com/facebook/buck/ide/intellij/model/AbstractIjProjectConfig.java
+++ b/src/com/facebook/buck/ide/intellij/model/AbstractIjProjectConfig.java
@@ -94,4 +94,6 @@ abstract class AbstractIjProjectConfig {
   public abstract boolean isGeneratingAndroidManifestEnabled();
 
   public abstract Optional<String> getOutputUrl();
+
+  public abstract Optional<Path> getExtraCompilerOutputModulesPath();
 }

--- a/test/com/facebook/buck/ide/intellij/ProjectIntegrationTest.java
+++ b/test/com/facebook/buck/ide/intellij/ProjectIntegrationTest.java
@@ -120,6 +120,12 @@ public class ProjectIntegrationTest {
   }
 
   @Test
+  public void testVersion2BuckProjectWithExtraOutputModules()
+      throws InterruptedException, IOException {
+    runBuckProjectAndVerify("project_with_extra_output_modules");
+  }
+
+  @Test
   public void testVersion2BuckProjectWithGeneratedSources()
       throws InterruptedException, IOException {
     runBuckProjectAndVerify("project_with_generated_sources");

--- a/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/.buckconfig
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/.buckconfig
@@ -1,0 +1,9 @@
+[project]
+  ide = intellij
+
+[intellij]
+  android_module_sdk_name = Android API 25 Platform
+  android_module_sdk_type = AndroidSDK
+  jdk_name = 1.8
+  jdk_type = JavaSDK
+  extra_compiler_output_modules_path = buck-out/extra-intellij-output

--- a/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/.idea/libraries/library_modules_dep1_extra_classpath.xml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/.idea/libraries/library_modules_dep1_extra_classpath.xml.expected
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="library_modules_dep1_extra_classpath">
+    <CLASSES>
+      <root url="file://$PROJECT_DIR$/buck-out/bin/modules/dep1/__dep2#dummy_r_dot_java_rdotjava_bin__" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/.idea/modules.xml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/.idea/modules.xml.expected
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/buck-out/extra-intellij-output/modules/dep1/buck_out_extra_intellij_output_modules_dep1.iml" filepath="$PROJECT_DIR$/buck-out/extra-intellij-output/modules/dep1/buck_out_extra_intellij_output_modules_dep1.iml" group="modules" />
+      <module fileurl="file://$PROJECT_DIR$/modules/dep1/modules_dep1.iml" filepath="$PROJECT_DIR$/modules/dep1/modules_dep1.iml" group="modules" />
+      <module fileurl="file://$PROJECT_DIR$/project_root.iml" filepath="$PROJECT_DIR$/project_root.iml" />
+    </modules>
+  </component>
+</project>

--- a/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/buck-out/extra-intellij-output/modules/dep1/buck_out_extra_intellij_output_modules_dep1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/buck-out/extra-intellij-output/modules/dep1/buck_out_extra_intellij_output_modules_dep1.iml.expected
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/../../../bin/modules/dep1/__dep2#dummy_r_dot_java_rdotjava_bin__" />
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+    </content>
+    <orderEntry type="jdk" jdkName="Android API 25 Platform" jdkType="AndroidSDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/modules/dep1/BUCK.fixture
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/modules/dep1/BUCK.fixture
@@ -1,0 +1,19 @@
+android_resource(
+    name = "dep1",
+    package = "com.test",
+    res = subdir_glob([("res", "**")]),
+    visibility = [
+        "PUBLIC",
+    ],
+)
+
+android_library(
+    name = "dep2",
+    srcs = glob(["src/**/*.java"]),
+    deps = [
+        ":dep1",
+    ],
+    visibility = [
+        "PUBLIC",
+    ],
+)

--- a/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/modules/dep1/modules_dep1.iml.expected
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android" name="Android">
+      <configuration>
+        <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
+        <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/../../buck-out/gen/modules/dep1/dep1#resources-symlink-tree/res" />
+        <option name="LIBRARY_PROJECT" value="true" />
+        <option name="PROJECT_TYPE" value="1" />
+        <option name="UPDATE_PROPERTY_FILES" value="false" />
+        <option name="ENABLE_SOURCES_AUTOGENERATION" value="true" />
+        <includeAssetsFromLibraries>true</includeAssetsFromLibraries>
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/../../buck-out/bin/modules/dep1/lib__dep2__classes" />
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../../buck-out/android/modules/dep1/gen">
+      <sourceFolder url="file://$MODULE_DIR$/../../buck-out/android/modules/dep1/gen" isTestSource="false" />
+    </content>
+    <content url="file://$MODULE_DIR$/../../buck-out/gen/modules/dep1/dep1#resources-symlink-tree/res">
+      <sourceFolder url="file://$MODULE_DIR$/../../buck-out/gen/modules/dep1/dep1#resources-symlink-tree/res" isTestSource="false" packagePrefix="com.test" type="java-resource" />
+    </content>
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/res" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" packagePrefix="com.test" />
+    </content>
+    <orderEntry type="jdk" jdkName="Android API 25 Platform" jdkType="AndroidSDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="buck_out_extra_intellij_output_modules_dep1" scope="COMPILE" />
+    <orderEntry type="library" name="library_modules_dep1_extra_classpath" scope="COMPILE" level="project" />
+  </component>
+</module>

--- a/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/modules/dep1/res/values/strings.xml
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/modules/dep1/res/values/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string
+            name="app_name"
+            description="The app name displayed under the app icon in the OS home screen"
+    >App</string>
+</resources>

--- a/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/modules/dep1/src/Foo.java
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/modules/dep1/src/Foo.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2013-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.test;
+
+public class Foo {}

--- a/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/project_root.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/project_root.iml.expected
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/buck-out/bin" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/buck-out/log" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>


### PR DESCRIPTION
Since the Layout Preview uses compiler output of modules, not the module dependencies, this diff adds the ability to generate extra modules. This is useful for generating an extra module for each Android Library module so that the generated R.java class files can be added to the compiler output path. Doing this allows IntelliJ's Android Layout Preview to resolve the R file classes and properly load views in the Preview tab.

This approach was necessary since Buck stores compiled module class files in a different directory than the compiled dummy R.java class files and IntelliJ only support one compiler output path per module. This functionality is put behind a `.buckconfig` flag.