### PR TITLE
Add support to buck for unbundled resources

### DIFF
--- a/src/com/facebook/buck/android/RobolectricTest.java
+++ b/src/com/facebook/buck/android/RobolectricTest.java
@@ -92,6 +92,7 @@ public class RobolectricTest extends JavaTest {
       ForkMode forkMode,
       Optional<Level> stdOutLogLevel,
       Optional<Level> stdErrLogLevel,
+      Optional<SourcePath> unbundledResourcesRoot,
       Optional<String> robolectricRuntimeDependency,
       Optional<SourcePath> robolectricManifest) {
     super(
@@ -117,7 +118,8 @@ public class RobolectricTest extends JavaTest {
         runTestSeparately,
         forkMode,
         stdOutLogLevel,
-        stdErrLogLevel);
+        stdErrLogLevel,
+        unbundledResourcesRoot);
     this.optionalDummyRDotJava = optionalDummyRDotJava;
     this.robolectricRuntimeDependency = robolectricRuntimeDependency;
     this.robolectricManifest = robolectricManifest;

--- a/src/com/facebook/buck/android/RobolectricTestDescription.java
+++ b/src/com/facebook/buck/android/RobolectricTestDescription.java
@@ -200,6 +200,7 @@ public class RobolectricTestDescription
         args.getForkMode(),
         args.getStdOutLogLevel(),
         args.getStdErrLogLevel(),
+        args.getUnbundledResourcesRoot(),
         args.getRobolectricRuntimeDependency(),
         args.getRobolectricManifest());
   }

--- a/src/com/facebook/buck/jvm/groovy/GroovyTestDescription.java
+++ b/src/com/facebook/buck/jvm/groovy/GroovyTestDescription.java
@@ -135,7 +135,8 @@ public class GroovyTestDescription
         args.getRunTestSeparately(),
         args.getForkMode(),
         args.getStdOutLogLevel(),
-        args.getStdErrLogLevel());
+        args.getStdErrLogLevel(),
+        args.getUnbundledResourcesRoot());
   }
 
   @Override

