### PR TITLE
Avoid leaking file descriptors when serving cache artifacts

### DIFF
--- a/src/com/facebook/buck/artifact_cache/HttpArtifactCacheBinaryProtocol.java
+++ b/src/com/facebook/buck/artifact_cache/HttpArtifactCacheBinaryProtocol.java
@@ -249,7 +249,7 @@ public class HttpArtifactCacheBinaryProtocol {
       try (DataOutputStream dataOutputStream = new DataOutputStream(responseSink)) {
         dataOutputStream.writeInt(rawMetadata.length);
         dataOutputStream.write(rawMetadata);
-        ByteStreams.copy(payloadSource.openStream(), responseSink);
+        payloadSource.copyTo(responseSink);
       }
     }
   }


### PR DESCRIPTION
### Summary:
The current implementation calls `ByteSource#openStream`, and none of the objects involved there close the stream in their `finalize` method, so the process keeps the file descriptors for the temp files open forever. This a) prevents the actual content from being removed and b) can cause the process to hit its maximum number of file descriptors.

The change here is to use `ByteSource#copyTo(OutputStream)`, which uses Guava's `Closer` class to ensure that the stream will be closed, then calls the exact `ByteStreams.copy` method that was being used before. Source for the newly used method can be found [here](https://github.com/google/guava/blob/master/guava/src/com/google/common/io/ByteSource.java#L240).

### Test Plan:
I ran the Buck daemon's HTTP server locally before the change and saw that `cat /proc/sys/fs/file-nr` reported a monotonically increasing number of file descriptors held, and that `lsof` reported the process holding onto a bunch of deleted files like `buck-out/bin/outgoing_rulekey7730674455440792418.tmp`.

After this change, I ran the server locally and saw that the number of used file descriptors stayed stable over time and verified with `lsof` that the process wasn't holding onto an tmp files.