### PR TITLE
Add ability to skip creating intermediate R.java

### DIFF
--- a/docs/rule/android_library.soy
+++ b/docs/rule/android_library.soy
@@ -69,6 +69,17 @@ compiled class files and resources.
 {/call}
 
 {call buck.arg}
+  {param name: 'skip_non_union_r_dot_java' /}
+  {param default : 'false' /}
+  {param desc}
+  When using <code>resource_union_package</code> setting <code>skip_non_union_r_dot_java</code> will
+  skip generating dummy R.java for other packages which are unnecessary. Reducing the number of
+  R.java helps in improving the overall compile time especially in libraries with large number of
+  dependent prebuilt targets.
+  {/param}
+{/call}
+
+{call buck.arg}
   {param name: 'deps' /}
   {param default : '[]' /}
   {param desc}

--- a/src/com/facebook/buck/android/AndroidLibrary.java
+++ b/src/com/facebook/buck/android/AndroidLibrary.java
@@ -194,7 +194,8 @@ public class AndroidLibrary extends DefaultJavaLibrary implements AndroidPackage
               /* forceFinalResourceIds */ false,
               args.getResourceUnionPackage(),
               args.getFinalRName(),
-              false);
+              /* useOldStyleableFormat */ false,
+              args.isSkipPrebuiltRDotJava());
 
       getDummyRDotJava()
           .ifPresent(

--- a/src/com/facebook/buck/android/AndroidLibrary.java
+++ b/src/com/facebook/buck/android/AndroidLibrary.java
@@ -195,7 +195,7 @@ public class AndroidLibrary extends DefaultJavaLibrary implements AndroidPackage
               args.getResourceUnionPackage(),
               args.getFinalRName(),
               /* useOldStyleableFormat */ false,
-              args.isSkipPrebuiltRDotJava());
+              args.isSkipNonUnionRDotJava());
 
       getDummyRDotJava()
           .ifPresent(

--- a/src/com/facebook/buck/android/AndroidLibraryDescription.java
+++ b/src/com/facebook/buck/android/AndroidLibraryDescription.java
@@ -155,6 +155,11 @@ public class AndroidLibraryDescription
 
     Optional<String> getResourceUnionPackage();
 
+    @Value.Default
+    default boolean isSkipPrebuiltRDotJava() {
+      return false;
+    }
+
     Optional<String> getFinalRName();
   }
 

--- a/src/com/facebook/buck/android/AndroidLibraryDescription.java
+++ b/src/com/facebook/buck/android/AndroidLibraryDescription.java
@@ -95,7 +95,7 @@ public class AndroidLibraryDescription
           buildTarget, projectFilesystem, params, args.getSrcs(), args.getMavenCoords());
     }
 
