### PR TITLE
Enable mixed sources compilation with scalac

### DIFF
--- a/src/com/facebook/buck/android/DefaultAndroidLibraryCompilerFactory.java
+++ b/src/com/facebook/buck/android/DefaultAndroidLibraryCompilerFactory.java
@@ -46,7 +46,8 @@ public class DefaultAndroidLibraryCompilerFactory implements AndroidLibraryCompi
       case JAVA:
         return new JavaConfiguredCompilerFactory(javaConfig, extraClasspathFromContextFunction);
       case SCALA:
-        return new ScalaConfiguredCompilerFactory(scalaConfig, extraClasspathFromContextFunction);
+        return new ScalaConfiguredCompilerFactory(
+            scalaConfig, javaConfig, extraClasspathFromContextFunction);
       case KOTLIN:
         return new KotlinConfiguredCompilerFactory(
             kotlinBuckConfig, javaConfig, extraClasspathFromContextFunction);

--- a/src/com/facebook/buck/jvm/scala/BUCK
+++ b/src/com/facebook/buck/jvm/scala/BUCK
@@ -11,6 +11,7 @@ java_immutables_library(
         "//src/com/facebook/buck/io:executable-finder",
         "//src/com/facebook/buck/io:io",
         "//src/com/facebook/buck/jvm/core:classhash",
+        "//src/com/facebook/buck/jvm/java:config",
         "//src/com/facebook/buck/jvm/java:rules",
         "//src/com/facebook/buck/jvm/java:steps",
         "//src/com/facebook/buck/jvm/java:support",

--- a/src/com/facebook/buck/jvm/scala/ScalaConfiguredCompilerFactory.java
+++ b/src/com/facebook/buck/jvm/scala/ScalaConfiguredCompilerFactory.java
@@ -19,10 +19,14 @@ package com.facebook.buck.jvm.scala;
 import com.facebook.buck.jvm.java.ConfiguredCompiler;
 import com.facebook.buck.jvm.java.ConfiguredCompilerFactory;
 import com.facebook.buck.jvm.java.ExtraClasspathFromContextFunction;
+import com.facebook.buck.jvm.java.JavaBuckConfig;
+import com.facebook.buck.jvm.java.Javac;
+import com.facebook.buck.jvm.java.JavacFactory;
 import com.facebook.buck.jvm.java.JavacOptions;
 import com.facebook.buck.jvm.java.JvmLibraryArg;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.SourcePathRuleFinder;
 import com.facebook.buck.rules.Tool;
 import com.facebook.buck.util.Optionals;
 import com.google.common.collect.ImmutableCollection;
@@ -30,12 +34,16 @@ import javax.annotation.Nullable;
 
 public class ScalaConfiguredCompilerFactory extends ConfiguredCompilerFactory {
   private final ScalaBuckConfig scalaBuckConfig;
+  private final JavaBuckConfig javaBuckConfig;
   private final ExtraClasspathFromContextFunction extraClasspathFromContextFunction;
   private @Nullable Tool scalac;
 
   public ScalaConfiguredCompilerFactory(
-      ScalaBuckConfig config, ExtraClasspathFromContextFunction extraClasspathFromContextFunction) {
+      ScalaBuckConfig config,
+      JavaBuckConfig javaBuckConfig,
+      ExtraClasspathFromContextFunction extraClasspathFromContextFunction) {
     this.scalaBuckConfig = config;
+    this.javaBuckConfig = javaBuckConfig;
     this.extraClasspathFromContextFunction = extraClasspathFromContextFunction;
   }
 
@@ -61,6 +69,8 @@ public class ScalaConfiguredCompilerFactory extends ConfiguredCompilerFactory {
         scalaBuckConfig.getCompilerFlags(),
         arg.getExtraArguments(),
         resolver.getAllRules(scalaBuckConfig.getCompilerPlugins()),
+        getJavac(resolver, arg),
+        javacOptions,
         extraClasspathFromContextFunction);
   }
 
@@ -73,5 +83,9 @@ public class ScalaConfiguredCompilerFactory extends ConfiguredCompilerFactory {
         .add(scalaBuckConfig.getScalaLibraryTarget())
         .addAll(scalaBuckConfig.getCompilerPlugins());
     Optionals.addIfPresent(scalaBuckConfig.getScalacTarget(), extraDepsBuilder);
+  }
+
+  private Javac getJavac(BuildRuleResolver resolver, JvmLibraryArg arg) {
+    return JavacFactory.create(new SourcePathRuleFinder(resolver), javaBuckConfig, arg);
   }
 }

