### PR TITLE
Fix test_host_app usage with swift

### DIFF
--- a/src/com/facebook/buck/apple/AppleTestDescription.java
+++ b/src/com/facebook/buck/apple/AppleTestDescription.java
@@ -64,6 +64,7 @@ import com.facebook.buck.rules.TargetGraph;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.fs.MakeCleanDirectoryStep;
 import com.facebook.buck.swift.SwiftLibraryDescription;
+import com.facebook.buck.swift.SwiftRuntimeNativeLinkable;
 import com.facebook.buck.toolchain.ToolchainProvider;
 import com.facebook.buck.unarchive.UnzipStep;
 import com.facebook.buck.util.HumanReadableException;
@@ -538,8 +539,14 @@ public class AppleTestDescription
     // ignored.
     ImmutableSet.Builder<BuildTarget> blacklistBuilder = ImmutableSet.builder();
     for (CxxPlatform platform : cxxPlatforms) {
-      blacklistBuilder.addAll(
-          NativeLinkables.getTransitiveNativeLinkables(platform, roots.values()).keySet());
+      ImmutableSet<BuildTarget> blacklistables =
+          NativeLinkables.getTransitiveNativeLinkables(platform, roots.values())
+              .entrySet()
+              .stream()
+              .filter(x -> !(x.getValue() instanceof SwiftRuntimeNativeLinkable))
+              .map(x -> x.getKey())
+              .collect(ImmutableSet.toImmutableSet());
+      blacklistBuilder.addAll(blacklistables);
     }
 
     if (!uiTestTargetAppBuildTarget.isPresent()) {

--- a/test/com/facebook/buck/swift/SwiftTestIOSIntegrationTest.java
+++ b/test/com/facebook/buck/swift/SwiftTestIOSIntegrationTest.java
@@ -110,7 +110,7 @@ public class SwiftTestIOSIntegrationTest {
         TestProjectFilesystems.createProjectFilesystem(workspace.getDestPath());
 
     BuildTarget target = workspace.newBuildTarget("//:swifttest#iphonesimulator-x86_64");
-    ProjectWorkspace.ProcessResult result =
+    ProcessResult result =
         workspace.runBuckCommand("test", target.getFullyQualifiedName());
     result.assertSuccess();
   }

--- a/test/com/facebook/buck/swift/SwiftTestIOSIntegrationTest.java
+++ b/test/com/facebook/buck/swift/SwiftTestIOSIntegrationTest.java
@@ -19,6 +19,7 @@ package com.facebook.buck.swift;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assume.assumeThat;
 
 import com.facebook.buck.apple.AppleDebugFormat;
@@ -144,6 +145,55 @@ public class SwiftTestIOSIntegrationTest {
     assertThat(
         workspace.runCommand("otool", "-l", binaryOutput.toString()).getStdout().get(),
         containsString("@loader_path/Frameworks"));
+  }
+
+  @Test
+  public void testSwiftInHostAndTestBundleAppleLibraryMacOS() throws Exception {
+    assumeThat(
+        AppleNativeIntegrationTestUtils.isSwiftAvailable(ApplePlatform.MACOSX), is(true));
+    ProjectWorkspace workspace =
+        TestDataHelper.createProjectWorkspaceForScenario(this, "swift_test_with_host", tmp);
+    workspace.setUp();
+    workspace.copyRecursively(
+        TestDataHelper.getTestDataDirectory(AppleTestBuilder.class).resolve("fbxctest"),
+        Paths.get("fbxctest"));
+    workspace.addBuckConfigLocalOption("apple", "xctool_path", "fbxctest/bin/fbxctest");
+
+    ProjectFilesystem filesystem =
+        TestProjectFilesystems.createProjectFilesystem(workspace.getDestPath());
+
+    BuildTarget target = workspace.newBuildTarget("//:swifttest#macosx-x86_64");
+    ProcessResult result =
+        workspace.runBuckCommand("test", target.getFullyQualifiedName(), "--config", "testconfig.dep_type=apple_library", "--config", "cxx.default_platform=macosx-x86_64");
+    result.assertSuccess();
+
+    Path binaryOutput =
+        workspace
+            .getPath(
+                BuildTargets.getGenPath(
+                    filesystem,
+                    target.withAppendedFlavors(
+                        InternalFlavor.of("macosx-x86_64"),
+                        InternalFlavor.of("apple-test-bundle"),
+                        AppleDebugFormat.DWARF.getFlavor(),
+                        LinkerMapMode.NO_LINKER_MAP.getFlavor(),
+                        AppleDescriptions.NO_INCLUDE_FRAMEWORKS_FLAVOR),
+                    "%s/swifttest.xctest"))
+            .resolve("Contents/MacOS/swifttest/");
+    assertThat(Files.exists(binaryOutput), CoreMatchers.is(true));
+
+    assertThat(
+        workspace.runCommand("file", binaryOutput.toString()).getStdout().get(),
+        containsString("bundle x86_64"));
+    assertThat(
+        workspace.runCommand("otool", "-hv", binaryOutput.toString()).getStdout().get(),
+        containsString("X86_64"));
+    assertThat(
+        workspace.runCommand("otool", "-L", binaryOutput.toString()).getStdout().get(),
+        containsString("XCTest.framework/Versions/A/XCTest"));
+    assertThat(
+        workspace.runCommand("otool", "-L", binaryOutput.toString()).getStdout().get(),
+        not(containsString("@rpath/libswiftCore.dylib")));
   }
 
   @Test

--- a/test/com/facebook/buck/swift/SwiftTestIOSIntegrationTest.java
+++ b/test/com/facebook/buck/swift/SwiftTestIOSIntegrationTest.java
@@ -95,7 +95,7 @@ public class SwiftTestIOSIntegrationTest {
   }
 
   @Test
-  public void testSwiftInHostAndTestBundle() throws Exception {
+  public void testSwiftInHostAndTestBundleAppleLibrary() throws Exception {
     assumeThat(
         AppleNativeIntegrationTestUtils.isSwiftAvailable(ApplePlatform.IPHONESIMULATOR), is(true));
     ProjectWorkspace workspace =
@@ -111,7 +111,90 @@ public class SwiftTestIOSIntegrationTest {
 
     BuildTarget target = workspace.newBuildTarget("//:swifttest#iphonesimulator-x86_64");
     ProcessResult result =
-        workspace.runBuckCommand("test", target.getFullyQualifiedName());
+        workspace.runBuckCommand("test", target.getFullyQualifiedName(), "--config", "testconfig.dep_type=apple_library");
     result.assertSuccess();
+
+    Path binaryOutput =
+        workspace
+            .getPath(
+                BuildTargets.getGenPath(
+                    filesystem,
+                    target.withAppendedFlavors(
+                        InternalFlavor.of("iphonesimulator-x86_64"),
+                        InternalFlavor.of("apple-test-bundle"),
+                        AppleDebugFormat.DWARF.getFlavor(),
+                        LinkerMapMode.NO_LINKER_MAP.getFlavor(),
+                        AppleDescriptions.NO_INCLUDE_FRAMEWORKS_FLAVOR),
+                    "%s/swifttest.xctest"))
+            .resolve("swifttest");
+    assertThat(Files.exists(binaryOutput), CoreMatchers.is(true));
+
+    assertThat(
+        workspace.runCommand("file", binaryOutput.toString()).getStdout().get(),
+        containsString("bundle x86_64"));
+    assertThat(
+        workspace.runCommand("otool", "-hv", binaryOutput.toString()).getStdout().get(),
+        containsString("X86_64"));
+    assertThat(
+        workspace.runCommand("otool", "-L", binaryOutput.toString()).getStdout().get(),
+        containsString("XCTest.framework/XCTest"));
+    assertThat(
+        workspace.runCommand("otool", "-L", binaryOutput.toString()).getStdout().get(),
+        containsString("@rpath/libswiftCore.dylib"));
+    assertThat(
+        workspace.runCommand("otool", "-l", binaryOutput.toString()).getStdout().get(),
+        containsString("@loader_path/Frameworks"));
+  }
+
+  @Test
+  public void testSwiftInHostAndTestBundleSwiftLibrary() throws Exception {
+    assumeThat(
+        AppleNativeIntegrationTestUtils.isSwiftAvailable(ApplePlatform.IPHONESIMULATOR), is(true));
+    ProjectWorkspace workspace =
+        TestDataHelper.createProjectWorkspaceForScenario(this, "swift_test_with_host", tmp);
+    workspace.setUp();
+    workspace.copyRecursively(
+        TestDataHelper.getTestDataDirectory(AppleTestBuilder.class).resolve("fbxctest"),
+        Paths.get("fbxctest"));
+    workspace.addBuckConfigLocalOption("apple", "xctool_path", "fbxctest/bin/fbxctest");
+
+    ProjectFilesystem filesystem =
+        TestProjectFilesystems.createProjectFilesystem(workspace.getDestPath());
+
+    BuildTarget target = workspace.newBuildTarget("//:swifttest#iphonesimulator-x86_64");
+    ProcessResult result =
+        workspace.runBuckCommand("test", target.getFullyQualifiedName(), "--config", "testconfig.dep_type=swift_library");
+    result.assertSuccess();
+
+    Path binaryOutput =
+        workspace
+            .getPath(
+                BuildTargets.getGenPath(
+                    filesystem,
+                    target.withAppendedFlavors(
+                        InternalFlavor.of("iphonesimulator-x86_64"),
+                        InternalFlavor.of("apple-test-bundle"),
+                        AppleDebugFormat.DWARF.getFlavor(),
+                        LinkerMapMode.NO_LINKER_MAP.getFlavor(),
+                        AppleDescriptions.NO_INCLUDE_FRAMEWORKS_FLAVOR),
+                    "%s/swifttest.xctest"))
+            .resolve("swifttest");
+    assertThat(Files.exists(binaryOutput), CoreMatchers.is(true));
+
+    assertThat(
+        workspace.runCommand("file", binaryOutput.toString()).getStdout().get(),
+        containsString("bundle x86_64"));
+    assertThat(
+        workspace.runCommand("otool", "-hv", binaryOutput.toString()).getStdout().get(),
+        containsString("X86_64"));
+    assertThat(
+        workspace.runCommand("otool", "-L", binaryOutput.toString()).getStdout().get(),
+        containsString("XCTest.framework/XCTest"));
+    assertThat(
+        workspace.runCommand("otool", "-L", binaryOutput.toString()).getStdout().get(),
+        containsString("@rpath/libswiftCore.dylib"));
+    assertThat(
+        workspace.runCommand("otool", "-l", binaryOutput.toString()).getStdout().get(),
+        containsString("@loader_path/Frameworks"));
   }
 }

--- a/test/com/facebook/buck/swift/SwiftTestIOSIntegrationTest.java
+++ b/test/com/facebook/buck/swift/SwiftTestIOSIntegrationTest.java
@@ -93,4 +93,25 @@ public class SwiftTestIOSIntegrationTest {
         workspace.runCommand("otool", "-l", binaryOutput.toString()).getStdout().get(),
         containsString("@loader_path/Frameworks"));
   }
+
+  @Test
+  public void testSwiftInHostAndTestBundle() throws Exception {
+    assumeThat(
+        AppleNativeIntegrationTestUtils.isSwiftAvailable(ApplePlatform.IPHONESIMULATOR), is(true));
+    ProjectWorkspace workspace =
+        TestDataHelper.createProjectWorkspaceForScenario(this, "swift_test_with_host", tmp);
+    workspace.setUp();
+    workspace.copyRecursively(
+        TestDataHelper.getTestDataDirectory(AppleTestBuilder.class).resolve("fbxctest"),
+        Paths.get("fbxctest"));
+    workspace.addBuckConfigLocalOption("apple", "xctool_path", "fbxctest/bin/fbxctest");
+
+    ProjectFilesystem filesystem =
+        TestProjectFilesystems.createProjectFilesystem(workspace.getDestPath());
+
+    BuildTarget target = workspace.newBuildTarget("//:swifttest#iphonesimulator-x86_64");
+    ProjectWorkspace.ProcessResult result =
+        workspace.runBuckCommand("test", target.getFullyQualifiedName());
+    result.assertSuccess();
+  }
 }