-    if (args.isSkipPrebuiltRDotJava()) {
+    if (args.isSkipNonUnionRDotJava()) {
       Preconditions.checkArgument(
           args.getResourceUnionPackage().isPresent(),
           "union_package should be specified if skip_prebuilt_r_dot_java is set");
@@ -163,7 +163,7 @@ public class AndroidLibraryDescription
     Optional<String> getResourceUnionPackage();
 
     @Value.Default
-    default boolean isSkipPrebuiltRDotJava() {
+    default boolean isSkipNonUnionRDotJava() {
       return false;
     }
 

--- a/src/com/facebook/buck/android/AndroidLibraryDescription.java
+++ b/src/com/facebook/buck/android/AndroidLibraryDescription.java
@@ -41,6 +41,7 @@ import com.facebook.buck.rules.SourcePath;
 import com.facebook.buck.rules.TargetGraph;
 import com.facebook.buck.toolchain.ToolchainProvider;
 import com.facebook.buck.util.immutables.BuckStyleImmutable;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableSet;
 import java.util.Optional;
@@ -92,6 +93,12 @@ public class AndroidLibraryDescription
     if (buildTarget.getFlavors().contains(JavaLibrary.SRC_JAR)) {
       return new JavaSourceJar(
           buildTarget, projectFilesystem, params, args.getSrcs(), args.getMavenCoords());
+    }
+
+    if (args.isSkipPrebuiltRDotJava()) {
+      Preconditions.checkArgument(
+          args.getResourceUnionPackage().isPresent(),
+          "union_package should be specified if skip_prebuilt_r_dot_java is set");
     }
 
     boolean hasDummyRDotJavaFlavor = buildTarget.getFlavors().contains(DUMMY_R_DOT_JAVA_FLAVOR);

--- a/src/com/facebook/buck/android/AndroidLibraryDescription.java
+++ b/src/com/facebook/buck/android/AndroidLibraryDescription.java
@@ -98,7 +98,7 @@ public class AndroidLibraryDescription
     if (args.isSkipNonUnionRDotJava()) {
       Preconditions.checkArgument(
           args.getResourceUnionPackage().isPresent(),
-          "union_package should be specified if skip_prebuilt_r_dot_java is set");
+          "union_package should be specified if skip_non_union_r_dot_java is set");
     }
 
     boolean hasDummyRDotJavaFlavor = buildTarget.getFlavors().contains(DUMMY_R_DOT_JAVA_FLAVOR);

--- a/src/com/facebook/buck/android/AndroidLibraryGraphEnhancer.java
+++ b/src/com/facebook/buck/android/AndroidLibraryGraphEnhancer.java
@@ -52,7 +52,7 @@ public class AndroidLibraryGraphEnhancer {
   private final Optional<String> finalRName;
   private final boolean useOldStyleableFormat;
   private final ProjectFilesystem projectFilesystem;
-  private final boolean skipPrebuiltRDotJava;
+  private final boolean skipNonUnionRDotJava;
 
   public AndroidLibraryGraphEnhancer(
       BuildTarget buildTarget,
@@ -65,7 +65,7 @@ public class AndroidLibraryGraphEnhancer {
       Optional<String> resourceUnionPackage,
       Optional<String> finalRName,
       boolean useOldStyleableFormat,
-      boolean skipPrebuiltRDotJava) {
+      boolean skipNonUnionRDotJava) {
     this.projectFilesystem = projectFilesystem;
     Preconditions.checkState(!HasJavaAbi.isAbiTarget(buildTarget));
     this.dummyRDotJavaBuildTarget = getDummyRDotJavaTarget(buildTarget);
@@ -81,7 +81,7 @@ public class AndroidLibraryGraphEnhancer {
     this.resourceUnionPackage = resourceUnionPackage;
     this.finalRName = finalRName;
     this.useOldStyleableFormat = useOldStyleableFormat;
-    this.skipPrebuiltRDotJava = skipPrebuiltRDotJava;
+    this.skipNonUnionRDotJava = skipNonUnionRDotJava;
   }
 
   public static BuildTarget getDummyRDotJavaTarget(BuildTarget buildTarget) {
@@ -146,7 +146,7 @@ public class AndroidLibraryGraphEnhancer {
                   resourceUnionPackage,
                   finalRName,
                   useOldStyleableFormat,
-                  skipPrebuiltRDotJava);
+                  skipNonUnionRDotJava);
             });
 
     return Optional.of((DummyRDotJava) dummyRDotJava);

--- a/src/com/facebook/buck/android/AndroidLibraryGraphEnhancer.java
+++ b/src/com/facebook/buck/android/AndroidLibraryGraphEnhancer.java
@@ -52,6 +52,7 @@ public class AndroidLibraryGraphEnhancer {
   private final Optional<String> finalRName;
   private final boolean useOldStyleableFormat;
   private final ProjectFilesystem projectFilesystem;
+  private final boolean skipPrebuiltRDotJava;
 
   public AndroidLibraryGraphEnhancer(
       BuildTarget buildTarget,
@@ -63,7 +64,8 @@ public class AndroidLibraryGraphEnhancer {
       boolean forceFinalResourceIds,
       Optional<String> resourceUnionPackage,
       Optional<String> finalRName,
-      boolean useOldStyleableFormat) {
+      boolean useOldStyleableFormat,
+      boolean skipPrebuiltRDotJava) {
     this.projectFilesystem = projectFilesystem;
     Preconditions.checkState(!HasJavaAbi.isAbiTarget(buildTarget));
     this.dummyRDotJavaBuildTarget = getDummyRDotJavaTarget(buildTarget);
@@ -79,6 +81,7 @@ public class AndroidLibraryGraphEnhancer {
     this.resourceUnionPackage = resourceUnionPackage;
     this.finalRName = finalRName;
     this.useOldStyleableFormat = useOldStyleableFormat;
+    this.skipPrebuiltRDotJava = skipPrebuiltRDotJava;
   }
 
   public static BuildTarget getDummyRDotJavaTarget(BuildTarget buildTarget) {
@@ -142,7 +145,8 @@ public class AndroidLibraryGraphEnhancer {
                   forceFinalResourceIds,
                   resourceUnionPackage,
                   finalRName,
-                  useOldStyleableFormat);
+                  useOldStyleableFormat,
+                  skipPrebuiltRDotJava);
             });
 
     return Optional.of((DummyRDotJava) dummyRDotJava);

--- a/src/com/facebook/buck/android/DummyRDotJava.java
+++ b/src/com/facebook/buck/android/DummyRDotJava.java
@@ -79,6 +79,7 @@ public class DummyRDotJava extends AbstractBuildRule
   @AddToRuleKey private final Optional<String> unionPackage;
   @AddToRuleKey private final Optional<String> finalRName;
   @AddToRuleKey private final boolean useOldStyleableFormat;
+  @AddToRuleKey private final boolean skipPrebuiltRDotJava;
 
   @AddToRuleKey
   @SuppressWarnings("PMD.UnusedPrivateField")
@@ -93,7 +94,8 @@ public class DummyRDotJava extends AbstractBuildRule
       boolean forceFinalResourceIds,
       Optional<String> unionPackage,
       Optional<String> finalRName,
-      boolean useOldStyleableFormat) {
+      boolean useOldStyleableFormat,
+      boolean skipPrebuiltRDotJava) {
     this(
         buildTarget,
         projectFilesystem,
@@ -104,7 +106,8 @@ public class DummyRDotJava extends AbstractBuildRule
         unionPackage,
         finalRName,
         useOldStyleableFormat,
-        abiPaths(androidResourceDeps));
+        abiPaths(androidResourceDeps),
+        skipPrebuiltRDotJava);
   }
 
   private DummyRDotJava(
@@ -117,7 +120,8 @@ public class DummyRDotJava extends AbstractBuildRule
       Optional<String> unionPackage,
       Optional<String> finalRName,
       boolean useOldStyleableFormat,
-      ImmutableList<SourcePath> abiInputs) {
+      ImmutableList<SourcePath> abiInputs,
+      boolean skipPrebuiltRDotJava) {
     super(buildTarget, projectFilesystem);
 
     // DummyRDotJava inherits no dependencies from its android_library beyond the compiler
@@ -135,6 +139,7 @@ public class DummyRDotJava extends AbstractBuildRule
             .sorted(Comparator.comparing(HasAndroidResourceDeps::getBuildTarget))
             .collect(ImmutableList.toImmutableList());
     this.useOldStyleableFormat = useOldStyleableFormat;
+    this.skipPrebuiltRDotJava = skipPrebuiltRDotJava;
     this.outputJar = getOutputJarPath(getBuildTarget(), getProjectFilesystem());
     this.compileStepFactory = compileStepFactory;
     this.forceFinalResourceIds = forceFinalResourceIds;
@@ -202,7 +207,8 @@ public class DummyRDotJava extends AbstractBuildRule
               forceFinalResourceIds,
               unionPackage,
               /* rName */ Optional.empty(),
-              useOldStyleableFormat);
+              useOldStyleableFormat,
+              skipPrebuiltRDotJava);
       steps.add(mergeStep);
 
       if (!finalRName.isPresent()) {
@@ -217,7 +223,8 @@ public class DummyRDotJava extends AbstractBuildRule
                 /* forceFinalResourceIds */ true,
                 unionPackage,
                 finalRName,
-                useOldStyleableFormat);
+                useOldStyleableFormat,
+                skipPrebuiltRDotJava);
         steps.add(mergeFinalRStep);
 
         javaSourceFilePaths =