--- a/src/com/facebook/buck/jvm/scala/ScalaLibraryBuilder.java
+++ b/src/com/facebook/buck/jvm/scala/ScalaLibraryBuilder.java
@@ -19,6 +19,8 @@ package com.facebook.buck.jvm.scala;
 import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.jvm.java.ConfiguredCompiler;
 import com.facebook.buck.jvm.java.DefaultJavaLibraryBuilder;
+import com.facebook.buck.jvm.java.JavaBuckConfig;
+import com.facebook.buck.jvm.java.JavacOptions;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildRuleResolver;
@@ -38,8 +40,16 @@ public class ScalaLibraryBuilder extends DefaultJavaLibraryBuilder {
       BuildRuleParams params,
       BuildRuleResolver buildRuleResolver,
       CellPathResolver cellRoots,
-      ScalaBuckConfig scalaBuckConfig) {
-    super(targetGraph, buildTarget, projectFilesystem, params, buildRuleResolver, cellRoots);
+      ScalaBuckConfig scalaBuckConfig,
+      JavaBuckConfig javaBuckConfig) {
+    super(
+        targetGraph,
+        buildTarget,
+        projectFilesystem,
+        params,
+        buildRuleResolver,
+        cellRoots,
+        javaBuckConfig);
     this.scalaBuckConfig = scalaBuckConfig;
   }
 
@@ -60,6 +70,12 @@ public class ScalaLibraryBuilder extends DefaultJavaLibraryBuilder {
     return new BuilderHelper();
   }
 
+  @Override
+  public ScalaLibraryBuilder setJavacOptions(JavacOptions javacOptions) {
+    super.setJavacOptions(javacOptions);
+    return this;
+  }
+
   protected class BuilderHelper extends DefaultJavaLibraryBuilder.BuilderHelper {
     @Override
     protected ConfiguredCompiler buildConfiguredCompiler() {
@@ -71,7 +87,9 @@ public class ScalaLibraryBuilder extends DefaultJavaLibraryBuilder {
           buildRuleResolver.getRule(scalaBuckConfig.getScalaLibraryTarget()),
           scalaBuckConfig.getCompilerFlags(),
           extraArguments,
-          buildRuleResolver.getAllRules(scalaBuckConfig.getCompilerPlugins()));
+          buildRuleResolver.getAllRules(scalaBuckConfig.getCompilerPlugins()),
+          getJavac(),
+          Preconditions.checkNotNull(getJavacOptions()));
     }
   }
 }

--- a/src/com/facebook/buck/jvm/scala/ScalaLibraryDescription.java
+++ b/src/com/facebook/buck/jvm/scala/ScalaLibraryDescription.java
@@ -18,7 +18,10 @@ package com.facebook.buck.jvm.scala;
 
 import com.facebook.buck.io.ProjectFilesystem;
 import com.facebook.buck.jvm.java.HasJavaAbi;
+import com.facebook.buck.jvm.java.JavaBuckConfig;
 import com.facebook.buck.jvm.java.JavaLibraryDescription;
