### PR TITLE
Docs: update supported values for cxx linker and archiver platforms

### DIFF
--- a/docs/concept/buckconfig.soy
+++ b/docs/concept/buckconfig.soy
@@ -1401,8 +1401,8 @@ $ buck build //big:expensive-rule            # Action Graph is reused.</pre>
     The platform for the linker.  Normally this is autodetected based on the system, but it useful
     to set when cross compiling.  Valid values are:
     <ul>
-      <li><code>MACOS</code></li>
-      <li><code>LINUX</code></li>
+      <li><code>DARWIN</code></li>
+      <li><code>GNU</code></li>
       <li><code>WINDOWS</code></li>
     </ul>
   {/param}
@@ -1461,8 +1461,9 @@ $ buck build //big:expensive-rule            # Action Graph is reused.</pre>
     The platform for the archiver.  Normally this is autodetected based on the system, but it useful
     to set when cross compiling.  Valid values are:
     <ul>
-      <li><code>MACOS</code></li>
       <li><code>LINUX</code></li>
+      <li><code>MACOS</code></li>
+      <li><code>FREEBSD</code></li>
       <li><code>WINDOWS</code></li>
     </ul>
   {/param}


### PR DESCRIPTION
## Linker platform

Documentation lists `MACOS`, `LINUX`, `WINDOWS`, but seems that actual values are:

https://github.com/facebook/buck/blob/4b5591162c4b69e20fe224744be13df04e03a6b0/src/com/facebook/buck/cxx/platform/LinkerProvider.java#L30-L35

Setting this key to `LINUX` results in following error:

```
BUILD FAILED: .buckconfig: cxx:linker_platform must be one of DARWIN, GNU, WINDOWS, UNKNOWN (case insensitive) (was "LINUX")
```

## Archiver platform

Documentation lists `MACOS`, `LINUX`, `WINDOWS`, but actual values are:

https://github.com/facebook/buck/blob/f95f70e379ed0ec3098397e7d2696c07dd739cf7/src/com/facebook/buck/util/environment/Platform.java#L18-L23

I'm not sure if `UNKNOWN` should be listed in docs too.