### PR TITLE
Add an option to disallow all duplicates in java_binary

### DIFF
--- a/src/com/facebook/buck/jvm/java/AbstractJarParameters.java
+++ b/src/com/facebook/buck/jvm/java/AbstractJarParameters.java
@@ -36,6 +36,11 @@ abstract class AbstractJarParameters {
     return false;
   }
 
+  @Value.Default
+  public boolean getDisallowAllDuplicates() {
+    return false;
+  }
+
   public abstract Path getJarPath();
 
   @Value.Default

--- a/src/com/facebook/buck/jvm/java/JarDirectoryStep.java
+++ b/src/com/facebook/buck/jvm/java/JarDirectoryStep.java
@@ -82,6 +82,7 @@ public class JarDirectoryStep implements Step {
             .setMainClass(parameters.getMainClass().orElse(null))
             .setManifestFile(parameters.getManifestFile().map(filesystem::resolve).orElse(null))
             .setShouldMergeManifests(parameters.getMergeManifests())
+            .setShouldDisallowAllDuplicates(parameters.getDisallowAllDuplicates())
             .setShouldHashEntries(parameters.getHashEntries())
             .setRemoveEntryPredicate(parameters.getRemoveEntryPredicate())
             .createJarFile(filesystem.resolve(parameters.getJarPath())));

--- a/src/com/facebook/buck/jvm/java/JavaBinary.java
+++ b/src/com/facebook/buck/jvm/java/JavaBinary.java
@@ -60,6 +60,7 @@ public class JavaBinary extends AbstractBuildRuleWithDeclaredAndExtraDeps
 
   @AddToRuleKey @Nullable private final SourcePath manifestFile;
   private final boolean mergeManifests;
+  private final boolean disallowAllDuplicates;
 
   @Nullable @AddToRuleKey private final SourcePath metaInfDirectory;
 
@@ -82,6 +83,7 @@ public class JavaBinary extends AbstractBuildRuleWithDeclaredAndExtraDeps
       @Nullable String mainClass,
       @Nullable SourcePath manifestFile,
       boolean mergeManifests,
+      boolean disallowAllDuplicates,
       @Nullable Path metaInfDirectory,
       ImmutableSet<Pattern> blacklist,
       ImmutableSet<JavaLibrary> transitiveClasspathDeps,
@@ -92,6 +94,7 @@ public class JavaBinary extends AbstractBuildRuleWithDeclaredAndExtraDeps
     this.mainClass = mainClass;
     this.manifestFile = manifestFile;
     this.mergeManifests = mergeManifests;
+    this.disallowAllDuplicates = disallowAllDuplicates;
     this.metaInfDirectory =
         metaInfDirectory != null
             ? new PathSourcePath(getProjectFilesystem(), metaInfDirectory)
@@ -155,6 +158,7 @@ public class JavaBinary extends AbstractBuildRuleWithDeclaredAndExtraDeps
                 .setMainClass(Optional.ofNullable(mainClass))
                 .setManifestFile(Optional.ofNullable(manifestPath))
                 .setMergeManifests(mergeManifests)
+                .setDisallowAllDuplicates(disallowAllDuplicates)
                 .setRemoveEntryPredicate(
                     entry ->
                         blacklistPatternsMatcher.hasPatterns()

--- a/src/com/facebook/buck/jvm/java/JavaBinaryDescription.java
+++ b/src/com/facebook/buck/jvm/java/JavaBinaryDescription.java
@@ -112,6 +112,7 @@ public class JavaBinaryDescription
             args.getMainClass().orElse(null),
             args.getManifestFile().orElse(null),
             args.getMergeManifests().orElse(true),
+            args.getDisallowAllDuplicates().orElse(false),
             args.getMetaInfDirectory().orElse(null),
             args.getBlacklist(),
             transitiveClasspathDeps,
@@ -174,6 +175,8 @@ public class JavaBinaryDescription
     Optional<SourcePath> getManifestFile();
 
     Optional<Boolean> getMergeManifests();
+
+    Optional<Boolean> getDisallowAllDuplicates();
 
     Optional<Path> getMetaInfDirectory();
 

--- a/src/com/facebook/buck/zip/JarBuilder.java
+++ b/src/com/facebook/buck/zip/JarBuilder.java
@@ -66,6 +66,7 @@ public class JarBuilder {
   @Nullable private String mainClass;
   @Nullable private Path manifestFile;
   private boolean shouldMergeManifests;
+  private boolean shouldDisallowAllDuplicates;
   private boolean shouldHashEntries;
   private Predicate<? super CustomZipEntry> removeEntryPredicate = entry -> false;
   private List<JarEntryContainer> sourceContainers = new ArrayList<>();
@@ -113,6 +114,11 @@ public class JarBuilder {
 
   public JarBuilder setShouldMergeManifests(boolean shouldMergeManifests) {
     this.shouldMergeManifests = shouldMergeManifests;
+    return this;
+  }
+
+  public JarBuilder setShouldDisallowAllDuplicates(boolean shouldDisallowAllDuplicates) {
+    this.shouldDisallowAllDuplicates = shouldDisallowAllDuplicates;
     return this;
   }
 
@@ -333,7 +339,7 @@ public class JarBuilder {
   }
 
   private boolean isDuplicateAllowed(String name) {
-    return !name.endsWith(".class") && !name.endsWith("/");
+    return !shouldDisallowAllDuplicates && !name.endsWith(".class") && !name.endsWith("/");
   }
 
   private static class SingletonJarEntryContainer implements JarEntryContainer {

--- a/test/com/facebook/buck/jvm/java/JavaBinaryTest.java
+++ b/test/com/facebook/buck/jvm/java/JavaBinaryTest.java
@@ -93,6 +93,7 @@ public class JavaBinaryTest {
                 "com.facebook.base.Main",
                 null,
                 /* merge manifests */ true,
+                false,
                 null,
                 /* blacklist */ ImmutableSet.of(),
                 ImmutableSet.of(),


### PR DESCRIPTION
When processing jars output from `java_binary` rules with tools like jarjar, it is not possible to remove all the entries from the jar (non class files) that buck added duplicate entries for.

This adds an option for consumers to treat duplicate files the same (`.class` and non class files) and not re-add them if they are already added