### PR TITLE
Add library path instead of classpath for android jar in d8

### DIFF
--- a/src/com/facebook/buck/android/DxStep.java
+++ b/src/com/facebook/buck/android/DxStep.java
@@ -263,7 +263,7 @@ public class DxStep extends ShellStep {
             D8Command.builder(diagnosticsHandler)
                 .addProgramFiles(inputs)
                 .setIntermediate(intermediate)
-                .addClasspathFiles(androidPlatformTarget.getAndroidJar())
+                .addLibraryFiles(androidPlatformTarget.getAndroidJar())
                 .setMode(
                     options.contains(Option.NO_OPTIMIZE)
                         ? CompilationMode.DEBUG


### PR DESCRIPTION
d8 was trying to desugar classes in android.jar which makes no sense since they are provided by the os