### PR TITLE
clarify BuildRule-RuleKey arity in doc

### DIFF
--- a/docs/concept/rule_keys.soy
+++ b/docs/concept/rule_keys.soy
@@ -22,7 +22,7 @@
     </p>
     <p>
       RuleKeys are used to encapsulate all of the factors which may contribute to the output of a BuildRule into a single value - a hashcode.
-      If any RuleKey of a BuildRule has not changed, the output of that BuildRule cannot have changed.
+      If the RuleKey of a BuildRule has not changed, the output of that BuildRule cannot have changed.
     <p>
     <p>
       The goal of the RuleKeys is to help buck minimise the amount of BuildRules that need to be built locally on each buck run.


### PR DESCRIPTION
Use of the word "any" implies a BuildRule can have more than one RuleKey.

I believe a BuildRule has exactly one RuleKey.