### PR TITLE
Add ability to right click on files and folders to generate project.

### DIFF
--- a/src/com/facebook/buck/intellij/ideabuck/META-INF/plugin.xml
+++ b/src/com/facebook/buck/intellij/ideabuck/META-INF/plugin.xml
@@ -239,6 +239,16 @@
   </extensions>
 
   <actions>
+    <group description="Generate projects below" id="GenerateProjects" text="GenProjects" type="">
+      <action
+              class="com.facebook.buck.intellij.ideabuck.actions.select.RunSelectedProjectsAction"
+              description="Generates project below."
+              icon="/icons/actions/Project.png"
+              id="GenerateProject"
+              text="Generate Buck Project below">
+        <add-to-group group-id="ProjectViewPopupMenu" anchor="after" relative-to-action="ReplaceInPath"/>
+      </action>
+    </group>
     <group id="buck.Menu">
       <action
           id="buck.GoToBuckFile"

--- a/src/com/facebook/buck/intellij/ideabuck/META-INF/plugin.xml
+++ b/src/com/facebook/buck/intellij/ideabuck/META-INF/plugin.xml
@@ -239,13 +239,13 @@
   </extensions>
 
   <actions>
-    <group description="Generate projects below" id="GenerateProjects" text="GenProjects" type="">
+    <group description="Generate buck projects" id="buck.GenerateProjects" text="GenProjects" type="">
       <action
-              class="com.facebook.buck.intellij.ideabuck.actions.select.RunSelectedProjectsAction"
-              description="Generates project below."
+              class="com.facebook.buck.intellij.ideabuck.actions.select.RunSelectedProjectsFromFolderAction"
+              description="Generate buck project"
               icon="/icons/actions/Project.png"
-              id="GenerateProject"
-              text="Generate Buck Project below">
+              id="buck.GenerateProjectFromFolder"
+              text="Generate Buck Project">
         <add-to-group group-id="ProjectViewPopupMenu" anchor="after" relative-to-action="ReplaceInPath"/>
       </action>
     </group>
@@ -256,6 +256,13 @@
           text="Go to Buck file"
           description="Go to Buck file for this source file.">
         <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift P"/>
+      </action>
+      <action
+        id="buck.GenerateProjectFromFile"
+        class="com.facebook.buck.intellij.ideabuck.actions.select.RunSelectedProjectFromFileAction"
+        text="Generate Buck Project"
+        description="Generate Buck Project">
+        <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift L"/>
       </action>
       <add-to-group anchor="first" group-id="BuildMenu"/>
       <add-to-group anchor="first" group-id="EditorPopupMenu"/>

--- a/src/com/facebook/buck/intellij/ideabuck/src/com/facebook/buck/intellij/ideabuck/actions/select/RunSelectedProjectFromFileAction.java
+++ b/src/com/facebook/buck/intellij/ideabuck/src/com/facebook/buck/intellij/ideabuck/actions/select/RunSelectedProjectFromFileAction.java
@@ -1,0 +1,87 @@
+package com.facebook.buck.intellij.ideabuck.actions.select;
+
+import com.facebook.buck.intellij.ideabuck.build.BuckBuildCommandHandler;
+import com.facebook.buck.intellij.ideabuck.build.BuckBuildManager;
+import com.facebook.buck.intellij.ideabuck.build.BuckCommand;
+import com.facebook.buck.intellij.ideabuck.build.BuckQueryCommandHandler;
+import com.facebook.buck.intellij.ideabuck.config.BuckModule;
+import com.facebook.buck.intellij.ideabuck.file.BuckFileUtil;
+import com.facebook.buck.intellij.ideabuck.icons.BuckIcons;
+import com.google.common.base.Function;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * Generate the iml file for the module that holds a file.
+ */
+public class RunSelectedProjectFromFileAction extends DumbAwareAction {
+
+  public static final String ACTION_TITLE = "Generate Buck Project";
+
+  public RunSelectedProjectFromFileAction() {
+    super(ACTION_TITLE, ACTION_TITLE, BuckIcons.ACTION_PROJECT);
+  }
+
+  @Override
+  public void actionPerformed(AnActionEvent e) {
+    final Project project = e.getProject();
+    if (project == null) {
+      return;
+    }
+    Editor editor = FileEditorManager.getInstance(project).getSelectedTextEditor();
+    if (editor == null) {
+      return;
+    }
+    final Document document = editor.getDocument();
+    if (document == null) {
+      return;
+    }
+    VirtualFile virtualFile = FileDocumentManager.getInstance().getFile(document);
+
+    final VirtualFile file = BuckFileUtil.getBuckFile(virtualFile);
+    if (file != null) {
+      BuckQueryCommandHandler handler =
+          new BuckQueryCommandHandler(
+              project,
+              file.getParent(),
+              BuckCommand.QUERY,
+              new Function<List<String>, Void>() {
+                @Nullable
+                @Override
+                public Void apply(@Nullable List<String> strings) {
+                  if (strings == null
+                      || strings.isEmpty()
+                      || strings.get(0) == null
+                      || strings.get(0).isEmpty()) {
+                    return null;
+                  }
+                  String target = strings.get(0);
+                  BuckBuildCommandHandler handler =
+                      new BuckBuildCommandHandler(project, project.getBaseDir(), BuckCommand.PROJECT);
+                  handler.command().addParameter(target);
+                  handler.command().addParameter("--ide");
+                  handler.command().addParameter("INTELLIJ");
+
+                  BuckModule buckModule = project.getComponent(BuckModule.class);
+                  BuckBuildManager buildManager = BuckBuildManager.getInstance(project);
+                  buildManager.setBuilding(project, true);
+                  buckModule.attach(target);
+                  buildManager.runBuckCommand(handler, "Running buck project for selected file.");
+                  buildManager.setBuilding(project, false);
+                  return null;
+                }
+              });
+      BuckBuildManager buildManager = BuckBuildManager.getInstance(project);
+      handler.command().addParameter("owner(" + virtualFile.getPath() + ")");
+      buildManager.runBuckCommand(handler, "Searching for owning target.");
+    }
+  }
+}