--- a/src/com/facebook/buck/android/DummyRDotJava.java
+++ b/src/com/facebook/buck/android/DummyRDotJava.java
@@ -79,7 +79,7 @@ public class DummyRDotJava extends AbstractBuildRule
   @AddToRuleKey private final Optional<String> unionPackage;
   @AddToRuleKey private final Optional<String> finalRName;
   @AddToRuleKey private final boolean useOldStyleableFormat;
-  @AddToRuleKey private final boolean skipPrebuiltRDotJava;
+  @AddToRuleKey private final boolean skipNonUnionRDotJava;
 
   @AddToRuleKey
   @SuppressWarnings("PMD.UnusedPrivateField")
@@ -95,7 +95,7 @@ public class DummyRDotJava extends AbstractBuildRule
       Optional<String> unionPackage,
       Optional<String> finalRName,
       boolean useOldStyleableFormat,
-      boolean skipPrebuiltRDotJava) {
+      boolean skipNonUnionRDotJava) {
     this(
         buildTarget,
         projectFilesystem,
@@ -107,7 +107,7 @@ public class DummyRDotJava extends AbstractBuildRule
         finalRName,
         useOldStyleableFormat,
         abiPaths(androidResourceDeps),
-        skipPrebuiltRDotJava);
+        skipNonUnionRDotJava);
   }
 
   private DummyRDotJava(
@@ -121,7 +121,7 @@ public class DummyRDotJava extends AbstractBuildRule
       Optional<String> finalRName,
       boolean useOldStyleableFormat,
       ImmutableList<SourcePath> abiInputs,
-      boolean skipPrebuiltRDotJava) {
+      boolean skipNonUnionRDotJava) {
     super(buildTarget, projectFilesystem);
 
     // DummyRDotJava inherits no dependencies from its android_library beyond the compiler
@@ -139,7 +139,7 @@ public class DummyRDotJava extends AbstractBuildRule
             .sorted(Comparator.comparing(HasAndroidResourceDeps::getBuildTarget))
             .collect(ImmutableList.toImmutableList());
     this.useOldStyleableFormat = useOldStyleableFormat;
-    this.skipPrebuiltRDotJava = skipPrebuiltRDotJava;
+    this.skipNonUnionRDotJava = skipNonUnionRDotJava;
     this.outputJar = getOutputJarPath(getBuildTarget(), getProjectFilesystem());
     this.compileStepFactory = compileStepFactory;
     this.forceFinalResourceIds = forceFinalResourceIds;
@@ -208,7 +208,7 @@ public class DummyRDotJava extends AbstractBuildRule
               unionPackage,
               /* rName */ Optional.empty(),
               useOldStyleableFormat,
-              skipPrebuiltRDotJava);
+              skipNonUnionRDotJava);
       steps.add(mergeStep);
 
       if (!finalRName.isPresent()) {
@@ -224,7 +224,7 @@ public class DummyRDotJava extends AbstractBuildRule
                 unionPackage,
                 finalRName,
                 useOldStyleableFormat,
-                skipPrebuiltRDotJava);
+                skipNonUnionRDotJava);
         steps.add(mergeFinalRStep);
 
         javaSourceFilePaths =

