### PR TITLE
Fix buck plugin finder root

### DIFF
--- a/src/com/facebook/buck/plugin/BuckPluginManagerFactory.java
+++ b/src/com/facebook/buck/plugin/BuckPluginManagerFactory.java
@@ -16,6 +16,8 @@
 
 package com.facebook.buck.plugin;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.pf4j.DefaultPluginManager;
 import org.pf4j.ExtensionFinder;
 import org.pf4j.PluginManager;
@@ -33,6 +35,11 @@ public class BuckPluginManagerFactory {
           @Override
           protected ExtensionFinder createExtensionFinder() {
             return new BuckExtensionFinder();
+          }
+
+          @Override
+          public Path getPluginsRoot() {
+            return Paths.get("buck-plugins");
           }
         };
 


### PR DESCRIPTION
https://github.com/decebals/pf4j/blob/1822cdede37ba649033021583ab29ee662835071/pf4j/src/main/java/org/pf4j/PropertiesPluginDescriptorFinder.java#L39

Without this fix, the following warnings are thrown when buck starts up on the main console

```
[2017-10-18 16:33:58.844][error][command:null][tid:15][org.pf4j.CompoundPluginDescriptorFinder] Cannot find 'plugins/analytics-plugin/plugin.properties' path
[2017-10-18 16:33:58.847][error][command:null][tid:15][org.pf4j.CompoundPluginDescriptorFinder] Cannot find the manifest path
[2017-10-18 16:33:58.848][error][command:null][tid:15][org.pf4j.AbstractPluginManager] No PluginDescriptorFinder for plugin 'plugins/analytics-plugin'
org.pf4j.PluginException: No PluginDescriptorFinder for plugin 'plugins/analytics-plugin'
    at org.pf4j.CompoundPluginDescriptorFinder.find(CompoundPluginDescriptorFinder.java:78)
    at org.pf4j.AbstractPluginManager.loadPluginFromPath(AbstractPluginManager.java:786)
    at org.pf4j.DefaultPluginManager.loadPluginFromPath(DefaultPluginManager.java:137)
    at org.pf4j.AbstractPluginManager.loadPlugins(AbstractPluginManager.java:230)
    at com.facebook.buck.plugin.BuckPluginManagerFactory.createPluginManager(BuckPluginManagerFactory.java:39)
    at com.facebook.buck.cli.Main.runMainWithExitCode(Main.java:569)
    at com.facebook.buck.cli.Main.runMainThenExit(Main.java:389)
    at com.facebook.buck.cli.Main.nailMain(Main.java:1840)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at com.martiansoftware.nailgun.NGSession.run(NGSession.java:329)
```