### PR TITLE
Document provided_deps for android_library.

### DIFF
--- a/docs/rule/android_library.soy
+++ b/docs/rule/android_library.soy
@@ -148,22 +148,12 @@ compiled class files and resources.
   {/param}
 {/call}
 
-{call buck.arg}
-  {param name: 'exported_deps' /}
-  {param default : '[]' /}
-  {param desc}
-  This is the same as in <a href="{ROOT}rule/java_library.html">
-  <code>java_library</code></a>.
-  {/param}
+{call jvm_common.exported_deps}
+  {param library: 'android_library' /}
 {/call}
 
-{call buck.arg}
-  {param name: 'provided_deps' /}
-  {param default : '[]' /}
-  {param desc}
-  This is the same as in <a href="{ROOT}rule/java_library.html">
-  <code>java_library</code></a>.
-  {/param}
+{call jvm_common.provided_deps}
+  {param binary: 'android_binary' /}
 {/call}
 
 {call buck.deps_query_arg /}

--- a/docs/rule/android_library.soy
+++ b/docs/rule/android_library.soy
@@ -157,6 +157,15 @@ compiled class files and resources.
   {/param}
 {/call}
 
+{call buck.arg}
+  {param name: 'provided_deps' /}
+  {param default : '[]' /}
+  {param desc}
+  This is the same as in <a href="{ROOT}rule/java_library.html">
+  <code>java_library</code></a>.
+  {/param}
+{/call}
+
 {call buck.deps_query_arg /}
 
 {call buck.provided_deps_query_arg /}


### PR DESCRIPTION
Summary:
`provided_deps` is a valid attribute for android_library. Copied the format of `exported_deps`.

Test Plan:
- Run `docs/soyweb-local.sh`
- Open `http://localhost:9811/rule/android_library.html` and observe change