+import com.facebook.buck.jvm.java.JavacOptions;
+import com.facebook.buck.jvm.java.JavacOptionsFactory;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleParams;
@@ -39,9 +42,14 @@ public class ScalaLibraryDescription
             ScalaLibraryDescription.AbstractScalaLibraryDescriptionArg> {
 
   private final ScalaBuckConfig scalaBuckConfig;
+  private final JavaBuckConfig javaBuckConfig;
+  private final JavacOptions defaultOptions;
 
-  public ScalaLibraryDescription(ScalaBuckConfig scalaBuckConfig) {
+  public ScalaLibraryDescription(
+      ScalaBuckConfig scalaBuckConfig, JavaBuckConfig javaBuckConfig, JavacOptions defaultOptions) {
     this.scalaBuckConfig = scalaBuckConfig;
+    this.javaBuckConfig = javaBuckConfig;
+    this.defaultOptions = defaultOptions;
   }
 
   @Override
@@ -58,6 +66,9 @@ public class ScalaLibraryDescription
       final BuildRuleResolver resolver,
       CellPathResolver cellRoots,
       ScalaLibraryDescriptionArg args) {
+    JavacOptions javacOptions =
+        JavacOptionsFactory.create(defaultOptions, buildTarget, projectFilesystem, resolver, args);
+
     ScalaLibraryBuilder scalaLibraryBuilder =
         new ScalaLibraryBuilder(
                 targetGraph,
@@ -66,7 +77,9 @@ public class ScalaLibraryDescription
                 rawParams,
                 resolver,
                 cellRoots,
-                scalaBuckConfig)
+                scalaBuckConfig,
+                javaBuckConfig)
+            .setJavacOptions(javacOptions)
             .setArgs(args);
 
     return HasJavaAbi.isAbiTarget(buildTarget)

--- a/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
+++ b/src/com/facebook/buck/rules/KnownBuildRuleTypes.java
@@ -615,10 +615,15 @@ public class KnownBuildRuleTypes {
     builder.register(new RustLibraryDescription(rustBuckConfig, cxxPlatforms, defaultCxxPlatform));
     builder.register(new RustTestDescription(rustBuckConfig, cxxPlatforms, defaultCxxPlatform));
     builder.register(new PrebuiltRustLibraryDescription());
-    builder.register(new ScalaLibraryDescription(scalaConfig));
+    builder.register(new ScalaLibraryDescription(scalaConfig, javaConfig, defaultJavacOptions));
     builder.register(
         new ScalaTestDescription(
-            scalaConfig, defaultJavaOptionsForTests, defaultTestRuleTimeoutMs, defaultCxxPlatform));
+            scalaConfig,
+            javaConfig,
+            defaultJavacOptions,
+            defaultJavaOptionsForTests,
+            defaultTestRuleTimeoutMs,
+            defaultCxxPlatform));
     builder.register(new SceneKitAssetsDescription());
     builder.register(new ShBinaryDescription());
     builder.register(new ShTestDescription(defaultTestRuleTimeoutMs));

--- a/test/com/facebook/buck/jvm/scala/FauxScalaLibraryBuilder.java
+++ b/test/com/facebook/buck/jvm/scala/FauxScalaLibraryBuilder.java
@@ -35,7 +35,7 @@ public class FauxScalaLibraryBuilder
 
   private FauxScalaLibraryBuilder(
       BuildTarget target, ProjectFilesystem projectFilesystem, HashCode hashCode) {
-    super(new ScalaLibraryDescription(null), target, projectFilesystem, hashCode);
+    super(new ScalaLibraryDescription(null, null, null), target, projectFilesystem, hashCode);
     this.projectFilesystem = projectFilesystem;
   }
 

--- a/test/com/facebook/buck/jvm/scala/ScalaLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/scala/ScalaLibraryIntegrationTest.java
@@ -102,4 +102,20 @@ public class ScalaLibraryIntegrationTest {
 
     assertThat(secondRuleKey, not(equalTo(firstRuleKey)));
   }
+
+  @Test(timeout = (2 * 60 * 1000))
+  public void shouldCompileMixedJavaAndScalaSources() throws Exception {
+    assertThat(
+        workspace
+            .runBuckCommand(
+                "run",
+                "--config",
+                "scala.compiler=//:scala-compiler",
+                "//:bin_mixed",
+                "--",
+                "world!")
+            .assertSuccess()
+            .getStdout(),
+        Matchers.containsString("Hello WORLD!"));
+  }
 }

--- a/test/com/facebook/buck/jvm/scala/testdata/scala_binary/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/scala/testdata/scala_binary/BUCK.fixture
@@ -17,6 +17,19 @@ java_binary(
     ],
 )
 
+scala_library(
+    name='mixed',
+    srcs=['MainMixed.scala', 'Class2.java'],
+)
+
+java_binary(
+    name='bin_mixed',
+    main_class='buck.MainMixed',
+    deps=[
+        ':mixed',
+    ],
+)
+
 ###### Compiler
 
 prebuilt_jar(

--- a/test/com/facebook/buck/jvm/scala/testdata/scala_binary/Class2.java
+++ b/test/com/facebook/buck/jvm/scala/testdata/scala_binary/Class2.java
@@ -1,0 +1,14 @@
+package buck;
+
+class Class2 {
+
+  private final String hello;
+
+  public Class2(String hello) {
+    this.hello = hello;
+  }
+
+  void sayHello() {
+    System.out.println("Hello " + hello);
+  }
+}

--- a/test/com/facebook/buck/jvm/scala/testdata/scala_binary/MainMixed.scala
+++ b/test/com/facebook/buck/jvm/scala/testdata/scala_binary/MainMixed.scala
@@ -1,0 +1,6 @@
+package buck
+
+object MainMixed extends App {
+  val argString = args map { _.toUpperCase } mkString ","
+  new Class2(argString).sayHello()
+}


### PR DESCRIPTION
This enables `scala` rules to correctly compile mixed scala+java sources similar to the kotlin rules