### PR TITLE
Add test target to xml output

### DIFF
--- a/src/com/facebook/buck/cli/TestRunning.java
+++ b/src/com/facebook/buck/cli/TestRunning.java
@@ -598,6 +598,7 @@ public class TestRunning {
           testEl.setAttribute("name", testCase.getTestCaseName());
           testEl.setAttribute("status", testCase.isSuccess() ? "PASS" : "FAIL");
           testEl.setAttribute("time", Long.toString(testCase.getTotalTime()));
+          testEl.setAttribute("target", results.getBuildTarget().getFullyQualifiedName());
           testsEl.appendChild(testEl);
 
           // Loop through the test case and add XML data (name, message, and

--- a/test/com/facebook/buck/cli/TestRunningTest.java
+++ b/test/com/facebook/buck/cli/TestRunningTest.java
@@ -371,9 +371,12 @@ public class TestRunningTest {
     NodeList testList = testsEl.getElementsByTagName("test");
     assertEquals(testList.getLength(), 1);
 
+    // Check the target has been set
+    Element testEl = (Element) testList.item(0);
+    assertEquals(testEl.getAttribute("target"), "//foo/bar:baz");
+
     // Check for exactly three <testresult> tags.
     // There should be two failures and one success.
-    Element testEl = (Element) testList.item(0);
     NodeList resultsList = testEl.getElementsByTagName("testresult");
     assertEquals(resultsList.getLength(), 3);
 
@@ -382,6 +385,7 @@ public class TestRunningTest {
     assertEquals(passResultEl.getAttribute("name"), "passTest");
     assertEquals(passResultEl.getAttribute("time"), "5000");
     assertEquals(passResultEl.getAttribute("status"), "PASS");
+
     checkXmlTextContents(passResultEl, "message", "");
     checkXmlTextContents(passResultEl, "stacktrace", "");
 

--- a/test/com/facebook/buck/cli/TestRunningTest.java
+++ b/test/com/facebook/buck/cli/TestRunningTest.java
@@ -385,7 +385,6 @@ public class TestRunningTest {
     assertEquals(passResultEl.getAttribute("name"), "passTest");
     assertEquals(passResultEl.getAttribute("time"), "5000");
     assertEquals(passResultEl.getAttribute("status"), "PASS");
-
     checkXmlTextContents(passResultEl, "message", "");
     checkXmlTextContents(passResultEl, "stacktrace", "");
 


### PR DESCRIPTION
Using the test output across languages can be troublesome as they all implement the test attributes differently. Some use the target name as the `testCaseName` (eg python), some use the current test class name (eg xctool).

To make it possible to know which target a test result belongs to, add a new `target` attribute to each `test` element.