--- a/src/com/facebook/buck/intellij/ideabuck/src/com/facebook/buck/intellij/ideabuck/actions/select/RunSelectedProjectFromFileAction.java
+++ b/src/com/facebook/buck/intellij/ideabuck/src/com/facebook/buck/intellij/ideabuck/actions/select/RunSelectedProjectFromFileAction.java
@@ -1,10 +1,8 @@
 package com.facebook.buck.intellij.ideabuck.actions.select;
 
-import com.facebook.buck.intellij.ideabuck.build.BuckBuildCommandHandler;
 import com.facebook.buck.intellij.ideabuck.build.BuckBuildManager;
 import com.facebook.buck.intellij.ideabuck.build.BuckCommand;
 import com.facebook.buck.intellij.ideabuck.build.BuckQueryCommandHandler;
-import com.facebook.buck.intellij.ideabuck.config.BuckModule;
 import com.facebook.buck.intellij.ideabuck.file.BuckFileUtil;
 import com.facebook.buck.intellij.ideabuck.icons.BuckIcons;
 import com.google.common.base.Function;
@@ -64,18 +62,7 @@ public class RunSelectedProjectFromFileAction extends DumbAwareAction {
                     return null;
                   }
                   String target = strings.get(0);
-                  BuckBuildCommandHandler handler =
-                      new BuckBuildCommandHandler(project, project.getBaseDir(), BuckCommand.PROJECT);
-                  handler.command().addParameter(target);
-                  handler.command().addParameter("--ide");
-                  handler.command().addParameter("INTELLIJ");
-
-                  BuckModule buckModule = project.getComponent(BuckModule.class);
-                  BuckBuildManager buildManager = BuckBuildManager.getInstance(project);
-                  buildManager.setBuilding(project, true);
-                  buckModule.attach(target);
-                  buildManager.runBuckCommand(handler, "Running buck project for selected file.");
-                  buildManager.setBuilding(project, false);
+                  SelectProjectUtils.generateTargetForProject(target, project);
                   return null;
                 }
               });

