### PR TITLE
Add support for downloading prebuilt binaries of buck via jitpack at any sha

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,9 +1,6 @@
-jdk:
-  - oraclejdk8
 install:
    - set -exo pipefail
    - ant
-   - bin/buck build buck
+   - PEX=$(bin/buck build buck --show-output | awk '{print $2}')
    - SHA=$(git rev-parse HEAD)
-   - PEX=$(bin/buck targets --show-output buck | awk '{print $2}')
    - mvn install:install-file -Dfile="$PEX" -DgroupId="$GROUP" -DartifactId="$ARTIFACT" -Dversion="$SHA" -Dpackaging="pex" -DgeneratePom=true

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,9 @@
+jdk:
+  - oraclejdk8
+install:
+   - set -exo pipefail
+   - ant
+   - bin/buck build buck
+   - SHA=$(git rev-parse HEAD)
+   - PEX=$(bin/buck targets --show-output buck | awk '{print $2}')
+   - mvn install:install-file -Dfile="$PEX" -DgroupId="$GROUP" -DartifactId="$ARTIFACT" -Dversion="$SHA" -Dpackaging="pex" -DgeneratePom=true


### PR DESCRIPTION
- Uses Jitpack to build buck pex and serve them on demand. The very first time a version of buck is requested, it is built via [jitpack](https://jitpack.io/). Every subsequent request will just serve the built artifact directly.
- This enables anyone to just fetch `https://jitpack.io/com/github/facebook/buck/<sha>/buck-<sha>.pex` to download a prebuilt buck pex at any sha.
- Once this merges, this functionality will be available for any forks of buck as well, so one can fetch for example `https://jitpack.io/com/github/kageiit/buck/f0655d65907df1262b191339a51aa94a587f9f3c/buck-f0655d65907df1262b191339a51aa94a587f9f3c.pex`

<img width="1034" alt="screen shot 2018-01-18 at 12 36 57 am" src="https://user-images.githubusercontent.com/291148/35073252-6f8a87b0-fbe8-11e7-8f5f-a384818cc04e.png">

- This will allow users of okbuck to not have to rely on checking out the entire buck repo and build it using ant before being able to use buck