### PR TITLE
Create a FeatureEnableService so Layout Preview tab appears in IntelliJ

### DIFF
--- a/src/com/facebook/buck/intellij/ideabuck/META-INF/plugin.xml
+++ b/src/com/facebook/buck/intellij/ideabuck/META-INF/plugin.xml
@@ -146,6 +146,8 @@
   <depends>com.intellij.modules.platform</depends>
   <depends>com.intellij.modules.lang</depends>
 
+  <depends optional="true">org.jetbrains.android</depends>
+
   <extensions defaultExtensionNs="com.intellij">
     <fileTypeFactory implementation="com.facebook.buck.intellij.ideabuck.file.BuckFileTypeFactory"/>
     <lang.parserDefinition
@@ -205,6 +207,10 @@
     <programRunner
             implementation="com.facebook.buck.intellij.ideabuck.configurations.TestProgramRunner"/>
     <runLineMarkerContributor language="JAVA" implementationClass="com.facebook.buck.intellij.ideabuck.actions.select.SelectedTestRunLineMarkerContributor"/>
+  </extensions>
+
+  <extensions defaultExtensionNs="com.android.project">
+    <featureEnableService implementation="com.facebook.buck.intellij.ideabuck.proj.BuckFeatureEnableService"/>
   </extensions>
 
   <actions>

--- a/src/com/facebook/buck/intellij/ideabuck/src/com/facebook/buck/intellij/ideabuck/proj/BuckFeatureEnableService.java
+++ b/src/com/facebook/buck/intellij/ideabuck/src/com/facebook/buck/intellij/ideabuck/proj/BuckFeatureEnableService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.intellij.ideabuck.proj;
+
+import com.android.tools.idea.project.FeatureEnableService;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+
+public class BuckFeatureEnableService extends FeatureEnableService {
+  @Override
+  protected boolean isApplicable(@NotNull Project project) {
+    return BuckProjectInfo.isBuckProject(project) && BuckProjectInfo.hasAndroidModule(project);
+  }
+
+  @Override
+  public boolean isLayoutEditorEnabled(@NotNull Project project) {
+    return true;
+  }
+}

--- a/src/com/facebook/buck/intellij/ideabuck/src/com/facebook/buck/intellij/ideabuck/proj/BuckProjectInfo.java
+++ b/src/com/facebook/buck/intellij/ideabuck/src/com/facebook/buck/intellij/ideabuck/proj/BuckProjectInfo.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.intellij.ideabuck.proj;
+
+import com.facebook.buck.intellij.ideabuck.build.BuckBuildManager;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.project.Project;
+import java.util.Arrays;
+import org.jetbrains.android.facet.AndroidFacet;
+
+public final class BuckProjectInfo {
+  private BuckProjectInfo() {
+    throw new AssertionError("No instances");
+  }
+
+  public static boolean isBuckProject(Project project) {
+    return BuckBuildManager.getInstance(project).isBuckProject(project);
+  }
+
+  public static boolean hasAndroidModule(Project project) {
+    return Arrays.stream(ModuleManager.getInstance(project).getModules())
+        .anyMatch(BuckProjectInfo::isAndroidModule);
+  }
+
+  public static boolean isAndroidModule(Module module) {
+    return AndroidFacet.getInstance(module) != null;
+  }
+}

--- a/third-party/java/intellij/BUCK
+++ b/third-party/java/intellij/BUCK
@@ -1,6 +1,7 @@
 java_library(
     name = "intellij-plugin-sdk",
     exported_deps = [
+        ":android",
         ":annotations",
         ":extensions",
         ":idea",
@@ -47,4 +48,9 @@ prebuilt_jar(
 prebuilt_jar(
     name = "jdom",
     binary_jar = "jdom.jar",
+)
+
+prebuilt_jar(
+    name = "android",
+    binary_jar = "android.jar",
 )


### PR DESCRIPTION
This diffs adds a `FeatureEnableService` to the IdeaBuck plugin so that IntelliJ displays the Layout Preview "Design" tab for Android layout XML files.

Without "Design" tab below XML editor:
![layout-xml-without-tabs](https://user-images.githubusercontent.com/3178606/28805673-9ab28d32-7620-11e7-9808-9960e973e680.png)

With "Design" tab below XML editor that provides access to Android Layout Preview:
![layout-xml-with-tabs](https://user-images.githubusercontent.com/3178606/28805674-9ac5cf6e-7620-11e7-8045-f97c92e7d0e3.png)