### PR TITLE
clarify conditions under which BuildRule output can change

### DIFF
--- a/docs/concept/rule_keys.soy
+++ b/docs/concept/rule_keys.soy
@@ -22,7 +22,7 @@
     </p>
     <p>
       RuleKeys are used to encapsulate all of the factors which may contribute to the output of a BuildRule into a single value - a hashcode.
-      If any RuleKey of a BuildRule has not changed, the output of that BuildRule cannot have changed.
+      If no RuleKey of a BuildRule has changed, the output of that BuildRule cannot have changed.
     <p>
     <p>
       The goal of the RuleKeys is to help buck minimise the amount of BuildRules that need to be built locally on each buck run.


### PR DESCRIPTION
Original wording implies that _all_ RuleKeys must change in order for the output of a BuildRule to change.

Fixed.

## Background

My previous [PR-1683](https://github.com/facebook/buck/pull/1683) was closed. In that PR, I assumed that a BuildRule could have only one RuleKey. The commenter told me that in fact a BuildRule could have more than one RuleKey.

That being the case, the sentence is still wrong.