--- a/src/com/facebook/buck/intellij/ideabuck/src/com/facebook/buck/intellij/ideabuck/actions/select/RunSelectedProjectsAction.java
+++ b/src/com/facebook/buck/intellij/ideabuck/src/com/facebook/buck/intellij/ideabuck/actions/select/RunSelectedProjectsAction.java
@@ -1,0 +1,60 @@
+package com.facebook.buck.intellij.ideabuck.actions.select;
+
+import com.facebook.buck.intellij.ideabuck.build.BuckBuildCommandHandler;
+import com.facebook.buck.intellij.ideabuck.build.BuckBuildManager;
+import com.facebook.buck.intellij.ideabuck.build.BuckCommand;
+import com.facebook.buck.intellij.ideabuck.config.BuckModule;
+import com.intellij.ide.IdeView;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.LangDataKeys;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiDirectory;
+
+/**
+ * Action to generate projects from the project tool view.
+ */
+public class RunSelectedProjectsAction extends AnAction {
+
+  @Override
+  public void actionPerformed(AnActionEvent anActionEvent) {
+    final Project project = anActionEvent.getProject();
+    if (project == null) {
+      return;
+    }
+
+    BuckModule buckModule = project.getComponent(BuckModule.class);
+    DataContext dataContext = anActionEvent.getDataContext();
+    final IdeView view = LangDataKeys.IDE_VIEW.getData(dataContext);
+    if (view == null) {
+      return;
+    }
+
+    final PsiDirectory directory = view.getOrChooseDirectory();
+    if (directory == null) {
+      return;
+    }
+
+    String directoryString = directory.getVirtualFile().getPath();
+    String basepath = project.getBasePath();
+    if (basepath == null) {
+      return;
+    }
+
+    String relative = directoryString.replace(basepath, "");
+    String target = "/" + relative + "/...";
+
+    BuckBuildCommandHandler handler =
+        new BuckBuildCommandHandler(project, project.getBaseDir(), BuckCommand.PROJECT);
+    handler.command().addParameter(target);
+    handler.command().addParameter("--ide");
+    handler.command().addParameter("INTELLIJ");
+
+    BuckBuildManager buildManager = BuckBuildManager.getInstance(project);
+    buildManager.setBuilding(project, true);
+    buckModule.attach(target);
+    buildManager.runBuckCommand(handler, "Running buck project on selected groups.");
+    buildManager.setBuilding(project, false);
+  }
+}

--- a/src/com/facebook/buck/intellij/ideabuck/src/com/facebook/buck/intellij/ideabuck/actions/select/RunSelectedProjectsFromFolderAction.java
+++ b/src/com/facebook/buck/intellij/ideabuck/src/com/facebook/buck/intellij/ideabuck/actions/select/RunSelectedProjectsFromFolderAction.java
@@ -4,18 +4,20 @@ import com.facebook.buck.intellij.ideabuck.build.BuckBuildCommandHandler;
 import com.facebook.buck.intellij.ideabuck.build.BuckBuildManager;
 import com.facebook.buck.intellij.ideabuck.build.BuckCommand;
 import com.facebook.buck.intellij.ideabuck.config.BuckModule;
+import com.facebook.buck.intellij.ideabuck.file.BuckFileUtil;
 import com.intellij.ide.IdeView;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.actionSystem.LangDataKeys;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDirectory;
 
 /**
  * Action to generate projects from the project tool view.
  */
