### PR TITLE
Change Android compiler output from classes dir to output jar

### DIFF
--- a/src/com/facebook/buck/ide/intellij/DefaultIjModuleFactoryResolver.java
+++ b/src/com/facebook/buck/ide/intellij/DefaultIjModuleFactoryResolver.java
@@ -25,6 +25,7 @@ import com.facebook.buck.ide.intellij.model.IjModuleFactoryResolver;
 import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.jvm.java.AnnotationProcessingParams;
 import com.facebook.buck.jvm.java.CompilerParameters;
+import com.facebook.buck.jvm.java.DefaultJavaLibrary;
 import com.facebook.buck.jvm.java.JvmLibraryArg;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.rules.BuildRule;
@@ -126,7 +127,7 @@ class DefaultIjModuleFactoryResolver implements IjModuleFactoryResolver {
   @Override
   public Optional<Path> getCompilerOutputPath(TargetNode<? extends JvmLibraryArg, ?> targetNode) {
     BuildTarget buildTarget = targetNode.getBuildTarget();
-    Path compilerOutputPath = CompilerParameters.getClassesDir(buildTarget, projectFilesystem);
+    Path compilerOutputPath = DefaultJavaLibrary.getOutputJarPath(buildTarget, projectFilesystem);
     return Optional.of(compilerOutputPath);
   }
 

--- a/src/com/facebook/buck/ide/intellij/IjProjectPaths.java
+++ b/src/com/facebook/buck/ide/intellij/IjProjectPaths.java
@@ -39,17 +39,19 @@ public class IjProjectPaths {
   }
 
   /**
-   * @param path path to folder.
+   * @param path path to folder or jar.
    * @param moduleLocationBasePath path to the location of the .iml file.
-   * @return a path, relative to the module .iml file location describing a folder in IntelliJ
-   *     format.
+   * @return a path, relative to the module .iml file location describing a folder or jar in
+   *     IntelliJ format.
    */
   static String toModuleDirRelativeString(Path path, Path moduleLocationBasePath) {
     String moduleRelativePath = moduleLocationBasePath.relativize(path).toString();
     if (moduleRelativePath.isEmpty()) {
       return "file://$MODULE_DIR$";
+    } else if (moduleRelativePath.endsWith(".jar")) {
+      return "jar://$MODULE_DIR$/" + MorePaths.pathWithUnixSeparators(moduleRelativePath) + "!/";
     } else {
-      return "file://$MODULE_DIR$/" + moduleRelativePath;
+      return "file://$MODULE_DIR$/" + MorePaths.pathWithUnixSeparators(moduleRelativePath);
     }
   }
 

--- a/src/com/facebook/buck/ide/intellij/IjProjectTemplateDataPreparer.java
+++ b/src/com/facebook/buck/ide/intellij/IjProjectTemplateDataPreparer.java
@@ -525,6 +525,8 @@ public class IjProjectTemplateDataPreparer {
     if (compilerOutputPath.isPresent()) {
       Path relativeCompilerOutputPath = moduleBasePath.relativize(compilerOutputPath.get());
       androidProperties.put(
+          "is_compiler_output_path_jar", compilerOutputPath.get().toString().endsWith(".jar"));
+      androidProperties.put(
           "compiler_output_path",
           "/" + MorePaths.pathWithUnixSeparators(relativeCompilerOutputPath));
     }

--- a/src/com/facebook/buck/ide/intellij/IjProjectTemplateDataPreparer.java
+++ b/src/com/facebook/buck/ide/intellij/IjProjectTemplateDataPreparer.java
@@ -74,11 +74,6 @@ public class IjProjectTemplateDataPreparer {
   private static final String ASSETS_FOLDER_TEMPLATE_PARAMETER = "asset_folder";
   private static final String PROGUARD_CONFIG_TEMPLATE_PARAMETER = "proguard_config";
   private static final String RESOURCES_RELATIVE_PATH_TEMPLATE_PARAMETER = "res";
-  private static final String JAR_FILE_EXTENSION = ".jar";
-  private static final String MODULE_DIR = "$MODULE_DIR$/";
-  private static final String FILE_PREFIX = "file://";
-  private static final String JAR_PREFIX = "jar://";
-  private static final String JAR_SUFFIX = "!/";
 
   private static final String EMPTY_STRING = "";
 
@@ -528,19 +523,9 @@ public class IjProjectTemplateDataPreparer {
     // The compiler output path is relative to the project root
     Optional<Path> compilerOutputPath = module.getCompilerOutputPath();
     if (compilerOutputPath.isPresent()) {
-      String fullCompilerOutputPath;
-      String relativeOutputPath =
-          MODULE_DIR
-              + MorePaths.pathWithUnixSeparators(
-                  moduleBasePath.relativize(compilerOutputPath.get()));
-
-      if (compilerOutputPath.get().toString().endsWith(JAR_FILE_EXTENSION)) {
-        fullCompilerOutputPath = JAR_PREFIX + relativeOutputPath + JAR_SUFFIX;
-      } else {
-        fullCompilerOutputPath = FILE_PREFIX + relativeOutputPath;
-      }
-
-      androidProperties.put("compiler_output_path", fullCompilerOutputPath);
+      androidProperties.put(
+          "compiler_output_path",
+          IjProjectPaths.toModuleDirRelativeString(compilerOutputPath.get(), moduleBasePath));
     }
   }
 

--- a/src/com/facebook/buck/ide/intellij/templates/ij-module.st
+++ b/src/com/facebook/buck/ide/intellij/templates/ij-module.st
@@ -45,7 +45,11 @@
     %if(androidFacet.compiler_output_path)%inherit-compiler-output="false"%else%inherit-compiler-output="true"%endif%>
 %endif%
     %if(androidFacet.compiler_output_path)%
+    %if(androidFacet.is_compiler_output_path_jar)%
+    <output url="jar://$MODULE_DIR$%androidFacet.compiler_output_path%!/" />
+    %else%
     <output url="file://$MODULE_DIR$%androidFacet.compiler_output_path%" />
+    %endif%
     %endif%
     <exclude-output />
 %if(androidFacet.enabled)%

--- a/src/com/facebook/buck/ide/intellij/templates/ij-module.st
+++ b/src/com/facebook/buck/ide/intellij/templates/ij-module.st
@@ -45,11 +45,7 @@
     %if(androidFacet.compiler_output_path)%inherit-compiler-output="false"%else%inherit-compiler-output="true"%endif%>
 %endif%
     %if(androidFacet.compiler_output_path)%
-    %if(androidFacet.is_compiler_output_path_jar)%
-    <output url="jar://$MODULE_DIR$%androidFacet.compiler_output_path%!/" />
-    %else%
-    <output url="file://$MODULE_DIR$%androidFacet.compiler_output_path%" />
-    %endif%
+    <output url="%androidFacet.compiler_output_path%" />
     %endif%
     <exclude-output />
 %if(androidFacet.enabled)%

--- a/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
+++ b/src/com/facebook/buck/jvm/java/DefaultJavaLibrary.java
@@ -206,7 +206,7 @@ public class DefaultJavaLibrary extends AbstractBuildRuleWithDeclaredAndExtraDep
     return Optional.ofNullable(jarBuildStepsFactory.getSourcePathToOutput(getBuildTarget()));
   }
 
-  static Path getOutputJarPath(BuildTarget target, ProjectFilesystem filesystem) {
+  public static Path getOutputJarPath(BuildTarget target, ProjectFilesystem filesystem) {
     return Paths.get(
         String.format(
             "%s/%s.jar",

--- a/test/com/facebook/buck/ide/intellij/testdata/aggregation/java/code/modules/java_code_modules.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/aggregation/java/code/modules/java_code_modules.iml.expected
@@ -15,7 +15,7 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/../../../buck-out/bin/java/code/modules/tip/lib__tip__classes" />
+    <output url="jar://$MODULE_DIR$/../../../buck-out/gen/java/code/modules/tip/lib__tip__output/tip.jar!/" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../buck-out/android/java/code/modules/gen">
       <sourceFolder url="file://$MODULE_DIR$/../../../buck-out/android/java/code/modules/gen" isTestSource="false" />

--- a/test/com/facebook/buck/ide/intellij/testdata/android_library/lib/lib.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/android_library/lib/lib.iml.expected
@@ -15,7 +15,7 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/../buck-out/bin/lib/lib__src_release__classes" />
+    <output url="jar://$MODULE_DIR$/../buck-out/gen/lib/lib__src_release__output/src_release.jar!/" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../buck-out/android/lib/gen">
       <sourceFolder url="file://$MODULE_DIR$/../buck-out/android/lib/gen" isTestSource="false" />

--- a/test/com/facebook/buck/ide/intellij/testdata/android_library/lib_with_non_default_manifest/lib_with_non_default_manifest.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/android_library/lib_with_non_default_manifest/lib_with_non_default_manifest.iml.expected
@@ -16,7 +16,7 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/../buck-out/bin/lib_with_non_default_manifest/lib__src_release__classes" />
+    <output url="jar://$MODULE_DIR$/../buck-out/gen/lib_with_non_default_manifest/lib__src_release__output/src_release.jar!/" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../buck-out/android/lib_with_non_default_manifest/gen">
       <sourceFolder url="file://$MODULE_DIR$/../buck-out/android/lib_with_non_default_manifest/gen" isTestSource="false" />

--- a/test/com/facebook/buck/ide/intellij/testdata/android_library/lib_with_variant_named_buildrule/lib_with_variant_named_buildrule.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/android_library/lib_with_variant_named_buildrule/lib_with_variant_named_buildrule.iml.expected
@@ -16,7 +16,7 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/../buck-out/bin/lib_with_variant_named_buildrule/lib__src_devDebug__classes" />
+    <output url="jar://$MODULE_DIR$/../buck-out/gen/lib_with_variant_named_buildrule/lib__src_devDebug__output/src_devDebug.jar!/" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../buck-out/android/lib_with_variant_named_buildrule/gen">
       <sourceFolder url="file://$MODULE_DIR$/../buck-out/android/lib_with_variant_named_buildrule/gen" isTestSource="false" />

--- a/test/com/facebook/buck/ide/intellij/testdata/android_library/lib_without_manifest/lib_without_manifest.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/android_library/lib_without_manifest/lib_without_manifest.iml.expected
@@ -16,7 +16,7 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/../buck-out/bin/lib_without_manifest/lib__src_release__classes" />
+    <output url="jar://$MODULE_DIR$/../buck-out/gen/lib_without_manifest/lib__src_release__output/src_release.jar!/" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../buck-out/android/lib_without_manifest/gen">
       <sourceFolder url="file://$MODULE_DIR$/../buck-out/android/lib_without_manifest/gen" isTestSource="false" />

--- a/test/com/facebook/buck/ide/intellij/testdata/android_resources_in_the_same_folder/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/android_resources_in_the_same_folder/modules/dep1/modules_dep1.iml.expected
@@ -15,7 +15,7 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/../../buck-out/bin/modules/dep1/lib__dep2__classes" />
+    <output url="jar://$MODULE_DIR$/../../buck-out/gen/modules/dep1/lib__dep2__output/dep2.jar!/" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../buck-out/android/modules/dep1/gen">
       <sourceFolder url="file://$MODULE_DIR$/../../buck-out/android/modules/dep1/gen" isTestSource="false" />

--- a/test/com/facebook/buck/ide/intellij/testdata/generate_android_manifest/modules/aggregate_multiple_manifests_with_package/modules_aggregate_multiple_manifests_with_package.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/generate_android_manifest/modules/aggregate_multiple_manifests_with_package/modules_aggregate_multiple_manifests_with_package.iml.expected
@@ -17,7 +17,7 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/../../buck-out/bin/modules/aggregate_multiple_manifests_with_package/lib2/lib__lib2__classes" />
+    <output url="jar://$MODULE_DIR$/../../buck-out/gen/modules/aggregate_multiple_manifests_with_package/lib2/lib__lib2__output/lib2.jar!/" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../buck-out/android/modules/aggregate_multiple_manifests_with_package/gen">
       <sourceFolder url="file://$MODULE_DIR$/../../buck-out/android/modules/aggregate_multiple_manifests_with_package/gen" isTestSource="false" />

--- a/test/com/facebook/buck/ide/intellij/testdata/generate_android_manifest/modules/aggregate_multiple_manifests_without_package/modules_aggregate_multiple_manifests_without_package.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/generate_android_manifest/modules/aggregate_multiple_manifests_without_package/modules_aggregate_multiple_manifests_without_package.iml.expected
@@ -17,7 +17,7 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/../../buck-out/bin/modules/aggregate_multiple_manifests_without_package/lib2/lib__lib2__classes" />
+    <output url="jar://$MODULE_DIR$/../../buck-out/gen/modules/aggregate_multiple_manifests_without_package/lib2/lib__lib2__output/lib2.jar!/" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../buck-out/android/modules/aggregate_multiple_manifests_without_package/gen">
       <sourceFolder url="file://$MODULE_DIR$/../../buck-out/android/modules/aggregate_multiple_manifests_without_package/gen" isTestSource="false" />

--- a/test/com/facebook/buck/ide/intellij/testdata/generate_android_manifest/modules/aggregate_one_manifest/modules_aggregate_one_manifest.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/generate_android_manifest/modules/aggregate_one_manifest/modules_aggregate_one_manifest.iml.expected
@@ -17,7 +17,7 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/../../buck-out/bin/modules/aggregate_one_manifest/lib2/lib__lib2__classes" />
+    <output url="jar://$MODULE_DIR$/../../buck-out/gen/modules/aggregate_one_manifest/lib2/lib__lib2__output/lib2.jar!/" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../buck-out/android/modules/aggregate_one_manifest/gen">
       <sourceFolder url="file://$MODULE_DIR$/../../buck-out/android/modules/aggregate_one_manifest/gen" isTestSource="false" />

--- a/test/com/facebook/buck/ide/intellij/testdata/project1/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/project1/modules/dep1/modules_dep1.iml.expected
@@ -15,7 +15,7 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/../../buck-out/bin/modules/dep1/lib__generated__classes" />
+    <output url="jar://$MODULE_DIR$/../../buck-out/gen/modules/dep1/lib__generated__output/generated.jar!/" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../buck-out/android/modules/dep1/gen">
       <sourceFolder url="file://$MODULE_DIR$/../../buck-out/android/modules/dep1/gen" isTestSource="false" />

--- a/test/com/facebook/buck/ide/intellij/testdata/project1/modules/tip/modules_tip.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/project1/modules/tip/modules_tip.iml.expected
@@ -15,7 +15,7 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/../../buck-out/bin/modules/tip/lib__tip__classes" />
+    <output url="jar://$MODULE_DIR$/../../buck-out/gen/modules/tip/lib__tip__output/tip.jar!/" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../buck-out/android/modules/tip/gen">
       <sourceFolder url="file://$MODULE_DIR$/../../buck-out/android/modules/tip/gen" isTestSource="false" />

--- a/test/com/facebook/buck/ide/intellij/testdata/project_slice/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_slice/modules/dep1/modules_dep1.iml.expected
@@ -15,7 +15,7 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/../../buck-out/bin/modules/dep1/lib__dep1__classes" />
+    <output url="jar://$MODULE_DIR$/../../buck-out/gen/modules/dep1/lib__dep1__output/dep1.jar!/" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../buck-out/android/modules/dep1/gen">
       <sourceFolder url="file://$MODULE_DIR$/../../buck-out/android/modules/dep1/gen" isTestSource="false" />

--- a/test/com/facebook/buck/ide/intellij/testdata/project_slice/modules/dep2/modules_dep2.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_slice/modules/dep2/modules_dep2.iml.expected
@@ -15,7 +15,7 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/../../buck-out/bin/modules/dep2/lib__dep2__classes" />
+    <output url="jar://$MODULE_DIR$/../../buck-out/gen/modules/dep2/lib__dep2__output/dep2.jar!/" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../buck-out/android/modules/dep2/gen">
       <sourceFolder url="file://$MODULE_DIR$/../../buck-out/android/modules/dep2/gen" isTestSource="false" />

--- a/test/com/facebook/buck/ide/intellij/testdata/project_with_android_resources/modules/dep2/modules_dep2.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_with_android_resources/modules/dep2/modules_dep2.iml.expected
@@ -15,7 +15,7 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/../../buck-out/bin/modules/dep2/lib__dep3__classes" />
+    <output url="jar://$MODULE_DIR$/../../buck-out/gen/modules/dep2/lib__dep3__output/dep3.jar!/" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../buck-out/android/modules/dep2/gen">
       <sourceFolder url="file://$MODULE_DIR$/../../buck-out/android/modules/dep2/gen" isTestSource="false" />

--- a/test/com/facebook/buck/ide/intellij/testdata/project_with_custom_android_sdks/modules/libA/modules_libA.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_with_custom_android_sdks/modules/libA/modules_libA.iml.expected
@@ -15,7 +15,7 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/../../buck-out/bin/modules/libA/lib__src__classes" />
+    <output url="jar://$MODULE_DIR$/../../buck-out/gen/modules/libA/lib__src__output/src.jar!/" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../buck-out/android/modules/libA/gen">
       <sourceFolder url="file://$MODULE_DIR$/../../buck-out/android/modules/libA/gen" isTestSource="false" />

--- a/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/modules/dep1/modules_dep1.iml.expected
@@ -15,7 +15,7 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/../../buck-out/bin/modules/dep1/lib__dep2__classes" />
+    <output url="jar://$MODULE_DIR$/../../buck-out/gen/modules/dep1/lib__dep2__output/dep2.jar!/" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../buck-out/android/modules/dep1/gen">
       <sourceFolder url="file://$MODULE_DIR$/../../buck-out/android/modules/dep1/gen" isTestSource="false" />

--- a/test/com/facebook/buck/ide/intellij/testdata/project_with_scripts/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_with_scripts/modules/dep1/modules_dep1.iml.expected
@@ -15,7 +15,7 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/../../buck-out/bin/modules/dep1/lib__dep1__classes" />
+    <output url="jar://$MODULE_DIR$/../../buck-out/gen/modules/dep1/lib__dep1__output/dep1.jar!/" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../buck-out/android/modules/dep1/gen">
       <sourceFolder url="file://$MODULE_DIR$/../../buck-out/android/modules/dep1/gen" isTestSource="false" />

--- a/test/com/facebook/buck/ide/intellij/testdata/project_without_autogeneration/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_without_autogeneration/modules/dep1/modules_dep1.iml.expected
@@ -15,7 +15,7 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/../../buck-out/bin/modules/dep1/lib__dep1__classes" />
+    <output url="jar://$MODULE_DIR$/../../buck-out/gen/modules/dep1/lib__dep1__output/dep1.jar!/" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../buck-out/android/modules/dep1/gen">
       <sourceFolder url="file://$MODULE_DIR$/../../buck-out/android/modules/dep1/gen" isTestSource="false" />


### PR DESCRIPTION
This diff is a followup to #1412 since the IntelliJ Layout Preview can load classes from the compiler output using the output jar path. This makes it so that you do not necessarily need to change the `spool_to_jar` buckconfig option to `intermediates_to_disk` in order to get Layout Preview working.