### PR TITLE
Hide stdout from version_aware_buck

### DIFF
--- a/programs/version_aware_buck.py
+++ b/programs/version_aware_buck.py
@@ -30,6 +30,7 @@ def get_buck_version(project):
 def revision_exists(repo, revision):
     returncode = subprocess.call(
         ['git', 'rev-parse', '--verify', revision],
+        stdout=sys.stderr,
         cwd=repo.buck_dir)
     return returncode == 0
 


### PR DESCRIPTION
So tools don't have to care if you use `buck` or `version_aware_buck`