### PR TITLE
Use absolute paths for referencing ifvsoverlay to swiftc

### DIFF
--- a/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
+++ b/src/com/facebook/buck/apple/project_generator/ProjectGenerator.java
@@ -2979,11 +2979,11 @@ public class ProjectGenerator {
     targetSpecificSwiftFlags.add("-import-underlying-module");
     Path vfsOverlay =
         getObjcModulemapVFSOverlayLocationFromSymlinkTreeRoot(
-            getHeaderSymlinkTreeRelativePath(targetNode, HeaderVisibility.PUBLIC));
+            getPathToHeaderSymlinkTree(targetNode, HeaderVisibility.PUBLIC));
     targetSpecificSwiftFlags.add("-Xcc");
     targetSpecificSwiftFlags.add("-ivfsoverlay");
     targetSpecificSwiftFlags.add("-Xcc");
-    targetSpecificSwiftFlags.add(vfsOverlay.toString());
+    targetSpecificSwiftFlags.add("$REPO_ROOT/" + vfsOverlay.toString());
     return targetSpecificSwiftFlags.build();
   }
 

--- a/test/com/facebook/buck/apple/project_generator/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/apple/project_generator/ProjectGeneratorTest.java
@@ -560,7 +560,7 @@ public class ProjectGeneratorTest {
     assertThat(
         settings.get("OTHER_SWIFT_FLAGS"),
         containsString(
-            "-Xcc -ivfsoverlay -Xcc ../buck-out/gen/_p/CwkbTNOBmb-pub/objc-module-overlay.yaml"));
+            "-Xcc -ivfsoverlay -Xcc $REPO_ROOT/buck-out/gen/_p/CwkbTNOBmb-pub/objc-module-overlay.yaml"));
 
     List<Path> headerSymlinkTrees = projectGenerator.getGeneratedHeaderSymlinkTrees();
     assertThat(headerSymlinkTrees, hasSize(2));

--- a/test/com/facebook/buck/apple/project_generator/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/apple/project_generator/ProjectGeneratorTest.java
@@ -560,7 +560,7 @@ public class ProjectGeneratorTest {
     assertThat(
         settings.get("OTHER_SWIFT_FLAGS"),
         containsString(
-            "-Xcc -ivfsoverlay -Xcc $REPO_ROOT/buck-out/gen/_p/CwkbTNOBmb-pub/objc-module-overlay.yaml"));
+            "-Xcc -ivfsoverlay -Xcc '$REPO_ROOT/buck-out/gen/_p/CwkbTNOBmb-pub/objc-module-overlay.yaml'"));
 
     List<Path> headerSymlinkTrees = projectGenerator.getGeneratedHeaderSymlinkTrees();
     assertThat(headerSymlinkTrees, hasSize(2));


### PR DESCRIPTION
When using relative paths, autocomplete will not work in Xcode. See
https://openradar.appspot.com/36072590