### PR TITLE
Add res_folder_relative_path property to Android IML file

### DIFF
--- a/src/com/facebook/buck/ide/intellij/DefaultIjModuleFactory.java
+++ b/src/com/facebook/buck/ide/intellij/DefaultIjModuleFactory.java
@@ -107,6 +107,7 @@ public class DefaultIjModuleFactory implements IjModuleFactory {
         .setModuleType(context.getModuleType())
         .setMetaInfDirectory(context.getMetaInfDirectory())
         .setCompilerOutputPath(context.getCompilerOutputPath())
+        .setPreferredResFolderPath(context.getPreferredResFolderPath())
         .build();
   }
 }

--- a/src/com/facebook/buck/ide/intellij/IjProjectPaths.java
+++ b/src/com/facebook/buck/ide/intellij/IjProjectPaths.java
@@ -55,6 +55,21 @@ public class IjProjectPaths {
     }
   }
 
+  /**
+   * @param path path to folder.
+   * @param moduleLocationBasePath path to the location of the .iml file.
+   * @return a path, relative to the module .iml file location describing a folder without the
+   *     IntelliJ format.
+   */
+  static String toRelativeString(Path path, Path moduleLocationBasePath) {
+    String moduleRelativePath = moduleLocationBasePath.relativize(path).toString();
+    if (moduleRelativePath.isEmpty()) {
+      return "";
+    } else {
+      return "/" + MorePaths.pathWithUnixSeparators(moduleRelativePath);
+    }
+  }
+
   String toProjectDirRelativeString(Path repoRelativePath) {
     return MorePaths.pathWithUnixSeparators(
         projectRootPath.toAbsolutePath().relativize(repoRelativePath.toAbsolutePath()));

--- a/src/com/facebook/buck/ide/intellij/IjProjectPaths.java
+++ b/src/com/facebook/buck/ide/intellij/IjProjectPaths.java
@@ -16,6 +16,7 @@
 package com.facebook.buck.ide.intellij;
 
 import com.facebook.buck.io.MorePaths;
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -66,7 +67,7 @@ public class IjProjectPaths {
     if (moduleRelativePath.isEmpty()) {
       return "";
     } else {
-      return "/" + MorePaths.pathWithUnixSeparators(moduleRelativePath);
+      return File.separator + MorePaths.pathWithUnixSeparators(moduleRelativePath);
     }
   }
 

--- a/src/com/facebook/buck/ide/intellij/IjProjectTemplateDataPreparer.java
+++ b/src/com/facebook/buck/ide/intellij/IjProjectTemplateDataPreparer.java
@@ -73,7 +73,8 @@ public class IjProjectTemplateDataPreparer {
   private static final String APK_PATH_TEMPLATE_PARAMETER = "apk_path";
   private static final String ASSETS_FOLDER_TEMPLATE_PARAMETER = "asset_folder";
   private static final String PROGUARD_CONFIG_TEMPLATE_PARAMETER = "proguard_config";
-  private static final String RESOURCES_RELATIVE_PATH_TEMPLATE_PARAMETER = "res";
+  private static final String RESOURCE_RELATIVE_PATH_TEMPLATE_PARAMETER = "res_folder";
+  private static final String RESOURCES_RELATIVE_PATH_TEMPLATE_PARAMETER = "res_folders";
 
   private static final String EMPTY_STRING = "";
 
@@ -507,6 +508,17 @@ public class IjProjectTemplateDataPreparer {
       for (Path resourcePath : resourcePaths) {
         relativeResourcePaths.add(
             IjProjectPaths.toModuleDirRelativeString(resourcePath, moduleBase));
+      }
+
+      if (!resourcePaths.isEmpty()) {
+        Path resFolderPath =
+            (resourcePaths.size() == 1 || !module.getPreferredResFolderPath().isPresent())
+                ? resourcePaths.iterator().next()
+                : module.getPreferredResFolderPath().get();
+
+        androidProperties.put(
+            RESOURCE_RELATIVE_PATH_TEMPLATE_PARAMETER,
+            IjProjectPaths.toRelativeString(resFolderPath, moduleBase));
       }
 
       androidProperties.put(

--- a/src/com/facebook/buck/ide/intellij/ModuleBuildContext.java
+++ b/src/com/facebook/buck/ide/intellij/ModuleBuildContext.java
@@ -54,6 +54,7 @@ public class ModuleBuildContext {
   private Optional<Path> metaInfDirectory;
   private Optional<String> javaLanguageLevel;
   private Optional<Path> compilerOutputPath;
+  private Optional<Path> preferredResFolderPath;
 
   public ModuleBuildContext(ImmutableSet<BuildTarget> circularDependencyInducingTargets) {
     this.circularDependencyInducingTargets = circularDependencyInducingTargets;
@@ -67,6 +68,7 @@ public class ModuleBuildContext {
     this.metaInfDirectory = Optional.empty();
     this.javaLanguageLevel = Optional.empty();
     this.compilerOutputPath = Optional.empty();
+    this.preferredResFolderPath = Optional.empty();
   }
 
   public void ensureAndroidFacetBuilder() {
@@ -151,6 +153,14 @@ public class ModuleBuildContext {
 
   public void setCompilerOutputPath(Optional<Path> compilerOutputPath) {
     this.compilerOutputPath = compilerOutputPath;
+  }
+
+  public Optional<Path> getPreferredResFolderPath() {
+    return preferredResFolderPath;
+  }
+
+  public void setPreferredResFolderPath(Optional<Path> preferredResFolderPath) {
+    this.preferredResFolderPath = preferredResFolderPath;
   }
 
   /**

--- a/src/com/facebook/buck/ide/intellij/lang/android/AndroidResourceModuleRule.java
+++ b/src/com/facebook/buck/ide/intellij/lang/android/AndroidResourceModuleRule.java
@@ -97,6 +97,12 @@ public class AndroidResourceModuleRule extends AndroidModuleRule<AndroidResource
         && target
             .getConstructorArg()
             .labelsContainsAnyOf(Collections.singleton(PREFERRED_RES_FOLDER_LABEL))) {
+      if (context.getPreferredResFolderPath().isPresent()) {
+        throw new AssertionError(
+            "Multiple resource rules declared as preferred"
+                + " for module "
+                + target.getBuildTarget().getBaseName());
+      }
       context.setPreferredResFolderPath(Optional.of(resources.get()));
     }
   }

--- a/src/com/facebook/buck/ide/intellij/lang/android/AndroidResourceModuleRule.java
+++ b/src/com/facebook/buck/ide/intellij/lang/android/AndroidResourceModuleRule.java
@@ -30,10 +30,13 @@ import com.facebook.buck.rules.Description;
 import com.facebook.buck.rules.TargetNode;
 import com.google.common.collect.ImmutableSet;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 public class AndroidResourceModuleRule extends AndroidModuleRule<AndroidResourceDescriptionArg> {
+
+  public static final String PREFERRED_RES_FOLDER_LABEL = "preferred_res_folder";
 
   public AndroidResourceModuleRule(
       ProjectFilesystem projectFilesystem,
@@ -89,6 +92,13 @@ public class AndroidResourceModuleRule extends AndroidModuleRule<AndroidResource
     }
 
     context.addDeps(resourceFolders, target.getBuildDeps(), DependencyType.PROD);
+
+    if (resources.isPresent()
+        && target
+            .getConstructorArg()
+            .labelsContainsAnyOf(Collections.singleton(PREFERRED_RES_FOLDER_LABEL))) {
+      context.setPreferredResFolderPath(Optional.of(resources.get()));
+    }
   }
 
   @Override

--- a/src/com/facebook/buck/ide/intellij/model/AbstractIjModule.java
+++ b/src/com/facebook/buck/ide/intellij/model/AbstractIjModule.java
@@ -79,6 +79,8 @@ abstract class AbstractIjModule implements IjProjectElement {
 
   public abstract Optional<Path> getCompilerOutputPath();
 
+  public abstract Optional<Path> getPreferredResFolderPath();
+
   /** @return path where the XML describing the module to IntelliJ will be written to. */
   @Value.Derived
   public Path getModuleImlFilePath() {

--- a/src/com/facebook/buck/ide/intellij/templates/ij-module.st
+++ b/src/com/facebook/buck/ide/intellij/templates/ij-module.st
@@ -15,7 +15,10 @@
 %if(androidFacet.android_manifest)%
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="%androidFacet.android_manifest%" />
 %endif%
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="%androidFacet.res%" />
+%if(androidFacet.res_folder)%
+        <option name="RES_FOLDER_RELATIVE_PATH" value="%androidFacet.res_folder%" />
+%endif%
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="%androidFacet.res_folders%" />
 %if(androidFacet.asset_folder)%
         <option name="ASSETS_FOLDER_RELATIVE_PATH" value="%androidFacet.asset_folder%" />
 %endif%

--- a/test/com/facebook/buck/ide/intellij/testdata/aggregation_with_custom_packages/java/default/dep1/android_res/java_default_dep1_android_res.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/aggregation_with_custom_packages/java/default/dep1/android_res/java_default_dep1_android_res.iml.expected
@@ -5,6 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../../../buck-out/android/java/default/dep1/android_res/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../../../buck-out/android/java/default/dep1/android_res/gen" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/../../../../buck-out/gen/java/default/dep1/android_res/android_res#resources-symlink-tree/res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/../../../../buck-out/gen/java/default/dep1/android_res/android_res#resources-symlink-tree/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />

--- a/test/com/facebook/buck/ide/intellij/testdata/android_resource_aggregation/modules/android_res_custom_package/modules_android_res_custom_package.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/android_resource_aggregation/modules/android_res_custom_package/modules_android_res_custom_package.iml.expected
@@ -6,6 +6,7 @@
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/android_res_custom_package/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/android_res_custom_package/gen" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />

--- a/test/com/facebook/buck/ide/intellij/testdata/android_resource_aggregation/modules/modules.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/android_resource_aggregation/modules/modules.iml.expected
@@ -6,6 +6,7 @@
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../buck-out/android/modules/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../buck-out/android/modules/gen" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/android_res1/res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/android_res2/res;file://$MODULE_DIR$/android_res1/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />

--- a/test/com/facebook/buck/ide/intellij/testdata/android_resource_aggregation_with_limit/modules/android_res2/BUCK.fixture
+++ b/test/com/facebook/buck/ide/intellij/testdata/android_resource_aggregation_with_limit/modules/android_res2/BUCK.fixture
@@ -1,5 +1,6 @@
 android_resource(
   name = 'android_res2',
+  labels = ['preferred_res_folder'],
   package = 'com.test',
   project_res = 'res',
   visibility = [

--- a/test/com/facebook/buck/ide/intellij/testdata/android_resource_aggregation_with_limit/modules/android_res_custom_package/modules_android_res_custom_package.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/android_resource_aggregation_with_limit/modules/android_res_custom_package/modules_android_res_custom_package.iml.expected
@@ -6,6 +6,7 @@
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/android_res_custom_package/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/android_res_custom_package/gen" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />

--- a/test/com/facebook/buck/ide/intellij/testdata/android_resource_aggregation_with_limit/modules/modules.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/android_resource_aggregation_with_limit/modules/modules.iml.expected
@@ -6,6 +6,7 @@
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../buck-out/android/modules/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../buck-out/android/modules/gen" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/android_res2/res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/android_res2/res;file://$MODULE_DIR$/android_res3/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />

--- a/test/com/facebook/buck/ide/intellij/testdata/android_resources_in_the_same_folder/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/android_resources_in_the_same_folder/modules/dep1/modules_dep1.iml.expected
@@ -5,6 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/proj-res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/proj-res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />

--- a/test/com/facebook/buck/ide/intellij/testdata/create_new_workspace/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/create_new_workspace/modules/dep1/modules_dep1.iml.expected
@@ -5,6 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />

--- a/test/com/facebook/buck/ide/intellij/testdata/generate_android_manifest/modules/android_res1/modules_android_res1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/generate_android_manifest/modules/android_res1/modules_android_res1.iml.expected
@@ -7,6 +7,7 @@
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/android_res1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/android_res1/gen" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/../../buck-out/android/modules/android_res1/gen/com/test/AndroidManifest.xml" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />

--- a/test/com/facebook/buck/ide/intellij/testdata/generate_android_manifest/modules/android_res2/modules_android_res2.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/generate_android_manifest/modules/android_res2/modules_android_res2.iml.expected
@@ -7,6 +7,7 @@
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/android_res2/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/android_res2/gen" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/../../buck-out/android/modules/android_res2/gen/com/test/AndroidManifest.xml" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />

--- a/test/com/facebook/buck/ide/intellij/testdata/generate_android_manifest/modules/android_res_custom_package/modules_android_res_custom_package.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/generate_android_manifest/modules/android_res_custom_package/modules_android_res_custom_package.iml.expected
@@ -7,6 +7,7 @@
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/android_res_custom_package/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/android_res_custom_package/gen" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/../../buck-out/android/modules/android_res_custom_package/gen/com/test/custom/AndroidManifest.xml" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />

--- a/test/com/facebook/buck/ide/intellij/testdata/project_with_android_resources/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_with_android_resources/modules/dep1/modules_dep1.iml.expected
@@ -5,6 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/proj-res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/proj-res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />

--- a/test/com/facebook/buck/ide/intellij/testdata/project_with_excluded_resources/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_with_excluded_resources/modules/dep1/modules_dep1.iml.expected
@@ -5,6 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />

--- a/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_with_extra_output_modules/modules/dep1/modules_dep1.iml.expected
@@ -5,6 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/../../buck-out/gen/modules/dep1/dep1#resources-symlink-tree/res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/../../buck-out/gen/modules/dep1/dep1#resources-symlink-tree/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />

--- a/test/com/facebook/buck/ide/intellij/testdata/project_with_multiple_resources_with_package_names/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_with_multiple_resources_with_package_names/modules/dep1/modules_dep1.iml.expected
@@ -5,6 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/proj-res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/proj-res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />

--- a/test/com/facebook/buck/ide/intellij/testdata/project_with_subdir_glob_resources/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_with_subdir_glob_resources/modules/dep1/modules_dep1.iml.expected
@@ -5,6 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/proj-res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/proj-res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />

--- a/test/com/facebook/buck/ide/intellij/testdata/project_with_subdir_glob_resources/modules/dep2/modules_dep2.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/project_with_subdir_glob_resources/modules/dep2/modules_dep2.iml.expected
@@ -5,6 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep2/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep2/gen" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/../../buck-out/gen/modules/dep2/dep2#resources-symlink-tree/res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/../../buck-out/gen/modules/dep2/dep2#resources-symlink-tree/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />

--- a/test/com/facebook/buck/ide/intellij/testdata/save_generated_files_list/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/save_generated_files_list/modules/dep1/modules_dep1.iml.expected
@@ -5,6 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />

--- a/test/com/facebook/buck/ide/intellij/testdata/update_existing_workspace/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/update_existing_workspace/modules/dep1/modules_dep1.iml.expected
@@ -5,6 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />

--- a/test/com/facebook/buck/ide/intellij/testdata/update_malformed_workspace/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/update_malformed_workspace/modules/dep1/modules_dep1.iml.expected
@@ -5,6 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />

--- a/test/com/facebook/buck/ide/intellij/testdata/update_workspace_without_ignored_nodes/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/update_workspace_without_ignored_nodes/modules/dep1/modules_dep1.iml.expected
@@ -5,6 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />

--- a/test/com/facebook/buck/ide/intellij/testdata/update_workspace_without_manager_node/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/update_workspace_without_manager_node/modules/dep1/modules_dep1.iml.expected
@@ -5,6 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />

--- a/test/com/facebook/buck/ide/intellij/testdata/update_workspace_without_project_node/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/ide/intellij/testdata/update_workspace_without_project_node/modules/dep1/modules_dep1.iml.expected
@@ -5,6 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />


### PR DESCRIPTION
This diff sets the RES_FOLDER_RELATIVE_PATH property of the Android Facet. The resource folder path is used by the Android Layout Preview to load themes and styles in order to properly visualize and load views into the Preview window. The logic for which path to use for the module is as follows:
- if only one path, use it
- if a module's resource rule is labeled as preferred, then use that one
- otherwise, choose the first one