### PR TITLE
Fix modulars swift project umbrella header generation issue

### DIFF
--- a/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
+++ b/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
@@ -2235,10 +2235,11 @@ public class ProjectGenerator {
             .map(Path::getFileName)
             .map(Path::toString)
             .collect(ImmutableList.toImmutableList());
-    if (!headerPaths.contains(moduleName + ".h")) {
+    if (!headerPathStrings.contains(moduleName + ".h")) {
+      Path umbrellaPath = headerSymlinkTreeRoot.resolve(Paths.get(moduleName, moduleName + ".h"));
+      Preconditions.checkState(!projectFilesystem.exists(umbrellaPath));
       projectFilesystem.writeContentsToPath(
-          new UmbrellaHeader(moduleName, headerPathStrings).render(),
-          headerSymlinkTreeRoot.resolve(Paths.get(moduleName, moduleName + ".h")));
+          new UmbrellaHeader(moduleName, headerPathStrings).render(), umbrellaPath);
     }
   }
 


### PR DESCRIPTION
In a previous refactor, accidentally we check the wrong variable to determine if the user supplied an umbrella header. The result is if the user sets `apple.generate_missing_umbrella_headers`, buck project would overwrite the user's symlinked header. This fixes it and adds a unittest.