### PR TITLE
[Travis] Update Travis Ubuntu image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,7 @@ env:
   - CI_ACTION=heavy_integration
   - CI_ACTION=ant
 
-# Force Ubuntu 12.04 to support old dependencies
-# TODO(ttsugrii): upgrade to trusty once all deps are fixed
-dist: precise
+dist: trusty
 
 # Enable container-based architecture.
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,9 @@ before_install:
   # Haskell setup:
   - export PATH=/opt/ghc/8.0.2/bin:$PATH
 
+# Buck dependencies are checked in, so no need to download dependencies
+install: true
+
 # https://docs.travis-ci.com/user/caching#Things-not-to-cache
 # https://docs.travis-ci.com/user/caching#Explicitly-disabling-caching
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
     packages:
       # Travis is on 64bit and there will be a cryptic aapt error w/o these libs.
       # For native code tests, we need some additional libraries if we are in a 64-bit environment.
-      - libgd2-xpm
+      - libgd2-xpm-dev
       - libc6:i386
       - libstdc++6:i386
       - zlib1g:i386


### PR DESCRIPTION
Ubuntu Precise has been deprecated for a long time already.