### PR TITLE
Remove hard time limit on TestNG test suite

### DIFF
--- a/src/com/facebook/buck/testrunner/TestNGRunner.java
+++ b/src/com/facebook/buck/testrunner/TestNGRunner.java
@@ -92,7 +92,6 @@ public final class TestNGRunner extends BaseRunner {
   private XmlSuite createXmlSuite(Class<?> c) {
     XmlSuite xmlSuite = new XmlSuite();
     xmlSuite.setName("TmpSuite");
-    xmlSuite.setTimeOut(String.valueOf(defaultTestTimeoutMillis));
     XmlTest xmlTest = new XmlTest(xmlSuite);
     xmlTest.setName("TmpTest");
     xmlTest.setXmlClasses(Collections.singletonList(new XmlClass(c)));


### PR DESCRIPTION
Having a time limit on the test suite is confusing; instead, stick to specifying time limits on tests directly, or putting time limits on test targets.