### PR TITLE
Support Go Subtests

### DIFF
--- a/test/com/facebook/buck/go/GoAssumptions.java
+++ b/test/com/facebook/buck/go/GoAssumptions.java
@@ -30,6 +30,7 @@ import com.facebook.buck.util.HumanReadableException;
 import com.facebook.buck.util.ProcessExecutor;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
+import org.junit.Assume;
 
 abstract class GoAssumptions {
   public static void assumeGoCompilerAvailable() throws InterruptedException, IOException {
@@ -63,5 +64,11 @@ abstract class GoAssumptions {
       exception = e;
     }
     assumeNoException(exception);
+  }
+
+  public static void assumeGoVersionGreaterThan(double requiredVersion) {
+    float actualVersion = 0;
+    Assume.assumeTrue("Acutal Go version is lower than the required version",
+        actualVersion > requiredVersion);
   }
 }

--- a/test/com/facebook/buck/go/GoAssumptions.java
+++ b/test/com/facebook/buck/go/GoAssumptions.java
@@ -89,8 +89,8 @@ abstract class GoAssumptions {
               /* timeOutMs */ Optional.empty(),
               /* timeoutHandler */ Optional.empty());
       if (goToolResult.getExitCode() == 0) {
-        // e.g., "go version go1.9.2 darwin/amd64", "go version go1.9.2 windows/amd64", "go version
-        // go1.2.1 linux/amd64"
+        // e.g., "go version go1.9.2 darwin/amd64", "go version go1.9.2 windows/amd64",
+        // "go version go1.2.1 linux/amd64"
         actualVersion = goToolResult.getStdout().get().substring(13, 18);
       } else {
         exception = new HumanReadableException(goToolResult.getStderr().get());

--- a/test/com/facebook/buck/go/GoTestIntegrationTest.java
+++ b/test/com/facebook/buck/go/GoTestIntegrationTest.java
@@ -107,4 +107,11 @@ public class GoTestIntegrationTest {
         result2.getStderr(),
         containsString("TestPanic"));
   }
+
+  @Test
+  public void testSubTests() throws IOException {
+    GoAssumptions.assumeGoVersionGreaterThan(1.7);
+    ProcessResult result = workspace.runBuckCommand("test", "//:subtests");
+    result.assertSuccess();
+  }
 }

--- a/test/com/facebook/buck/go/GoTestIntegrationTest.java
+++ b/test/com/facebook/buck/go/GoTestIntegrationTest.java
@@ -110,7 +110,7 @@ public class GoTestIntegrationTest {
 
   @Test
   public void testSubTests() throws IOException {
-    GoAssumptions.assumeGoVersionGreaterThan(1.7);
+    GoAssumptions.assumeGoVersionAtLeast("1.7.0");
     ProcessResult result = workspace.runBuckCommand("test", "//:subtests");
     result.assertSuccess();
   }

--- a/test/com/facebook/buck/go/testdata/go_test/BUCK.fixture
+++ b/test/com/facebook/buck/go/testdata/go_test/BUCK.fixture
@@ -61,3 +61,8 @@ go_test(
     srcs = ["test_spinning.go"],
     test_rule_timeout_ms = 500,
 )
+
+go_test(
+    name = "subtests",
+    srcs = ["subtests.go"],
+)

--- a/test/com/facebook/buck/go/testdata/go_test/subtests.go
+++ b/test/com/facebook/buck/go/testdata/go_test/subtests.go
@@ -1,0 +1,33 @@
+package main
+
+// modified from an example here: https://blog.golang.org/subtests
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestTime(t *testing.T) {
+	testCases := []struct {
+		gmt  string
+		loc  string
+		want string
+	}{
+		{"12:31", "Europe/Zurich", "13:31"},
+		{"12:31", "America/New_York", "07:31"},
+		{"08:08", "Australia/Sydney", "18:08"},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s in %s", tc.gmt, tc.loc), func(t *testing.T) {
+			loc, err := time.LoadLocation(tc.loc)
+			if err != nil {
+				t.Fatal("could not load location")
+			}
+			gmt, _ := time.Parse("15:04", tc.gmt)
+			if got := gmt.In(loc).Format("15:04"); got != tc.want {
+				t.Errorf("got %s; want %s", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Go 1.7 introduced subtests, which will print out report like this:

```
=== RUN   TestTime
=== RUN   TestTime/12:31_in_Europe/Zuri
=== RUN   TestTime/12:31_in_America/New_York
=== RUN   TestTime/08:08_in_Australia/Sydney
--- FAIL: TestTime (0.00s)
    --- FAIL: TestTime/12:31_in_Europe/Zuri (0.00s)
    	command_test.go:23: could not load location
    --- PASS: TestTime/12:31_in_America/New_York (0.00s)
    --- PASS: TestTime/08:08_in_Australia/Sydney (0.00s)
```

This PR make Buck capable of consuming such test report.