### PR TITLE
Enable --no-xml-namespaces by default for aapt2 link

### DIFF
--- a/src/com/facebook/buck/android/Aapt2Link.java
+++ b/src/com/facebook/buck/android/Aapt2Link.java
@@ -220,6 +220,7 @@ public class Aapt2Link extends AbstractBuildRule {
         builder.add("--no-auto-version");
       }
       builder.add("--auto-add-overlay");
+      builder.add("--no-xml-namespaces");
 
       ProjectFilesystem pf = getProjectFilesystem();
       builder.add("-o", pf.resolve(getResourceApkPath()).toString());


### PR DESCRIPTION
```
--no-xml-namespaces             Removes XML namespace prefix and URI information from
                                                  AndroidManifest.xml and XML binaries in res/*.
```

This should make the output apks a bit smaller