### PR TITLE
[JVM] Remove test args that do not affect the output from rulekey computation

### DIFF
--- a/src/com/facebook/buck/android/AndroidInstrumentationTest.java
+++ b/src/com/facebook/buck/android/AndroidInstrumentationTest.java
@@ -24,7 +24,6 @@ import com.facebook.buck.io.filesystem.ProjectFilesystem;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargets;
 import com.facebook.buck.rules.AbstractBuildRuleWithDeclaredAndExtraDeps;
-import com.facebook.buck.rules.AddToRuleKey;
 import com.facebook.buck.rules.BuildContext;
 import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildableContext;
@@ -78,7 +77,7 @@ public class AndroidInstrumentationTest extends AbstractBuildRuleWithDeclaredAnd
 
   private final AndroidPlatformTarget androidPlatformTarget;
 
-  @AddToRuleKey private final Tool javaRuntimeLauncher;
+  private final Tool javaRuntimeLauncher;
 
   private final ImmutableSet<String> labels;
 

--- a/src/com/facebook/buck/jvm/java/JavaTest.java
+++ b/src/com/facebook/buck/jvm/java/JavaTest.java
@@ -29,7 +29,6 @@ import com.facebook.buck.model.BuildTargets;
 import com.facebook.buck.model.Flavor;
 import com.facebook.buck.model.InternalFlavor;
 import com.facebook.buck.rules.AbstractBuildRuleWithDeclaredAndExtraDeps;
-import com.facebook.buck.rules.AddToRuleKey;
 import com.facebook.buck.rules.BuildContext;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleParams;
@@ -112,9 +111,9 @@ public class JavaTest extends AbstractBuildRuleWithDeclaredAndExtraDeps
   private final JavaLibrary compiledTestsLibrary;
 
   private final ImmutableSet<Either<SourcePath, Path>> additionalClasspathEntries;
-  @AddToRuleKey private final Tool javaRuntimeLauncher;
+  private final Tool javaRuntimeLauncher;
 
-  @AddToRuleKey private final ImmutableList<String> vmArgs;
+  private final ImmutableList<String> vmArgs;
 
   private final ImmutableMap<String, String> nativeLibsEnvironment;
 
@@ -127,13 +126,13 @@ public class JavaTest extends AbstractBuildRuleWithDeclaredAndExtraDeps
   private final Optional<Level> stdOutLogLevel;
   private final Optional<Level> stdErrLogLevel;
 
-  @AddToRuleKey private final TestType testType;
+  private final TestType testType;
 
-  @AddToRuleKey private final Optional<Long> testRuleTimeoutMs;
+  private final Optional<Long> testRuleTimeoutMs;
 
-  @AddToRuleKey private final Optional<Long> testCaseTimeoutMs;
+  private final Optional<Long> testCaseTimeoutMs;
 
-  @AddToRuleKey private final ImmutableMap<String, Arg> env;
+  private final ImmutableMap<String, Arg> env;
 
   private final Path pathToTestLogs;
 
@@ -143,11 +142,11 @@ public class JavaTest extends AbstractBuildRuleWithDeclaredAndExtraDeps
 
   @Nullable private ImmutableList<JUnitStep> junits;
 
-  @AddToRuleKey private final boolean runTestSeparately;
+  private final boolean runTestSeparately;
 
-  @AddToRuleKey private final ForkMode forkMode;
+  private final ForkMode forkMode;
 
-  @AddToRuleKey private final Optional<SourcePath> unbundledResourcesRoot;
+  private final Optional<SourcePath> unbundledResourcesRoot;
 
   public JavaTest(
       BuildTarget buildTarget,


### PR DESCRIPTION
Buck does not cache results of tests anymore

This change removes all the args that affect the runtime behavior of tests (since the test rules run always anyway)

Before this change, changing a runtime related argument like `env` or `vm_args` etc. would cause the test rule to rebuild, which is unnecessary.

Fixes #1713