### PR TITLE
Modular apple_library set -fmodule-name flag in populateCxxLibraryDescriptionArg

### DIFF
--- a/src/com/facebook/buck/apple/AppleDescriptions.java
+++ b/src/com/facebook/buck/apple/AppleDescriptions.java
@@ -59,6 +59,7 @@ import com.facebook.buck.rules.TargetNode;
 import com.facebook.buck.rules.Tool;
 import com.facebook.buck.rules.coercer.PatternMatchedCollection;
 import com.facebook.buck.rules.coercer.SourceList;
+import com.facebook.buck.rules.macros.StringWithMacros;
 import com.facebook.buck.shell.AbstractGenruleDescription;
 import com.facebook.buck.util.HumanReadableException;
 import com.facebook.buck.util.Optionals;
@@ -311,6 +312,14 @@ public class AppleDescriptions {
         SourceList.ofNamedSources(
             convertAppleHeadersToPublicCxxHeaders(
                 buildTarget, resolver::getRelativePath, headerPathPrefix, arg)));
+    if (arg.isModular()) {
+      output.addCompilerFlags(
+          StringWithMacros.of(
+              ImmutableList.of(
+                  Either.ofLeft(
+                      "-fmodule-name="
+                          + arg.getHeaderPathPrefix().orElse(buildTarget.getShortName())))));
+    }
   }
 
   public static Optional<AppleAssetCatalog> createBuildRuleForTransitiveAssetCatalogDependencies(

--- a/src/com/facebook/buck/apple/AppleLibraryDescription.java
+++ b/src/com/facebook/buck/apple/AppleLibraryDescription.java
@@ -819,11 +819,6 @@ public class AppleLibraryDescription
     Optional<SourcePath> getInfoPlist();
 
     ImmutableMap<String, String> getInfoPlistSubstitutions();
-
-    @Value.Default
-    default boolean isModular() {
-      return false;
-    }
   }
 
   // CxxLibraryDescriptionDelegate

--- a/src/com/facebook/buck/apple/AppleLibraryDescription.java
+++ b/src/com/facebook/buck/apple/AppleLibraryDescription.java
@@ -250,7 +250,7 @@ public class AppleLibraryDescription
       BuildRuleResolver resolver,
       SourcePathRuleFinder ruleFinder,
       CellPathResolver cellRoots,