--- a/src/com/facebook/buck/android/MergeAndroidResourcesStep.java
+++ b/src/com/facebook/buck/android/MergeAndroidResourcesStep.java
@@ -254,9 +254,9 @@ public class MergeAndroidResourcesStep implements Step {
       if (skipNonUnionRDotJava) {
         Preconditions.checkArgument(
             unionPackage.isPresent(),
-            "union_package should be specified if skip_prebuilt_r_dot_java is set");
+            "union_package should be specified if skip_non_union_r_dot_java is set");
 
-        // If skip_prebuilt_r_dot_java is true remove all packages except union package
+        // If skip_non_union_r_dot_java is true remove all packages except union package
         rDotJavaPackageToResources = TreeMultimap.create();
 
       } else {

--- a/src/com/facebook/buck/android/MergeAndroidResourcesStep.java
+++ b/src/com/facebook/buck/android/MergeAndroidResourcesStep.java
@@ -246,15 +246,17 @@ public class MergeAndroidResourcesStep implements Step {
 
       ImmutableSet.Builder<String> requiredPackages = ImmutableSet.<String>builder();
 
-      // Create a temporary list to avoid concurrent modification problems.
+      // Create a temporary list as the multimap 
+      // will be concurrently modified below.
       ArrayList<Entry<String, RDotTxtEntry>> entries =
           new ArrayList<>(rDotJavaPackageToResources.entries());
 
       if (skipPrebuiltRDotJava) {
-        // If skip_prebuilt_r_dot_java is true remove all packages except union package
         Preconditions.checkArgument(
             unionPackage.isPresent(),
             "union_package should be specified if skip_prebuilt_r_dot_java is set");
+
+        // If skip_prebuilt_r_dot_java is true remove all packages except union package
         rDotJavaPackageToResources = TreeMultimap.create();
 
       } else {
@@ -267,7 +269,6 @@ public class MergeAndroidResourcesStep implements Step {
         String unionPackageName = unionPackage.get();
         requiredPackages.add(unionPackageName);
 
-        // Create a temporary list to avoid concurrent modification problems.
         for (Map.Entry<String, RDotTxtEntry> entry : entries) {
           if (!rDotJavaPackageToResources.containsEntry(unionPackageName, entry.getValue())) {
             rDotJavaPackageToResources.put(unionPackageName, entry.getValue());

--- a/src/com/facebook/buck/android/RobolectricTestDescription.java
+++ b/src/com/facebook/buck/android/RobolectricTestDescription.java
@@ -134,9 +134,10 @@ public class RobolectricTestDescription
             javacOptions,
             DependencyMode.TRANSITIVE,
             args.isForceFinalResourceIds(),
-            /* resourceUnionPackage */ Optional.empty(),
+            args.getResourceUnionPackage(),
             /* rName */ Optional.empty(),
-            args.isUseOldStyleableFormat());
+            args.isUseOldStyleableFormat(),
+            /* skipPrebuiltRDotJava */ false);
 
     ImmutableList<String> vmArgs = args.getVmArgs();
 
@@ -253,6 +254,8 @@ public class RobolectricTestDescription
     Optional<String> getRobolectricRuntimeDependency();
 
     Optional<SourcePath> getRobolectricManifest();
+
+    Optional<String> getResourceUnionPackage();
 
     @Value.Default
     default boolean isUseOldStyleableFormat() {

--- a/src/com/facebook/buck/android/RobolectricTestDescription.java
+++ b/src/com/facebook/buck/android/RobolectricTestDescription.java
@@ -137,7 +137,7 @@ public class RobolectricTestDescription
             args.getResourceUnionPackage(),
             /* rName */ Optional.empty(),
             args.isUseOldStyleableFormat(),
-            /* skipPrebuiltRDotJava */ false);
+            /* skipNonUnionRDotJava */ false);
 
     ImmutableList<String> vmArgs = args.getVmArgs();
 

--- a/test/com/facebook/buck/android/AndroidLibraryGraphEnhancerTest.java
+++ b/test/com/facebook/buck/android/AndroidLibraryGraphEnhancerTest.java
@@ -67,7 +67,9 @@ public class AndroidLibraryGraphEnhancerTest {
             /* forceFinalResourceIds */ false,
             /* unionPackage */ Optional.empty(),
             /* rName */ Optional.empty(),
-            false);
+            /* useOldStyleableFormat */ false,
+            /* skipPrebuiltRDotJava */ false);
+
     Optional<DummyRDotJava> result =
         graphEnhancer.getBuildableForAndroidResources(
             new SingleThreadedBuildRuleResolver(
@@ -90,7 +92,9 @@ public class AndroidLibraryGraphEnhancerTest {
             /* forceFinalResourceIds */ false,
             /* unionPackage */ Optional.empty(),
             /* rName */ Optional.empty(),
-            false);
+            /* useOldStyleableFormat */ false,
+            /* skipPrebuiltRDotJava */ false);
+
     BuildRuleResolver buildRuleResolver =
         new SingleThreadedBuildRuleResolver(
             TargetGraph.EMPTY, new DefaultTargetNodeToBuildRuleTransformer());
@@ -138,7 +142,9 @@ public class AndroidLibraryGraphEnhancerTest {
             /* forceFinalResourceIds */ false,
             /* unionPackage */ Optional.empty(),
             /* rName */ Optional.empty(),
-            false);
+            /* useOldStyleableFormat */ false,
+            /* skipPrebuiltRDotJava */ false);
+
     Optional<DummyRDotJava> dummyRDotJava =
         graphEnhancer.getBuildableForAndroidResources(
             ruleResolver, /* createBuildableIfEmptyDeps */ false);
@@ -203,7 +209,8 @@ public class AndroidLibraryGraphEnhancerTest {
             /* forceFinalResourceIds */ false,
             /* unionPackage */ Optional.empty(),
             /* rName */ Optional.empty(),
-            false);
+            /* useOldStyleableFormat */ false,
+            /* skipPrebuiltRDotJava */ false);
     Optional<DummyRDotJava> dummyRDotJava =
         graphEnhancer.getBuildableForAndroidResources(
             ruleResolver, /* createBuildableIfEmptyDeps */ false);
@@ -243,7 +250,8 @@ public class AndroidLibraryGraphEnhancerTest {
             /* forceFinalResourceIds */ false,
             /* unionPackage */ Optional.empty(),
             /* rName */ Optional.empty(),
-            false);
+            /* useOldStyleableFormat */ false,
+            /* skipPrebuiltRDotJava */ false);
     Optional<DummyRDotJava> result =
         graphEnhancer.getBuildableForAndroidResources(
             resolver, /* createdBuildableIfEmptyDeps */ true);

