### PR TITLE
[TestNG] Correctly handle test selectors

### DIFF
--- a/src/com/facebook/buck/testrunner/TestNGRunner.java
+++ b/src/com/facebook/buck/testrunner/TestNGRunner.java
@@ -92,7 +92,6 @@ public final class TestNGRunner extends BaseRunner {
   private XmlSuite createXmlSuite(Class<?> c) {
     XmlSuite xmlSuite = new XmlSuite();
     xmlSuite.setName("TmpSuite");
-    xmlSuite.setTimeOut(String.valueOf(defaultTestTimeoutMillis));
     XmlTest xmlTest = new XmlTest(xmlSuite);
     xmlTest.setName("TmpTest");
     xmlTest.setXmlClasses(Collections.singletonList(new XmlClass(c)));
@@ -217,7 +216,9 @@ public final class TestNGRunner extends BaseRunner {
     }
 
     @Override
-    public void onTestSkipped(ITestResult result) {}
+    public void onTestSkipped(ITestResult result) {
+      recordResult(result, ResultType.FAILURE, result.getThrowable());
+    }
 
     @Override
     public void onTestFailure(ITestResult result) {

--- a/test/com/facebook/buck/testrunner/TestNGIntegrationTest.java
+++ b/test/com/facebook/buck/testrunner/TestNGIntegrationTest.java
@@ -24,55 +24,50 @@ import com.facebook.buck.testutil.integration.ProjectWorkspace.ProcessResult;
 import com.facebook.buck.testutil.integration.TemporaryPaths;
 import com.facebook.buck.testutil.integration.TestDataHelper;
 import java.io.IOException;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class TestNGIntegrationTest {
 
+  private ProjectWorkspace workspace;
+
   @Rule public TemporaryPaths temporaryFolder = new TemporaryPaths();
+
+  @Before
+  public void setupSimpleTestNGWorkspace() throws IOException {
+    workspace = TestDataHelper.createProjectWorkspaceForScenario(
+            this, "simple_testng", temporaryFolder, true);
+    workspace.setUp();
+  }
 
   @Test
   public void testThatSuccessfulTestNGTestWorks() throws IOException {
-    ProjectWorkspace workspace = setupSimpleTestNGWorkspace();
-
     ProcessResult simpleTestNGTestResult = workspace.runBuckCommand("test", "//test:simple-test");
     simpleTestNGTestResult.assertSuccess();
   }
 
   @Test
   public void testThatFailingTestNGTestWorks() throws IOException {
-    ProjectWorkspace workspace = setupSimpleTestNGWorkspace();
-
-    ProcessResult simpleFailingTestNGTestResult =
+    ProcessResult failingTestNGTestResult =
         workspace.runBuckCommand("test", "//test:simple-failing-test");
-    simpleFailingTestNGTestResult.assertTestFailure();
+    failingTestNGTestResult.assertTestFailure();
   }
 
   @Test
   public void testThatSkippedTestNGTestFails() throws IOException {
-    ProjectWorkspace workspace = setupSimpleTestNGWorkspace();
-
-    ProcessResult simpleSkippedTestNGTestResult =
+    ProcessResult skippedTestNGTestResult =
         workspace.runBuckCommand("test", "//test:simple-skipped-test");
-    simpleSkippedTestNGTestResult.assertTestFailure();
+    skippedTestNGTestResult.assertTestFailure();
   }
 
   @Test
-  public void testThatInjectionWorks() throws IOException {
-    ProjectWorkspace workspace = setupSimpleTestNGWorkspace();
 
+  public void testThatInjectionWorks() throws IOException {
     ProcessResult injectionTestNGTestResult =
         workspace.runBuckCommand("test", "//test:injection-test");
     injectionTestNGTestResult.assertSuccess();
     // Make sure that we didn't just skip over the class.
     assertThat(injectionTestNGTestResult.getStderr(), containsString("1 Passed"));
-  }
-
-  private ProjectWorkspace setupSimpleTestNGWorkspace() throws IOException {
-    ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, "simple_testng", temporaryFolder, true);
-    workspace.setUp();
-    return workspace;
   }
 }

--- a/test/com/facebook/buck/testrunner/TestNGIntegrationTest.java
+++ b/test/com/facebook/buck/testrunner/TestNGIntegrationTest.java
@@ -33,10 +33,7 @@ public class TestNGIntegrationTest {
 
   @Test
   public void testThatSuccessfulTestNGTestWorks() throws IOException {
-    ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, "simple_testng", temporaryFolder, true);
-    workspace.setUp();
+    ProjectWorkspace workspace = setupSimpleTestNGWorkspace();
 
     ProcessResult simpleTestNGTestResult = workspace.runBuckCommand("test", "//test:simple-test");
     simpleTestNGTestResult.assertSuccess();
@@ -44,10 +41,7 @@ public class TestNGIntegrationTest {
 
   @Test
   public void testThatFailingTestNGTestWorks() throws IOException {
-    ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, "simple_testng", temporaryFolder, true);
-    workspace.setUp();
+    ProjectWorkspace workspace = setupSimpleTestNGWorkspace();
 
     ProcessResult simpleFailingTestNGTestResult =
         workspace.runBuckCommand("test", "//test:simple-failing-test");
@@ -55,16 +49,30 @@ public class TestNGIntegrationTest {
   }
 
   @Test
+  public void testThatSkippedTestNGTestFails() throws IOException {
+    ProjectWorkspace workspace = setupSimpleTestNGWorkspace();
+
+    ProcessResult simpleSkippedTestNGTestResult =
+        workspace.runBuckCommand("test", "//test:simple-skipped-test");
+    simpleSkippedTestNGTestResult.assertTestFailure();
+  }
+
+  @Test
   public void testThatInjectionWorks() throws IOException {
-    ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, "simple_testng", temporaryFolder, true);
-    workspace.setUp();
+    ProjectWorkspace workspace = setupSimpleTestNGWorkspace();
 
     ProcessResult injectionTestNGTestResult =
         workspace.runBuckCommand("test", "//test:injection-test");
     injectionTestNGTestResult.assertSuccess();
     // Make sure that we didn't just skip over the class.
     assertThat(injectionTestNGTestResult.getStderr(), containsString("1 Passed"));
+  }
+
+  private ProjectWorkspace setupSimpleTestNGWorkspace() throws IOException {
+    ProjectWorkspace workspace =
+        TestDataHelper.createProjectWorkspaceForScenario(
+            this, "simple_testng", temporaryFolder, true);
+    workspace.setUp();
+    return workspace;
   }
 }

--- a/test/com/facebook/buck/testrunner/TestNGIntegrationTest.java
+++ b/test/com/facebook/buck/testrunner/TestNGIntegrationTest.java
@@ -17,6 +17,7 @@
 package com.facebook.buck.testrunner;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 import com.facebook.buck.testutil.integration.ProjectWorkspace;
@@ -62,7 +63,17 @@ public class TestNGIntegrationTest {
   }
 
   @Test
+  public void testSelectors() throws IOException {
+    ProcessResult filteredTestNGTestResult =
+        workspace.runBuckCommand("test", "//test:", "-f", "SimpleTest");
+    filteredTestNGTestResult.assertSuccess();
+    // should run SimpleTest
+    assertThat(filteredTestNGTestResult.getStderr(), containsString("SimpleTest"));
+    // should not run SimpleTest
+    assertThat(filteredTestNGTestResult.getStderr(), not(containsString("SimpleFailingTest")));
+  }
 
+  @Test
   public void testThatInjectionWorks() throws IOException {
     ProcessResult injectionTestNGTestResult =
         workspace.runBuckCommand("test", "//test:injection-test");

--- a/test/com/facebook/buck/testrunner/testdata/simple_testng/test/BUCK.fixture
+++ b/test/com/facebook/buck/testrunner/testdata/simple_testng/test/BUCK.fixture
@@ -18,6 +18,15 @@ java_test(
 )
 
 java_test(
+    name = "simple-skipped-test",
+    srcs = ["SimpleSkippedTest.java"],
+    test_type = "testng",
+    deps = [
+        "buck//third-party/java/testng:testng",
+    ],
+)
+
+java_test(
     name = "injection-test",
     srcs = ["InjectionTest.java"],
     test_type = "testng",

--- a/test/com/facebook/buck/testrunner/testdata/simple_testng/test/SimpleSkippedTest.java
+++ b/test/com/facebook/buck/testrunner/testdata/simple_testng/test/SimpleSkippedTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.example;
+
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+public class SimpleSkippedTest {
+
+  @Test
+  public void skip() {
+    throw new SkipException("skipped");
+  }
+}


### PR DESCRIPTION
On top of #1662 and 2nd part of #1657 . Ignore commits before `Respect ClassName and MethodName filters in TestNG runner.`. (Didn't want to make a PR into that branch because the semantics become confusing, and no one will see a PR from our fork into our fork anyway.)

We now correctly handle test selectors in TestNG. 
Also, we do some minor refactoring, removing `TestNGWrapper` and the "TmpSuite" xml suite.

Test plan: test in TestNGIntegrationTest.