### PR TITLE
Fix missing Guava in coverage report jar.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -591,6 +591,7 @@
       <zipfileset includes="**/*.class" src="${third-party.dir}/java/asm/asm-tree-6.0.jar" />
       <zipfileset includes="**/*.class" src="${third-party.dir}/java/asm/asm-util-6.0.jar" />
       <zipfileset includes="**/*.class" src="${third-party.dir}/java/asm/asm-xml-6.0.jar" />
+      <zipfileset includes="**/*.class" src="${third-party.dir}/java/guava/guava-23.3-jre.jar"/>
       <fileset dir="${classes.dir}">
           <include name="com/facebook/buck/jvm/java/coverage/ReportGenerator.class"/>
       </fileset>


### PR DESCRIPTION
https://github.com/facebook/buck/commit/a6431936b9b07fa67ac21cdc455d161f16b321bb#diff-2cccd7bf48b7a9cc113ff564acd802a8 removed Guava from CodeCoverage target which causes `NoClassDefFoundError` in our builds:

```java
TESTS PASSED
Exception in thread "main" java.lang.NoClassDefFoundError: com/google/common/collect/Sets
	at com.facebook.buck.jvm.java.coverage.ReportGenerator.<clinit>(ReportGenerator.java:71)
Caused by: java.lang.ClassNotFoundException: com.google.common.collect.Sets
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:335)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 1 more

Command failed with exit code 1.
stderr: Exception in thread "main" java.lang.NoClassDefFoundError: com/google/common/collect/Sets
	at com.facebook.buck.jvm.java.coverage.ReportGenerator.<clinit>(ReportGenerator.java:71)
Caused by: java.lang.ClassNotFoundException: com.google.common.collect.Sets
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:335)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 1 more
```

This PR replaces PR #1620 to pass CLA as a Lyft employee since it's made from Lyft's fork of Buck instead of personal fork.