--- a/test/com/facebook/buck/android/AndroidLibraryGraphEnhancerTest.java
+++ b/test/com/facebook/buck/android/AndroidLibraryGraphEnhancerTest.java
@@ -68,7 +68,7 @@ public class AndroidLibraryGraphEnhancerTest {
             /* unionPackage */ Optional.empty(),
             /* rName */ Optional.empty(),
             /* useOldStyleableFormat */ false,
-            /* skipPrebuiltRDotJava */ false);
+            /* skipNonUnionRDotJava */ false);
 
     Optional<DummyRDotJava> result =
         graphEnhancer.getBuildableForAndroidResources(
@@ -93,7 +93,7 @@ public class AndroidLibraryGraphEnhancerTest {
             /* unionPackage */ Optional.empty(),
             /* rName */ Optional.empty(),
             /* useOldStyleableFormat */ false,
-            /* skipPrebuiltRDotJava */ false);
+            /* skipNonUnionRDotJava */ false);
 
     BuildRuleResolver buildRuleResolver =
         new SingleThreadedBuildRuleResolver(
@@ -143,7 +143,7 @@ public class AndroidLibraryGraphEnhancerTest {
             /* unionPackage */ Optional.empty(),
             /* rName */ Optional.empty(),
             /* useOldStyleableFormat */ false,
-            /* skipPrebuiltRDotJava */ false);
+            /* skipNonUnionRDotJava */ false);
 
     Optional<DummyRDotJava> dummyRDotJava =
         graphEnhancer.getBuildableForAndroidResources(
@@ -210,7 +210,7 @@ public class AndroidLibraryGraphEnhancerTest {
             /* unionPackage */ Optional.empty(),
             /* rName */ Optional.empty(),
             /* useOldStyleableFormat */ false,
-            /* skipPrebuiltRDotJava */ false);
+            /* skipNonUnionRDotJava */ false);
     Optional<DummyRDotJava> dummyRDotJava =
         graphEnhancer.getBuildableForAndroidResources(
             ruleResolver, /* createBuildableIfEmptyDeps */ false);
@@ -251,7 +251,7 @@ public class AndroidLibraryGraphEnhancerTest {
             /* unionPackage */ Optional.empty(),
             /* rName */ Optional.empty(),
             /* useOldStyleableFormat */ false,
-            /* skipPrebuiltRDotJava */ false);
+            /* skipNonUnionRDotJava */ false);
     Optional<DummyRDotJava> result =
         graphEnhancer.getBuildableForAndroidResources(
             resolver, /* createdBuildableIfEmptyDeps */ true);

--- a/test/com/facebook/buck/android/DummyRDotJavaTest.java
+++ b/test/com/facebook/buck/android/DummyRDotJavaTest.java
@@ -105,7 +105,8 @@ public class DummyRDotJavaTest {
             /* forceFinalResourceIds */ false,
             Optional.empty(),
             Optional.of("R2"),
-            false);
+            /* useOldStyleableFormat */ false,
+            /* skipPrebuiltRDotJava */ false);
 
     FakeBuildableContext buildableContext = new FakeBuildableContext();
     List<Step> steps = dummyRDotJava.getBuildSteps(FakeBuildContext.NOOP_CONTEXT, buildableContext);
@@ -206,7 +207,8 @@ public class DummyRDotJavaTest {
             /* forceFinalResourceIds */ false,
             Optional.empty(),
             Optional.empty(),
-            false);
+            /* useOldStyleableFormat */ false,
+            /* skipPrebuiltRDotJava */ false);
     assertEquals(
         BuildTargets.getScratchPath(
             dummyRDotJava.getProjectFilesystem(),

--- a/test/com/facebook/buck/android/DummyRDotJavaTest.java
+++ b/test/com/facebook/buck/android/DummyRDotJavaTest.java
@@ -106,7 +106,7 @@ public class DummyRDotJavaTest {
             Optional.empty(),
             Optional.of("R2"),
             /* useOldStyleableFormat */ false,
-            /* skipPrebuiltRDotJava */ false);
+            /* skipNonUnionRDotJava */ false);
 
     FakeBuildableContext buildableContext = new FakeBuildableContext();
     List<Step> steps = dummyRDotJava.getBuildSteps(FakeBuildContext.NOOP_CONTEXT, buildableContext);
@@ -208,7 +208,7 @@ public class DummyRDotJavaTest {
             Optional.empty(),
             Optional.empty(),
             /* useOldStyleableFormat */ false,
-            /* skipPrebuiltRDotJava */ false);
+            /* skipNonUnionRDotJava */ false);
     assertEquals(
         BuildTargets.getScratchPath(
             dummyRDotJava.getProjectFilesystem(),

--- a/test/com/facebook/buck/android/MergeAndroidResourcesStepTest.java
+++ b/test/com/facebook/buck/android/MergeAndroidResourcesStepTest.java
@@ -342,7 +342,7 @@ public class MergeAndroidResourcesStepTest {
             /* unionPackage */ Optional.empty(),
             /* rName */ Optional.empty(),
             /* useOldStyleableFormat */ false,
-            /* skipPrebuiltRDotJava */ false);
+            /* skipNonUnionRDotJava */ false);
 
     ExecutionContext executionContext = TestExecutionContext.newInstance();
 
@@ -413,7 +413,7 @@ public class MergeAndroidResourcesStepTest {
             /* unionPackage */ Optional.empty(),
             /* rName */ Optional.empty(),
             /* useOldStyleableFormat */ false,
-            /* skipPrebuiltRDotJava */ false);
+            /* skipNonUnionRDotJava */ false);
 
     ExecutionContext executionContext = TestExecutionContext.newInstance();
 
