### PR TITLE
[Python] Remove test args that do not affect the output from rulekeys

### DIFF
--- a/src/com/facebook/buck/python/PythonTest.java
+++ b/src/com/facebook/buck/python/PythonTest.java
@@ -21,7 +21,6 @@ import com.facebook.buck.io.filesystem.ProjectFilesystem;
 import com.facebook.buck.model.BuildTarget;
 import com.facebook.buck.model.BuildTargets;
 import com.facebook.buck.rules.AbstractBuildRuleWithDeclaredAndExtraDeps;
-import com.facebook.buck.rules.AddToRuleKey;
 import com.facebook.buck.rules.BinaryBuildRule;
 import com.facebook.buck.rules.BuildContext;
 import com.facebook.buck.rules.BuildRule;
@@ -64,8 +63,8 @@ public class PythonTest extends AbstractBuildRuleWithDeclaredAndExtraDeps
     implements TestRule, HasRuntimeDeps, ExternalTestRunnerRule, BinaryBuildRule {
 
   private final Supplier<? extends SortedSet<BuildRule>> originalDeclaredDeps;
-  @AddToRuleKey private final Supplier<ImmutableMap<String, String>> env;
-  @AddToRuleKey private final PythonBinary binary;
+  private final Supplier<ImmutableMap<String, String>> env;
+  private final PythonBinary binary;
   private final ImmutableSet<String> labels;
   private final Optional<Long> testRuleTimeoutMs;
   private final ImmutableSet<String> contacts;


### PR DESCRIPTION
Buck does not cache results of tests anymore

This change removes all the args that affect the runtime behavior of tests (since the test rules run always anyway)