### PR TITLE
Added details on unsupported flavors to flavor-related exceptions

### DIFF
--- a/src/com/facebook/buck/apple/ApplePlatforms.java
+++ b/src/com/facebook/buck/apple/ApplePlatforms.java
@@ -58,9 +58,11 @@ public class ApplePlatforms {
             e,
             "%s: Apple bundle requires an Apple platform, found '%s'\n\n"
                 + "A common cause of this error is that the required SDK is missing.\n"
-                + "Please check whether it's installed and retry.",
+                + "Please check whether it's installed and retry.\n"
+                + "Original exception: %s",
             target,
-            cxxPlatform.getFlavor().getName());
+            cxxPlatform.getFlavor().getName(),
+            e.getMessage());
       }
     }
 

--- a/src/com/facebook/buck/model/FlavorDomain.java
+++ b/src/com/facebook/buck/model/FlavorDomain.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /** Provides a named flavor abstraction on top of boolean flavors. */
 public class FlavorDomain<T> {
@@ -152,7 +153,12 @@ public class FlavorDomain<T> {
   public T getValue(Flavor flavor) {
     T result = translation.get(flavor);
     if (result == null) {
-      throw new FlavorDomainException(String.format("\"%s\" has no flavor \"%s\"", name, flavor));
+      final String availableFlavors =
+          translation.keySet().stream().map(Flavor::getName).collect(Collectors.joining(", "));
+
+      throw new FlavorDomainException(
+          String.format(
+              "\"%s\" has no flavor \"%s\"; available ones: %s", name, flavor, availableFlavors));
     }
     return result;
   }


### PR DESCRIPTION
This PR is aimed to provide more detailed feedback on why the build failed.

Currently, `apple_bundle` targets require the flavor to be provided. But if one is not provided, the error does not point to why the build really failed and what options to fix that failure are. For more details see the example below.

Before:

```
$ buck run //irrlicht-newton-game:bundle-osx1
Parsing buck files: finished in 2.3 sec (100%)
Creating action graph: finished in 0.7 sec (100%)
Building: finished in 1.1 sec
  Total time: 4.2 sec
BUILD FAILED: //irrlicht-newton-game:bundle-osx#dwarf-and-dsym,no-include-frameworks: Apple bundle requires an Apple platform, found 'default'

A common cause of this error is that the required SDK is missing.
Please check whether it's installed and retry.
```

After:

```
$ ../buck/bin/buck run //irrlicht-newton-game:bundle-osx
Parsing buck files: finished in 2.8 sec (100%)
Creating action graph: finished in 0.7 sec (100%)
Building: finished in 0.8 sec
  Total time: 4.4 sec
BUILD FAILED: //irrlicht-newton-game:bundle-osx#dwarf-and-dsym,no-include-frameworks: Apple bundle requires an Apple platform, found 'default'

A common cause of this error is that the required SDK is missing.
Please check whether it's installed and retry.
Original exception: "Apple C++ Platform" has no flavor "default"; available ones: appletvos11.0-arm64, appletvsimulator11.0-x86_64, iphoneos11.0-armv7, iphoneos11.0-arm64, iphonesimulator11.0-i386, iphonesimulator11.0-x86_64, macosx10.13-i386, macosx10.13-x86_64, watchos4.0-armv7k, watchsimulator4.0-i386, appletvos-arm64, appletvsimulator-x86_64, iphoneos-armv7, iphoneos-arm64, iphonesimulator-i386, iphonesimulator-x86_64, macosx-i386, macosx-x86_64, watchos-armv7k, watchsimulator-i386
```