@@ -500,7 +500,7 @@ public class MergeAndroidResourcesStepTest {
             /* unionPackage */ Optional.empty(),
             /* rName */ Optional.empty(),
             /* useOldStyleableFormat */ false,
-            /* skipPrebuiltRDotJava */ false);
+            /* skipNonUnionRDotJava */ false);
 
     ExecutionContext executionContext = TestExecutionContext.newInstance();
 
@@ -567,7 +567,7 @@ public class MergeAndroidResourcesStepTest {
             Optional.of("com.package"),
             /* rName */ Optional.empty(),
             /* useOldStyleableFormat */ false,
-            /* skipPrebuiltRDotJava */ true);
+            /* skipNonUnionRDotJava */ true);
 
     ImmutableSortedSet<Path> rDotJavaFiles = mergeStep.getRDotJavaFiles();
     assertEquals(rDotJavaFiles.size(), 1);
@@ -621,7 +621,7 @@ public class MergeAndroidResourcesStepTest {
             Optional.of("com.package"),
             /* rName */ Optional.empty(),
             /* useOldStyleableFormat */ false,
-            /* skipPrebuiltRDotJava */ false);
+            /* skipNonUnionRDotJava */ false);
 
     ImmutableSortedSet<Path> rDotJavaFiles = mergeStep.getRDotJavaFiles();
     assertEquals(rDotJavaFiles.size(), 3);
@@ -691,7 +691,7 @@ public class MergeAndroidResourcesStepTest {
             Optional.of("res"),
             /* rName */ Optional.empty(),
             /* useOldStyleableFormat */ false,
-            /* skipPrebuiltRDotJava */ true);
+            /* skipNonUnionRDotJava */ true);
 
     ExecutionContext executionContext = TestExecutionContext.newInstance();
 
@@ -763,7 +763,7 @@ public class MergeAndroidResourcesStepTest {
             Optional.of("res1"),
             /* rName */ Optional.empty(),
             /* useOldStyleableFormat */ false,
-            /* skipPrebuiltRDotJava */ false);
+            /* skipNonUnionRDotJava */ false);
 
     ExecutionContext executionContext = TestExecutionContext.newInstance();
 
@@ -814,7 +814,7 @@ public class MergeAndroidResourcesStepTest {
             Optional.of("resM"),
             /* rName */ Optional.empty(),
             /* useOldStyleableFormat */ false,
-            /* skipPrebuiltRDotJava */ false);
+            /* skipNonUnionRDotJava */ false);
 
     ExecutionContext executionContext = TestExecutionContext.newInstance();
 
@@ -865,7 +865,7 @@ public class MergeAndroidResourcesStepTest {
             Optional.of("res1"),
             Optional.of("R2"),
             /* useOldStyleableFormat */ false,
-            /* skipPrebuiltRDotJava */ false);
+            /* skipNonUnionRDotJava */ false);
 
     ExecutionContext executionContext = TestExecutionContext.newInstance();
 

--- a/test/com/facebook/buck/android/MergeAndroidResourcesStepTest.java
+++ b/test/com/facebook/buck/android/MergeAndroidResourcesStepTest.java
@@ -48,6 +48,7 @@ import com.facebook.buck.testutil.FakeProjectFilesystem;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.SortedSetMultimap;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -340,7 +341,8 @@ public class MergeAndroidResourcesStepTest {
             /* forceFinalResourceIds */ false,
             /* unionPackage */ Optional.empty(),
             /* rName */ Optional.empty(),
-            /* useOldStyleableFormat */ false);
+            /* useOldStyleableFormat */ false,
+            /* skipPrebuiltRDotJava */ false);
 
     ExecutionContext executionContext = TestExecutionContext.newInstance();
 
@@ -410,7 +412,8 @@ public class MergeAndroidResourcesStepTest {
             Optional.empty(),
             /* unionPackage */ Optional.empty(),
             /* rName */ Optional.empty(),
-            /* useOldStyleableFormat */ false);
+            /* useOldStyleableFormat */ false,
+            /* skipPrebuiltRDotJava */ false);
 
     ExecutionContext executionContext = TestExecutionContext.newInstance();
 
@@ -496,7 +499,8 @@ public class MergeAndroidResourcesStepTest {
             Optional.empty(),
             /* unionPackage */ Optional.empty(),
             /* rName */ Optional.empty(),
-            /* useOldStyleableFormat */ false);
+            /* useOldStyleableFormat */ false,
+            /* skipPrebuiltRDotJava */ false);
 
     ExecutionContext executionContext = TestExecutionContext.newInstance();
 
@@ -519,6 +523,188 @@ public class MergeAndroidResourcesStepTest {
             .readFileIfItExists(Paths.get("output/com/facebook/R.java"))
             .get()
             .replace("\r", ""));
