### PR TITLE
delete remnants of buck test --dry-run

### DIFF
--- a/src/com/facebook/buck/event/listener/SuperConsoleEventBusListener.java
+++ b/src/com/facebook/buck/event/listener/SuperConsoleEventBusListener.java
@@ -123,7 +123,6 @@ public class SuperConsoleEventBusListener extends AbstractConsoleEventBusListene
   private final AtomicInteger numExcludedTests = new AtomicInteger(0);
   private final AtomicInteger numDisabledTests = new AtomicInteger(0);
   private final AtomicInteger numAssumptionViolationTests = new AtomicInteger(0);
-  private final AtomicInteger numDryRunTests = new AtomicInteger(0);
 
   private final AtomicReference<TestRunEvent.Started> testRunStarted;
   private final AtomicReference<TestRunEvent.Finished> testRunFinished;
@@ -731,10 +730,8 @@ public class SuperConsoleEventBusListener extends AbstractConsoleEventBusListene
     int testFailuresVal = numFailingTests.get();
     int testSkipsVal =
         numDisabledTests.get()
-            + numAssumptionViolationTests.get()
-            +
             // don't count: numExcludedTests.get() +
-            numDryRunTests.get();
+            + numAssumptionViolationTests.get();
     if (testSkipsVal > 0) {
       return Optional.of(
           String.format(
@@ -942,9 +939,6 @@ public class SuperConsoleEventBusListener extends AbstractConsoleEventBusListene
         break;
       case DISABLED:
         numDisabledTests.incrementAndGet();
-        break;
-      case DRY_RUN:
-        numDryRunTests.incrementAndGet();
         break;
       case EXCLUDED:
         numExcludedTests.incrementAndGet();

--- a/src/com/facebook/buck/event/listener/TestResultFormatter.java
+++ b/src/com/facebook/buck/event/listener/TestResultFormatter.java
@@ -232,7 +232,6 @@ public class TestResultFormatter {
       List<TestResults> completedResults,
       List<TestStatusMessage> testStatusMessages) {
     // Print whether each test succeeded or failed.
-    boolean isDryRun = false;
     boolean hasAssumptionViolations = false;
     int numTestsPassed = 0;
     int numTestsFailed = 0;
@@ -250,7 +249,6 @@ public class TestResultFormatter {
       }
       // Get passes/skips by iterating through each case
       for (TestCaseSummary testCaseSummary : summary.getTestCases()) {
-        isDryRun = isDryRun || testCaseSummary.isDryRun();
         numTestsPassed += testCaseSummary.getPassedCount();
         numTestsSkipped += testCaseSummary.getSkippedCount();
         hasAssumptionViolations =
@@ -267,11 +265,7 @@ public class TestResultFormatter {
       } else {
         message = "NO TESTS RAN";
       }
-      if (isDryRun) {
-        addTo.add(ansi.asHighlightedSuccessText(message));
-      } else {
-        addTo.add(ansi.asHighlightedWarningText(message));
-      }
+      addTo.add(ansi.asHighlightedWarningText(message));
       return;
     }
 

--- a/src/com/facebook/buck/test/TestCaseSummary.java
+++ b/src/com/facebook/buck/test/TestCaseSummary.java
@@ -30,7 +30,6 @@ public class TestCaseSummary implements TestCaseSummaryExternalInterface<TestRes
 
   private final String testCaseName;
   private final ImmutableList<TestResultSummary> testResults;
-  private final boolean isDryRun;
   private final boolean hasAssumptionViolations;
   private final int skippedCount;
   private final int passCount;
@@ -41,7 +40,6 @@ public class TestCaseSummary implements TestCaseSummaryExternalInterface<TestRes
     this.testCaseName = testCaseName;
     this.testResults = ImmutableList.copyOf(testResults);
 
-    boolean isDryRun = false;
     boolean hasAssumptionViolations = false;
     int skippedCount = 0;
     int failureCount = 0;
@@ -52,11 +50,6 @@ public class TestCaseSummary implements TestCaseSummaryExternalInterface<TestRes
       switch (result.getType()) {
         case SUCCESS:
           ++passCount;
-          break;
-
-        case DRY_RUN:
-          isDryRun = true;
-          ++passCount; // "pass" in the sense that it confirms the class can be loaded
           break;
 
         case DISABLED:
@@ -76,17 +69,11 @@ public class TestCaseSummary implements TestCaseSummaryExternalInterface<TestRes
           break;
       }
     }
-    this.isDryRun = isDryRun;
     this.hasAssumptionViolations = hasAssumptionViolations;
     this.skippedCount = skippedCount;
     this.failureCount = failureCount;
     this.passCount = passCount;
     this.totalTime = totalTime;
-  }
-
-  @JsonIgnore
-  public boolean isDryRun() {
-    return isDryRun;
   }
 
   @Override
@@ -114,10 +101,7 @@ public class TestCaseSummary implements TestCaseSummaryExternalInterface<TestRes
   public String getOneLineSummary(Locale locale, boolean hasPassingDependencies, Ansi ansi) {
     String statusText;
     Ansi.SeverityLevel severityLevel;
-    if (isDryRun) {
-      severityLevel = Ansi.SeverityLevel.WARNING;
-      statusText = "DRYRUN";
-    } else if (!isSuccess()) {
+    if (!isSuccess()) {
       if (hasPassingDependencies) {
         severityLevel = Ansi.SeverityLevel.ERROR;
         statusText = "FAIL";
@@ -185,9 +169,6 @@ public class TestCaseSummary implements TestCaseSummaryExternalInterface<TestRes
   }
 
   private String getShortStatusSummaryString() {
-    if (isDryRun) {
-      return "DRYRUN";
-    }
     if (failureCount > 0) {
       return "FAIL";
     }

--- a/src/com/facebook/buck/test/result/type/ResultType.java
+++ b/src/com/facebook/buck/test/result/type/ResultType.java
@@ -19,14 +19,8 @@ package com.facebook.buck.test.result.type;
 /** The kind of result */
 public enum ResultType {
 
-  // First, three different reasons why the tests weren't even attempted:
+  // First, two different reasons why the tests weren't even attempted:
 
-  /**
-   * The test was not run because the user chose to run tests with the --dry-run flag, which caused
-   * the test runner to print out the names of tests that *would* have run without actually running
-   * them.
-   */
-  DRY_RUN,
   /**
    * The test was not run because it was excluded by the user (e.g., specifying {@link
    * com.facebook.buck.cli.TestSelectorOptions}).

--- a/src/com/facebook/buck/testrunner/BaseRunner.java
+++ b/src/com/facebook/buck/testrunner/BaseRunner.java
@@ -51,7 +51,6 @@ public abstract class BaseRunner {
   protected List<String> testClassNames;
   protected long defaultTestTimeoutMillis;
   protected TestSelectorList testSelectorList;
-  protected boolean isDryRun;
   protected boolean shouldExplainTestSelectors;
 
   public abstract void run() throws Throwable;
@@ -147,9 +146,6 @@ public abstract class BaseRunner {
     String testSelectorSuffix = "";
     if (!testSelectorList.isEmpty()) {
       testSelectorSuffix += ".test_selectors";
-    }
-    if (isDryRun) {
-      testSelectorSuffix += ".dry_run";
     }
     OutputStream output;
     if (outputDirectory != null) {
@@ -254,7 +250,6 @@ public abstract class BaseRunner {
 
     this.outputDirectory = outputDirectory;
     this.defaultTestTimeoutMillis = defaultTestTimeoutMillis;
-    this.isDryRun = isDryRun;
     this.testClassNames = testClassNames;
     this.testSelectorList = testSelectorListBuilder.build();
     if (!testSelectorList.isEmpty() && !shouldExplainTestSelectors) {

--- a/src/com/facebook/buck/testrunner/JUnitRunner.java
+++ b/src/com/facebook/buck/testrunner/JUnitRunner.java
@@ -218,7 +218,7 @@ public final class JUnitRunner extends BaseRunner {
         // we should use the original behavior to use our
         // BuckBlockJUnit4ClassRunner, which provides the Descriptions needed
         // to do test selecting properly.
-        if (defaultTestTimeoutMillis <= 0 || isDryRun || !testSelectorList.isEmpty()) {
+        if (defaultTestTimeoutMillis <= 0 || !testSelectorList.isEmpty()) {
           return super.annotatedBuilder();
         }
 
@@ -329,13 +329,6 @@ public final class JUnitRunner extends BaseRunner {
         type = ResultType.ASSUMPTION_VIOLATION;
         // Clear the assumption-failure field before the next test result appears.
         assumptionFailure = null;
-      } else if (isDryRun) {
-        if ("org.junit.runner.manipulation.Filter".equals(className)
-            && "initializationError".equals(methodName)) {
-          return; // don't record errors from failed class initialization during dry run
-        }
-        failure = null;
-        type = ResultType.DRY_RUN;
       } else if (numFailures == 0) {
         failure = null;
         type = ResultType.SUCCESS;
@@ -477,10 +470,6 @@ public final class JUnitRunner extends BaseRunner {
       }
       if (description.getAnnotation(Ignore.class) != null) {
         filteredOut.add(TestResult.forDisabled(className, methodName));
-        return false;
-      }
-      if (isDryRun) {
-        filteredOut.add(TestResult.forDryRun(className, methodName));
         return false;
       }
       return true;

--- a/src/com/facebook/buck/testrunner/TestNGRunner.java
+++ b/src/com/facebook/buck/testrunner/TestNGRunner.java
@@ -76,10 +76,6 @@ public final class TestNGRunner extends BaseRunner {
           listener.onFinish(null);
           System.out.println("TestNGRunner caught an exception");
           e.printStackTrace();
-          if (!isDryRun) {
-            results.add(
-                new TestResult(className, "<TestNG failure>", 0, ResultType.FAILURE, e, "", ""));
-          }
         }
         System.out.println("TestNGRunner tested " + className + ", got " + results.size());
       }
@@ -187,12 +183,6 @@ public final class TestNGRunner extends BaseRunner {
       if (!annotation.getEnabled()) {
         // on a dry run, have to record it now -- since it doesn't run, listener can't do it
         results.add(TestResult.forDisabled(className, methodName));
-        return;
-      }
-      if (isDryRun) {
-        // on a dry run, record it now and don't run it
-        results.add(TestResult.forDryRun(className, methodName));
-        annotation.setEnabled(false);
         return;
       }
     }

--- a/src/com/facebook/buck/testrunner/TestResult.java
+++ b/src/com/facebook/buck/testrunner/TestResult.java
@@ -48,10 +48,6 @@ final class TestResult {
     this.stdErr = stdErr;
   }
 
-  public static TestResult forDryRun(String testClassName, String testMethodName) {
-    return new TestResult(testClassName, testMethodName, 0, ResultType.DRY_RUN, null, null, null);
-  }
-
   public static TestResult forExcluded(String testClassName, String testMethodName, String reason) {
     return new TestResult(
         testClassName, testMethodName, 0, ResultType.EXCLUDED, null, reason, null);


### PR DESCRIPTION
This PR deletes the remaining dead code relating to `buck test --dry-run`.

https://github.com/facebook/buck/commit/4ea890754b5612c41cacf6a94d089a3960282e40 was an incomplete un-revert of https://github.com/facebook/buck/commit/b5f4e756a922c74b1e3d8fad7ba9d704dfd2f771.

Test Plan: `buck test`.