### PR TITLE
Bump max memory limit for ant in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ install:
   - cmd: set GOROOT=
   - cmd: set PATH=%PATH:C:\go\bin;=%
   - cmd: set PATH=%PATH:C:\go\bin=%
+  - cmd: set ANT_OPTS=-Xmx512m
   - cmd: set
   - cmd: python --version
   - cmd: java -version


### PR DESCRIPTION
Need to see what's the default max heap size.