### PR TITLE
Whitelist profile entitlements

### DIFF
--- a/src/com/facebook/buck/apple/ProvisioningProfileCopyStep.java
+++ b/src/com/facebook/buck/apple/ProvisioningProfileCopyStep.java
@@ -18,7 +18,6 @@ package com.facebook.buck.apple;
 
 import com.dd.plist.NSDictionary;
 import com.dd.plist.NSObject;
-import com.dd.plist.NSString;
 import com.dd.plist.PropertyListFormatException;
 import com.dd.plist.PropertyListParser;
 import com.facebook.buck.apple.toolchain.ApplePlatform;
@@ -193,8 +192,6 @@ class ProvisioningProfileCopyStep implements Step {
     // Copy the actual .mobileprovision.
     filesystem.copy(provisioningProfileSource, provisioningProfileDestination, CopySourceMode.FILE);
 
-    String appID = bestProfile.get().getAppID().getFirst() + "." + bundleID;
-
     // Merge the entitlements with the profile, and write out.
     if (entitlementsPlist.isPresent()) {
       return (new PlistProcessStep(
@@ -203,11 +200,12 @@ class ProvisioningProfileCopyStep implements Step {
               Optional.empty(),
               signingEntitlementsTempPath,
               bestProfile.get().getMergeableEntitlements(),
-              ImmutableMap.of(APPLICATION_IDENTIFIER, new NSString(appID)),
+              ImmutableMap.of(),
               PlistProcessStep.OutputFormat.XML))
           .execute(context);
     } else {
       // No entitlements.plist explicitly specified; write out the minimal entitlements needed.
+      String appID = bestProfile.get().getAppID().getFirst() + "." + bundleID;
       NSDictionary entitlementsPlist = new NSDictionary();
       entitlementsPlist.putAll(bestProfile.get().getMergeableEntitlements());
       entitlementsPlist.put(APPLICATION_IDENTIFIER, appID);

--- a/src/com/facebook/buck/apple/ProvisioningProfileCopyStep.java
+++ b/src/com/facebook/buck/apple/ProvisioningProfileCopyStep.java
@@ -193,7 +193,6 @@ class ProvisioningProfileCopyStep implements Step {
     // Copy the actual .mobileprovision.
     filesystem.copy(provisioningProfileSource, provisioningProfileDestination, CopySourceMode.FILE);
 
-    // Create the application identifier from the app ID and bundle ID
     String appID = bestProfile.get().getAppID().getFirst() + "." + bundleID;
 
     // Merge the entitlements with the profile, and write out.

--- a/src/com/facebook/buck/apple/ProvisioningProfileCopyStep.java
+++ b/src/com/facebook/buck/apple/ProvisioningProfileCopyStep.java
@@ -197,7 +197,6 @@ class ProvisioningProfileCopyStep implements Step {
 
     // Merge the entitlements with the profile, and write out.
     if (entitlementsPlist.isPresent()) {
-
       return (new PlistProcessStep(
               filesystem,
               entitlementsPlist.get(),

--- a/src/com/facebook/buck/apple/toolchain/AbstractProvisioningProfileMetadata.java
+++ b/src/com/facebook/buck/apple/toolchain/AbstractProvisioningProfileMetadata.java
@@ -102,6 +102,7 @@ abstract class AbstractProvisioningProfileMetadata implements AddsToRuleKey {
 
   public ImmutableMap<String, NSObject> getMergeableEntitlements() {
     final ImmutableSet<String> includedKeys = ImmutableSet.of(
+        "application-identifier",
         "beta-reports-active",
         "get-task-allow",
         "com.apple.developer.aps-environment",

--- a/src/com/facebook/buck/apple/toolchain/AbstractProvisioningProfileMetadata.java
+++ b/src/com/facebook/buck/apple/toolchain/AbstractProvisioningProfileMetadata.java
@@ -101,21 +101,16 @@ abstract class AbstractProvisioningProfileMetadata implements AddsToRuleKey {
   }
 
   public ImmutableMap<String, NSObject> getMergeableEntitlements() {
-    final ImmutableSet<String> excludedKeys =
-        ImmutableSet.of(
-            "com.apple.developer.restricted-resource-mode",
-            "inter-app-audio",
-            "com.apple.developer.icloud-container-development-container-identifiers",
-            "com.apple.developer.homekit",
-            "com.apple.developer.healthkit",
-            "com.apple.developer.in-app-payments",
-            "com.apple.developer.maps",
-            "com.apple.external-accessory.wireless-configuration");
+    final ImmutableSet<String> includedKeys = ImmutableSet.of(
+        "beta-reports-active",
+        "get-task-allow",
+        "com.apple.developer.aps-environment",
+        "com.apple.developer.team-identifier");
 
     ImmutableMap<String, NSObject> allEntitlements = getEntitlements();
     ImmutableMap.Builder<String, NSObject> filteredEntitlementsBuilder = ImmutableMap.builder();
     for (String key : allEntitlements.keySet()) {
-      if (!excludedKeys.contains(key)) {
+      if (includedKeys.contains(key)) {
         filteredEntitlementsBuilder.put(key, allEntitlements.get(key));
       }
     }


### PR DESCRIPTION
Fixes #1690. Don't use a blacklist for provisioning profile entitlements to merge, use a whitelist instead. Taken from `+[IDEEntitlementsMerger keysToAlwaysCopyFromProfile]` and ` +[IDEEntitlementsMerger genericallyDefinedAppKeysToCopyFromProfile]`. Prevents any profile entitlements with wildcards from being merged in to a signed app.