### PR TITLE
Fix shouldRefuseToRunAppleTestIfXctestNotPresent

### DIFF
--- a/test/com/facebook/buck/apple/AppleTestIntegrationTest.java
+++ b/test/com/facebook/buck/apple/AppleTestIntegrationTest.java
@@ -41,15 +41,15 @@ import com.facebook.buck.util.environment.Platform;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class AppleTestIntegrationTest {
 
@@ -284,7 +284,7 @@ public class AppleTestIntegrationTest {
         containsString(
             "Set xctool_path = /path/to/xctool or xctool_zip_target = //path/to:xctool-zip in the "
                 + "[apple] section of .buckconfig to run this test"));
-    workspace.runBuckCommand("test", "//:foo");
+    workspace.runBuckCommand("test", "//:foo", "--config", "apple.xctool_path=does/not/exist");
   }
 
   @Test


### PR DESCRIPTION
This currently fails if the xctool is available in the PATH, because
it auto resolves. Making the path fake makes this test consistently
fail regardless of environment.