-      CxxLibraryDescription.CommonArg args,
+      AppleNativeTargetDescriptionArg args,
       Optional<AppleLibrarySwiftDelegate> swiftDelegate) {
     Optional<Map.Entry<Flavor, Type>> maybeType = LIBRARY_TYPE.getFlavorAndValue(buildTarget);
     return maybeType.flatMap(

--- a/src/com/facebook/buck/apple/AppleLibraryDescriptionSwiftEnhancer.java
+++ b/src/com/facebook/buck/apple/AppleLibraryDescriptionSwiftEnhancer.java
@@ -18,7 +18,6 @@ package com.facebook.buck.apple;
 
 import com.facebook.buck.apple.toolchain.AppleCxxPlatform;
 import com.facebook.buck.cxx.CxxLibrary;
-import com.facebook.buck.cxx.CxxLibraryDescription;
 import com.facebook.buck.cxx.CxxPreprocessorInput;
 import com.facebook.buck.cxx.HeaderSymlinkTreeWithHeaderMap;
 import com.facebook.buck.cxx.PreprocessorFlags;
@@ -57,7 +56,7 @@ public class AppleLibraryDescriptionSwiftEnhancer {
       BuildRuleResolver resolver,
       SourcePathRuleFinder ruleFinder,
       BuildRuleParams params,
-      CxxLibraryDescription.CommonArg args,
+      AppleNativeTargetDescriptionArg args,
       ProjectFilesystem filesystem,
       CxxPlatform platform,
       AppleCxxPlatform applePlatform,

--- a/src/com/facebook/buck/apple/AppleNativeTargetDescriptionArg.java
+++ b/src/com/facebook/buck/apple/AppleNativeTargetDescriptionArg.java
@@ -30,4 +30,9 @@ public interface AppleNativeTargetDescriptionArg
   ImmutableSortedMap<String, ImmutableMap<String, String>> getConfigs();
 
   Optional<String> getHeaderPathPrefix();
+
+  @Value.Default
+  default boolean isModular() {
+    return false;
+  }
 }

--- a/test/com/facebook/buck/apple/AppleLibraryDescriptionTest.java
+++ b/test/com/facebook/buck/apple/AppleLibraryDescriptionTest.java
@@ -16,6 +16,7 @@
 
 package com.facebook.buck.apple;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -24,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeThat;
 
 import com.facebook.buck.cxx.CxxDescriptionEnhancer;
+import com.facebook.buck.cxx.CxxLibraryDescriptionArg;
 import com.facebook.buck.cxx.CxxLink;
 import com.facebook.buck.cxx.toolchain.DefaultCxxPlatforms;
 import com.facebook.buck.model.BuildTarget;
@@ -119,5 +121,35 @@ public class AppleLibraryDescriptionTest {
     SourcePath expectedSwiftSourcePath =
         metadata.get().getSwiftSources().iterator().next().getSourcePath();
     assertSame(swiftSourcePath, expectedSwiftSourcePath);
+  }
+
+  @Test
+  public void modularObjcFlags() {
+    BuildTarget libTarget = BuildTargetFactory.newInstance("//:library");
+    TargetNode<AppleLibraryDescriptionArg, ?> libNode =
+        new AppleLibraryBuilder(libTarget)
+            .setSrcs(ImmutableSortedSet.of(SourceWithFlags.of(FakeSourcePath.of("foo.m"))))
+            .setCompilerFlags(ImmutableList.of("-DDEBUG=1"))
+            .setModular(true)
+            .build();
+
+    BuildRuleResolver buildRuleResolver =
+        new SingleThreadedBuildRuleResolver(
+            TargetGraphFactory.newInstance(libNode), new DefaultTargetNodeToBuildRuleTransformer());
+
+    final SourcePathResolver pathResolver =
+        DefaultSourcePathResolver.from(new SourcePathRuleFinder(buildRuleResolver));
+
+    CxxLibraryDescriptionArg.Builder delegateArgBuilder =
+        CxxLibraryDescriptionArg.builder().from(libNode.getConstructorArg());
+
+    AppleDescriptions.populateCxxLibraryDescriptionArg(
+        pathResolver, delegateArgBuilder, libNode.getConstructorArg(), libTarget);
+    CxxLibraryDescriptionArg delegateArg = delegateArgBuilder.build();
+    assertThat(
+        delegateArg.getCompilerFlags(),
+        containsInAnyOrder(
+            StringWithMacrosUtils.format("-fmodule-name=library"),
+            StringWithMacrosUtils.format("-DDEBUG=1")));
   }
 }

--- a/test/com/facebook/buck/apple/AppleLibraryDescriptionTest.java
+++ b/test/com/facebook/buck/apple/AppleLibraryDescriptionTest.java
@@ -134,8 +134,7 @@ public class AppleLibraryDescriptionTest {
             .build();
 
     BuildRuleResolver buildRuleResolver =
-        new SingleThreadedBuildRuleResolver(
-            TargetGraphFactory.newInstance(libNode), new DefaultTargetNodeToBuildRuleTransformer());
+        new TestBuildRuleResolver(TargetGraphFactory.newInstance(libNode));
 
     final SourcePathResolver pathResolver =
         DefaultSourcePathResolver.from(new SourcePathRuleFinder(buildRuleResolver));


### PR DESCRIPTION
When building mixed swift/c modules, the c part of the code needs to be
compiled with the flag `-fmodule-name=` to correctly identify some
headers are part of the module it is building.