### PR TITLE
Fix issue in jacoco report with asm

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -533,6 +533,12 @@
       <zipfileset excludes="**/*SF **/*RSA" src="${third-party.dir}/java/jacoco/org.jacoco.report-0.7.7.201606060606.jar"/>
       <zipfileset excludes="**/*SF **/*RSA" src="${third-party.dir}/java/plexus/plexus-utils-3.0.20.jar"/>
       <zipfileset includes="**/*.class" src="${third-party.dir}/java/guava/guava-20.0.jar"/>
+      <zipfileset includes="**/*.class" src="${third-party.dir}/java/asm/asm-6.0.jar" />
+      <zipfileset includes="**/*.class" src="${third-party.dir}/java/asm/asm-analysis-6.0.jar" />
+      <zipfileset includes="**/*.class" src="${third-party.dir}/java/asm/asm-commons-6.0.jar" />
+      <zipfileset includes="**/*.class" src="${third-party.dir}/java/asm/asm-tree-6.0.jar" />
+      <zipfileset includes="**/*.class" src="${third-party.dir}/java/asm/asm-util-6.0.jar" />
+      <zipfileset includes="**/*.class" src="${third-party.dir}/java/asm/asm-xml-6.0.jar" />
       <fileset dir="${classes.dir}">
           <include name="com/facebook/buck/jvm/java/coverage/ReportGenerator.class"/>
       </fileset>

--- a/third-party/java/jacoco/BUCK
+++ b/third-party/java/jacoco/BUCK
@@ -3,12 +3,10 @@ java_library(
     exported_deps = [
         ":core",
         ":report",
+        "//third-party/java/asm:asm"
     ],
     visibility = [
         "//src/com/facebook/buck/jvm/java/coverage:coverage",
-    ],
-    deps = [
-        "//third-party/java/asm:asm",
     ],
 )
 


### PR DESCRIPTION
Without this, on latest buck the following exception occurs when computing code coverage

```
Exception in thread "main" java.lang.NoClassDefFoundError: org/objectweb/asm/ClassVisitor
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:763)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:467)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:73)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:368)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:362)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:361)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:335)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at com.facebook.buck.jvm.java.coverage.ReportGenerator.analyzeStructure(ReportGenerator.java:179)
	at com.facebook.buck.jvm.java.coverage.ReportGenerator.create(ReportGenerator.java:119)
	at com.facebook.buck.jvm.java.coverage.ReportGenerator.main(ReportGenerator.java:216)
Caused by: java.lang.ClassNotFoundException: org.objectweb.asm.ClassVisitor
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:335)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 15 more
```