### PR TITLE
 Xcode project gen add OTHER_SWIFT_FLAGS

### DIFF
--- a/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
+++ b/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
@@ -1311,7 +1311,7 @@ public class ProjectGenerator {
 
         Iterable<String> otherSwiftFlags =
             Iterables.concat(
-                swiftBuckConfig.getFlags("compiler_flags").orElse(DEFAULT_SWIFTFLAGS),
+                swiftBuckConfig.getCompilerFlags().orElse(DEFAULT_SWIFTFLAGS),
                 targetSpecificSwiftFlags.build());
         Iterable<String> otherCFlags =
             Iterables.concat(

--- a/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
+++ b/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
@@ -186,6 +186,7 @@ public class ProjectGenerator {
   private static final Logger LOG = Logger.get(ProjectGenerator.class);
   private static final ImmutableList<String> DEFAULT_CFLAGS = ImmutableList.of();
   private static final ImmutableList<String> DEFAULT_CXXFLAGS = ImmutableList.of();
+  private static final ImmutableList<String> DEFAULT_SWIFTFLAGS = ImmutableList.of();
   private static final String PRODUCT_NAME = "PRODUCT_NAME";
 
   private static final ImmutableSet<Class<? extends Description<?>>>
@@ -1300,6 +1301,18 @@ public class ProjectGenerator {
           appendConfigsBuilder.put("SWIFT_INCLUDE_PATHS", "$BUILT_PRODUCTS_DIR");
         }
 
+        ImmutableList.Builder<String> targetSpecificSwiftFlags = ImmutableList.builder();
+        if (targetNode.getConstructorArg() instanceof SwiftCommonArg) {
+          targetSpecificSwiftFlags.addAll(
+              convertStringWithMacros(
+                  targetNode,
+                  ((SwiftCommonArg) targetNode.getConstructorArg()).getSwiftCompilerFlags()));
+        }
+
+        Iterable<String> otherSwiftFlags =
+            Iterables.concat(
+                swiftBuckConfig.getFlags("compiler_flags").orElse(DEFAULT_SWIFTFLAGS),
+                targetSpecificSwiftFlags.build());
         Iterable<String> otherCFlags =
             Iterables.concat(
                 cxxBuckConfig.getFlags("cflags").orElse(DEFAULT_CFLAGS),
@@ -1326,6 +1339,9 @@ public class ProjectGenerator {
                     collectRecursiveExportedLinkerFlags(targetNode)));
 
         appendConfigsBuilder
+            .put(
+                "OTHER_SWIFT_FLAGS",
+                Joiner.on(' ').join(Iterables.transform(otherSwiftFlags, Escaper.BASH_ESCAPER)))
             .put(
                 "OTHER_CFLAGS",
                 Joiner.on(' ').join(Iterables.transform(otherCFlags, Escaper.BASH_ESCAPER)))

--- a/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
+++ b/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
@@ -1302,12 +1302,15 @@ public class ProjectGenerator {
         }
 
         ImmutableList.Builder<String> targetSpecificSwiftFlags = ImmutableList.builder();
-        if (targetNode.getConstructorArg() instanceof SwiftCommonArg) {
-          targetSpecificSwiftFlags.addAll(
-              convertStringWithMacros(
-                  targetNode,
-                  ((SwiftCommonArg) targetNode.getConstructorArg()).getSwiftCompilerFlags()));
-        }
+        Optional<TargetNode<SwiftCommonArg, ?>> swiftTargetNode =
+            targetNode.castArg(SwiftCommonArg.class);
+        targetSpecificSwiftFlags.addAll(
+            swiftTargetNode
+                .map(
+                    x ->
+                        convertStringWithMacros(
+                            targetNode, x.getConstructorArg().getSwiftCompilerFlags()))
+                .orElse(ImmutableList.of()));
 
         Iterable<String> otherSwiftFlags =
             Iterables.concat(

--- a/src/com/facebook/buck/swift/SwiftBuckConfig.java
+++ b/src/com/facebook/buck/swift/SwiftBuckConfig.java
@@ -18,6 +18,7 @@ package com.facebook.buck.swift;
 
 import com.facebook.buck.config.BuckConfig;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import java.util.Optional;
 
 /** A Swift-specific "view" of BuckConfig. */
@@ -34,6 +35,18 @@ public class SwiftBuckConfig {
   public Optional<Iterable<String>> getFlags() {
     Optional<String> value = delegate.getValue(SECTION_NAME, COMPILER_FLAGS_NAME);
     return value.map(input -> Splitter.on(" ").split(input.trim()));
+  }
+
+  public Optional<ImmutableList<String>> getFlags(String field) {
+    Optional<String> value = delegate.getValue(SECTION_NAME, field);
+    if (!value.isPresent()) {
+      return Optional.empty();
+    }
+    ImmutableList.Builder<String> split = ImmutableList.builder();
+    if (!value.get().trim().isEmpty()) {
+      split.addAll(Splitter.on(" ").split(value.get().trim()));
+    }
+    return Optional.of(split.build());
   }
 
   public Optional<String> getVersion() {

--- a/src/com/facebook/buck/swift/SwiftBuckConfig.java
+++ b/src/com/facebook/buck/swift/SwiftBuckConfig.java
@@ -23,7 +23,8 @@ import java.util.Optional;
 /** A Swift-specific "view" of BuckConfig. */
 public class SwiftBuckConfig {
   private static final String SECTION_NAME = "swift";
-  private static final String COMPILER_FLAGS_NAME = "compiler_flags";
+  public static final String COMPILER_FLAGS_NAME = "compiler_flags";
+  public static final String VERSION_NAME = "version";
 
   private final BuckConfig delegate;
 
@@ -31,16 +32,16 @@ public class SwiftBuckConfig {
     this.delegate = delegate;
   }
 
-  public Optional<Iterable<String>> getFlags(String field) {
+  private Optional<Iterable<String>> getFlags(String field) {
     Optional<String> value = delegate.getValue(SECTION_NAME, field);
     return value.map(input -> Splitter.on(" ").split(input.trim()));
   }
 
-  public Optional<Iterable<String>> getFlags() {
+  public Optional<Iterable<String>> getCompilerFlags() {
     return getFlags(COMPILER_FLAGS_NAME);
   }
 
   public Optional<String> getVersion() {
-    return delegate.getValue(SECTION_NAME, "version");
+    return delegate.getValue(SECTION_NAME, VERSION_NAME);
   }
 }

--- a/src/com/facebook/buck/swift/SwiftBuckConfig.java
+++ b/src/com/facebook/buck/swift/SwiftBuckConfig.java
@@ -18,7 +18,6 @@ package com.facebook.buck.swift;
 
 import com.facebook.buck.config.BuckConfig;
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
 import java.util.Optional;
 
 /** A Swift-specific "view" of BuckConfig. */
@@ -32,21 +31,13 @@ public class SwiftBuckConfig {
     this.delegate = delegate;
   }
 
-  public Optional<Iterable<String>> getFlags() {
-    Optional<String> value = delegate.getValue(SECTION_NAME, COMPILER_FLAGS_NAME);
+  public Optional<Iterable<String>> getFlags(String field) {
+    Optional<String> value = delegate.getValue(SECTION_NAME, field);
     return value.map(input -> Splitter.on(" ").split(input.trim()));
   }
 
-  public Optional<ImmutableList<String>> getFlags(String field) {
-    Optional<String> value = delegate.getValue(SECTION_NAME, field);
-    if (!value.isPresent()) {
-      return Optional.empty();
-    }
-    ImmutableList.Builder<String> split = ImmutableList.builder();
-    if (!value.get().trim().isEmpty()) {
-      split.addAll(Splitter.on(" ").split(value.get().trim()));
-    }
-    return Optional.of(split.build());
+  public Optional<Iterable<String>> getFlags() {
+    return getFlags(COMPILER_FLAGS_NAME);
   }
 
   public Optional<String> getVersion() {

--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -124,7 +124,7 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
     this.version = version;
     this.compilerFlags =
         new ImmutableList.Builder<Arg>()
-            .addAll(StringArg.from(swiftBuckConfig.getFlags().orElse(ImmutableSet.of())))
+            .addAll(StringArg.from(swiftBuckConfig.getCompilerFlags().orElse(ImmutableSet.of())))
             .addAll(compilerFlags)
             .build();
     this.enableObjcInterop = enableObjcInterop.orElse(true);

--- a/test/com/facebook/buck/apple/AppleLibraryBuilder.java
+++ b/test/com/facebook/buck/apple/AppleLibraryBuilder.java
@@ -201,6 +201,11 @@ public class AppleLibraryBuilder
     return this;
   }
 
+  public AppleLibraryBuilder setSwiftCompilerFlags(Iterable<? extends StringWithMacros> flags) {
+    getArgForPopulating().setSwiftCompilerFlags(flags);
+    return this;
+  }
+
   public AppleLibraryBuilder setXcodePrivateHeadersSymlinks(boolean xcodePrivateHeadersSymlinks) {
     getArgForPopulating().setXcodePrivateHeadersSymlinks(Optional.of(xcodePrivateHeadersSymlinks));
     return this;

--- a/test/com/facebook/buck/apple/project_generator/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/apple/project_generator/ProjectGeneratorTest.java
@@ -1608,6 +1608,8 @@ public class ProjectGeneratorTest {
             .setConfigs(ImmutableSortedMap.of("Debug", ImmutableMap.of()))
             .setCompilerFlags(ImmutableList.of("-fhello"))
             .setPreprocessorFlags(ImmutableList.of("-fworld"))
+            .setSwiftCompilerFlags(
+                StringWithMacrosUtils.fromStrings(ImmutableList.of("-fhello-swift")))
             .build();
 
     ProjectGenerator projectGenerator =
@@ -1622,6 +1624,7 @@ public class ProjectGeneratorTest {
     assertEquals(
         "$(inherited) -Wno-deprecated -Wno-conversion -fhello -fworld",
         settings.get("OTHER_CFLAGS"));
+    assertEquals("$(inherited) -fhello-swift", settings.get("OTHER_SWIFT_FLAGS"));
   }
 
   @Test

--- a/test/com/facebook/buck/swift/SwiftBuckConfigTest.java
+++ b/test/com/facebook/buck/swift/SwiftBuckConfigTest.java
@@ -43,6 +43,5 @@ public class SwiftBuckConfigTest {
   public void testAbsentFlags() {
     SwiftBuckConfig swiftBuckConfig = new SwiftBuckConfig(FakeBuckConfig.builder().build());
     assertThat(swiftBuckConfig.getCompilerFlags(), equalTo(Optional.empty()));
-    assertThat(swiftBuckConfig.getCompilerFlags(), equalTo(Optional.empty()));
   }
 }

--- a/test/com/facebook/buck/swift/SwiftBuckConfigTest.java
+++ b/test/com/facebook/buck/swift/SwiftBuckConfigTest.java
@@ -40,8 +40,20 @@ public class SwiftBuckConfigTest {
   }
 
   @Test
+  public void testGetFlagsWithArgument() throws Exception {
+    SwiftBuckConfig swiftBuckConfig =
+        new SwiftBuckConfig(
+            FakeBuckConfig.builder()
+                .setSections(ImmutableMap.of("swift", ImmutableMap.of("compiler_flags", "-g")))
+                .build());
+    assertThat(swiftBuckConfig.getFlags("compiler_flags"), not(equalTo(Optional.empty())));
+    assertThat(swiftBuckConfig.getFlags("compiler_flags").get(), contains("-g"));
+  }
+
+  @Test
   public void testAbsentFlags() {
     SwiftBuckConfig swiftBuckConfig = new SwiftBuckConfig(FakeBuckConfig.builder().build());
     assertThat(swiftBuckConfig.getFlags(), equalTo(Optional.empty()));
+    assertThat(swiftBuckConfig.getFlags("compiler_flags"), equalTo(Optional.empty()));
   }
 }

--- a/test/com/facebook/buck/swift/SwiftBuckConfigTest.java
+++ b/test/com/facebook/buck/swift/SwiftBuckConfigTest.java
@@ -35,25 +35,14 @@ public class SwiftBuckConfigTest {
             FakeBuckConfig.builder()
                 .setSections(ImmutableMap.of("swift", ImmutableMap.of("compiler_flags", "-g")))
                 .build());
-    assertThat(swiftBuckConfig.getFlags(), not(equalTo(Optional.empty())));
-    assertThat(swiftBuckConfig.getFlags().get(), contains("-g"));
-  }
-
-  @Test
-  public void testGetFlagsWithArgument() throws Exception {
-    SwiftBuckConfig swiftBuckConfig =
-        new SwiftBuckConfig(
-            FakeBuckConfig.builder()
-                .setSections(ImmutableMap.of("swift", ImmutableMap.of("compiler_flags", "-g")))
-                .build());
-    assertThat(swiftBuckConfig.getFlags("compiler_flags"), not(equalTo(Optional.empty())));
-    assertThat(swiftBuckConfig.getFlags("compiler_flags").get(), contains("-g"));
+    assertThat(swiftBuckConfig.getCompilerFlags(), not(equalTo(Optional.empty())));
+    assertThat(swiftBuckConfig.getCompilerFlags().get(), contains("-g"));
   }
 
   @Test
   public void testAbsentFlags() {
     SwiftBuckConfig swiftBuckConfig = new SwiftBuckConfig(FakeBuckConfig.builder().build());
-    assertThat(swiftBuckConfig.getFlags(), equalTo(Optional.empty()));
-    assertThat(swiftBuckConfig.getFlags("compiler_flags"), equalTo(Optional.empty()));
+    assertThat(swiftBuckConfig.getCompilerFlags(), equalTo(Optional.empty()));
+    assertThat(swiftBuckConfig.getCompilerFlags(), equalTo(Optional.empty()));
   }
 }


### PR DESCRIPTION
This takes the flags from `swift.compiler_flags` from `.buckconfig` and target specific flags and adds them to the `OTHER_SWIFT_FLAGS` in the xcconfig files.