### PR TITLE
Add generator for clang Modulemap, Umbrella Header and VFSOverlay

### DIFF
--- a/buck.iml
+++ b/buck.iml
@@ -17,6 +17,7 @@
       <excludeFolder url="file://$MODULE_DIR$/src/com/facebook/buck/intellij" />
       <excludeFolder url="file://$MODULE_DIR$/test/com/facebook/buck/android/agent/util/testdata" />
       <excludeFolder url="file://$MODULE_DIR$/test/com/facebook/buck/android/testdata" />
+      <excludeFolder url="file://$MODULE_DIR$/test/com/facebook/buck/apple/clang/testdata" />
       <excludeFolder url="file://$MODULE_DIR$/test/com/facebook/buck/apple/simulator/testdata" />
       <excludeFolder url="file://$MODULE_DIR$/test/com/facebook/buck/apple/testdata" />
       <excludeFolder url="file://$MODULE_DIR$/test/com/facebook/buck/apple/xcode/testdata" />

--- a/src/com/facebook/buck/apple/clang/BUCK
+++ b/src/com/facebook/buck/apple/clang/BUCK
@@ -13,6 +13,7 @@ java_library(
     ],
     deps = [
         "//src/com/facebook/buck/model:simple_types",
+        "//src/com/facebook/buck/util:exceptions",
         "//src/com/facebook/buck/util:util",
         "//third-party/java/guava:guava",
         "//third-party/java/jsr:jsr305",

--- a/src/com/facebook/buck/apple/clang/BUCK
+++ b/src/com/facebook/buck/apple/clang/BUCK
@@ -14,6 +14,7 @@ java_library(
     deps = [
         "//third-party/java/guava:guava",
         "//third-party/java/jsr:jsr305",
+        "//third-party/java/stringtemplate:stringtemplate",
     ],
 )
 

--- a/src/com/facebook/buck/apple/clang/BUCK
+++ b/src/com/facebook/buck/apple/clang/BUCK
@@ -1,8 +1,12 @@
 java_library(
-    name = "headermap",
-    srcs = ["HeaderMap.java"],
+    name = "clang",
+    srcs = glob([
+        "*.java",
+    ], excludes = [
+        "PrintHeaderMap.java"
+    ]),
     tests = [
-        "//test/com/facebook/buck/apple/clang:headermap",
+        "//test/com/facebook/buck/apple/clang:clang",
     ],
     visibility = [
         "PUBLIC",
@@ -20,7 +24,7 @@ java_library(
         "PUBLIC",
     ],
     deps = [
-        "//src/com/facebook/buck/apple/clang:headermap",
+        "//src/com/facebook/buck/apple/clang:clang",
         "//third-party/java/jsr:jsr305",
     ],
 )

--- a/src/com/facebook/buck/apple/clang/BUCK
+++ b/src/com/facebook/buck/apple/clang/BUCK
@@ -12,8 +12,12 @@ java_library(
         "PUBLIC",
     ],
     deps = [
+        "//src/com/facebook/buck/model:simple_types",
+        "//src/com/facebook/buck/util:util",
         "//third-party/java/guava:guava",
         "//third-party/java/jsr:jsr305",
+        "//third-party/java/jackson:jackson-annotations",
+        "//third-party/java/jackson:jackson-databind",
         "//third-party/java/stringtemplate:stringtemplate",
     ],
 )

--- a/src/com/facebook/buck/apple/clang/ModuleMap.java
+++ b/src/com/facebook/buck/apple/clang/ModuleMap.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2014-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.apple.clang;
+
+import org.stringtemplate.v4.ST;
+
+/**
+ * Generate a modulemap, with optional references to a swift generated swift header.
+ *
+ * <p>Note: currently only supports modulemaps for modules with an umbrella header, as otherwise the
+ * inferred submodule functionality does not work.
+ */
+public class ModuleMap {
+
+  public enum SwiftMode {
+    NO_SWIFT,
+    EXCLUDE_SWIFT_HEADER,
+    INCLUDE_SWIFT_HEADER
+  }
+
+  private final SwiftMode swiftMode;
+  private final String moduleName;
+
+  private String generatedModule;
+  private static final String template =
+      "module <module_name> {\n"
+          + "    umbrella header \"<module_name>.h\"\n"
+          + "\n"
+          + "    export *\n"
+          + "    module * { export * }\n"
+          + "}\n"
+          + "\n"
+          + "<if(include_swift_header)>"
+          + "module <module_name>.Swift {\n"
+          + "    header \"<module_name>-Swift.h\"\n"
+          + "    requires objc\n"
+          + "}\n"
+          + "<endif>"
+          + "\n"
+          + "<if(exclude_swift_header)>"
+          + "module <module_name>.__Swift {\n"
+          + "    exclude header \"<module_name>-Swift.h\"\n"
+          + "}\n"
+          + "<endif>"
+          + "\n";
+
+  public ModuleMap(String moduleName, SwiftMode swiftMode) {
+    this.moduleName = moduleName;
+    this.swiftMode = swiftMode;
+  }
+
+  public String render() {
+    if (this.generatedModule == null) {
+      ST st =
+          new ST(template)
+              .add("module_name", moduleName)
+              .add("include_swift_header", false)
+              .add("exclude_swift_header", false);
+      switch (swiftMode) {
+        case INCLUDE_SWIFT_HEADER:
+          st.add("include_swift_header", true);
+          break;
+        case EXCLUDE_SWIFT_HEADER:
+          st.add("exclude_swift_header", true);
+          break;
+        default:
+        case NO_SWIFT:
+      }
+      this.generatedModule = st.render();
+    }
+    return this.generatedModule;
+  }
+}

--- a/src/com/facebook/buck/apple/clang/UmbrellaHeader.java
+++ b/src/com/facebook/buck/apple/clang/UmbrellaHeader.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.buck.apple.clang;
+
+import com.google.common.collect.ImmutableList;
+
+public class UmbrellaHeader {
+
+  private final ImmutableList<String> headerNames;
+
+  public UmbrellaHeader(ImmutableList<String> headerNames) {
+    this.headerNames = headerNames;
+  }
+
+  public String render() {
+    return headerNames.stream().map(x -> "#import \"" + x + "\"\n").reduce("", String::concat);
+  }
+}

--- a/src/com/facebook/buck/apple/clang/UmbrellaHeader.java
+++ b/src/com/facebook/buck/apple/clang/UmbrellaHeader.java
@@ -19,13 +19,18 @@ import com.google.common.collect.ImmutableList;
 
 public class UmbrellaHeader {
 
+  private final String targetName;
   private final ImmutableList<String> headerNames;
 
-  public UmbrellaHeader(ImmutableList<String> headerNames) {
+  public UmbrellaHeader(String targetName, ImmutableList<String> headerNames) {
+    this.targetName = targetName;
     this.headerNames = headerNames;
   }
 
   public String render() {
-    return headerNames.stream().map(x -> "#import \"" + x + "\"\n").reduce("", String::concat);
+    return headerNames
+        .stream()
+        .map(x -> String.format("#import <%s/%s>\n", targetName, x))
+        .reduce("", String::concat);
   }
 }

--- a/src/com/facebook/buck/apple/clang/VFSOverlay.java
+++ b/src/com/facebook/buck/apple/clang/VFSOverlay.java
@@ -1,0 +1,92 @@
+package com.facebook.buck.apple.clang;
+
+import com.facebook.buck.model.Pair;
+import com.facebook.buck.util.MoreCollectors;
+import com.facebook.buck.util.ObjectMappers;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collection;
+
+/**
+ * VFSOverlays are used for similar purposes to headermaps, but can be used to overlay more than
+ * headers on the filesystem (such as modulemaps)
+ *
+ * <p>This class provides support for reading and generating clang vfs overlays. No spec is
+ * available but we conform to the https://clang.llvm.org/doxygen/VirtualFileSystem_8cpp_source.html
+ * writer class defined in the Clang documentation.
+ */
+@JsonSerialize(as = VFSOverlay.class)
+public class VFSOverlay {
+
+  @JsonProperty private final int version = 0;
+
+  @JsonProperty("case-sensitive")
+  private final boolean case_sensitive = false;
+
+  @JsonProperty("roots")
+  private ImmutableList<Directory> computeRoots() {
+    Multimap<Path, Pair<Path, Path>> byParent = MultimapBuilder.hashKeys().hashSetValues().build();
+    overlays.forEach(
+        (virtual, real) -> {
+          byParent.put(virtual.getParent(), new Pair<>(virtual.getFileName(), real));
+        });
+    return byParent
+        .asMap()
+        .entrySet()
+        .stream()
+        .map(e -> new Directory(e.getKey(), e.getValue()))
+        .collect(MoreCollectors.toImmutableList());
+  }
+
+  private final ImmutableSortedMap<Path, Path> overlays;
+
+  public VFSOverlay(ImmutableSortedMap<Path, Path> overlays) {
+    this.overlays = overlays;
+  }
+
+  public String render() throws IOException {
+    return ObjectMappers.WRITER.withDefaultPrettyPrinter().writeValueAsString(this);
+  }
+
+  @JsonSerialize(as = Directory.class)
+  private class Directory {
+
+    @JsonProperty private final String type = "directory";
+    @JsonProperty private final Path name;
+
+    private final Collection<Pair<Path, Path>> contents;
+
+    @JsonProperty("contents")
+    private ImmutableList<File> computeContents() {
+      return this.contents
+          .stream()
+          .map(x -> new File(x.getFirst(), x.getSecond()))
+          .collect(MoreCollectors.toImmutableList());
+    }
+
+    public Directory(Path root, Collection<Pair<Path, Path>> contents) {
+      this.name = root;
+      this.contents = contents;
+    }
+  }
+
+  @JsonSerialize(as = File.class)
+  private class File {
+    @JsonProperty private final String type = "file";
+    @JsonProperty private final Path name;
+
+    @JsonProperty("external-contents")
+    private final Path realPath;
+
+    public File(Path name, Path realPath) {
+      this.name = name;
+      this.realPath = realPath;
+    }
+  }
+}

--- a/src/com/facebook/buck/apple/clang/VFSOverlay.java
+++ b/src/com/facebook/buck/apple/clang/VFSOverlay.java
@@ -1,11 +1,11 @@
 package com.facebook.buck.apple.clang;
 
 import com.facebook.buck.model.Pair;
-import com.facebook.buck.util.HumanReadableException;
 import com.facebook.buck.util.MoreCollectors;
 import com.facebook.buck.util.ObjectMappers;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Multimap;
@@ -94,14 +94,13 @@ public class VFSOverlay {
     private final Path realPath;
 
     public VirtualFile(Path name, Path realPath) {
+      Preconditions.checkState(
+          realPath.isAbsolute(),
+          "Attempting to make vfsoverlay with non-absolute path '%s' for "
+              + "external contents field. Only absolute paths are currently supported.",
+          realPath);
       this.name = name;
       this.realPath = realPath;
-      if (!realPath.isAbsolute()) {
-        throw new HumanReadableException(
-            "Attempting to make vfsoverlay with non-absolute path '%s' for external contents "
-                + "field. Only absolute paths are currently supported.",
-            realPath);
-      }
     }
   }
 }

--- a/src/com/facebook/buck/apple/clang/VFSOverlay.java
+++ b/src/com/facebook/buck/apple/clang/VFSOverlay.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.facebook.buck.apple.clang;
 
 import com.facebook.buck.model.Pair;

--- a/src/com/facebook/buck/apple/clang/VFSOverlay.java
+++ b/src/com/facebook/buck/apple/clang/VFSOverlay.java
@@ -24,8 +24,11 @@ import java.util.Collection;
 @JsonSerialize(as = VFSOverlay.class)
 public class VFSOverlay {
 
-  @JsonProperty private final int version = 0;
+  @SuppressWarnings("PMD.UnusedPrivateField")
+  @JsonProperty
+  private final int version = 0;
 
+  @SuppressWarnings("PMD.UnusedPrivateField")
   @JsonProperty("case-sensitive")
   private final boolean case_sensitive = false;
 
@@ -57,7 +60,10 @@ public class VFSOverlay {
   @JsonSerialize(as = Directory.class)
   private class Directory {
 
-    @JsonProperty private final String type = "directory";
+    @SuppressWarnings("PMD.UnusedPrivateField")
+    @JsonProperty
+    private final String type = "directory";
+
     @JsonProperty private final Path name;
 
     private final Collection<Pair<Path, Path>> contents;
@@ -78,7 +84,10 @@ public class VFSOverlay {
 
   @JsonSerialize(as = File.class)
   private class File {
-    @JsonProperty private final String type = "file";
+    @SuppressWarnings("PMD.UnusedPrivateField")
+    @JsonProperty
+    private final String type = "file";
+
     @JsonProperty private final Path name;
 
     @JsonProperty("external-contents")

--- a/src/com/facebook/buck/apple/project_generator/BUCK
+++ b/src/com/facebook/buck/apple/project_generator/BUCK
@@ -11,7 +11,7 @@ java_immutables_library(
     visibility = ["PUBLIC"],
     deps = [
         "//src/com/facebook/buck/apple:apple",
-        "//src/com/facebook/buck/apple/clang:headermap",
+        "//src/com/facebook/buck/apple/clang:clang",
         "//src/com/facebook/buck/apple/xcode:xcode",
         "//src/com/facebook/buck/cli/output:output",
         "//src/com/facebook/buck/config:config",

--- a/src/com/facebook/buck/cxx/BUCK
+++ b/src/com/facebook/buck/cxx/BUCK
@@ -17,7 +17,7 @@ java_immutables_library(
         "PUBLIC",
     ],
     deps = [
-        "//src/com/facebook/buck/apple/clang:headermap",
+        "//src/com/facebook/buck/apple/clang:clang",
         "//src/com/facebook/buck/cxx/toolchain:toolchain",
         "//src/com/facebook/buck/cxx/toolchain/elf:elf",
         "//src/com/facebook/buck/cxx/toolchain/linker:linker",

--- a/test/com/facebook/buck/apple/clang/BUCK
+++ b/test/com/facebook/buck/apple/clang/BUCK
@@ -1,8 +1,8 @@
 java_test(
-    name = "headermap",
+    name = "clang",
     srcs = glob(["*.java"]),
     deps = [
-        "//src/com/facebook/buck/apple/clang:headermap",
+        "//src/com/facebook/buck/apple/clang:clang",
         "//src/com/facebook/buck/util/environment:platform",
         "//third-party/java/jsr:jsr305",
         "//third-party/java/junit:junit",

--- a/test/com/facebook/buck/apple/clang/BUCK
+++ b/test/com/facebook/buck/apple/clang/BUCK
@@ -8,5 +8,7 @@ java_test(
         "//third-party/java/guava:guava",
         "//third-party/java/jsr:jsr305",
         "//third-party/java/junit:junit",
+        "//test/com/facebook/buck/io/file:testutil",
+        "//test/com/facebook/buck/util:testutil",
     ],
 )

--- a/test/com/facebook/buck/apple/clang/BUCK
+++ b/test/com/facebook/buck/apple/clang/BUCK
@@ -1,9 +1,11 @@
 java_test(
     name = "clang",
     srcs = glob(["*.java"]),
+    resources = glob(["testdata/**"]),
     deps = [
         "//src/com/facebook/buck/apple/clang:clang",
         "//src/com/facebook/buck/util/environment:platform",
+        "//third-party/java/guava:guava",
         "//third-party/java/jsr:jsr305",
         "//third-party/java/junit:junit",
     ],

--- a/test/com/facebook/buck/apple/clang/ModuleMapTest.java
+++ b/test/com/facebook/buck/apple/clang/ModuleMapTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.apple.clang;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ModuleMapTest {
+
+  @Test
+  public void testNoSwift() {
+    ModuleMap testMap = new ModuleMap("TestModule", ModuleMap.SwiftMode.NO_SWIFT);
+    assertEquals(
+        "module TestModule {\n"
+            + "    umbrella header \"TestModule.h\"\n"
+            + "\n"
+            + "    export *\n"
+            + "    module * { export * }\n"
+            + "}\n"
+            + "\n",
+        testMap.render());
+  }
+
+  @Test
+  public void testIncludeSwift() {
+    ModuleMap testMap = new ModuleMap("TestModule", ModuleMap.SwiftMode.INCLUDE_SWIFT_HEADER);
+    assertEquals(
+        "module TestModule {\n"
+            + "    umbrella header \"TestModule.h\"\n"
+            + "\n"
+            + "    export *\n"
+            + "    module * { export * }\n"
+            + "}\n"
+            + "\n"
+            + "module TestModule.Swift {\n"
+            + "    header \"TestModule-Swift.h\"\n"
+            + "    requires objc\n"
+            + "}"
+            + "\n",
+        testMap.render());
+  }
+
+  @Test
+  public void testExcludeSwift() {
+    ModuleMap testMap = new ModuleMap("TestModule", ModuleMap.SwiftMode.EXCLUDE_SWIFT_HEADER);
+    assertEquals(
+        "module TestModule {\n"
+            + "    umbrella header \"TestModule.h\"\n"
+            + "\n"
+            + "    export *\n"
+            + "    module * { export * }\n"
+            + "}\n"
+            + "\n"
+            + "module TestModule.__Swift {\n"
+            + "    exclude header \"TestModule-Swift.h\"\n"
+            + "}"
+            + "\n",
+        testMap.render());
+  }
+}

--- a/test/com/facebook/buck/apple/clang/ModuleMapTest.java
+++ b/test/com/facebook/buck/apple/clang/ModuleMapTest.java
@@ -16,7 +16,8 @@
 
 package com.facebook.buck.apple.clang;
 
-import static org.junit.Assert.assertEquals;
+import static com.facebook.buck.util.MoreStringsForTests.equalToIgnoringPlatformNewlines;
+import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 
@@ -25,7 +26,7 @@ public class ModuleMapTest {
   @Test
   public void testNoSwift() {
     ModuleMap testMap = new ModuleMap("TestModule", ModuleMap.SwiftMode.NO_SWIFT);
-    assertEquals(
+    assertThat(
         "module TestModule {\n"
             + "    umbrella header \"TestModule.h\"\n"
             + "\n"
@@ -33,13 +34,13 @@ public class ModuleMapTest {
             + "    module * { export * }\n"
             + "}\n"
             + "\n",
-        testMap.render());
+        equalToIgnoringPlatformNewlines(testMap.render()));
   }
 
   @Test
   public void testIncludeSwift() {
     ModuleMap testMap = new ModuleMap("TestModule", ModuleMap.SwiftMode.INCLUDE_SWIFT_HEADER);
-    assertEquals(
+    assertThat(
         "module TestModule {\n"
             + "    umbrella header \"TestModule.h\"\n"
             + "\n"
@@ -52,13 +53,13 @@ public class ModuleMapTest {
             + "    requires objc\n"
             + "}"
             + "\n",
-        testMap.render());
+        equalToIgnoringPlatformNewlines(testMap.render()));
   }
 
   @Test
   public void testExcludeSwift() {
     ModuleMap testMap = new ModuleMap("TestModule", ModuleMap.SwiftMode.EXCLUDE_SWIFT_HEADER);
-    assertEquals(
+    assertThat(
         "module TestModule {\n"
             + "    umbrella header \"TestModule.h\"\n"
             + "\n"
@@ -70,6 +71,6 @@ public class ModuleMapTest {
             + "    exclude header \"TestModule-Swift.h\"\n"
             + "}"
             + "\n",
-        testMap.render());
+        equalToIgnoringPlatformNewlines(testMap.render()));
   }
 }

--- a/test/com/facebook/buck/apple/clang/UmbrellaHeaderTest.java
+++ b/test/com/facebook/buck/apple/clang/UmbrellaHeaderTest.java
@@ -1,0 +1,15 @@
+package com.facebook.buck.apple.clang;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+public class UmbrellaHeaderTest {
+
+  @Test
+  public void testUmbrellaHeader() {
+    UmbrellaHeader header = new UmbrellaHeader(ImmutableList.of("header1.h", "header2.h"));
+    assertEquals("#import \"header1.h\"\n" + "#import \"header2.h\"\n", header.render());
+  }
+}

--- a/test/com/facebook/buck/apple/clang/UmbrellaHeaderTest.java
+++ b/test/com/facebook/buck/apple/clang/UmbrellaHeaderTest.java
@@ -9,7 +9,7 @@ public class UmbrellaHeaderTest {
 
   @Test
   public void testUmbrellaHeader() {
-    UmbrellaHeader header = new UmbrellaHeader(ImmutableList.of("header1.h", "header2.h"));
-    assertEquals("#import \"header1.h\"\n" + "#import \"header2.h\"\n", header.render());
+    UmbrellaHeader header = new UmbrellaHeader("lib", ImmutableList.of("header1.h", "header2.h"));
+    assertEquals("#import <lib/header1.h>\n#import <lib/header2.h>\n", header.render());
   }
 }

--- a/test/com/facebook/buck/apple/clang/UmbrellaHeaderTest.java
+++ b/test/com/facebook/buck/apple/clang/UmbrellaHeaderTest.java
@@ -16,7 +16,8 @@
 
 package com.facebook.buck.apple.clang;
 
-import static org.junit.Assert.assertEquals;
+import static com.facebook.buck.util.MoreStringsForTests.equalToIgnoringPlatformNewlines;
+import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
@@ -26,6 +27,8 @@ public class UmbrellaHeaderTest {
   @Test
   public void testUmbrellaHeader() {
     UmbrellaHeader header = new UmbrellaHeader("lib", ImmutableList.of("header1.h", "header2.h"));
-    assertEquals("#import <lib/header1.h>\n#import <lib/header2.h>\n", header.render());
+    assertThat(
+        "#import <lib/header1.h>\n#import <lib/header2.h>\n",
+        equalToIgnoringPlatformNewlines(header.render()));
   }
 }

--- a/test/com/facebook/buck/apple/clang/UmbrellaHeaderTest.java
+++ b/test/com/facebook/buck/apple/clang/UmbrellaHeaderTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.facebook.buck.apple.clang;
 
 import static org.junit.Assert.assertEquals;

--- a/test/com/facebook/buck/apple/clang/VFSOverlayTest.java
+++ b/test/com/facebook/buck/apple/clang/VFSOverlayTest.java
@@ -20,9 +20,11 @@ import static com.facebook.buck.util.MoreStringsForTests.equalToIgnoringPlatform
 import static org.junit.Assert.assertThat;
 
 import com.facebook.buck.io.file.MorePathsForTests;
+import com.facebook.buck.util.environment.Platform;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.io.ByteStreams;
 import java.io.IOException;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class VFSOverlayTest {
@@ -33,6 +35,7 @@ public class VFSOverlayTest {
 
   @Test
   public void testSerialization() throws IOException {
+    Assume.assumeTrue(Platform.detect() != Platform.WINDOWS);
     VFSOverlay vfsOverlay =
         new VFSOverlay(
             ImmutableSortedMap.of(
@@ -44,7 +47,21 @@ public class VFSOverlayTest {
   }
 
   @Test
+  public void testSerializationWindows() throws IOException {
+    Assume.assumeTrue(Platform.detect() == Platform.WINDOWS);
+    VFSOverlay vfsOverlay =
+        new VFSOverlay(
+            ImmutableSortedMap.of(
+                MorePathsForTests.rootRelativePath("virtual/path/module.modulemap"),
+                MorePathsForTests.rootRelativePath("real/path/overlayed.modulemap")));
+    assertThat(
+        readTestData("testdata/vfs_simple_windows.yaml"),
+        equalToIgnoringPlatformNewlines(vfsOverlay.render()));
+  }
+
+  @Test
   public void testTwoFiles() throws IOException {
+    Assume.assumeTrue(Platform.detect() != Platform.WINDOWS);
     VFSOverlay vfsOverlay =
         new VFSOverlay(
             ImmutableSortedMap.of(
@@ -59,6 +76,7 @@ public class VFSOverlayTest {
 
   @Test
   public void testTwoDirectories() throws IOException {
+    Assume.assumeTrue(Platform.detect() != Platform.WINDOWS);
     VFSOverlay vfsOverlay =
         new VFSOverlay(
             ImmutableSortedMap.of(
@@ -73,6 +91,7 @@ public class VFSOverlayTest {
 
   @Test
   public void testNestedDirectories() throws IOException {
+    Assume.assumeTrue(Platform.detect() != Platform.WINDOWS);
     // the default clang writer groups nested directories, for simplicity this generator doesn't.
     // This test shows the expectation for this generator, we can update it if we implement
     // directory nesting/grouping. Clang has an internal representation after reading the vfs so as

--- a/test/com/facebook/buck/apple/clang/VFSOverlayTest.java
+++ b/test/com/facebook/buck/apple/clang/VFSOverlayTest.java
@@ -48,4 +48,22 @@ public class VFSOverlayTest {
                 Paths.get("/real/path/umbrella/umbrella.h")));
     assertEquals(readTestData("testdata/vfs_twodirs.yaml"), vfsOverlay.render());
   }
+
+  @Test
+  public void testNestedDirectories() throws IOException {
+    // the default clang writer groups nested directories, for simplicity this generator doesn't.
+    // This test shows the expectation for this generator, we can update it if we implement
+    // directory nesting/grouping. Clang has an internal representation after reading the vfs so as
+    // long as the contents of the vfs are correct the layout is not relevant for speed/correctness.
+    VFSOverlay vfsOverlay =
+        new VFSOverlay(
+            ImmutableSortedMap.of(
+                Paths.get("/virtual/module.modulemap"),
+                Paths.get("/real/path/overlayed.modulemap"),
+                Paths.get("/virtual/path/priv/umbrella.h"),
+                Paths.get("/real/path/umbrella/umbrella.h"),
+                Paths.get("/virtual/path/priv/entry.h"),
+                Paths.get("/real/path/umbrella/lib/entry.h")));
+    assertEquals(readTestData("testdata/vfs_nesteddirs.yaml"), vfsOverlay.render());
+  }
 }

--- a/test/com/facebook/buck/apple/clang/VFSOverlayTest.java
+++ b/test/com/facebook/buck/apple/clang/VFSOverlayTest.java
@@ -1,0 +1,51 @@
+package com.facebook.buck.apple.clang;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.io.ByteStreams;
+import java.io.IOException;
+import java.nio.file.Paths;
+import org.junit.Test;
+
+public class VFSOverlayTest {
+
+  private String readTestData(String name) throws IOException {
+    return new String(ByteStreams.toByteArray(getClass().getResourceAsStream(name)));
+  }
+
+  @Test
+  public void testSerialization() throws IOException {
+    VFSOverlay vfsOverlay =
+        new VFSOverlay(
+            ImmutableSortedMap.of(
+                Paths.get("/virtual/path/module.modulemap"),
+                Paths.get("/real/path/overlayed.modulemap")));
+    assertEquals(readTestData("testdata/vfs_simple.yaml"), vfsOverlay.render());
+  }
+
+  @Test
+  public void testTwoFiles() throws IOException {
+    VFSOverlay vfsOverlay =
+        new VFSOverlay(
+            ImmutableSortedMap.of(
+                Paths.get("/virtual/path/module.modulemap"),
+                Paths.get("/real/path/overlayed.modulemap"),
+                Paths.get("/virtual/path/umbrella.h"),
+                Paths.get("/real/path/umbrella/umbrella.h")));
+
+    assertEquals(readTestData("testdata/vfs_twofiles.yaml"), vfsOverlay.render());
+  }
+
+  @Test
+  public void testTwoDirectories() throws IOException {
+    VFSOverlay vfsOverlay =
+        new VFSOverlay(
+            ImmutableSortedMap.of(
+                Paths.get("/virtual/path/module.modulemap"),
+                Paths.get("/real/path/overlayed.modulemap"),
+                Paths.get("/virtual/path-priv/umbrella.h"),
+                Paths.get("/real/path/umbrella/umbrella.h")));
+    assertEquals(readTestData("testdata/vfs_twodirs.yaml"), vfsOverlay.render());
+  }
+}

--- a/test/com/facebook/buck/apple/clang/VFSOverlayTest.java
+++ b/test/com/facebook/buck/apple/clang/VFSOverlayTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.facebook.buck.apple.clang;
 
 import static org.junit.Assert.assertEquals;

--- a/test/com/facebook/buck/apple/clang/VFSOverlayTest.java
+++ b/test/com/facebook/buck/apple/clang/VFSOverlayTest.java
@@ -16,12 +16,13 @@
 
 package com.facebook.buck.apple.clang;
 
-import static org.junit.Assert.assertEquals;
+import static com.facebook.buck.util.MoreStringsForTests.equalToIgnoringPlatformNewlines;
+import static org.junit.Assert.assertThat;
 
+import com.facebook.buck.io.file.MorePathsForTests;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.io.ByteStreams;
 import java.io.IOException;
-import java.nio.file.Paths;
 import org.junit.Test;
 
 public class VFSOverlayTest {
@@ -35,9 +36,11 @@ public class VFSOverlayTest {
     VFSOverlay vfsOverlay =
         new VFSOverlay(
             ImmutableSortedMap.of(
-                Paths.get("/virtual/path/module.modulemap"),
-                Paths.get("/real/path/overlayed.modulemap")));
-    assertEquals(readTestData("testdata/vfs_simple.yaml"), vfsOverlay.render());
+                MorePathsForTests.rootRelativePath("virtual/path/module.modulemap"),
+                MorePathsForTests.rootRelativePath("real/path/overlayed.modulemap")));
+    assertThat(
+        readTestData("testdata/vfs_simple.yaml"),
+        equalToIgnoringPlatformNewlines(vfsOverlay.render()));
   }
 
   @Test
@@ -45,12 +48,13 @@ public class VFSOverlayTest {
     VFSOverlay vfsOverlay =
         new VFSOverlay(
             ImmutableSortedMap.of(
-                Paths.get("/virtual/path/module.modulemap"),
-                Paths.get("/real/path/overlayed.modulemap"),
-                Paths.get("/virtual/path/umbrella.h"),
-                Paths.get("/real/path/umbrella/umbrella.h")));
-
-    assertEquals(readTestData("testdata/vfs_twofiles.yaml"), vfsOverlay.render());
+                MorePathsForTests.rootRelativePath("virtual/path/module.modulemap"),
+                MorePathsForTests.rootRelativePath("real/path/overlayed.modulemap"),
+                MorePathsForTests.rootRelativePath("virtual/path/umbrella.h"),
+                MorePathsForTests.rootRelativePath("real/path/umbrella/umbrella.h")));
+    assertThat(
+        readTestData("testdata/vfs_twofiles.yaml"),
+        equalToIgnoringPlatformNewlines(vfsOverlay.render()));
   }
 
   @Test
@@ -58,11 +62,13 @@ public class VFSOverlayTest {
     VFSOverlay vfsOverlay =
         new VFSOverlay(
             ImmutableSortedMap.of(
-                Paths.get("/virtual/path/module.modulemap"),
-                Paths.get("/real/path/overlayed.modulemap"),
-                Paths.get("/virtual/path-priv/umbrella.h"),
-                Paths.get("/real/path/umbrella/umbrella.h")));
-    assertEquals(readTestData("testdata/vfs_twodirs.yaml"), vfsOverlay.render());
+                MorePathsForTests.rootRelativePath("virtual/path/module.modulemap"),
+                MorePathsForTests.rootRelativePath("real/path/overlayed.modulemap"),
+                MorePathsForTests.rootRelativePath("virtual/path-priv/umbrella.h"),
+                MorePathsForTests.rootRelativePath("real/path/umbrella/umbrella.h")));
+    assertThat(
+        readTestData("testdata/vfs_twodirs.yaml"),
+        equalToIgnoringPlatformNewlines(vfsOverlay.render()));
   }
 
   @Test
@@ -74,12 +80,14 @@ public class VFSOverlayTest {
     VFSOverlay vfsOverlay =
         new VFSOverlay(
             ImmutableSortedMap.of(
-                Paths.get("/virtual/module.modulemap"),
-                Paths.get("/real/path/overlayed.modulemap"),
-                Paths.get("/virtual/path/priv/umbrella.h"),
-                Paths.get("/real/path/umbrella/umbrella.h"),
-                Paths.get("/virtual/path/priv/entry.h"),
-                Paths.get("/real/path/umbrella/lib/entry.h")));
-    assertEquals(readTestData("testdata/vfs_nesteddirs.yaml"), vfsOverlay.render());
+                MorePathsForTests.rootRelativePath("virtual/module.modulemap"),
+                MorePathsForTests.rootRelativePath("real/path/overlayed.modulemap"),
+                MorePathsForTests.rootRelativePath("virtual/path/priv/umbrella.h"),
+                MorePathsForTests.rootRelativePath("real/path/umbrella/umbrella.h"),
+                MorePathsForTests.rootRelativePath("virtual/path/priv/entry.h"),
+                MorePathsForTests.rootRelativePath("real/path/umbrella/lib/entry.h")));
+    assertThat(
+        readTestData("testdata/vfs_nesteddirs.yaml"),
+        equalToIgnoringPlatformNewlines(vfsOverlay.render()));
   }
 }

--- a/test/com/facebook/buck/apple/clang/testdata/vfs_nesteddirs.yaml
+++ b/test/com/facebook/buck/apple/clang/testdata/vfs_nesteddirs.yaml
@@ -1,0 +1,25 @@
+{
+  "version" : 0,
+  "case-sensitive" : false,
+  "roots" : [ {
+    "type" : "directory",
+    "name" : "/virtual/path/priv",
+    "contents" : [ {
+      "type" : "file",
+      "name" : "entry.h",
+      "external-contents" : "/real/path/umbrella/lib/entry.h"
+    }, {
+      "type" : "file",
+      "name" : "umbrella.h",
+      "external-contents" : "/real/path/umbrella/umbrella.h"
+    } ]
+  }, {
+    "type" : "directory",
+    "name" : "/virtual",
+    "contents" : [ {
+      "type" : "file",
+      "name" : "module.modulemap",
+      "external-contents" : "/real/path/overlayed.modulemap"
+    } ]
+  } ]
+}

--- a/test/com/facebook/buck/apple/clang/testdata/vfs_simple.yaml
+++ b/test/com/facebook/buck/apple/clang/testdata/vfs_simple.yaml
@@ -1,0 +1,13 @@
+{
+  "version" : 0,
+  "case-sensitive" : false,
+  "roots" : [ {
+    "type" : "directory",
+    "name" : "/virtual/path",
+    "contents" : [ {
+      "type" : "file",
+      "name" : "module.modulemap",
+      "external-contents" : "/real/path/overlayed.modulemap"
+    } ]
+  } ]
+}

--- a/test/com/facebook/buck/apple/clang/testdata/vfs_simple_windows.yaml
+++ b/test/com/facebook/buck/apple/clang/testdata/vfs_simple_windows.yaml
@@ -1,0 +1,13 @@
+{
+  "version" : 0,
+  "case-sensitive" : false,
+  "roots" : [ {
+    "type" : "directory",
+    "name" : "C:\\virtual\\path",
+    "contents" : [ {
+      "type" : "file",
+      "name" : "module.modulemap",
+      "external-contents" : "C:\\real\\path\\overlayed.modulemap"
+    } ]
+  } ]
+}

--- a/test/com/facebook/buck/apple/clang/testdata/vfs_twodirs.yaml
+++ b/test/com/facebook/buck/apple/clang/testdata/vfs_twodirs.yaml
@@ -1,0 +1,21 @@
+{
+  "version" : 0,
+  "case-sensitive" : false,
+  "roots" : [ {
+    "type" : "directory",
+    "name" : "/virtual/path-priv",
+    "contents" : [ {
+      "type" : "file",
+      "name" : "umbrella.h",
+      "external-contents" : "/real/path/umbrella/umbrella.h"
+    } ]
+  }, {
+    "type" : "directory",
+    "name" : "/virtual/path",
+    "contents" : [ {
+      "type" : "file",
+      "name" : "module.modulemap",
+      "external-contents" : "/real/path/overlayed.modulemap"
+    } ]
+  } ]
+}

--- a/test/com/facebook/buck/apple/clang/testdata/vfs_twofiles.yaml
+++ b/test/com/facebook/buck/apple/clang/testdata/vfs_twofiles.yaml
@@ -1,0 +1,17 @@
+{
+  "version" : 0,
+  "case-sensitive" : false,
+  "roots" : [ {
+    "type" : "directory",
+    "name" : "/virtual/path",
+    "contents" : [ {
+      "type" : "file",
+      "name" : "module.modulemap",
+      "external-contents" : "/real/path/overlayed.modulemap"
+    }, {
+      "type" : "file",
+      "name" : "umbrella.h",
+      "external-contents" : "/real/path/umbrella/umbrella.h"
+    } ]
+  } ]
+}

--- a/test/com/facebook/buck/apple/project_generator/BUCK
+++ b/test/com/facebook/buck/apple/project_generator/BUCK
@@ -137,7 +137,7 @@ standard_java_test(
         "//src/com/facebook/buck/android/aapt:aapt",
         "//src/com/facebook/buck/android/redex:options",
         "//src/com/facebook/buck/annotations:annotations",
-        "//src/com/facebook/buck/apple/clang:headermap",
+        "//src/com/facebook/buck/apple/clang:clang",
         "//src/com/facebook/buck/apple/project_generator:project_generator",
         "//src/com/facebook/buck/apple/toolchain:toolchain",
         "//src/com/facebook/buck/apple/xcode:xcode",

--- a/test/com/facebook/buck/cxx/BUCK
+++ b/test/com/facebook/buck/cxx/BUCK
@@ -182,7 +182,7 @@ java_test(
         "//src/com/facebook/buck/android/redex:options",
         "//src/com/facebook/buck/android/toolchain:toolchain",
         "//src/com/facebook/buck/annotations:annotations",
-        "//src/com/facebook/buck/apple/clang:headermap",
+        "//src/com/facebook/buck/apple/clang:clang",
         "//src/com/facebook/buck/apple/project_generator:project_generator",
         "//src/com/facebook/buck/apple/toolchain:toolchain",
         "//src/com/facebook/buck/apple/xcode:xcode",


### PR DESCRIPTION
This extends the clang package with classes for generating some clang related build concepts:
- Modulemaps to support modular imports.
- Umbrella headers for use within module maps.
- VFSOverlays to be able to use module maps in virtual places, like header maps can do for headers.