+  }
+
+  @Test
+  public void testGetRDotJavaFilesWithSkipPrebuiltRDotJava() throws Exception {
+    BuildTarget res1Target = BuildTargetFactory.newInstance("//:res1");
+    BuildTarget res2Target = BuildTargetFactory.newInstance("//:res2");
+
+    RDotTxtEntryBuilder entriesBuilder = new RDotTxtEntryBuilder();
+    FakeProjectFilesystem filesystem = entriesBuilder.getProjectFilesystem();
+
+    BuildRuleResolver buildRuleResolver =
+        new SingleThreadedBuildRuleResolver(
+            TargetGraph.EMPTY, new DefaultTargetNodeToBuildRuleTransformer());
+    SourcePathRuleFinder ruleFinder = new SourcePathRuleFinder(buildRuleResolver);
+    SourcePathResolver resolver = DefaultSourcePathResolver.from(ruleFinder);
+
+    AndroidResource res1 =
+        AndroidResourceRuleBuilder.newBuilder()
+            .setRuleFinder(ruleFinder)
+            .setBuildTarget(res1Target)
+            .setRes(FakeSourcePath.of("res1"))
+            .setRDotJavaPackage("com.package1")
+            .build();
+
+    AndroidResource res2 =
+        AndroidResourceRuleBuilder.newBuilder()
+            .setRuleFinder(ruleFinder)
+            .setBuildTarget(res2Target)
+            .setRes(FakeSourcePath.of("res2"))
+            .setRDotJavaPackage("com.package2")
+            .build();
+
+    ImmutableList<HasAndroidResourceDeps> resourceDeps = ImmutableList.of(res1, res2);
+
+    MergeAndroidResourcesStep mergeStep =
+        MergeAndroidResourcesStep.createStepForDummyRDotJava(
+            filesystem,
+            resolver,
+            resourceDeps,
+            Paths.get("output"),
+            /* forceFinalResourceIds */ false,
+            Optional.of("com.package"),
+            /* rName */ Optional.empty(),
+            /* useOldStyleableFormat */ false,
+            /* skipPrebuiltRDotJava */ true);
+
+    ImmutableSortedSet<Path> rDotJavaFiles = mergeStep.getRDotJavaFiles();
+    assertEquals(rDotJavaFiles.size(), 1);
+
+    ImmutableSortedSet<Path> expected = ImmutableSortedSet.<Path>naturalOrder()
+        .add(mergeStep.getPathToRDotJava("com.package"))
+        .build();
+
+    assertEquals(expected, rDotJavaFiles);
+  }
+
+  @Test
+  public void testGetRDotJavaFilesWithoutSkipPrebuiltRDotJava() throws Exception {
+    BuildTarget res1Target = BuildTargetFactory.newInstance("//:res1");
+    BuildTarget res2Target = BuildTargetFactory.newInstance("//:res2");
+
+    RDotTxtEntryBuilder entriesBuilder = new RDotTxtEntryBuilder();
+    FakeProjectFilesystem filesystem = entriesBuilder.getProjectFilesystem();
+
+    BuildRuleResolver buildRuleResolver =
+        new SingleThreadedBuildRuleResolver(
+            TargetGraph.EMPTY, new DefaultTargetNodeToBuildRuleTransformer());
+    SourcePathRuleFinder ruleFinder = new SourcePathRuleFinder(buildRuleResolver);
+    SourcePathResolver resolver = DefaultSourcePathResolver.from(ruleFinder);
+
+    AndroidResource res1 =
+        AndroidResourceRuleBuilder.newBuilder()
+            .setRuleFinder(ruleFinder)
+            .setBuildTarget(res1Target)
+            .setRes(FakeSourcePath.of("res1"))
+            .setRDotJavaPackage("com.package1")
+            .build();
+
+    AndroidResource res2 =
+        AndroidResourceRuleBuilder.newBuilder()
+            .setRuleFinder(ruleFinder)
+            .setBuildTarget(res2Target)
+            .setRes(FakeSourcePath.of("res2"))
+            .setRDotJavaPackage("com.package2")
+            .build();
+
+    ImmutableList<HasAndroidResourceDeps> resourceDeps = ImmutableList.of(res1, res2);
+
+    MergeAndroidResourcesStep mergeStep =
+        MergeAndroidResourcesStep.createStepForDummyRDotJava(
+            filesystem,
+            resolver,
+            resourceDeps,
+            Paths.get("output"),
+            /* forceFinalResourceIds */ false,
+            Optional.of("com.package"),
+            /* rName */ Optional.empty(),
+            /* useOldStyleableFormat */ false,
+            /* skipPrebuiltRDotJava */ false);
+
+    ImmutableSortedSet<Path> rDotJavaFiles = mergeStep.getRDotJavaFiles();
+    assertEquals(rDotJavaFiles.size(), 3);
+
+    ImmutableSortedSet<Path> expected = ImmutableSortedSet.<Path>naturalOrder()
+        .add(mergeStep.getPathToRDotJava("com.package"))
+        .add(mergeStep.getPathToRDotJava("com.package1"))
+        .add(mergeStep.getPathToRDotJava("com.package2"))
+        .build();
+
+    assertEquals(expected, rDotJavaFiles);
+  }
+
+  @Test
+  public void testGenerateRDotJavaWithResourceUnionPackageAndSkipPrebuiltRDotJava() throws Exception {
+    BuildTarget res1Target = BuildTargetFactory.newInstance("//:res1");
+    BuildTarget res2Target = BuildTargetFactory.newInstance("//:res2");
+    RDotTxtEntryBuilder entriesBuilder = new RDotTxtEntryBuilder();
+    entriesBuilder.add(
+        new RDotTxtFile(
+            "com.res1",
+            BuildTargets.getGenPath(
+                entriesBuilder.getProjectFilesystem(), res1Target, "__%s_text_symbols__/R.txt")
+                .toString(),
+            ImmutableList.of("int id id1 0x7f020000")));
+    entriesBuilder.add(
+        new RDotTxtFile(
+            "com.res2",
+            BuildTargets.getGenPath(
+                entriesBuilder.getProjectFilesystem(), res2Target, "__%s_text_symbols__/R.txt")
+                .toString(),
+            ImmutableList.of("int id id2 0x7f020000")));
+
+    FakeProjectFilesystem filesystem = entriesBuilder.getProjectFilesystem();
+
+    BuildRuleResolver buildRuleResolver =
+        new SingleThreadedBuildRuleResolver(
+            TargetGraph.EMPTY, new DefaultTargetNodeToBuildRuleTransformer());
+    SourcePathRuleFinder ruleFinder = new SourcePathRuleFinder(buildRuleResolver);
+    SourcePathResolver resolver = DefaultSourcePathResolver.from(ruleFinder);
+
+    AndroidResource res1 =
+        AndroidResourceRuleBuilder.newBuilder()
+            .setRuleFinder(ruleFinder)
+            .setBuildTarget(res1Target)
+            .setRes(FakeSourcePath.of("res1"))
+            .setRDotJavaPackage("res1")
+            .build();
+    buildRuleResolver.addToIndex(res1);
+
+    AndroidResource res2 =
+        AndroidResourceRuleBuilder.newBuilder()
+            .setRuleFinder(ruleFinder)
+            .setBuildTarget(res2Target)
+            .setRes(FakeSourcePath.of("res2"))
+            .setRDotJavaPackage("res2")
+            .build();
+    buildRuleResolver.addToIndex(res2);
+
+    MergeAndroidResourcesStep mergeStep =
+        MergeAndroidResourcesStep.createStepForDummyRDotJava(
+            filesystem,
+            resolver,
+            ImmutableList.of(res1, res2),
+            Paths.get("output"),
+            /* forceFinalResourceIds */ false,
+            Optional.of("res"),
+            /* rName */ Optional.empty(),
+            /* useOldStyleableFormat */ false,
+            /* skipPrebuiltRDotJava */ true);
+
+    ExecutionContext executionContext = TestExecutionContext.newInstance();
+
+    assertEquals(0, mergeStep.execute(executionContext).getExitCode());
+
+    String resJava = filesystem.readFileIfItExists(Paths.get("output/res/R.java")).get();
+    assertThat(resJava, StringContains.containsString("id1"));
+    assertThat(resJava, StringContains.containsString("id2"));
+
+    Optional<String> res1Java = filesystem.readFileIfItExists(Paths.get("output/res1/R.java"));
+    Optional<String> res2Java = filesystem.readFileIfItExists(Paths.get("output/res2/R.java"));
+    assertFalse(res1Java.isPresent());
+    assertFalse(res2Java.isPresent());
   }
 
   @Test
