### PR TITLE
Updated code-coverage-format in test task to support multiple formats…

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -518,6 +518,7 @@
       <zipfileset excludes="**/*SF **/*RSA" src="${third-party.dir}/java/jacoco/org.jacoco.report-0.7.7.201606060606.jar"/>
       <zipfileset excludes="**/*SF **/*RSA" src="${third-party.dir}/java/asm/asm-debug-all-5.0.3.jar"/>
       <zipfileset excludes="**/*SF **/*RSA" src="${third-party.dir}/java/plexus/plexus-utils-3.0.20.jar"/>
+      <zipfileset includes="**/*.class" src="${third-party.dir}/java/guava/guava-20.0.jar"/>
       <fileset dir="${classes.dir}">
           <include name="com/facebook/buck/jvm/java/coverage/ReportGenerator.class"/>
       </fileset>

--- a/src/com/facebook/buck/cli/TestRunning.java
+++ b/src/com/facebook/buck/cli/TestRunning.java
@@ -78,6 +78,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
@@ -104,8 +106,6 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 
 /** Utility class for running tests from {@link TestRule}s which have been built. */
 public class TestRunning {
@@ -417,7 +417,7 @@ public class TestRunning {
                 buildContext.getSourcePathResolver(),
                 ruleFinder,
                 JacocoConstants.getJacocoOutputDir(params.getCell().getFilesystem()),
-                options.getCoverageReportFormat(),
+                options.getCoverageReportFormats(),
                 options.getCoverageReportTitle(),
                 javaBuckConfig.getDefaultJavacOptions().getSpoolMode()
                     == JavacOptions.SpoolMode.INTERMEDIATE_TO_DISK,
@@ -675,7 +675,7 @@ public class TestRunning {
       SourcePathResolver sourcePathResolver,
       SourcePathRuleFinder ruleFinder,
       Path outputDirectory,
-      CoverageReportFormat format,
+      Set<CoverageReportFormat> formats,
       String title,
       boolean useIntermediateClassesDir,
       Optional<String> coverageIncludes,
@@ -712,7 +712,7 @@ public class TestRunning {
         srcDirectories.build(),
         pathsToJars.build(),
         outputDirectory,
-        format,
+        formats,
         title,
         coverageIncludes,
         coverageExcludes);

--- a/src/com/facebook/buck/jvm/java/GenerateCodeCoverageReportStep.java
+++ b/src/com/facebook/buck/jvm/java/GenerateCodeCoverageReportStep.java
@@ -17,6 +17,7 @@
 package com.facebook.buck.jvm.java;
 
 import static com.facebook.buck.jvm.java.JacocoConstants.JACOCO_EXEC_COVERAGE_FILE;
+import static java.util.stream.Collectors.joining;
 
 import com.facebook.buck.io.MoreFiles;
 import com.facebook.buck.io.ProjectFilesystem;
@@ -50,7 +51,7 @@ public class GenerateCodeCoverageReportStep extends ShellStep {
   private final Set<String> sourceDirectories;
   private final Set<Path> jarFiles;
   private final Path outputDirectory;
-  private CoverageReportFormat format;
+  private final Set<CoverageReportFormat> formats;
   private final String title;
   private final Path propertyFile;
   private final Optional<String> coverageIncludes;
@@ -62,7 +63,7 @@ public class GenerateCodeCoverageReportStep extends ShellStep {
       Set<String> sourceDirectories,
       Set<Path> jarFiles,
       Path outputDirectory,
-      CoverageReportFormat format,
+      Set<CoverageReportFormat> formats,
       String title,
       Optional<String> coverageIncludes,
       Optional<String> coverageExcludes) {
@@ -72,7 +73,7 @@ public class GenerateCodeCoverageReportStep extends ShellStep {
     this.sourceDirectories = ImmutableSet.copyOf(sourceDirectories);
     this.jarFiles = ImmutableSet.copyOf(jarFiles);
     this.outputDirectory = outputDirectory;
-    this.format = format;
+    this.formats = formats;
     this.title = title;
     this.propertyFile = outputDirectory.resolve("parameters.properties");
     this.coverageIncludes = coverageIncludes;
@@ -130,7 +131,9 @@ public class GenerateCodeCoverageReportStep extends ShellStep {
 
     properties.setProperty("jacoco.output.dir", filesystem.resolve(outputDirectory).toString());
     properties.setProperty("jacoco.exec.data.file", JACOCO_EXEC_COVERAGE_FILE);
-    properties.setProperty("jacoco.format", format.toString().toLowerCase());
+    properties.setProperty(
+        "jacoco.format",
+        formats.stream().map(format -> format.name().toLowerCase()).collect(joining(",")));
     properties.setProperty("jacoco.title", title);
 
     properties.setProperty("classes.jars", formatPathSet(jarFiles));

--- a/src/com/facebook/buck/jvm/java/coverage/BUCK
+++ b/src/com/facebook/buck/jvm/java/coverage/BUCK
@@ -4,6 +4,7 @@ java_library(
     visibility = [],  # Only visible to this build file.
     deps = [
         "//third-party/java/jacoco:jacoco",
+        "//third-party/java/guava:guava",
         "//third-party/java/plexus:plexus-utils",
     ],
 )

--- a/src/com/facebook/buck/test/AbstractTestRunningOptions.java
+++ b/src/com/facebook/buck/test/AbstractTestRunningOptions.java
@@ -19,8 +19,10 @@ package com.facebook.buck.test;
 import com.facebook.buck.test.selectors.TestSelectorList;
 import com.facebook.buck.util.immutables.BuckStyleImmutable;
 import com.google.common.collect.ImmutableMap;
-import java.util.Optional;
 import org.immutables.value.Value;
+import java.util.EnumSet;
+import java.util.Optional;
+import java.util.Set;
 
 @Value.Immutable
 @BuckStyleImmutable
@@ -56,8 +58,8 @@ abstract class AbstractTestRunningOptions {
   public abstract Optional<String> getPathToJavaAgent();
 
   @Value.Default
-  public CoverageReportFormat getCoverageReportFormat() {
-    return CoverageReportFormat.HTML;
+  public Set<CoverageReportFormat> getCoverageReportFormats() {
+    return EnumSet.of(CoverageReportFormat.HTML);
   }
 
   @Value.Default

--- a/test/com/facebook/buck/jvm/java/GenerateCodeCoverageReportStepTest.java
+++ b/test/com/facebook/buck/jvm/java/GenerateCodeCoverageReportStepTest.java
@@ -31,6 +31,10 @@ import com.facebook.buck.test.CoverageReportFormat;
 import com.facebook.buck.testutil.MoreAsserts;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -41,15 +45,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 public class GenerateCodeCoverageReportStepTest {
 
@@ -95,7 +96,7 @@ public class GenerateCodeCoverageReportStepTest {
             SOURCE_DIRECTORIES,
             jarFiles,
             Paths.get(OUTPUT_DIRECTORY),
-            CoverageReportFormat.HTML,
+            EnumSet.of(CoverageReportFormat.HTML),
             "TitleFoo",
             Optional.empty(),
             Optional.empty());
@@ -132,7 +133,7 @@ public class GenerateCodeCoverageReportStepTest {
             SOURCE_DIRECTORIES,
             jarFiles,
             Paths.get(OUTPUT_DIRECTORY),
-            CoverageReportFormat.HTML,
+            EnumSet.of(CoverageReportFormat.HTML),
             "TitleFoo",
             Optional.empty(),
             Optional.empty()) {
@@ -166,7 +167,7 @@ public class GenerateCodeCoverageReportStepTest {
             SOURCE_DIRECTORIES,
             jarFiles,
             Paths.get(OUTPUT_DIRECTORY),
-            CoverageReportFormat.HTML,
+            EnumSet.of(CoverageReportFormat.HTML),
             "TitleFoo",
             Optional.empty(),
             Optional.empty()) {


### PR DESCRIPTION
Updated code-coverage-format in test task to support multiple formats.

- Change made in the way existing users will see no difference.
- Verified change locally.

