### PR TITLE
Force use of Python 2.7

### DIFF
--- a/bin/buck
+++ b/bin/buck
@@ -18,5 +18,5 @@ function abs_script_dir_path {
 
 BUCK_DIR=$(abs_script_dir_path "$0")
 
-PYTHON=$(command -v python2.7 python | head -1)
+PYTHON=$(command -v python2.7 python2 python | head -1)
 PYTHONPATH="$BUCK_DIR"/../third-party/nailgun exec $PYTHON "$BUCK_DIR"/../programs/buck.py "$@"

--- a/bin/buck
+++ b/bin/buck
@@ -18,5 +18,5 @@ function abs_script_dir_path {
 
 BUCK_DIR=$(abs_script_dir_path "$0")
 
-PYTHON=$(command -v python2 python | head -1)
+PYTHON=$(command -v python2.7 python | head -1)
 PYTHONPATH="$BUCK_DIR"/../third-party/nailgun exec $PYTHON "$BUCK_DIR"/../programs/buck.py "$@"


### PR DESCRIPTION
Buck requires Python 2.7, so force its use.  One one of my machines, "python2" unfortunately resolves to Python 2.6 even though Python 2.7 is on my PATH.

Unfortunately, I can't uninstall Python 2.6 for reasons I won't go into.