### PR TITLE
Don't use test_host as bundle_loader for UI tests

### DIFF
--- a/src/com/facebook/buck/apple/AppleTest.java
+++ b/src/com/facebook/buck/apple/AppleTest.java
@@ -46,6 +46,7 @@ import com.facebook.buck.test.TestRunningOptions;
 import com.facebook.buck.util.HumanReadableException;
 import com.facebook.buck.util.MoreCollectors;
 import com.facebook.buck.util.Optionals;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
@@ -495,4 +496,7 @@ public class AppleTest extends AbstractBuildRuleWithDeclaredAndExtraDeps
   public boolean isUiTest() {
     return isUiTest;
   }
+
+  @VisibleForTesting
+  public boolean hasTestHost() { return testHostApp.isPresent(); }
 }

--- a/src/com/facebook/buck/apple/AppleTestDescription.java
+++ b/src/com/facebook/buck/apple/AppleTestDescription.java
@@ -70,10 +70,10 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
+import org.immutables.value.Value;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Set;
-import org.immutables.value.Value;
 
 public class AppleTestDescription
     implements Description<AppleTestDescriptionArg>,
@@ -208,8 +208,9 @@ public class AppleTestDescription
       }
     }
 
+    // UI test bundles do not use the test host as their bundle_loader, but instead a stub app
     Optional<TestHostInfo> testHostInfo;
-    if (args.getTestHostApp().isPresent()) {
+    if (args.getTestHostApp().isPresent()  && !args.getIsUiTest()) {
       testHostInfo =
           Optional.of(
               createTestHostInfo(

--- a/test/com/facebook/buck/apple/AppleTestDescriptionTest.java
+++ b/test/com/facebook/buck/apple/AppleTestDescriptionTest.java
@@ -37,7 +37,6 @@ import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.SourcePathRuleFinder;
 import com.facebook.buck.rules.SourceWithFlags;
 import com.facebook.buck.rules.TargetGraph;
-import com.facebook.buck.rules.TargetNode;
 import com.facebook.buck.rules.args.Arg;
 import com.facebook.buck.rules.macros.LocationMacro;
 import com.facebook.buck.rules.macros.StringWithMacrosUtils;
@@ -48,9 +47,9 @@ import com.facebook.buck.util.RichStream;
 import com.facebook.buck.util.environment.Platform;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
+import java.util.Optional;
 import org.hamcrest.Matchers;
 import org.junit.Test;
-import java.util.Optional;
 
 public class AppleTestDescriptionTest {
 
@@ -97,31 +96,34 @@ public class AppleTestDescriptionTest {
     assumeThat(Platform.detect(), is(Platform.MACOS));
 
     BuildTarget testHostBinTarget = BuildTargetFactory.newInstance("//:testhostbin#macosx-x86_64");
-    BuildTarget testHostBundleTarget = BuildTargetFactory.newInstance("//:testhostbundle#macosx-x86_64");
+    BuildTarget testHostBundleTarget =
+        BuildTargetFactory.newInstance("//:testhostbundle#macosx-x86_64");
     BuildTarget testTarget = BuildTargetFactory.newInstance("//:test#macosx-x86_64");
 
-    TargetNode testHostBinaryNode = AppleBinaryBuilder
-        .createBuilder(testHostBinTarget)
-        .setSrcs(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("foo.c"))))
-        .build();
-    TargetNode testHostBundleNode = AppleBundleBuilder
-        .createBuilder(testHostBundleTarget)
-        .setBinary(testHostBinTarget)
-        .setExtension(Either.ofLeft(AppleBundleExtension.APP))
-        .setInfoPlist(new FakeSourcePath(("Info.plist")))
-        .build();
-    AppleTestBuilder testBuilder = AppleTestBuilder
-        .createBuilder(testTarget)
-        .setInfoPlist(new FakeSourcePath(("Info.plist")))
-        .setSrcs(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("foo.c"))))
-        .isUiTest(true)
-        .setTestHostApp(Optional.of(testHostBundleTarget));
+    AppleBinaryBuilder testHostBinaryBuilder =
+        AppleBinaryBuilder.createBuilder(testHostBinTarget)
+            .setSrcs(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("foo.c"))));
 
-    TargetGraph targetGraph = TargetGraphFactory.newInstance(testBuilder.build(), testHostBundleNode, testHostBinaryNode);
+    AppleBundleBuilder testHostBundleBuilder =
+        AppleBundleBuilder.createBuilder(testHostBundleTarget)
+            .setBinary(testHostBinTarget)
+            .setExtension(Either.ofLeft(AppleBundleExtension.APP))
+            .setInfoPlist(new FakeSourcePath(("Info.plist")));
+
+    AppleTestBuilder testBuilder =
+        AppleTestBuilder.createBuilder(testTarget)
+            .setInfoPlist(new FakeSourcePath(("Info.plist")))
+            .setSrcs(ImmutableSortedSet.of(SourceWithFlags.of(new FakeSourcePath("foo.c"))))
+            .isUiTest(true)
+            .setTestHostApp(Optional.of(testHostBundleTarget));
+
+    TargetGraph targetGraph =
+        TargetGraphFactory.newInstance(
+            testBuilder.build(), testHostBundleBuilder.build(), testHostBinaryBuilder.build());
     BuildRuleResolver resolver =
         new DefaultBuildRuleResolver(targetGraph, new DefaultTargetNodeToBuildRuleTransformer());
     resolver.requireRule(testHostBundleTarget);
-    AppleTest test = (AppleTest) testBuilder.build(resolver, targetGraph);
+    AppleTest test = testBuilder.build(resolver, targetGraph);
 
     assertTrue(test.isUiTest());
     assertFalse(test.hasTestHost());


### PR DESCRIPTION
This allows `apple_test` bundles with `is_ui_test` to be correctly build
with buck, so that they can be used with an external test runner.

Currently, the `test_host_app` is used as the `bundle_loader` when
linking an apple_test. Since the uitest bundle isn't injected into the
app it is testing, but into a stub app when building a uitest we should
not use it as the bundle_loader.