### PR TITLE
Expand directories in Go srcs param

### DIFF
--- a/src/com/facebook/buck/go/GoCompile.java
+++ b/src/com/facebook/buck/go/GoCompile.java
@@ -266,7 +266,8 @@ public class GoCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
       Path srcPath = context.getSourcePathResolver().getAbsolutePath(path);
       if (Files.isDirectory(srcPath)) {
         try {
-          srcFiles.addAll(Files.list(srcPath).filter(Files::isRegularFile).collect(Collectors.toList()));
+          srcFiles.addAll(
+              Files.list(srcPath).filter(Files::isRegularFile).collect(Collectors.toList()));
         } catch (IOException e) {
           throw new RuntimeException("An error occur when listing the files under " + srcPath, e);
         }

--- a/src/com/facebook/buck/go/GoCompile.java
+++ b/src/com/facebook/buck/go/GoCompile.java
@@ -113,7 +113,7 @@ public class GoCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
     ImmutableList.Builder<Path> compileSrcListBuilder = ImmutableList.builder();
     ImmutableList.Builder<Path> headerSrcListBuilder = ImmutableList.builder();
     ImmutableList.Builder<Path> asmSrcListBuilder = ImmutableList.builder();
-    List<Path> srcFiles = getSourchFiles(context);
+    List<Path> srcFiles = getSourceFiles(context);
     for (Path sourceFile : srcFiles) {
       String extension = MorePaths.getFileExtension(sourceFile).toLowerCase();
       if (extension.equals("s")) {
@@ -260,7 +260,7 @@ public class GoCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
     return steps.build();
   }
 
-  private List<Path> getSourchFiles(BuildContext context) {
+  private List<Path> getSourceFiles(BuildContext context) {
     List<Path> srcFiles = new ArrayList<>();
     for (SourcePath path : srcs) {
       Path srcPath = context.getSourcePathResolver().getAbsolutePath(path);

--- a/src/com/facebook/buck/go/GoCompile.java
+++ b/src/com/facebook/buck/go/GoCompile.java
@@ -113,27 +113,15 @@ public class GoCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
     ImmutableList.Builder<Path> compileSrcListBuilder = ImmutableList.builder();
     ImmutableList.Builder<Path> headerSrcListBuilder = ImmutableList.builder();
     ImmutableList.Builder<Path> asmSrcListBuilder = ImmutableList.builder();
-    List<Path> srcFiles = new ArrayList<>();
-    for (SourcePath path : srcs) {
-      Path srcPath = context.getSourcePathResolver().getAbsolutePath(path);
-      if (Files.isDirectory(srcPath)) {
-        try {
-          srcFiles.addAll(Files.list(srcPath).filter(Files::isRegularFile).collect(Collectors.toList()));
-        } catch (IOException e) {
-          throw new RuntimeException("An error occur when listing the files under " + srcPath, e);
-        }
-      } else {
-        srcFiles.add(srcPath);
-      }
-    }
-    for (Path f : srcFiles) {
-      String extension = MorePaths.getFileExtension(f).toLowerCase();
+    List<Path> srcFiles = getSourchFiles(context);
+    for (Path sourceFile : srcFiles) {
+      String extension = MorePaths.getFileExtension(sourceFile).toLowerCase();
       if (extension.equals("s")) {
-        asmSrcListBuilder.add(f);
+        asmSrcListBuilder.add(sourceFile);
       } else if (extension.equals("go")) {
-        compileSrcListBuilder.add(f);
+        compileSrcListBuilder.add(sourceFile);
       } else {
-        headerSrcListBuilder.add(f);
+        headerSrcListBuilder.add(sourceFile);
       }
     }
 
@@ -270,6 +258,23 @@ public class GoCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
     }
 
     return steps.build();
+  }
+
+  private List<Path> getSourchFiles(BuildContext context) {
+    List<Path> srcFiles = new ArrayList<>();
+    for (SourcePath path : srcs) {
+      Path srcPath = context.getSourcePathResolver().getAbsolutePath(path);
+      if (Files.isDirectory(srcPath)) {
+        try {
+          srcFiles.addAll(Files.list(srcPath).filter(Files::isRegularFile).collect(Collectors.toList()));
+        } catch (IOException e) {
+          throw new RuntimeException("An error occur when listing the files under " + srcPath, e);
+        }
+      } else {
+        srcFiles.add(srcPath);
+      }
+    }
+    return srcFiles;
   }
 
   @Override

--- a/src/com/facebook/buck/go/GoCompile.java
+++ b/src/com/facebook/buck/go/GoCompile.java
@@ -124,8 +124,7 @@ public class GoCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
               }
           );
         } catch (IOException e) {
-          e.printStackTrace();
-          throw new RuntimeException("An error occur when listing the files under " + srcPath);
+          throw new RuntimeException("An error occur when listing the files under " + srcPath, e);
         }
       } else {
         srcFiles.add(srcPath);

--- a/test/com/facebook/buck/go/GoBinaryIntegrationTest.java
+++ b/test/com/facebook/buck/go/GoBinaryIntegrationTest.java
@@ -171,6 +171,14 @@ public class GoBinaryIntegrationTest {
   }
 
   @Test
+  public void generatedSourceDir() throws IOException, InterruptedException {
+    ProjectWorkspace workspace =
+        TestDataHelper.createProjectWorkspaceForScenario(this, "generated_source_dir", tmp);
+    workspace.setUp();
+    workspace.runBuckBuild("//:main").assertSuccess();
+  }
+
+  @Test
   public void emptySources() throws IOException, InterruptedException {
     ProjectWorkspace workspace =
         TestDataHelper.createProjectWorkspaceForScenario(this, "empty_sources", tmp);

--- a/test/com/facebook/buck/go/testdata/generated_source_dir/BUCK.fixture
+++ b/test/com/facebook/buck/go/testdata/generated_source_dir/BUCK.fixture
@@ -1,0 +1,12 @@
+go_binary(
+    name = "main",
+    srcs = [
+        ":gen-go",
+    ],
+)
+
+genrule(
+    name = "gen-go",
+    out = ".",
+    cmd = "echo 'package main\nfunc main() { A() }\n' > $OUT/main.go && echo 'package main\nfunc A() {}\n' > $OUT/a.go",
+)


### PR DESCRIPTION
As discussed in #518 and #560, to compile the output files of a genrule, we need to make a genrule for each output. This could be problematic when the first genrule produces multiple files and their names are not predictable.

This PR makes it possible to put such genrule target in the `srcs` and compile the all generated files.