-public class RunSelectedProjectsAction extends AnAction {
+public class RunSelectedProjectsFromFolderAction extends AnAction {
 
   @Override
   public void actionPerformed(AnActionEvent anActionEvent) {
@@ -37,6 +39,12 @@ public class RunSelectedProjectsAction extends AnAction {
     }
 
     String directoryString = directory.getVirtualFile().getPath();
+
+    VirtualFile potentialBuckFile = BuckFileUtil.getBuckFile(directory.getVirtualFile());
+    if (potentialBuckFile != null) {
+      directoryString = potentialBuckFile.getParent().getPath();
+    }
+    
     String basepath = project.getBasePath();
     if (basepath == null) {
       return;

--- a/src/com/facebook/buck/intellij/ideabuck/src/com/facebook/buck/intellij/ideabuck/actions/select/RunSelectedProjectsFromFolderAction.java
+++ b/src/com/facebook/buck/intellij/ideabuck/src/com/facebook/buck/intellij/ideabuck/actions/select/RunSelectedProjectsFromFolderAction.java
@@ -1,9 +1,5 @@
 package com.facebook.buck.intellij.ideabuck.actions.select;
 
-import com.facebook.buck.intellij.ideabuck.build.BuckBuildCommandHandler;
-import com.facebook.buck.intellij.ideabuck.build.BuckBuildManager;
-import com.facebook.buck.intellij.ideabuck.build.BuckCommand;
-import com.facebook.buck.intellij.ideabuck.config.BuckModule;
 import com.facebook.buck.intellij.ideabuck.file.BuckFileUtil;
 import com.intellij.ide.IdeView;
 import com.intellij.openapi.actionSystem.AnAction;
@@ -26,7 +22,6 @@ public class RunSelectedProjectsFromFolderAction extends AnAction {
       return;
     }
 
-    BuckModule buckModule = project.getComponent(BuckModule.class);
     DataContext dataContext = anActionEvent.getDataContext();
     final IdeView view = LangDataKeys.IDE_VIEW.getData(dataContext);
     if (view == null) {
@@ -39,12 +34,11 @@ public class RunSelectedProjectsFromFolderAction extends AnAction {
     }
 
     String directoryString = directory.getVirtualFile().getPath();
-
     VirtualFile potentialBuckFile = BuckFileUtil.getBuckFile(directory.getVirtualFile());
     if (potentialBuckFile != null) {
       directoryString = potentialBuckFile.getParent().getPath();
     }
-    
+
     String basepath = project.getBasePath();
     if (basepath == null) {
       return;
@@ -52,17 +46,6 @@ public class RunSelectedProjectsFromFolderAction extends AnAction {
 
     String relative = directoryString.replace(basepath, "");
     String target = "/" + relative + "/...";
-
-    BuckBuildCommandHandler handler =
-        new BuckBuildCommandHandler(project, project.getBaseDir(), BuckCommand.PROJECT);
-    handler.command().addParameter(target);
-    handler.command().addParameter("--ide");
-    handler.command().addParameter("INTELLIJ");
-
-    BuckBuildManager buildManager = BuckBuildManager.getInstance(project);
-    buildManager.setBuilding(project, true);
-    buckModule.attach(target);
-    buildManager.runBuckCommand(handler, "Running buck project on selected groups.");
-    buildManager.setBuilding(project, false);
+    SelectProjectUtils.generateTargetForProject(target, project);
   }
 }

--- a/src/com/facebook/buck/intellij/ideabuck/src/com/facebook/buck/intellij/ideabuck/actions/select/SelectProjectUtils.java
+++ b/src/com/facebook/buck/intellij/ideabuck/src/com/facebook/buck/intellij/ideabuck/actions/select/SelectProjectUtils.java
@@ -1,0 +1,25 @@
+package com.facebook.buck.intellij.ideabuck.actions.select;
+
+import com.facebook.buck.intellij.ideabuck.build.BuckBuildCommandHandler;
+import com.facebook.buck.intellij.ideabuck.build.BuckBuildManager;
+import com.facebook.buck.intellij.ideabuck.build.BuckCommand;
+import com.facebook.buck.intellij.ideabuck.config.BuckModule;
+import com.intellij.openapi.project.Project;
+
+public class SelectProjectUtils {
+
+  public static void generateTargetForProject(String target, Project project) {
+    BuckBuildCommandHandler handler =
+        new BuckBuildCommandHandler(project, project.getBaseDir(), BuckCommand.PROJECT);
+    handler.command().addParameter(target);
+    handler.command().addParameter("--ide");
+    handler.command().addParameter("INTELLIJ");
+
+    BuckModule buckModule = project.getComponent(BuckModule.class);
+    BuckBuildManager buildManager = BuckBuildManager.getInstance(project);
+    buildManager.setBuilding(project, true);
+    buckModule.attach(target);
+    buildManager.runBuckCommand(handler, "Running buck project on " + target);
+    buildManager.setBuilding(project, false);
+  }
+}


### PR DESCRIPTION
This diff seeks to mitigate an issue where our devs are opening too many modules at once. With this add-on you can right click the directory you want to get ready, and run project on it. It is very useful in large mono repos, for generating projects that would be pesky to do on the command line. I tested it on the buck, okbuck and our internal mono repo.

**Creating projects from project tool:**
<img width="1221" alt="screen shot 2017-10-16 at 11 18 20 am" src="https://user-images.githubusercontent.com/6720993/31627909-cba46904-b263-11e7-8b95-61b72eb3aa4f.png">
<img width="1214" alt="screen shot 2017-10-16 at 11 18 37 am" src="https://user-images.githubusercontent.com/6720993/31627908-cb901d50-b263-11e7-87f5-e718ff6cdc10.png">

**Creating projects from file:**
<img width="1216" alt="screen shot 2017-10-16 at 11 14 59 am" src="https://user-images.githubusercontent.com/6720993/31627813-6f74ae1e-b263-11e7-8c4c-3c4b779ee84f.png">
<img width="1211" alt="screen shot 2017-10-16 at 11 15 25 am" src="https://user-images.githubusercontent.com/6720993/31627812-6f5b458c-b263-11e7-88e3-73deb823f718.png">


From my instrumentation testing:
Average indexing time before 8599.29ms
Average indexing time after 444.786ms

**Indexing time in ms before and after plugin:**
<img width="1178" alt="screen shot 2017-10-13 at 2 47 24 pm" src="https://user-images.githubusercontent.com/6720993/31567727-c09fa4f0-b025-11e7-839d-0afd7416636b.png">
Indexing time in ms with plugin:
<img width="1166" alt="screen shot 2017-10-13 at 2 47 02 pm" src="https://user-images.githubusercontent.com/6720993/31567728-c0b81512-b025-11e7-8c1a-e2676ceae4df.png">
