### PR TITLE
Enable path detection when running executables using buckd

### DIFF
--- a/programs/buck.py
+++ b/programs/buck.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
         setup_logging()
         propagate_failure(main(sys.argv))
     except ExecuteTarget as e:
-        e.execve()
+        e.execvpe()
     except RestartBuck:
         os.execvp(os.path.join(os.path.dirname(THIS_DIR), 'bin', 'buck'), sys.argv)
     except (BuckToolException, NailgunException, NoBuckConfigFoundException) as e:

--- a/programs/buck_tool.py
+++ b/programs/buck_tool.py
@@ -107,11 +107,11 @@ class ExecuteTarget(Exception):
         self._envp = envp
         self._cwd = cwd
 
-    def execve(self):
+    def execvpe(self):
         # Restore default handling of SIGPIPE.  See https://bugs.python.org/issue1652.
         signal.signal(signal.SIGPIPE, signal.SIG_DFL)
         os.chdir(self._cwd)
-        os.execve(self._path, self._argv, self._envp)
+        os.execvpe(self._path, self._argv, self._envp)
 
 
 class JvmCrashLogger(object):


### PR DESCRIPTION
After [this commit](https://github.com/facebook/buck/commit/a271a23a24a63e88decba55e176d623717628719), running executables using buckd doesn't detect the PATH environment variable correctly, (e.g. `bin/buck run //src/com/facebook/buck/jvm/java/abi:api-stubber` doesn't find the `java` executable correctly). This uses execvpe instead of execve, which does respect the PATH variable.