### PR TITLE
Pass logger's STDERR to the execution results of swift compilation steps

### DIFF
--- a/src/com/facebook/buck/swift/SwiftCompileStep.java
+++ b/src/com/facebook/buck/swift/SwiftCompileStep.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Optional;
 
 /** A step that compiles Swift sources to a single module. */
 class SwiftCompileStep implements Step {
@@ -73,7 +74,7 @@ class SwiftCompileStep implements Step {
     if (result != 0) {
       LOG.error("Error running %s: %s", getDescription(context), listener.getStderr());
     }
-    return StepExecutionResult.of(result);
+    return StepExecutionResult.of(result, Optional.of(listener.getStderr()));
   }
 
   @Override


### PR DESCRIPTION
This will allow us to get the standard error stream of a swift
compilation command when it fails, into the file specified by
the --build-report option.