### PR TITLE
Allow services to be merged when disallowing all duplicates

### DIFF
--- a/src/com/facebook/buck/zip/JarBuilder.java
+++ b/src/com/facebook/buck/zip/JarBuilder.java
@@ -339,7 +339,8 @@ public class JarBuilder {
   }
 
   private boolean isDuplicateAllowed(String name) {
-    return !shouldDisallowAllDuplicates && !name.endsWith(".class") && !name.endsWith("/");
+    return isService(name)
+        || (!shouldDisallowAllDuplicates && !name.endsWith(".class") && !name.endsWith("/"));
   }
 
   private static class SingletonJarEntryContainer implements JarEntryContainer {

--- a/test/com/facebook/buck/jvm/java/JarBuilderTest.java
+++ b/test/com/facebook/buck/jvm/java/JarBuilderTest.java
@@ -32,6 +32,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -41,53 +42,172 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(Enclosed.class)
 public class JarBuilderTest {
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-  @Test
-  public void testSortsEntriesFromAllContainers() throws IOException {
-    File tempFile = temporaryFolder.newFile();
-    try (TestJarEntryContainer container1 = new TestJarEntryContainer("Container1");
-        TestJarEntryContainer container2 = new TestJarEntryContainer("Container2");
-        TestJarEntryContainer container3 = new TestJarEntryContainer("Container3")) {
-      new JarBuilder()
-          .addEntryContainer(container1.addEntry("Foo", "Foo").addEntry("Bar", "Bar"))
-          .addEntryContainer(
-              container2.addEntry("Bird", "Bird").addEntry("Dog", "Dog").addEntry("Cat", "Cat"))
-          .addEntryContainer(
-              container3
-                  .addEntry("A", "A")
-                  .addEntry("B", "B")
-                  .addEntry("C", "C")
-                  .addEntry("D", "D"))
-          .createJarFile(tempFile.toPath());
+  public static class RegularTests {
+
+    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void testSortsEntriesFromAllContainers() throws IOException {
+      File tempFile = temporaryFolder.newFile();
+      try (TestJarEntryContainer container1 = new TestJarEntryContainer("Container1");
+          TestJarEntryContainer container2 = new TestJarEntryContainer("Container2");
+          TestJarEntryContainer container3 = new TestJarEntryContainer("Container3")) {
+        new JarBuilder()
+            .addEntryContainer(container1.addEntry("Foo", "Foo").addEntry("Bar", "Bar"))
+            .addEntryContainer(
+                container2.addEntry("Bird", "Bird").addEntry("Dog", "Dog").addEntry("Cat", "Cat"))
+            .addEntryContainer(
+                container3
+                    .addEntry("A", "A")
+                    .addEntry("B", "B")
+                    .addEntry("C", "C")
+                    .addEntry("D", "D"))
+            .createJarFile(tempFile.toPath());
+      }
+
+      try (JarFile jarFile = new JarFile(tempFile)) {
+        assertEquals(
+            ImmutableList.of(
+                "META-INF/",
+                "META-INF/MANIFEST.MF",
+                "A",
+                "B",
+                "Bar",
+                "Bird",
+                "C",
+                "Cat",
+                "D",
+                "Dog",
+                "Foo"),
+            jarFile.stream().map(JarEntry::getName).collect(Collectors.toList()));
+      }
     }
 
-    try (JarFile jarFile = new JarFile(tempFile)) {
-      assertEquals(
-          ImmutableList.of(
-              "META-INF/",
-              "META-INF/MANIFEST.MF",
-              "A",
-              "B",
-              "Bar",
-              "Bird",
-              "C",
-              "Cat",
-              "D",
-              "Dog",
-              "Foo"),
-          jarFile.stream().map(JarEntry::getName).collect(Collectors.toList()));
+    @Test
+    public void testDisallowAllDuplicates() throws IOException {
+      File tempFile = temporaryFolder.newFile();
+      JarBuilder builder;
+      try (TestJarEntryContainer container1 = new TestJarEntryContainer("Container1");
+          TestJarEntryContainer container2 = new TestJarEntryContainer("Container2")) {
+        builder =
+            new JarBuilder()
+                .addEntryContainer(
+                    container1
+                        .addEntry("Foo.class", "Foo1")
+                        .addEntry("Bar.class", "Bar1")
+                        .addEntry("Buz.txt", "Buz1"))
+                .addEntryContainer(
+                    container2
+                        .addEntry("Foo.class", "Foo2")
+                        .addEntry("Fiz.class", "Fiz2")
+                        .addEntry("Buz.txt", "Buz2"));
+      }
+
+      builder.createJarFile(tempFile.toPath());
+      try (JarFile jarFile = new JarFile(tempFile)) {
+        assertEquals(
+            ImmutableList.of(
+                "META-INF/",
+                "META-INF/MANIFEST.MF",
+                "Bar.class",
+                "Buz.txt",
+                "Buz.txt",
+                "Fiz.class",
+                "Foo.class"),
+            jarFile.stream().map(JarEntry::getName).collect(Collectors.toList()));
+      }
+
+      try (TestJarEntryContainer container1 = new TestJarEntryContainer("Container1");
+          TestJarEntryContainer container2 = new TestJarEntryContainer("Container2")) {
+        builder =
+            new JarBuilder()
+                .addEntryContainer(
+                    container1
+                        .addEntry("Foo.class", "Foo1")
+                        .addEntry("Bar.class", "Bar1")
+                        .addEntry("Buz.txt", "Buz1"))
+                .addEntryContainer(
+                    container2
+                        .addEntry("Foo.class", "Foo2")
+                        .addEntry("Fiz.class", "Fiz2")
+                        .addEntry("Buz.txt", "Buz2"));
+      }
+
+      builder.setShouldDisallowAllDuplicates(true);
+      builder.createJarFile(tempFile.toPath());
+      try (JarFile jarFile = new JarFile(tempFile)) {
+        assertEquals(
+            ImmutableList.of(
+                "META-INF/",
+                "META-INF/MANIFEST.MF",
+                "Bar.class",
+                "Buz.txt",
+                "Fiz.class",
+                "Foo.class"),
+            jarFile.stream().map(JarEntry::getName).collect(Collectors.toList()));
+      }
+    }
+
+    @Test
+    public void testMakesDirectoriesForEntries() throws IOException {
+      File tempFile = temporaryFolder.newFile();
+      JarBuilder jarBuilder = new JarBuilder();
+      addEntry(jarBuilder, "foo/1.txt", "1");
+      addEntry(jarBuilder, "foo/2.txt", "2");
+      addEntry(jarBuilder, "foo/bar/3.txt", "3");
+      jarBuilder.createJarFile(tempFile.toPath());
+
+      try (JarFile jarFile = new JarFile(tempFile)) {
+        assertEquals(
+            ImmutableList.of(
+                "META-INF/",
+                "META-INF/MANIFEST.MF",
+                "foo/",
+                "foo/1.txt",
+                "foo/2.txt",
+                "foo/bar/",
+                "foo/bar/3.txt"),
+            jarFile.stream().map(JarEntry::getName).collect(Collectors.toList()));
+      }
+    }
+
+    private void addEntry(JarBuilder builder, String name, String contents) {
+      builder.addEntry(
+          new JarEntrySupplier(
+              new CustomZipEntry(name),
+              "owner",
+              () -> new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8))));
     }
   }
 
-  @Test
-  public void testMergesServicesFromAllContainers() throws IOException {
-    File tempFile = temporaryFolder.newFile();
+  @RunWith(Parameterized.class)
+  public static class ParameterizedTests {
 
-    for (boolean shouldDisallowAllDuplicates : Arrays.asList(true, false)) {
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+      return Arrays.asList(new Object[][] {{true}, {false}});
+    }
+
+    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private final boolean shouldDisallowAllDuplicates;
+
+    public ParameterizedTests(boolean shouldDisallowAllDuplicates) {
+      this.shouldDisallowAllDuplicates = shouldDisallowAllDuplicates;
+    }
+
+    @Test
+    public void testMergesServicesFromAllContainers() throws IOException {
+      File tempFile = temporaryFolder.newFile();
+
       try (TestJarEntryContainer container1 = new TestJarEntryContainer("Container1");
           TestJarEntryContainer container2 = new TestJarEntryContainer("Container2");
           TestJarEntryContainer container3 = new TestJarEntryContainer("Container3")) {
@@ -138,102 +258,6 @@ public class JarBuilderTest {
             jarFile.stream().map(JarEntry::getName).collect(Collectors.toList()));
       }
     }
-  }
-
-  @Test
-  public void testDisallowAllDuplicates() throws IOException {
-    File tempFile = temporaryFolder.newFile();
-    JarBuilder builder;
-    try (TestJarEntryContainer container1 = new TestJarEntryContainer("Container1");
-        TestJarEntryContainer container2 = new TestJarEntryContainer("Container2")) {
-      builder =
-          new JarBuilder()
-              .addEntryContainer(
-                  container1
-                      .addEntry("Foo.class", "Foo1")
-                      .addEntry("Bar.class", "Bar1")
-                      .addEntry("Buz.txt", "Buz1"))
-              .addEntryContainer(
-                  container2
-                      .addEntry("Foo.class", "Foo2")
-                      .addEntry("Fiz.class", "Fiz2")
-                      .addEntry("Buz.txt", "Buz2"));
-    }
-
-    builder.createJarFile(tempFile.toPath());
-    try (JarFile jarFile = new JarFile(tempFile)) {
-      assertEquals(
-          ImmutableList.of(
-              "META-INF/",
-              "META-INF/MANIFEST.MF",
-              "Bar.class",
-              "Buz.txt",
-              "Buz.txt",
-              "Fiz.class",
-              "Foo.class"),
-          jarFile.stream().map(JarEntry::getName).collect(Collectors.toList()));
-    }
-
-    try (TestJarEntryContainer container1 = new TestJarEntryContainer("Container1");
-        TestJarEntryContainer container2 = new TestJarEntryContainer("Container2")) {
-      builder =
-          new JarBuilder()
-              .addEntryContainer(
-                  container1
-                      .addEntry("Foo.class", "Foo1")
-                      .addEntry("Bar.class", "Bar1")
-                      .addEntry("Buz.txt", "Buz1"))
-              .addEntryContainer(
-                  container2
-                      .addEntry("Foo.class", "Foo2")
-                      .addEntry("Fiz.class", "Fiz2")
-                      .addEntry("Buz.txt", "Buz2"));
-    }
-
-    builder.setShouldDisallowAllDuplicates(true);
-    builder.createJarFile(tempFile.toPath());
-    try (JarFile jarFile = new JarFile(tempFile)) {
-      assertEquals(
-          ImmutableList.of(
-              "META-INF/",
-              "META-INF/MANIFEST.MF",
-              "Bar.class",
-              "Buz.txt",
-              "Fiz.class",
-              "Foo.class"),
-          jarFile.stream().map(JarEntry::getName).collect(Collectors.toList()));
-    }
-  }
-
-  @Test
-  public void testMakesDirectoriesForEntries() throws IOException {
-    File tempFile = temporaryFolder.newFile();
-    JarBuilder jarBuilder = new JarBuilder();
-    addEntry(jarBuilder, "foo/1.txt", "1");
-    addEntry(jarBuilder, "foo/2.txt", "2");
-    addEntry(jarBuilder, "foo/bar/3.txt", "3");
-    jarBuilder.createJarFile(tempFile.toPath());
-
-    try (JarFile jarFile = new JarFile(tempFile)) {
-      assertEquals(
-          ImmutableList.of(
-              "META-INF/",
-              "META-INF/MANIFEST.MF",
-              "foo/",
-              "foo/1.txt",
-              "foo/2.txt",
-              "foo/bar/",
-              "foo/bar/3.txt"),
-          jarFile.stream().map(JarEntry::getName).collect(Collectors.toList()));
-    }
-  }
-
-  private void addEntry(JarBuilder builder, String name, String contents) {
-    builder.addEntry(
-        new JarEntrySupplier(
-            new CustomZipEntry(name),
-            "owner",
-            () -> new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8))));
   }
 
   private static class TestJarEntryContainer implements JarEntryContainer {


### PR DESCRIPTION
Services are treated specially just like manifest during merging and should be excluded from duplicate disallow logic