--- a/src/com/facebook/buck/jvm/java/DefaultJavaLibraryBuilder.java
+++ b/src/com/facebook/buck/jvm/java/DefaultJavaLibraryBuilder.java
@@ -64,6 +64,7 @@ public class DefaultJavaLibraryBuilder {
   protected boolean trackClassUsage = false;
   protected boolean compileAgainstAbis = false;
   protected Optional<Path> resourcesRoot = Optional.empty();
+  protected Optional<SourcePath> unbundledResourcesRoot = Optional.empty();
   protected Optional<SourcePath> manifestFile = Optional.empty();
   protected Optional<String> mavenCoords = Optional.empty();
   protected ImmutableSortedSet<BuildTarget> tests = ImmutableSortedSet.of();
@@ -119,6 +120,7 @@ public class DefaultJavaLibraryBuilder {
     return setSrcs(args.getSrcs())
         .setResources(args.getResources())
         .setResourcesRoot(args.getResourcesRoot())
+        .setUnbundledResourcesRoot(args.getUnbundledResourcesRoot())
         .setProguardConfig(args.getProguardConfig())
         .setPostprocessClassesCommands(args.getPostprocessClassesCommands())
         .setExportedDeps(args.getExportedDeps())
@@ -190,6 +192,11 @@ public class DefaultJavaLibraryBuilder {
 
   public DefaultJavaLibraryBuilder setResourcesRoot(Optional<Path> resourcesRoot) {
     this.resourcesRoot = resourcesRoot;
+    return this;
+  }
+
+  public DefaultJavaLibraryBuilder setUnbundledResourcesRoot(Optional<SourcePath> unbundledResourcesRoot) {
+    this.unbundledResourcesRoot = unbundledResourcesRoot;
     return this;
   }
 

--- a/src/com/facebook/buck/jvm/java/JavaLibraryDescription.java
+++ b/src/com/facebook/buck/jvm/java/JavaLibraryDescription.java
@@ -210,6 +210,8 @@ public class JavaLibraryDescription
     @Hint(isInput = false)
     Optional<Path> getResourcesRoot();
 
+    Optional<SourcePath> getUnbundledResourcesRoot();
+
     Optional<SourcePath> getManifestFile();
 
     Optional<String> getMavenCoords();

--- a/src/com/facebook/buck/jvm/java/JavaTest.java
+++ b/src/com/facebook/buck/jvm/java/JavaTest.java
@@ -144,6 +144,8 @@ public class JavaTest extends AbstractBuildRuleWithDeclaredAndExtraDeps
 
   @AddToRuleKey private final ForkMode forkMode;
 
+  @AddToRuleKey private final Optional<SourcePath> unbundledResourcesRoot;
+
   public JavaTest(
       BuildTarget buildTarget,
       ProjectFilesystem projectFilesystem,
@@ -162,7 +164,8 @@ public class JavaTest extends AbstractBuildRuleWithDeclaredAndExtraDeps
       boolean runTestSeparately,
       ForkMode forkMode,
       Optional<Level> stdOutLogLevel,
-      Optional<Level> stdErrLogLevel) {
+      Optional<Level> stdErrLogLevel,
+      Optional<SourcePath> unbundledResourcesRoot) {
     super(buildTarget, projectFilesystem, params);
     this.compiledTestsLibrary = compiledTestsLibrary;
 
@@ -189,6 +192,7 @@ public class JavaTest extends AbstractBuildRuleWithDeclaredAndExtraDeps
     this.forkMode = forkMode;
     this.stdOutLogLevel = stdOutLogLevel;
     this.stdErrLogLevel = stdErrLogLevel;
+    this.unbundledResourcesRoot = unbundledResourcesRoot;
     this.pathToTestLogs = getPathToTestOutputDirectory().resolve("logs.txt");
   }
 
@@ -659,8 +663,13 @@ public class JavaTest extends AbstractBuildRuleWithDeclaredAndExtraDeps
               @Override
               public StepExecutionResult execute(ExecutionContext context)
                   throws IOException, InterruptedException {
+                ImmutableSet.Builder<Path> builder = ImmutableSet.<Path>builder();
+                if (unbundledResourcesRoot.isPresent()) {
+                  builder.add(
+                      buildContext.getSourcePathResolver().getAbsolutePath(unbundledResourcesRoot.get()));
+                }
                 ImmutableSet<Path> classpathEntries =
-                    ImmutableSet.<Path>builder()
+                    builder
                         .addAll(
                             compiledTestsLibrary
                                 .getTransitiveClasspaths()

--- a/src/com/facebook/buck/jvm/java/JavaTestDescription.java
+++ b/src/com/facebook/buck/jvm/java/JavaTestDescription.java
@@ -156,7 +156,8 @@ public class JavaTestDescription
         args.getRunTestSeparately(),
         args.getForkMode(),
         args.getStdOutLogLevel(),
-        args.getStdErrLogLevel());
+        args.getStdErrLogLevel(),
+        args.getUnbundledResourcesRoot());
   }
 
   @Override

--- a/src/com/facebook/buck/jvm/kotlin/KotlinTestDescription.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinTestDescription.java
@@ -144,7 +144,8 @@ public class KotlinTestDescription
         args.getRunTestSeparately(),
         args.getForkMode(),
         args.getStdOutLogLevel(),
-        args.getStdErrLogLevel());
+        args.getStdErrLogLevel(),
+        args.getUnbundledResourcesRoot());
   }
 
   @Override

--- a/src/com/facebook/buck/jvm/scala/ScalaLibraryDescription.java
+++ b/src/com/facebook/buck/jvm/scala/ScalaLibraryDescription.java
@@ -111,6 +111,8 @@ public class ScalaLibraryDescription
     @Hint(isInput = false)
     Optional<Path> getResourcesRoot();
 
+    Optional<SourcePath> getUnbundledResourcesRoot();
+
     Optional<SourcePath> getManifestFile();
 
     Optional<String> getMavenCoords();

--- a/src/com/facebook/buck/jvm/scala/ScalaTestDescription.java
+++ b/src/com/facebook/buck/jvm/scala/ScalaTestDescription.java
@@ -146,7 +146,8 @@ public class ScalaTestDescription
         args.getRunTestSeparately(),
         args.getForkMode(),
         args.getStdOutLogLevel(),
-        args.getStdErrLogLevel());
+        args.getStdErrLogLevel(),
+        args.getUnbundledResourcesRoot());
   }
 
   @Override


### PR DESCRIPTION
Fixes #699

Verified this by adding the unbundled_resources_root and running tests that access resources via `getResource` which relies on the file path.