### PR TITLE
Xcode project set LD_RUNPATH_SEARCH_PATHS with Swift

### DIFF
--- a/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
+++ b/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
@@ -1483,6 +1483,8 @@ public class ProjectGenerator {
     HashSet<String> librarySearchPaths = new HashSet<>();
     librarySearchPaths.add("$BUILT_PRODUCTS_DIR");
     HashSet<String> ldRunpathSearchPaths = new HashSet<>();
+    ImmutableSet<PBXFileReference> swiftDeps =
+        collectRecursiveLibraryDependenciesWithSwiftSources(node);
 
     Stream.concat(
             // Collect all the nodes that contribute to linking
@@ -1560,11 +1562,14 @@ public class ProjectGenerator {
       // we have a plain apple_binary that has Swift deps. So we're manually doing exactly what
       // Xcode does to make sure binaries link successfully if they use Swift directly or
       // transitively.
-      ImmutableSet<PBXFileReference> swiftDeps =
-          collectRecursiveLibraryDependenciesWithSwiftSources(node);
       if (swiftDeps.size() > 0) {
         librarySearchPaths.add("$DT_TOOLCHAIN_DIR/usr/lib/swift/$PLATFORM_NAME");
       }
+    }
+
+    if (swiftDeps.size() > 0) {
+      ldRunpathSearchPaths.add("@executable_path/Frameworks");
+      ldRunpathSearchPaths.add("@loader_path/Frameworks");
     }
 
     ImmutableMap.Builder<String, String> results =

--- a/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
+++ b/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
@@ -1555,7 +1555,7 @@ public class ProjectGenerator {
                       });
             });
 
-    if (includeFrameworks) {
+    if (includeFrameworks && swiftDeps.size() > 0) {
       // When Xcode compiles static Swift libs, it will include linker commands (LC_LINKER_OPTION)
       // that will be carried over for the final binary to link to the appropriate Swift overlays
       // and libs. This means that the final binary must be able to locate the Swift libs in the
@@ -1564,9 +1564,7 @@ public class ProjectGenerator {
       // we have a plain apple_binary that has Swift deps. So we're manually doing exactly what
       // Xcode does to make sure binaries link successfully if they use Swift directly or
       // transitively.
-      if (swiftDeps.size() > 0) {
-        librarySearchPaths.add("$DT_TOOLCHAIN_DIR/usr/lib/swift/$PLATFORM_NAME");
-      }
+      librarySearchPaths.add("$DT_TOOLCHAIN_DIR/usr/lib/swift/$PLATFORM_NAME");
     }
 
     if (swiftDeps.size() > 0) {

--- a/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
+++ b/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
@@ -1483,7 +1483,7 @@ public class ProjectGenerator {
     HashSet<String> librarySearchPaths = new HashSet<>();
     librarySearchPaths.add("$BUILT_PRODUCTS_DIR");
     HashSet<String> iOSLdRunpathSearchPaths = new HashSet<>();
-    HashSet<String> macOSLdldRunpathSearchPaths = new HashSet<>();
+    HashSet<String> macOSLdRunpathSearchPaths = new HashSet<>();
     ImmutableSet<PBXFileReference> swiftDeps =
         collectRecursiveLibraryDependenciesWithSwiftSources(node);
 
@@ -1550,7 +1550,7 @@ public class ProjectGenerator {
                             != NativeLinkable.Linkage.STATIC) {
                           // Frameworks that are copied into the binary.
                           iOSLdRunpathSearchPaths.add("@executable_path/Frameworks");
-                          macOSLdldRunpathSearchPaths.add("@executable_path/../Frameworks");
+                          macOSLdRunpathSearchPaths.add("@executable_path/../Frameworks");
                         }
                       });
             });
@@ -1572,8 +1572,8 @@ public class ProjectGenerator {
     if (swiftDeps.size() > 0) {
       iOSLdRunpathSearchPaths.add("@executable_path/Frameworks");
       iOSLdRunpathSearchPaths.add("@loader_path/Frameworks");
-      macOSLdldRunpathSearchPaths.add("@executable_path/../Frameworks");
-      macOSLdldRunpathSearchPaths.add("@loader_path/../Frameworks");
+      macOSLdRunpathSearchPaths.add("@executable_path/../Frameworks");
+      macOSLdRunpathSearchPaths.add("@loader_path/../Frameworks");
     }
 
     ImmutableMap.Builder<String, String> results =
@@ -1587,9 +1587,9 @@ public class ProjectGenerator {
           "LD_RUNPATH_SEARCH_PATHS[sdk=iphonesimulator*]",
           Joiner.on(' ').join(iOSLdRunpathSearchPaths));
     }
-    if (!macOSLdldRunpathSearchPaths.isEmpty()) {
+    if (!macOSLdRunpathSearchPaths.isEmpty()) {
       results.put(
-          "LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]", Joiner.on(' ').join(macOSLdldRunpathSearchPaths));
+          "LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]", Joiner.on(' ').join(macOSLdRunpathSearchPaths));
     }
     return results.build();
   }

--- a/test/com/facebook/buck/apple/project_generator/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/apple/project_generator/ProjectGeneratorTest.java
@@ -4527,6 +4527,9 @@ public class ProjectGeneratorTest {
     assertThat(
         buildSettings.get("LIBRARY_SEARCH_PATHS"),
         containsString("$DT_TOOLCHAIN_DIR/usr/lib/swift/$PLATFORM_NAME"));
+    assertThat(
+        buildSettings.get("LD_RUNPATH_SEARCH_PATHS"),
+        equalTo("$(inherited) @executable_path/Frameworks @loader_path/Frameworks"));
   }
 
   @Test

--- a/test/com/facebook/buck/apple/project_generator/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/apple/project_generator/ProjectGeneratorTest.java
@@ -4528,8 +4528,14 @@ public class ProjectGeneratorTest {
         buildSettings.get("LIBRARY_SEARCH_PATHS"),
         containsString("$DT_TOOLCHAIN_DIR/usr/lib/swift/$PLATFORM_NAME"));
     assertThat(
-        buildSettings.get("LD_RUNPATH_SEARCH_PATHS"),
+        buildSettings.get("LD_RUNPATH_SEARCH_PATHS[sdk=iphoneos*]"),
         equalTo("$(inherited) @executable_path/Frameworks @loader_path/Frameworks"));
+    assertThat(
+        buildSettings.get("LD_RUNPATH_SEARCH_PATHS[sdk=iphonesimulator*]"),
+        equalTo("$(inherited) @executable_path/Frameworks @loader_path/Frameworks"));
+    assertThat(
+        buildSettings.get("LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]"),
+        equalTo("$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks"));
   }
 
   @Test


### PR DESCRIPTION
Xcode copies the `libswift*.dylib` into the `Frameworks` folder of the binary bundle when you have a swift dependency. To be able to load these libraries, this requires the `LC_RPATH` (controlled in Xcode by`LD_RUNPATH_SEARCH_PATHS`) to be set to that folder.