### PR TITLE
Don't add androidFacet.module_gen_path if disable_r_java_idea_generator is true

### DIFF
--- a/src/com/facebook/buck/ide/intellij/templates/ij-module.st
+++ b/src/com/facebook/buck/ide/intellij/templates/ij-module.st
@@ -48,7 +48,7 @@
     <output url="%androidFacet.compiler_output_path%" />
     %endif%
     <exclude-output />
-%if(androidFacet.enabled)%
+%if(androidFacet.enabled && androidFacet.autogenerate_sources)%
     <content url="file://$MODULE_DIR$%androidFacet.module_gen_path%">
       <sourceFolder url="file://$MODULE_DIR$%androidFacet.module_gen_path%" isTestSource="false" />
     </content>


### PR DESCRIPTION
Adding module_get_path somehow messes up R.java autocomplete in intellij