@@ -576,7 +762,8 @@ public class MergeAndroidResourcesStepTest {
             /* forceFinalResourceIds */ false,
             Optional.of("res1"),
             /* rName */ Optional.empty(),
-            /* useOldStyleableFormat */ false);
+            /* useOldStyleableFormat */ false,
+            /* skipPrebuiltRDotJava */ false);
 
     ExecutionContext executionContext = TestExecutionContext.newInstance();
 
@@ -626,7 +813,8 @@ public class MergeAndroidResourcesStepTest {
             /* forceFinalResourceIds */ false,
             Optional.of("resM"),
             /* rName */ Optional.empty(),
-            /* useOldStyleableFormat */ false);
+            /* useOldStyleableFormat */ false,
+            /* skipPrebuiltRDotJava */ false);
 
     ExecutionContext executionContext = TestExecutionContext.newInstance();
 
@@ -676,7 +864,8 @@ public class MergeAndroidResourcesStepTest {
             /* forceFinalResourceIds */ true,
             Optional.of("res1"),
             Optional.of("R2"),
-            /* useOldStyleableFormat */ false);
+            /* useOldStyleableFormat */ false,
+            /* skipPrebuiltRDotJava */ false);
 
     ExecutionContext executionContext = TestExecutionContext.newInstance();
 
@@ -801,7 +990,8 @@ public class MergeAndroidResourcesStepTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
-            /* useOldStyleableFormat */ false);
+            /* useOldStyleableFormat */ false,
+            false);
 
     StepExecutionResult result = mergeStep.execute(TestExecutionContext.newInstance());
     String message = result.getStderr().orElse("");


### PR DESCRIPTION
of dependent libraries/aar for android_library target via skip_prebuilt_r_dot_java

- add `skip_non_union_r_dot_java` arg to `android_library` target.
- add `resource_union_package` arg to `robolectric_test` target.
- Only return RDotJavaFiles of union package when `skip_non_union_r_dot_java` is true.
- Only create union package’s R.java file and skip other packages when `skip_non_union_r_dot_java` is true.

This helps in improving the build times as only `n` R.java will be compiled now (1 for each library in the dependency graph), which earlier it used to be `n * log(n)`.