### PR TITLE
Add support for extra kotlinc args

### DIFF
--- a/docs/rule/android_library.soy
+++ b/docs/rule/android_library.soy
@@ -141,6 +141,14 @@ compiled class files and resources.
 {/call}
 
 {call buck.arg}
+  {param name: 'extra_kotlinc_arguments' /}
+  {param default : '[]' /}
+  {param desc}
+  List of additional arguments to pass into the Kotlin compiler.
+  {/param}
+{/call}
+
+{call buck.arg}
   {param name: 'exported_deps' /}
   {param default : '[]' /}
   {param desc}

--- a/docs/rule/robolectric_test.soy
+++ b/docs/rule/robolectric_test.soy
@@ -55,6 +55,14 @@ with Robolectric test runner. It extends from <code>java_test()</code> rule.
   {/param}
 {/call}
 
+{call buck.arg}
+  {param name: 'extra_kotlinc_arguments' /}
+  {param default : '[]' /}
+  {param desc}
+  List of additional arguments to pass into the Kotlin compiler.
+  {/param}
+{/call}
+
 {/param} // close args
 
 {/call} // close buck.rule

--- a/src/com/facebook/buck/android/AndroidKotlinCoreArg.java
+++ b/src/com/facebook/buck/android/AndroidKotlinCoreArg.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.buck.android;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Optional;
+
+public interface AndroidKotlinCoreArg {
+  Optional<AndroidLibraryDescription.JvmLanguage> getLanguage();
+
+  Optional<ImmutableList<String>> getExtraKotlincArguments();
+}

--- a/src/com/facebook/buck/android/AndroidLibraryDescription.java
+++ b/src/com/facebook/buck/android/AndroidLibraryDescription.java
@@ -42,8 +42,8 @@ import com.facebook.buck.rules.TargetGraph;
 import com.facebook.buck.util.immutables.BuckStyleImmutable;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableSet;
-import java.util.Optional;
 import org.immutables.value.Value;
+import java.util.Optional;
 
 public class AndroidLibraryDescription
     implements Description<AndroidLibraryDescriptionArg>,
@@ -143,14 +143,12 @@ public class AndroidLibraryDescription
   }
 
   public interface CoreArg
