### PR TITLE
Revert "Enable --no-xml-namespaces by default for aapt2 link"

### DIFF
--- a/src/com/facebook/buck/android/Aapt2Link.java
+++ b/src/com/facebook/buck/android/Aapt2Link.java
@@ -223,7 +223,6 @@ public class Aapt2Link extends AbstractBuildRule {
         builder.add("--no-auto-version");
       }
       builder.add("--auto-add-overlay");
-      builder.add("--no-xml-namespaces");
 
       ProjectFilesystem pf = getProjectFilesystem();
       builder.add("-o", pf.resolve(getResourceApkPath()).toString());


### PR DESCRIPTION
This option can cause crashes at runtime in some cases dealing with style attributes. So turning this off by default