### PR TITLE
Add support for splitting large jvm based test suites

### DIFF
--- a/src/com/facebook/buck/android/RobolectricTest.java
+++ b/src/com/facebook/buck/android/RobolectricTest.java
@@ -94,7 +94,9 @@ public class RobolectricTest extends JavaTest {
       Optional<Level> stdErrLogLevel,
       Optional<SourcePath> unbundledResourcesRoot,
       Optional<String> robolectricRuntimeDependency,
-      Optional<SourcePath> robolectricManifest) {
+      Optional<SourcePath> robolectricManifest,
+      int splits,
+      int part) {
     super(
         buildTarget,
         projectFilesystem,
@@ -119,7 +121,9 @@ public class RobolectricTest extends JavaTest {
         forkMode,
         stdOutLogLevel,
         stdErrLogLevel,
-        unbundledResourcesRoot);
+        unbundledResourcesRoot,
+        splits,
+        part);
     this.optionalDummyRDotJava = optionalDummyRDotJava;
     this.robolectricRuntimeDependency = robolectricRuntimeDependency;
     this.robolectricManifest = robolectricManifest;

--- a/src/com/facebook/buck/android/RobolectricTestDescription.java
+++ b/src/com/facebook/buck/android/RobolectricTestDescription.java
@@ -66,7 +66,6 @@ public class RobolectricTestDescription
   private static final MacroHandler MACRO_HANDLER =
       new MacroHandler(ImmutableMap.of("location", new LocationMacroExpander()));
 
-
   private final JavaBuckConfig javaBuckConfig;
   private final JavaOptions javaOptions;
   private final JavacOptions templateOptions;
@@ -208,7 +207,9 @@ public class RobolectricTestDescription
         args.getStdErrLogLevel(),
         args.getUnbundledResourcesRoot(),
         args.getRobolectricRuntimeDependency(),
-        args.getRobolectricManifest());
+        args.getRobolectricManifest(),
+        args.getSplits(),
+        args.getPart());
   }
 
   @Override
@@ -246,6 +247,5 @@ public class RobolectricTestDescription
     default boolean isForceFinalResourceIds() {
       return true;
     }
-
   }
 }

--- a/src/com/facebook/buck/jvm/groovy/GroovyTestDescription.java
+++ b/src/com/facebook/buck/jvm/groovy/GroovyTestDescription.java
@@ -130,7 +130,9 @@ public class GroovyTestDescription
         args.getForkMode(),
         args.getStdOutLogLevel(),
         args.getStdErrLogLevel(),
-        args.getUnbundledResourcesRoot());
+        args.getUnbundledResourcesRoot(),
+        args.getSplits(),
+        args.getPart());
   }
 
   @Override

--- a/src/com/facebook/buck/jvm/java/JavaTestDescription.java
+++ b/src/com/facebook/buck/jvm/java/JavaTestDescription.java
@@ -155,7 +155,9 @@ public class JavaTestDescription
         args.getForkMode(),
         args.getStdOutLogLevel(),
         args.getStdErrLogLevel(),
-        args.getUnbundledResourcesRoot());
+        args.getUnbundledResourcesRoot(),
+        args.getSplits(),
+        args.getPart());
   }
 
   @Override
@@ -209,6 +211,16 @@ public class JavaTestDescription
     Optional<Long> getTestCaseTimeoutMs();
 
     ImmutableMap<String, String> getEnv();
+
+    @Value.Default
+    default int getSplits() {
+      return 1;
+    }
+
+    @Value.Default
+    default int getPart() {
+      return 1;
+    }
   }
 
   @BuckStyleImmutable

--- a/src/com/facebook/buck/jvm/kotlin/KotlinTestDescription.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinTestDescription.java
@@ -139,7 +139,9 @@ public class KotlinTestDescription
         args.getForkMode(),
         args.getStdOutLogLevel(),
         args.getStdErrLogLevel(),
-        args.getUnbundledResourcesRoot());
+        args.getUnbundledResourcesRoot(),
+        args.getSplits(),
+        args.getPart());
   }
 
   @Override

--- a/src/com/facebook/buck/jvm/scala/ScalaTestDescription.java
+++ b/src/com/facebook/buck/jvm/scala/ScalaTestDescription.java
@@ -140,7 +140,9 @@ public class ScalaTestDescription
         args.getForkMode(),
         args.getStdOutLogLevel(),
         args.getStdErrLogLevel(),
-        args.getUnbundledResourcesRoot());
+        args.getUnbundledResourcesRoot(),
+        args.getSplits(),
+        args.getPart());
   }
 
   @Override


### PR DESCRIPTION
This adds support for splitting up jvm test suites with a large number of tests.

This can be used effectively on CI/machines with a lot of cores to run an existing large test suite in parallel by bucketing the test classes evenly. We have seen our test suite speedup from 1 hour down to 20 min by using this change.

This change usually accompanies a definition like
```
test_bucket_size = 200


original_java_test = java_test
def java_test(
    name,
    srcs=[],
    **kwargs
    ):
  splits = (len(srcs) + test_bucket_size - 1) / test_bucket_size
  if splits > 1:
    for part in xrange(splits):
      n_name = name if part == 0 else '{}_{}'.format(name, part + 1)
      original_java_test(
        name=n_name,
        srcs=srcs,
        splits=splits,
        part=part+1,
        **kwargs
      )
```

When running on CI