### PR TITLE
Don't invoke kotlinc if we don't have any kotlin files

### DIFF
--- a/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
 public class KotlincToJarStepFactory extends BaseCompileToJarStepFactory {
 
   private static final PathOrGlobMatcher JAVA_PATH_MATCHER = new PathOrGlobMatcher("**.java");
+  private static final PathOrGlobMatcher KOTLIN_PATH_MATCHER = new PathOrGlobMatcher("**.kt");
 
   private final Kotlinc kotlinc;
   private final ImmutableList<String> extraArguments;
@@ -82,21 +83,24 @@ public class KotlincToJarStepFactory extends BaseCompileToJarStepFactory {
       ImmutableList.Builder<Step> steps,
       BuildableContext buildableContext) {
 
-    steps.add(
-        new KotlincStep(
-            invokingRule,
-            outputDirectory,
-            sourceFilePaths,
-            pathToSrcsList,
-            ImmutableSortedSet.<Path>naturalOrder()
-                .addAll(
-                    Optional.ofNullable(extraClassPath.apply(buildContext))
-                        .orElse(ImmutableList.of()))
-                .addAll(declaredClasspathEntries)
-                .build(),
-            kotlinc,
-            extraArguments,
-            filesystem));
+    // Don't invoke kotlinc if we don't have any kotlin files.
+    if (sourceFilePaths.stream().anyMatch(KOTLIN_PATH_MATCHER::matches)) {
+      steps.add(
+          new KotlincStep(
+              invokingRule,
+              outputDirectory,
+              sourceFilePaths,
+              pathToSrcsList,
+              ImmutableSortedSet.<Path>naturalOrder()
+                  .addAll(
+                      Optional.ofNullable(extraClassPath.apply(buildContext))
+                          .orElse(ImmutableList.of()))
+                  .addAll(declaredClasspathEntries)
+                  .build(),
+              kotlinc,
+              extraArguments,
+              filesystem));
+    }
 
     ImmutableSortedSet<Path> javaSourceFiles =
         ImmutableSortedSet.copyOf(


### PR DESCRIPTION
Don't bother invoking the kotlin compiler if you don't actually pass it any kotlin files. It will result in `error: no source file`.