### PR TITLE
SwiftCompile use list for object output

### DIFF
--- a/src/com/facebook/buck/apple/AppleLibraryDescription.java
+++ b/src/com/facebook/buck/apple/AppleLibraryDescription.java
@@ -934,7 +934,7 @@ public class AppleLibraryDescription
     BuildTarget swiftTarget =
         AppleLibraryDescriptionSwiftEnhancer.createBuildTargetForSwiftCompile(target, cxxPlatform);
     SwiftCompile compile = (SwiftCompile) resolver.requireRule(swiftTarget);
-    return Optional.of(ImmutableList.of(compile.getObjectPath()));
+    return Optional.of(compile.getObjectPaths());
   }
 
   @Override

--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -360,7 +360,7 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
     return moduleName;
   }
 
-  /** @return {@link SourcePath} to the output object file (i.e., .o file) */
+  /** @return List of {@link SourcePath} to the output object file(s) (i.e., .o file) */
   public ImmutableList<SourcePath> getObjectPaths() {
     // Ensures that users of the object path can depend on this build target
     return objectPaths

--- a/src/com/facebook/buck/swift/SwiftLibrary.java
+++ b/src/com/facebook/buck/swift/SwiftLibrary.java
@@ -173,7 +173,7 @@ class SwiftLibrary extends NoopBuildRuleWithDeclaredAndExtraDeps
           FileListableLinkerInputArg.withSourcePathArg(
               SourcePathArg.of(swiftLinkRule.getSourcePathToOutput())));
     } else {
-      inputBuilder.addArgs(rule.getFileListLinkArg());
+      inputBuilder.addAllArgs(rule.getFileListLinkArg());
     }
     return inputBuilder.build();
   }

--- a/src/com/facebook/buck/swift/SwiftLibraryDescription.java
+++ b/src/com/facebook/buck/swift/SwiftLibraryDescription.java
@@ -344,7 +344,7 @@ public class SwiftLibraryDescription implements Description<SwiftLibraryDescript
                 swiftRuntimeLinkable.getNativeLinkableInput(
                     cxxPlatform, Linker.LinkableDepType.SHARED))
             .addAllArgs(rule.getAstLinkArgs())
-            .addArgs(rule.getFileListLinkArg());
+            .addAllArgs(rule.getFileListLinkArg());
     return resolver.addToIndex(
         CxxLinkableEnhancer.createCxxLinkableBuildRule(
             cxxBuckConfig,

--- a/test/com/facebook/buck/swift/SwiftLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/swift/SwiftLibraryIntegrationTest.java
@@ -175,7 +175,7 @@ public class SwiftLibraryIntegrationTest {
                     .getRelativePath(buildRule.getSourcePathToOutput())
                     .resolve("bar.swiftmodule"))));
 
-    Arg objArg = buildRule.getFileListLinkArg();
+    Arg objArg = buildRule.getFileListLinkArg().get(0);
     assertThat(objArg, Matchers.instanceOf(FileListableLinkerInputArg.class));
     FileListableLinkerInputArg fileListArg = (FileListableLinkerInputArg) objArg;
     ExplicitBuildTargetSourcePath fileListSourcePath =


### PR DESCRIPTION
The swift compiler is capable of outputting an object file per swift file when compiling without whole module optimisation or when doing parallel llvm code generation. Using a list of object output paths in swiftcompile would be a better abstraction than having a single object file output path.