### PR TITLE
Don't add SDKROOT to framework search paths

### DIFF
--- a/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
+++ b/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
@@ -761,10 +761,10 @@ public class ProjectGenerator {
           node.castArg(PrebuiltAppleFrameworkDescriptionArg.class)
               .ifPresent(
                   prebuiltFramework -> {
-                    // Technically (see Apple Tech Notes 2435), static frameworks are lies. In case a static
-                    // framework is used, they can escape the incorrect project generation by marking its
-                    // preferred linkage static (what does preferred linkage even mean for a prebuilt thing?
-                    // none of this makes sense anyways).
+                    // Technically (see Apple Tech Notes 2435), static frameworks are lies. In case
+                    // a static framework is used, they can escape the incorrect project generation
+                    // by marking its preferred linkage static (what does preferred linkage even
+                    // mean for a prebuilt thing? none of this makes sense anyways).
                     if (prebuiltFramework.getConstructorArg().getPreferredLinkage()
                         != NativeLinkable.Linkage.STATIC) {
                       filteredRules.add(node);
@@ -1017,9 +1017,9 @@ public class ProjectGenerator {
                 .castArg(AppleTestDescriptionArg.class)
                 .flatMap(
                     testNode -> {
-                      // only application tests share a runtime with their host application and need to
-                      // avoid linking dependencies already linked by the host.
-                      // we know this is an application test if it is not a UI test and has a bundle loader.
+                      // only application tests share a runtime with their host application and need
+                      // to avoid linking dependencies already linked by the host. we know this is
+                      // an application test if it is not a UI test and has a bundle loader.
                       return testNode.getConstructorArg().getIsUiTest()
                           ? Optional.empty()
                           : bundleLoaderNode;
@@ -1422,7 +1422,8 @@ public class ProjectGenerator {
   }
 
   private void addPBXTargetDependency(PBXNativeTarget pbxTarget, BuildTarget dependency) {
-    // Xcode appears to only support target dependencies if both targets are within the same project.
+    // Xcode appears to only support target dependencies if both targets are within the same
+    // project.
     // If the desired target dependency is not in the same project, then just ignore it.
     if (!isBuiltByCurrentProject(dependency)) {
       return;
@@ -1481,6 +1482,7 @@ public class ProjectGenerator {
                   .getConstructorArg()
                   .getFrameworks()
                   .stream()
+                  .filter(x -> !x.isSDKROOTFrameworkPath())
                   .map(
                       frameworkPath ->
                           FrameworkPath.getUnexpandedSearchPath(
@@ -2132,7 +2134,7 @@ public class ProjectGenerator {
                   .setDestination(PBXCopyFilesBuildPhase.Destination.XPC)
                   .setPath("$(CONTENTS_FOLDER_PATH)/XPCServices")
                   .build());
-          //$CASES-OMITTED$
+          // $CASES-OMITTED$
         default:
           return Optional.of(
               CopyFilePhaseDestinationSpec.of(PBXCopyFilesBuildPhase.Destination.PRODUCTS));

--- a/src/com/facebook/buck/cxx/AbstractCxxIncludePaths.java
+++ b/src/com/facebook/buck/cxx/AbstractCxxIncludePaths.java
@@ -29,11 +29,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
+import org.immutables.value.Value;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Optional;
-import org.immutables.value.Value;
 
 @Value.Immutable
 @BuckStylePackageVisibleTuple
@@ -90,6 +90,7 @@ abstract class AbstractCxxIncludePaths {
         MoreIterables.zipAndConcat(
             Iterables.cycle("-F"),
             FluentIterable.from(getFPaths())
+                .filter(x -> !x.isSDKROOTFrameworkPath())
                 .transform(frameworkPathTransformer)
                 .transform(Object::toString)
                 .toSortedSet(Ordering.natural())));

--- a/src/com/facebook/buck/rules/coercer/AbstractFrameworkPath.java
+++ b/src/com/facebook/buck/rules/coercer/AbstractFrameworkPath.java
@@ -16,6 +16,7 @@
 
 package com.facebook.buck.rules.coercer;
 
+import com.facebook.buck.apple.xcode.xcodeproj.PBXReference;
 import com.facebook.buck.apple.xcode.xcodeproj.SourceTreePath;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.RuleKeyAppendable;
@@ -27,11 +28,11 @@ import com.facebook.buck.util.immutables.BuckStyleImmutable;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.io.Files;
+import org.immutables.value.Value;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.Optional;
-import org.immutables.value.Value;
 
 /**
  * Frameworks can be specified as either a path to a file, or a path prefixed by a build setting.
@@ -78,6 +79,13 @@ abstract class AbstractFrameworkPath
   public String getName(Function<SourcePath, Path> resolver) {
     String fileName = getFileName(resolver).toString();
     return Files.getNameWithoutExtension(fileName);
+  }
+
+  public  boolean isSDKROOTFrameworkPath() {
+    if (getSourceTreePath().isPresent()){
+      return getSourceTreePath().get().getSourceTree() == PBXReference.SourceTree.SDKROOT;
+    }
+    return false;
   }
 
   public static Path getUnexpandedSearchPath(

--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -158,6 +158,7 @@ class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
     compilerCommand.addAll(
         frameworks
             .stream()
+            .filter(x -> !x.isSDKROOTFrameworkPath())
             .map(frameworkPathToSearchPath::apply)
             .flatMap(searchPath -> ImmutableSet.of("-F", searchPath.toString()).stream())
             .iterator());

--- a/test/com/facebook/buck/apple/CompilationDatabaseIntegrationTest.java
+++ b/test/com/facebook/buck/apple/CompilationDatabaseIntegrationTest.java
@@ -38,7 +38,6 @@ import com.facebook.buck.util.RichStream;
 import com.facebook.buck.util.environment.Platform;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -88,9 +87,6 @@ public class CompilationDatabaseIntegrationTest {
     Map<String, CxxCompilationDatabaseEntry> fileToEntry =
         CxxCompilationDatabaseUtils.parseCompilationDatabaseJsonFile(compilationDatabase);
 
-    ImmutableSet<String> frameworks =
-        ImmutableSet.of(
-            Paths.get("/System/Library/Frameworks/Foundation.framework").getParent().toString());
     String pathToPrivateHeaders =
         BuildTargets.getGenPath(
                 filesystem,
@@ -123,7 +119,6 @@ public class CompilationDatabaseIntegrationTest {
         Paths.get("EXExample/EXExampleModel.m.o"),
         /* isLibrary */ true,
         fileToEntry,
-        frameworks,
         includes);
     assertFlags(
         filesystem,
@@ -134,7 +129,6 @@ public class CompilationDatabaseIntegrationTest {
         Paths.get("EXExample/EXUser.mm.o"),
         /* isLibrary */ true,
         fileToEntry,
-        frameworks,
         includes);
     assertFlags(
         filesystem,
@@ -146,7 +140,6 @@ public class CompilationDatabaseIntegrationTest {
         Paths.get("EXExample/Categories/NSString+Palindrome.m.o"),
         /* isLibrary */ true,
         fileToEntry,
-        frameworks,
         includes);
   }
 
@@ -164,10 +157,6 @@ public class CompilationDatabaseIntegrationTest {
     Map<String, CxxCompilationDatabaseEntry> fileToEntry =
         CxxCompilationDatabaseUtils.parseCompilationDatabaseJsonFile(compilationDatabase);
 
-    ImmutableSet<String> frameworks =
-        ImmutableSet.of(
-            Paths.get("/System/Library/Frameworks/Foundation.framework").getParent().toString(),
-            Paths.get("/System/Library/Frameworks/UIKit.framework").getParent().toString());
     String pathToPrivateHeaders =
         BuildTargets.getGenPath(
                 filesystem,
@@ -201,7 +190,6 @@ public class CompilationDatabaseIntegrationTest {
         Paths.get("Weather/EXViewController.m.o"),
         /* isLibrary */ false,
         fileToEntry,
-        frameworks,
         includes);
     assertFlags(
         filesystem,
@@ -212,7 +200,6 @@ public class CompilationDatabaseIntegrationTest {
         Paths.get("Weather/main.m.o"),
         /* isLibrary */ false,
         fileToEntry,
-        frameworks,
         includes);
   }
 
@@ -223,7 +210,6 @@ public class CompilationDatabaseIntegrationTest {
       Path outputPath,
       boolean isLibrary,
       Map<String, CxxCompilationDatabaseEntry> fileToEntry,
-      ImmutableSet<String> additionalFrameworks,
       Iterable<String> includes)
       throws IOException {
     Path tmpRoot = tmp.getRoot().toRealPath();
@@ -276,11 +262,6 @@ public class CompilationDatabaseIntegrationTest {
     for (String include : includes) {
       commandArgs.add("-I");
       commandArgs.add(include);
-    }
-
-    for (String framework : additionalFrameworks) {
-      commandArgs.add("-F");
-      commandArgs.add(sdkRoot + framework);
     }
 
     String output =

--- a/test/com/facebook/buck/apple/project_generator/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/apple/project_generator/ProjectGeneratorTest.java
@@ -133,6 +133,11 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
 import com.google.common.io.ByteStreams;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
@@ -149,11 +154,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class ProjectGeneratorTest {
 
@@ -2176,7 +2176,7 @@ public class ProjectGeneratorTest {
     assertEquals(null, settings.get("USER_HEADER_SEARCH_PATHS"));
     assertEquals("$(inherited) $BUILT_PRODUCTS_DIR", settings.get("LIBRARY_SEARCH_PATHS"));
     assertEquals(
-        "$(inherited) $BUILT_PRODUCTS_DIR $SDKROOT", settings.get("FRAMEWORK_SEARCH_PATHS"));
+        "$(inherited) $BUILT_PRODUCTS_DIR", settings.get("FRAMEWORK_SEARCH_PATHS"));
   }
 
   @Test
@@ -2239,7 +2239,7 @@ public class ProjectGeneratorTest {
         settings.get("HEADER_SEARCH_PATHS"));
     assertEquals("user_headers", settings.get("USER_HEADER_SEARCH_PATHS"));
     assertEquals("libraries $BUILT_PRODUCTS_DIR", settings.get("LIBRARY_SEARCH_PATHS"));
-    assertEquals("frameworks $BUILT_PRODUCTS_DIR $SDKROOT", settings.get("FRAMEWORK_SEARCH_PATHS"));
+    assertEquals("frameworks $BUILT_PRODUCTS_DIR", settings.get("FRAMEWORK_SEARCH_PATHS"));
   }
 
   @Test
@@ -2313,7 +2313,7 @@ public class ProjectGeneratorTest {
     assertEquals(null, settings.get("USER_HEADER_SEARCH_PATHS"));
     assertEquals("$(inherited) " + "$BUILT_PRODUCTS_DIR", settings.get("LIBRARY_SEARCH_PATHS"));
     assertEquals(
-        "$(inherited) " + "$BUILT_PRODUCTS_DIR $SDKROOT", settings.get("FRAMEWORK_SEARCH_PATHS"));
+        "$(inherited) " + "$BUILT_PRODUCTS_DIR", settings.get("FRAMEWORK_SEARCH_PATHS"));
   }
 
   @Test


### PR DESCRIPTION
Not all of Apple's system frameworks have correct modular headers.
Adding the `$SDKROOT` in a `-F` flag triggers an attempt of clang to 
create a module for these, which gives unexpected errors.

Omitting the `$SDKROOT` is not an issue when the `-sdk` flag is passed to
`clang`/`swiftc`. When generating a new project in Xcode, it does not
include the `$SDKROOT` variable in `FRAMEWORK_SEARCH_PATHS` by
default.

Related radars:
- http://openradar.appspot.com/33774557
- http://openradar.appspot.com/33795982