### PR TITLE
Decouple proguard application logic from package type

### DIFF
--- a/src/com/facebook/buck/android/AndroidBinary.java
+++ b/src/com/facebook/buck/android/AndroidBinary.java
@@ -94,11 +94,6 @@ public class AndroidBinary extends AbstractBuildRule
     RELEASE,
     TEST,
     ;
-
-    /** @return true if ProGuard should be used to obfuscate the output */
-    boolean isBuildWithObfuscation() {
-      return this == RELEASE;
-    }
   }
 
   enum ExopackageMode {
@@ -182,7 +177,6 @@ public class AndroidBinary extends AbstractBuildRule
       Optional<List<String>> proguardJvmArgs,
       Optional<String> proguardAgentPath,
       Keystore keystore,
-      PackageType packageType,
       DexSplitMode dexSplitMode,
       Set<BuildTarget> buildTargetsToExcludeFromDex,
       ProGuardObfuscateStep.SdkProguardType sdkProguardConfig,
@@ -260,7 +254,6 @@ public class AndroidBinary extends AbstractBuildRule
             getProjectFilesystem(),
             keystore.getPathToStore(),
             keystore.getPathToPropertiesFile(),
-            packageType,
             dexSplitMode,
             sdkProguardConfig,
             optimizationPasses,

--- a/src/com/facebook/buck/android/AndroidBinaryDescription.java
+++ b/src/com/facebook/buck/android/AndroidBinaryDescription.java
@@ -207,7 +207,7 @@ public class AndroidBinaryDescription
       }
 
       ProGuardObfuscateStep.SdkProguardType androidSdkProguardConfig =
-          args.getAndroidSdkProguardConfig().orElse(ProGuardObfuscateStep.SdkProguardType.DEFAULT);
+          args.getAndroidSdkProguardConfig().orElse(ProGuardObfuscateStep.SdkProguardType.NONE);
 
       // If the old boolean version of this argument was specified, make sure the new form
       // was not specified, and allow the old form to override the default.
@@ -223,7 +223,7 @@ public class AndroidBinaryDescription
         androidSdkProguardConfig =
             args.getUseAndroidProguardConfigWithOptimizations().orElse(false)
                 ? ProGuardObfuscateStep.SdkProguardType.OPTIMIZED
-                : ProGuardObfuscateStep.SdkProguardType.DEFAULT;
+                : ProGuardObfuscateStep.SdkProguardType.NONE;
       }
 
       EnumSet<ExopackageMode> exopackageModes = EnumSet.noneOf(ExopackageMode.class);
@@ -239,9 +239,15 @@ public class AndroidBinaryDescription
       DexSplitMode dexSplitMode = createDexSplitMode(args, exopackageModes);
 
       PackageType packageType = getPackageType(args);
+      boolean shouldProguard =
+          args.getProguardConfig().isPresent()
+              || (args.getAndroidSdkProguardConfig().isPresent()
+                  && !ProGuardObfuscateStep.SdkProguardType.NONE.equals(
+                      args.getAndroidSdkProguardConfig().get()));
+
       boolean shouldPreDex =
           !args.getDisablePreDex()
-              && PackageType.DEBUG.equals(packageType)
+              && !shouldProguard
               && !args.getPreprocessJavaClassesBash().isPresent();
 
       ResourceFilter resourceFilter = new ResourceFilter(args.getResourceFilter());
@@ -286,7 +292,7 @@ public class AndroidBinaryDescription
               args.getNativeLibraryMergeGlue(),
               args.getNativeLibraryMergeCodeGenerator(),
               args.getNativeLibraryMergeLocalizedSymbols(),
-              args.getNativeLibraryProguardConfigGenerator(),
+              shouldProguard ? args.getNativeLibraryProguardConfigGenerator() : Optional.empty(),
               args.isEnableRelinker() ? RelinkerMode.ENABLED : RelinkerMode.DISABLED,
               dxExecutorService,
               args.getManifestEntries(),
@@ -325,7 +331,6 @@ public class AndroidBinaryDescription
               Optional.of(args.getProguardJvmArgs()),
               proGuardConfig.getProguardAgentPath(),
               (Keystore) keystore,
-              packageType,
               dexSplitMode,
               args.getNoDx(),
               androidSdkProguardConfig,

--- a/src/com/facebook/buck/android/AndroidBinaryGraphEnhancer.java
+++ b/src/com/facebook/buck/android/AndroidBinaryGraphEnhancer.java
@@ -244,7 +244,7 @@ public class AndroidBinaryGraphEnhancer {
       copyNativeLibraries.get().values().forEach(ruleResolver::addToIndex);
     }
 
-    if (nativeLibraryProguardConfigGenerator.isPresent() && packageType.isBuildWithObfuscation()) {
+    if (nativeLibraryProguardConfigGenerator.isPresent()) {
       NativeLibraryProguardGenerator nativeLibraryProguardGenerator =
           createNativeLibraryProguardGenerator(
               copyNativeLibraries

--- a/src/com/facebook/buck/android/AndroidInstrumentationApk.java
+++ b/src/com/facebook/buck/android/AndroidInstrumentationApk.java
@@ -66,7 +66,6 @@ public class AndroidInstrumentationApk extends AndroidBinary {
         apkUnderTest.getProguardJvmArgs(),
         proguardAgentPath,
         apkUnderTest.getKeystore(),
-        PackageType.INSTRUMENTED,
         // Do not split the test apk even if the tested apk is split
         DexSplitMode.NO_SPLIT,
         apkUnderTest.getBuildTargetsToExcludeFromDex(),

--- a/test/com/facebook/buck/android/AndroidBinaryTest.java
+++ b/test/com/facebook/buck/android/AndroidBinaryTest.java
@@ -158,7 +158,7 @@ public class AndroidBinaryTest {
         /* proguardAgentPath */ Optional.empty(),
         aaptProguardDir.resolve("proguard.txt"),
         /* customProguardConfigs */ ImmutableSet.of(),
-        ProGuardObfuscateStep.SdkProguardType.DEFAULT,
+        ProGuardObfuscateStep.SdkProguardType.NONE,
         /* optimizationPasses */ Optional.empty(),
         /* proguardJvmArgs */ Optional.empty(),
         ImmutableMap.of(


### PR DESCRIPTION
Decoupling proguard application from the package type as there are cases when one would want to apply proguard on a debug build for debugging purposes with a different configuration than release