### PR TITLE
Use filelists in SwiftCompile

### DIFF
--- a/src/com/facebook/buck/swift/SwiftBuckConfig.java
+++ b/src/com/facebook/buck/swift/SwiftBuckConfig.java
@@ -26,6 +26,7 @@ public class SwiftBuckConfig {
   public static final String COMPILER_FLAGS_NAME = "compiler_flags";
   public static final String VERSION_NAME = "version";
   public static final String COMPILE_FORCE_CACHE = "compile_force_cache";
+  public static final String USE_FILELIST = "use_filelist";
 
   private final BuckConfig delegate;
 
@@ -48,5 +49,9 @@ public class SwiftBuckConfig {
 
   public boolean getCompileForceCache() {
     return delegate.getBooleanValue(SECTION_NAME, COMPILE_FORCE_CACHE, false);
+  }
+
+  public boolean getUseFileList() {
+    return delegate.getBooleanValue(SECTION_NAME, USE_FILELIST, false);
   }
 }


### PR DESCRIPTION
Introduces a new config option `use_filelist` on the `[swift]` section. If enabled it will pass a `-filelist` parameter to swiftc instead of passing all file names in argv.

This can make compile commands significantly shorter when having a large amount of source files.