### PR TITLE
Add an argument for scheme pre and post actions in Xcode

### DIFF
--- a/src/com/facebook/buck/apple/XcodeWorkspaceConfigDescription.java
+++ b/src/com/facebook/buck/apple/XcodeWorkspaceConfigDescription.java
@@ -26,6 +26,7 @@ import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.CommonDescriptionArg;
 import com.facebook.buck.rules.Description;
 import com.facebook.buck.rules.NoopBuildRuleWithDeclaredAndExtraDeps;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
@@ -103,5 +104,10 @@ public class XcodeWorkspaceConfigDescription
     Optional<String> getExplicitRunnablePath();
 
     Optional<XCScheme.LaunchAction.LaunchStyle> getLaunchStyle();
+
+    Optional<
+            ImmutableMap<
+                SchemeActionType, ImmutableMap<XCScheme.AdditionalActions, ImmutableList<String>>>>
+        getAdditionalSchemeActions();
   }
 }

--- a/src/com/facebook/buck/apple/project_generator/SchemeGenerator.java
+++ b/src/com/facebook/buck/apple/project_generator/SchemeGenerator.java
@@ -25,6 +25,7 @@ import com.facebook.buck.log.Logger;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -77,6 +78,13 @@ class SchemeGenerator {
   private final Optional<String> remoteRunnablePath;
   private final ImmutableMap<SchemeActionType, String> actionConfigNames;
   private final ImmutableMap<PBXTarget, Path> targetToProjectPathMap;
+
+  @SuppressWarnings("unused")
+  private Optional<
+          ImmutableMap<
+              SchemeActionType, ImmutableMap<XCScheme.AdditionalActions, ImmutableList<String>>>>
+      additionalSchemeActions;
+
   private Optional<XCScheme> outputScheme = Optional.empty();
   private final XCScheme.LaunchAction.LaunchStyle launchStyle;
   private final Optional<ImmutableMap<SchemeActionType, ImmutableMap<String, String>>>
@@ -96,6 +104,11 @@ class SchemeGenerator {
       ImmutableMap<SchemeActionType, String> actionConfigNames,
       ImmutableMap<PBXTarget, Path> targetToProjectPathMap,
       Optional<ImmutableMap<SchemeActionType, ImmutableMap<String, String>>> environmentVariables,
+      Optional<
+              ImmutableMap<
+                  SchemeActionType,
+                  ImmutableMap<XCScheme.AdditionalActions, ImmutableList<String>>>>
+          additionalSchemeActions,
       XCScheme.LaunchAction.LaunchStyle launchStyle) {
     this.projectFilesystem = projectFilesystem;
     this.primaryTarget = primaryTarget;
@@ -111,6 +124,7 @@ class SchemeGenerator {
     this.actionConfigNames = actionConfigNames;
     this.targetToProjectPathMap = targetToProjectPathMap;
     this.environmentVariables = environmentVariables;
+    this.additionalSchemeActions = additionalSchemeActions;
 
     LOG.debug(
         "Generating scheme with build targets %s, test build targets %s, test bundle targets %s",

--- a/src/com/facebook/buck/apple/project_generator/WorkspaceAndProjectGenerator.java
+++ b/src/com/facebook/buck/apple/project_generator/WorkspaceAndProjectGenerator.java
@@ -944,6 +944,7 @@ public class WorkspaceAndProjectGenerator {
               XcodeWorkspaceConfigDescription.getActionConfigNamesFromArg(workspaceArguments),
               targetToProjectPathMap,
               schemeConfigArg.getEnvironmentVariables(),
+              schemeConfigArg.getAdditionalSchemeActions(),
               schemeConfigArg.getLaunchStyle().orElse(XCScheme.LaunchAction.LaunchStyle.AUTO));
       schemeGenerator.writeScheme();
       schemeGenerators.put(schemeName, schemeGenerator);

--- a/src/com/facebook/buck/apple/xcode/XCScheme.java
+++ b/src/com/facebook/buck/apple/xcode/XCScheme.java
@@ -16,6 +16,7 @@
 
 package com.facebook.buck.apple.xcode;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -116,12 +117,54 @@ public class XCScheme {
     }
   }
 
-  public static class BuildAction {
+  public static class SchemePrePostAction {
+    private final Optional<BuildableReference> buildableReference;
+    private String command;
+
+    public SchemePrePostAction(Optional<BuildableReference> buildableReference, String command) {
+      this.buildableReference = buildableReference;
+      this.command = command;
+    }
+
+    public Optional<BuildableReference> getBuildableReference() {
+      return buildableReference;
+    }
+
+    public String getCommand() {
+      return command;
+    }
+  }
+
+  public abstract static class SchemeAction {
+    private final Optional<ImmutableList<SchemePrePostAction>> preActions;
+    private final Optional<ImmutableList<SchemePrePostAction>> postActions;
+
+    public SchemeAction(
+        Optional<ImmutableList<SchemePrePostAction>> preActions,
+        Optional<ImmutableList<SchemePrePostAction>> postActions) {
+      this.preActions = preActions;
+      this.postActions = postActions;
+    }
+
+    public Optional<ImmutableList<SchemePrePostAction>> getPreActions() {
+      return this.preActions;
+    }
+
+    public Optional<ImmutableList<SchemePrePostAction>> getPostActions() {
+      return this.postActions;
+    }
+  }
+
+  public static class BuildAction extends SchemeAction {
     private List<BuildActionEntry> buildActionEntries;
 
     private final boolean parallelizeBuild;
 
-    public BuildAction(boolean parallelizeBuild) {
+    public BuildAction(
+        boolean parallelizeBuild,
+        Optional<ImmutableList<SchemePrePostAction>> preActions,
+        Optional<ImmutableList<SchemePrePostAction>> postActions) {
+      super(preActions, postActions);
       buildActionEntries = new ArrayList<>();
       this.parallelizeBuild = parallelizeBuild;
     }
@@ -170,7 +213,7 @@ public class XCScheme {
     }
   }
 
-  public static class LaunchAction {
+  public static class LaunchAction extends SchemeAction {
 
     public enum LaunchStyle {
       /** Starts the process with attached debugger. */
@@ -193,7 +236,10 @@ public class XCScheme {
         Optional<String> runnablePath,
         Optional<String> remoteRunnablePath,
         LaunchStyle launchStyle,
-        Optional<ImmutableMap<String, String>> environmentVariables) {
+        Optional<ImmutableMap<String, String>> environmentVariables,
+        Optional<ImmutableList<SchemePrePostAction>> preActions,
+        Optional<ImmutableList<SchemePrePostAction>> postActions) {
+      super(preActions, postActions);
       this.buildableReference = buildableReference;
       this.buildConfiguration = buildConfiguration;
       this.runnablePath = runnablePath;
@@ -227,7 +273,7 @@ public class XCScheme {
     }
   }
 
-  public static class ProfileAction {
+  public static class ProfileAction extends SchemeAction {
     BuildableReference buildableReference;
     private final String buildConfiguration;
     private final Optional<ImmutableMap<String, String>> environmentVariables;
@@ -235,7 +281,10 @@ public class XCScheme {
     public ProfileAction(
         BuildableReference buildableReference,
         String buildConfiguration,
-        Optional<ImmutableMap<String, String>> environmentVariables) {
+        Optional<ImmutableMap<String, String>> environmentVariables,
+        Optional<ImmutableList<SchemePrePostAction>> preActions,
+        Optional<ImmutableList<SchemePrePostAction>> postActions) {
+      super(preActions, postActions);
       this.buildableReference = buildableReference;
       this.buildConfiguration = buildConfiguration;
       this.environmentVariables = environmentVariables;
@@ -254,13 +303,17 @@ public class XCScheme {
     }
   }
 
-  public static class TestAction {
+  public static class TestAction extends SchemeAction {
     List<TestableReference> testables;
     private final String buildConfiguration;
     private final Optional<ImmutableMap<String, String>> environmentVariables;
 
     public TestAction(
-        String buildConfiguration, Optional<ImmutableMap<String, String>> environmentVariables) {
+        String buildConfiguration,
+        Optional<ImmutableMap<String, String>> environmentVariables,
+        Optional<ImmutableList<SchemePrePostAction>> preActions,
+        Optional<ImmutableList<SchemePrePostAction>> postActions) {
+      super(preActions, postActions);
       this.testables = new ArrayList<>();
       this.buildConfiguration = buildConfiguration;
       this.environmentVariables = environmentVariables;
@@ -295,10 +348,14 @@ public class XCScheme {
     }
   }
 
-  public static class AnalyzeAction {
+  public static class AnalyzeAction extends SchemeAction {
     public final String buildConfiguration;
 
-    public AnalyzeAction(String buildConfiguration) {
+    public AnalyzeAction(
+        String buildConfiguration,
+        Optional<ImmutableList<SchemePrePostAction>> preActions,
+        Optional<ImmutableList<SchemePrePostAction>> postActions) {
+      super(preActions, postActions);
       this.buildConfiguration = buildConfiguration;
     }
 
@@ -307,10 +364,14 @@ public class XCScheme {
     }
   }
 
-  public static class ArchiveAction {
+  public static class ArchiveAction extends SchemeAction {
     public final String buildConfiguration;
 
-    public ArchiveAction(String buildConfiguration) {
+    public ArchiveAction(
+        String buildConfiguration,
+        Optional<ImmutableList<SchemePrePostAction>> preActions,
+        Optional<ImmutableList<SchemePrePostAction>> postActions) {
+      super(preActions, postActions);
       this.buildConfiguration = buildConfiguration;
     }
 

--- a/src/com/facebook/buck/apple/xcode/XCScheme.java
+++ b/src/com/facebook/buck/apple/xcode/XCScheme.java
@@ -76,6 +76,12 @@ public class XCScheme {
     return archiveAction;
   }
 
+  public enum AdditionalActions {
+    PRE_SCHEME_ACTIONS,
+    POST_SCHEME_ACTIONS,
+    ;
+  }
+
   public static class BuildableReference {
     private String containerRelativePath;
     private String blueprintIdentifier;

--- a/test/com/facebook/buck/apple/XcodeWorkspaceConfigBuilder.java
+++ b/test/com/facebook/buck/apple/XcodeWorkspaceConfigBuilder.java
@@ -20,6 +20,8 @@ import com.facebook.buck.apple.xcode.XCScheme;
 import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.rules.AbstractNodeBuilder;
 import com.facebook.buck.rules.BuildRule;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.Optional;
@@ -77,6 +79,16 @@ public class XcodeWorkspaceConfigBuilder
   public XcodeWorkspaceConfigBuilder setLaunchStyle(
       Optional<XCScheme.LaunchAction.LaunchStyle> launchStyle) {
     getArgForPopulating().setLaunchStyle(launchStyle);
+    return this;
+  }
+
+  public XcodeWorkspaceConfigBuilder setAdditionalSchemeActions(
+      Optional<
+              ImmutableMap<
+                  SchemeActionType,
+                  ImmutableMap<XCScheme.AdditionalActions, ImmutableList<String>>>>
+          additionalSchemeActions) {
+    getArgForPopulating().setAdditionalSchemeActions(additionalSchemeActions);
     return this;
   }
 }

--- a/test/com/facebook/buck/apple/project_generator/SchemeGeneratorTest.java
+++ b/test/com/facebook/buck/apple/project_generator/SchemeGeneratorTest.java
@@ -120,6 +120,7 @@ public class SchemeGeneratorTest {
             SchemeActionType.DEFAULT_CONFIG_NAMES,
             targetToProjectPathMapBuilder.build(),
             Optional.empty(),
+            Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO);
 
     Path schemePath = schemeGenerator.writeScheme();
@@ -199,6 +200,7 @@ public class SchemeGeneratorTest {
             Optional.empty() /* remoteRunnablePath */,
             SchemeActionType.DEFAULT_CONFIG_NAMES,
             targetToProjectPathMapBuilder.build(),
+            Optional.empty(),
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO);
 
@@ -288,6 +290,7 @@ public class SchemeGeneratorTest {
             SchemeActionType.DEFAULT_CONFIG_NAMES,
             targetToProjectPathMapBuilder.build(),
             Optional.empty(),
+            Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO);
 
     Path schemePath = schemeGenerator.writeScheme();
@@ -364,6 +367,7 @@ public class SchemeGeneratorTest {
             SchemeActionType.DEFAULT_CONFIG_NAMES,
             targetToProjectPathMapBuilder.build(),
             Optional.empty(),
+            Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO);
 
     Path schemePath = schemeGenerator.writeScheme();
@@ -421,6 +425,7 @@ public class SchemeGeneratorTest {
             Optional.empty() /* remoteRunnablePath */,
             SchemeActionType.DEFAULT_CONFIG_NAMES,
             targetToProjectPathMapBuilder.build(),
+            Optional.empty(),
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO);
 
@@ -504,6 +509,7 @@ public class SchemeGeneratorTest {
               SchemeActionType.DEFAULT_CONFIG_NAMES,
               targetToProjectPathMapBuilder.build(),
               Optional.empty(),
+              Optional.empty(),
               XCScheme.LaunchAction.LaunchStyle.AUTO);
 
       Path schemePath = schemeGenerator.writeScheme();
@@ -536,6 +542,7 @@ public class SchemeGeneratorTest {
               Optional.empty() /* remoteRunnablePath */,
               SchemeActionType.DEFAULT_CONFIG_NAMES,
               ImmutableMap.of(rootTarget, pbxprojectPath),
+              Optional.empty(),
               Optional.empty(),
               XCScheme.LaunchAction.LaunchStyle.AUTO);
 
@@ -573,7 +580,9 @@ public class SchemeGeneratorTest {
               SchemeActionType.DEFAULT_CONFIG_NAMES,
               ImmutableMap.of(rootTarget, pbxprojectPath),
               Optional.empty(),
+              Optional.empty(),
               XCScheme.LaunchAction.LaunchStyle.AUTO);
+
       Path schemePath = schemeGenerator.writeScheme();
       assertThat(
           projectFilesystem.getLastModifiedTime(schemePath), equalTo(FileTime.fromMillis(49152L)));
@@ -604,6 +613,7 @@ public class SchemeGeneratorTest {
               Optional.empty() /* remoteRunnablePath */,
               SchemeActionType.DEFAULT_CONFIG_NAMES,
               ImmutableMap.of(rootTarget, pbxprojectPath),
+              Optional.empty(),
               Optional.empty(),
               XCScheme.LaunchAction.LaunchStyle.AUTO);
       Path schemePath = schemeGenerator.writeScheme();
@@ -659,6 +669,7 @@ public class SchemeGeneratorTest {
             Optional.empty() /* remoteRunnablePath */,
             SchemeActionType.DEFAULT_CONFIG_NAMES,
             targetToProjectPathMapBuilder.build(),
+            Optional.empty(),
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO);
 
@@ -764,6 +775,7 @@ public class SchemeGeneratorTest {
             SchemeActionType.DEFAULT_CONFIG_NAMES,
             targetToProjectPathMapBuilder.build(),
             Optional.empty(),
+            Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO);
 
     Path schemePath = schemeGenerator.writeScheme();
@@ -811,6 +823,7 @@ public class SchemeGeneratorTest {
             Optional.of("/RemoteApp") /* remoteRunnablePath */,
             SchemeActionType.DEFAULT_CONFIG_NAMES,
             targetToProjectPathMapBuilder.build(),
+            Optional.empty(),
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO);
 
@@ -881,6 +894,7 @@ public class SchemeGeneratorTest {
             SchemeActionType.DEFAULT_CONFIG_NAMES,
             targetToProjectPathMapBuilder.build(),
             Optional.empty(),
+            Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO);
 
     Path schemePath = schemeGenerator.writeScheme();
@@ -939,6 +953,7 @@ public class SchemeGeneratorTest {
             SchemeActionType.DEFAULT_CONFIG_NAMES,
             targetToProjectPathMapBuilder.build(),
             Optional.of(environmentVariables),
+            Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO);
 
     Path schemePath = schemeGenerator.writeScheme();

--- a/test/com/facebook/buck/apple/project_generator/WorkspaceAndProjectGeneratorTest.java
+++ b/test/com/facebook/buck/apple/project_generator/WorkspaceAndProjectGeneratorTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import com.facebook.buck.apple.AppleBinaryBuilder;
 import com.facebook.buck.apple.AppleBundleBuilder;
@@ -72,6 +73,7 @@ import com.facebook.buck.shell.GenruleDescriptionArg;
 import com.facebook.buck.swift.SwiftBuckConfig;
 import com.facebook.buck.testutil.TargetGraphFactory;
 import com.facebook.buck.util.CloseableMemoizedSupplier;
+import com.facebook.buck.util.environment.Platform;
 import com.facebook.buck.util.timing.IncrementingFakeClock;
 import com.facebook.buck.util.types.Either;
 import com.google.common.collect.ImmutableList;
@@ -119,6 +121,7 @@ public class WorkspaceAndProjectGeneratorTest {
 
   @Before
   public void setUp() throws InterruptedException, IOException {
+    assumeTrue(Platform.detect() == Platform.MACOS);
     rootCell = (new TestCellBuilder()).build();
     ProjectFilesystem projectFilesystem = rootCell.getFilesystem();
     BuckConfig fakeBuckConfig = FakeBuckConfig.builder().build();
@@ -957,9 +960,11 @@ public class WorkspaceAndProjectGeneratorTest {
         schemeActions =
             ImmutableMap.of(
                 SchemeActionType.BUILD,
-                ImmutableMap.of(AdditionalActions.PRE_SCHEME_ACTIONS, ImmutableList.of("echo yeha")),
+                ImmutableMap.of(
+                    AdditionalActions.PRE_SCHEME_ACTIONS, ImmutableList.of("echo yeha")),
                 SchemeActionType.LAUNCH,
-                ImmutableMap.of(AdditionalActions.POST_SCHEME_ACTIONS, ImmutableList.of("echo takeoff")));
+                ImmutableMap.of(
+                    AdditionalActions.POST_SCHEME_ACTIONS, ImmutableList.of("echo takeoff")));
     TargetNode<XcodeWorkspaceConfigDescriptionArg, ?> workspaceNode =
         XcodeWorkspaceConfigBuilder.createBuilder(
                 BuildTargetFactory.newInstance(rootCell.getRoot(), "//foo", "workspace"))


### PR DESCRIPTION
Xcode currently allows you to execute a shell step when you start an stop executing in a scheme. I would like buck to be able to generate a project with this configured.

I have an implementation of this on an internal fork, it works but the interface isn't very satisfying. Although the rule configuration seems reasonable:
```
xcode_workspace_config(
    ...
    additional_scheme_actions = {
      'Build': {
          'Pre': ['echo start'],
          'Post': ['echo stop'],
      }
    }
    ...
)
```
The current argument type that is coerced seems too long
```
Optional<ImmutableMap<SchemeActionType, ImmutableMap<XCScheme.AdditionalActions, ImmutableList<String>>>>
```
Any suggestions on how to handle this? Is this acceptable in java? Should I try to achieve this outside of buck?