-      extends JavaLibraryDescription.CoreArg, HasDepsQuery, HasProvidedDepsQuery {
+      extends JavaLibraryDescription.CoreArg, AndroidKotlinCoreArg, HasDepsQuery, HasProvidedDepsQuery {
     Optional<SourcePath> getManifest();
 
     Optional<String> getResourceUnionPackage();
 
     Optional<String> getFinalRName();
-
-    Optional<JvmLanguage> getLanguage();
   }
 
   @BuckStyleImmutable

--- a/src/com/facebook/buck/android/BUCK
+++ b/src/com/facebook/buck/android/BUCK
@@ -94,6 +94,7 @@ RULES_SRCS = [
     "AndroidInstrumentationApkDescription.java",
     "AndroidInstrumentationTest.java",
     "AndroidInstrumentationTestDescription.java",
+    "AndroidKotlinCoreArg.java",
     "AndroidLibrary.java",
     "AndroidLibraryCompiler.java",
     "AndroidLibraryCompilerFactory.java",

--- a/src/com/facebook/buck/android/KotlinAndroidLibraryCompiler.java
+++ b/src/com/facebook/buck/android/KotlinAndroidLibraryCompiler.java
@@ -50,7 +50,7 @@ public class KotlinAndroidLibraryCompiler extends AndroidLibraryCompiler {
       JvmLibraryArg args, JavacOptions javacOptions, BuildRuleResolver resolver) {
     return new KotlincToJarStepFactory(
         kotlinBuckConfig.getKotlinc(),
-        ImmutableList.of(),
+        ((AndroidKotlinCoreArg) args).getExtraKotlincArguments().orElse(ImmutableList.of()),
         ANDROID_CLASSPATH_FROM_CONTEXT,
         getJavac(resolver, args),
         javacOptions,

--- a/src/com/facebook/buck/android/RobolectricTestDescription.java
+++ b/src/com/facebook/buck/android/RobolectricTestDescription.java
@@ -56,8 +56,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Maps;
-import java.util.Optional;
 import org.immutables.value.Value;
+import java.util.Optional;
 
 public class RobolectricTestDescription
     implements Description<RobolectricTestDescriptionArg>,
@@ -232,12 +232,11 @@ public class RobolectricTestDescription
 
   @BuckStyleImmutable
   @Value.Immutable
-  interface AbstractRobolectricTestDescriptionArg extends JavaTestDescription.CoreArg {
+  interface AbstractRobolectricTestDescriptionArg extends JavaTestDescription.CoreArg, AndroidKotlinCoreArg {
+
     Optional<String> getRobolectricRuntimeDependency();
 
     Optional<SourcePath> getRobolectricManifest();
-
-    Optional<AndroidLibraryDescription.JvmLanguage> getLanguage();
 
     @Value.Default
     default boolean isUseOldStyleableFormat() {

--- a/test/com/facebook/buck/android/AndroidLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/android/AndroidLibraryIntegrationTest.java
@@ -25,11 +25,11 @@ import com.facebook.buck.testutil.integration.ProjectWorkspace.ProcessResult;
 import com.facebook.buck.testutil.integration.TemporaryPaths;
 import com.facebook.buck.testutil.integration.TestDataHelper;
 import com.facebook.buck.util.HumanReadableException;
-import java.io.IOException;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import java.io.IOException;
 
 public class AndroidLibraryIntegrationTest extends AbiCompilationModeTest {
 
@@ -73,6 +73,17 @@ public class AndroidLibraryIntegrationTest extends AbiCompilationModeTest {
     ProcessResult result =
         workspace.runBuckBuild("//kotlin/com/sample/lib:lib_depending_on_main_lib");
     result.assertSuccess();
+  }
+
+  // TODO: When https://github.com/facebook/buck/issues/1371 is fixed, this test can use -Xplugin
+  @Test
+  public void testAndroidKotlinLibraryExtraArgumentsCompilation() throws Exception {
+    AssumeAndroidPlatform.assumeSdkIsAvailable();
+    KotlinTestAssumptions.assumeCompilerAvailable(workspace.asCell().getBuckConfig());
+    ProcessResult result =
+        workspace.runBuckBuild("//kotlin/com/sample/lib:lib_extra_kotlinc_arguments");
+    result.assertFailure();
+    assertTrue(result.getStderr().contains("warning: flag is not supported by this version of the compiler: -Xplugin="));
   }
 
   @Test

--- a/test/com/facebook/buck/android/testdata/android_project/kotlin/com/sample/lib/BUCK.fixture
+++ b/test/com/facebook/buck/android/testdata/android_project/kotlin/com/sample/lib/BUCK.fixture
@@ -34,6 +34,22 @@ android_library(
   ],
 )
 
+
+android_library(
+  name = 'lib_extra_kotlinc_arguments',
+  srcs = glob(['Activity.kt', 'Sample.kt', 'Sample2.kt']),
+  language = 'KOTLIN',
+  extra_kotlinc_arguments = [
+    '-Xplugin=',
+  ],
+  deps = [
+    # deps are intentionally left out to fail the test since -Xplugin is not available yet.
+  ],
+  visibility = [
+    'PUBLIC',
+  ],
+)
+
 android_library(
   name = 'lib_mixed_sources',
   srcs = glob(['*.kt', 'JavaClass.java']),


### PR DESCRIPTION
This provides the ability to add kotlinc plugins such as kotlin android extensions. Both `robolectric_test` rule and `android_library` rules needed support.

Since `extra_arguments` only applies to the java compiler, we needed a separate argument for the kotlin compiler.

Example of its use (for kotlin android extensions):

```
extra_kotlinc_arguments = [
   '-Xplugin=<kotlin_home>/kotlin-android-extensions.jar',
   '-P',
   'plugin:org.jetbrains.kotlin.android:variant=main;<project-root>/app/src 
    /main/res,plugin:org.jetbrains.kotlin.android:package=com.example.app',
],
```