--- a/test/com/facebook/buck/swift/SwiftTestIOSIntegrationTest.java
+++ b/test/com/facebook/buck/swift/SwiftTestIOSIntegrationTest.java
@@ -112,7 +112,11 @@ public class SwiftTestIOSIntegrationTest {
 
     BuildTarget target = workspace.newBuildTarget("//:swifttest#iphonesimulator-x86_64");
     ProcessResult result =
-        workspace.runBuckCommand("test", target.getFullyQualifiedName(), "--config", "testconfig.dep_type=apple_library");
+        workspace.runBuckCommand(
+            "test",
+            target.getFullyQualifiedName(),
+            "--config",
+            "testconfig.dep_type=apple_library");
     result.assertSuccess();
 
     Path binaryOutput =
@@ -149,8 +153,7 @@ public class SwiftTestIOSIntegrationTest {
 
   @Test
   public void testSwiftInHostAndTestBundleAppleLibraryMacOS() throws Exception {
-    assumeThat(
-        AppleNativeIntegrationTestUtils.isSwiftAvailable(ApplePlatform.MACOSX), is(true));
+    assumeThat(AppleNativeIntegrationTestUtils.isSwiftAvailable(ApplePlatform.MACOSX), is(true));
     ProjectWorkspace workspace =
         TestDataHelper.createProjectWorkspaceForScenario(this, "swift_test_with_host", tmp);
     workspace.setUp();
@@ -164,7 +167,13 @@ public class SwiftTestIOSIntegrationTest {
 
     BuildTarget target = workspace.newBuildTarget("//:swifttest#macosx-x86_64");
     ProcessResult result =
-        workspace.runBuckCommand("test", target.getFullyQualifiedName(), "--config", "testconfig.dep_type=apple_library", "--config", "cxx.default_platform=macosx-x86_64");
+        workspace.runBuckCommand(
+            "test",
+            target.getFullyQualifiedName(),
+            "--config",
+            "testconfig.dep_type=apple_library",
+            "--config",
+            "cxx.default_platform=macosx-x86_64");
     result.assertSuccess();
 
     Path binaryOutput =
@@ -213,7 +222,11 @@ public class SwiftTestIOSIntegrationTest {
 
     BuildTarget target = workspace.newBuildTarget("//:swifttest#iphonesimulator-x86_64");
     ProcessResult result =
-        workspace.runBuckCommand("test", target.getFullyQualifiedName(), "--config", "testconfig.dep_type=swift_library");
+        workspace.runBuckCommand(
+            "test",
+            target.getFullyQualifiedName(),
+            "--config",
+            "testconfig.dep_type=swift_library");
     result.assertSuccess();
 
     Path binaryOutput =

--- a/test/com/facebook/buck/swift/testdata/swift_test_with_host/.buckconfig
+++ b/test/com/facebook/buck/swift/testdata/swift_test_with_host/.buckconfig
@@ -1,0 +1,5 @@
+[cxx]
+default_platform = iphonesimulator-x86_64
+
+[swift]
+compiler_flags = -enable-testing

--- a/test/com/facebook/buck/swift/testdata/swift_test_with_host/BUCK.fixture
+++ b/test/com/facebook/buck/swift/testdata/swift_test_with_host/BUCK.fixture
@@ -1,22 +1,14 @@
-if read_config('testconfig', 'dep_type') == 'swift_library':
-  swift_library(
-      name = "dep",
-      srcs = [
-          "dep.swift",
-      ],
-  )
-elif read_config('testconfig', 'dep_type') == 'apple_library':
-  apple_library(
-      name = "dep",
-      srcs = [
-          "dep.swift",
-      ],
-  )
-
 if 'macosx' in read_config('cxx', 'default_platform'):
   default_frameworks = ["$SDKROOT/System/Library/Frameworks/AppKit.framework"]
 else:
   default_frameworks = ["$SDKROOT/System/Library/Frameworks/UIKit.framework"]
+
+apple_library(
+    name = "dep",
+    srcs = [
+        "dep.swift",
+    ],
+)
 
 apple_binary(
     name = "binary",

--- a/test/com/facebook/buck/swift/testdata/swift_test_with_host/BUCK.fixture
+++ b/test/com/facebook/buck/swift/testdata/swift_test_with_host/BUCK.fixture
@@ -13,6 +13,11 @@ elif read_config('testconfig', 'dep_type') == 'apple_library':
       ],
   )
 
+if 'macosx' in read_config('cxx', 'default_platform'):
+  default_frameworks = ["$SDKROOT/System/Library/Frameworks/AppKit.framework"]
+else:
+  default_frameworks = ["$SDKROOT/System/Library/Frameworks/UIKit.framework"]
+
 apple_binary(
     name = "binary",
     srcs = [
@@ -23,8 +28,7 @@ apple_binary(
     ],
     frameworks = [
         "$SDKROOT/System/Library/Frameworks/Foundation.framework",
-        "$SDKROOT/System/Library/Frameworks/UIKit.framework",
-    ],
+    ] + default_frameworks,
 )
 
 apple_bundle(

--- a/test/com/facebook/buck/swift/testdata/swift_test_with_host/BUCK.fixture
+++ b/test/com/facebook/buck/swift/testdata/swift_test_with_host/BUCK.fixture
@@ -1,9 +1,17 @@
-swift_library(
-    name = "dep",
-    srcs = [
-        "dep.swift",
-    ],
-)
+if read_config('testconfig', 'dep_type') == 'swift_library':
+  swift_library(
+      name = "dep",
+      srcs = [
+          "dep.swift",
+      ],
+  )
+elif read_config('testconfig', 'dep_type') == 'apple_library':
+  apple_library(
+      name = "dep",
+      srcs = [
+          "dep.swift",
+      ],
+  )
 
 apple_binary(
     name = "binary",

--- a/test/com/facebook/buck/swift/testdata/swift_test_with_host/BUCK.fixture
+++ b/test/com/facebook/buck/swift/testdata/swift_test_with_host/BUCK.fixture
@@ -1,0 +1,49 @@
+swift_library(
+    name = "dep",
+    srcs = [
+        "dep.swift",
+    ],
+)
+
+apple_binary(
+    name = "binary",
+    srcs = [
+        "main.m",
+    ],
+    deps = [
+        ":dep",
+    ],
+    frameworks = [
+        "$SDKROOT/System/Library/Frameworks/Foundation.framework",
+        "$SDKROOT/System/Library/Frameworks/UIKit.framework",
+    ],
+)
+
+apple_bundle(
+    name = "bundle",
+    binary = ":binary",
+    extension = "app",
+    info_plist = "Bundle.plist",
+    info_plist_substitutions = {
+        "PRODUCT_BUNDLE_IDENTIFIER": "com.uber.test1",
+        "EXECUTABLE_NAME": "bundle",
+    },
+    product_name = "bundle",
+)
+
+
+apple_test(
+    name = "swifttest",
+    test_host_app = ":bundle",
+    srcs = [
+        "test.swift",
+    ],
+    frameworks = [
+        "$PLATFORM_DIR/Developer/Library/Frameworks/XCTest.framework",
+        "$SDKROOT/System/Library/Frameworks/Foundation.framework",
+    ],
+    info_plist = "Test.plist",
+    info_plist_substitutions = {
+        "PRODUCT_BUNDLE_IDENTIFIER": "com.ubercab.swiftunittest",
+    },
+)

--- a/test/com/facebook/buck/swift/testdata/swift_test_with_host/Bundle.plist
+++ b/test/com/facebook/buck/swift/testdata/swift_test_with_host/Bundle.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/test/com/facebook/buck/swift/testdata/swift_test_with_host/Test.plist
+++ b/test/com/facebook/buck/swift/testdata/swift_test_with_host/Test.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/test/com/facebook/buck/swift/testdata/swift_test_with_host/dep.swift
+++ b/test/com/facebook/buck/swift/testdata/swift_test_with_host/dep.swift
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import UIKit
+
+@objc public class AppDelegate: UIResponder, UIApplicationDelegate {
+
+}
+
+public class Echo {
+  public class func echo() -> String {
+    return "echo"
+  }
+}

--- a/test/com/facebook/buck/swift/testdata/swift_test_with_host/dep.swift
+++ b/test/com/facebook/buck/swift/testdata/swift_test_with_host/dep.swift
@@ -14,14 +14,19 @@
  * under the License.
  */
 
+#if os(OSX)
+import Cocoa
+@objc public class AppDelegate: NSObject, NSApplicationDelegate {}
+
+#elseif os(iOS)
 import UIKit
+@objc public class AppDelegate: UIResponder, UIApplicationDelegate {}
 
-@objc public class AppDelegate: UIResponder, UIApplicationDelegate {
-
-}
+#endif
 
 public class Echo {
   public class func echo() -> String {
     return "echo"
   }
 }
+

--- a/test/com/facebook/buck/swift/testdata/swift_test_with_host/main.m
+++ b/test/com/facebook/buck/swift/testdata/swift_test_with_host/main.m
@@ -1,0 +1,8 @@
+#import <UIKit/UIKit.h>
+#import "dep-Swift.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/test/com/facebook/buck/swift/testdata/swift_test_with_host/main.m
+++ b/test/com/facebook/buck/swift/testdata/swift_test_with_host/main.m
@@ -1,8 +1,23 @@
+#include <Foundation/Foundation.h>
+#if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
+#elif TARGET_OS_MAC
+#import <Appkit/Appkit.h>
+#endif
+
+
 #import "dep-Swift.h"
 
 int main(int argc, char * argv[]) {
     @autoreleasepool {
+        #if TARGET_OS_IPHONE
         return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+        #elif TARGET_OS_MAC
+        NSApplication * application = [NSApplication sharedApplication];
+
+        AppDelegate * appDelegate = [[AppDelegate alloc] init];
+        [application setDelegate:appDelegate];
+        [application run];
+        #endif
     }
 }

--- a/test/com/facebook/buck/swift/testdata/swift_test_with_host/test.swift
+++ b/test/com/facebook/buck/swift/testdata/swift_test_with_host/test.swift
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import XCTest
+@testable import dep
+
+class test_withdep: XCTestCase {
+  func testEcho() {
+    XCTAssertEqual(Echo.echo(), "echo", "Pass")
+  }
+}


### PR DESCRIPTION
Tests with swift in both the test host and test target currently fail compilation with a cryptic error like 
```
ld: library not found for -lswiftMetal for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
``` 
This is because the `SwiftRuntimeNativeLinkable` is both dependency of the test_host_app and the tests. When linking the tests, the dependencies it shares with its test_host_app (`bundle_loader` in ld) are added to a blacklist so they are not linked into the tests to prevent duplicate symbols. 

However, if there's usage of swift in the tests their object files will contain linker directives to link against some wrappers around the standard library which require the flags added by `SwiftRuntimeNativeLinkable` to link correctly.

