### PR TITLE
[Cxx] Remove test args that do not affect the output from rulekeys

### DIFF
--- a/src/com/facebook/buck/cxx/CxxTest.java
+++ b/src/com/facebook/buck/cxx/CxxTest.java
@@ -63,9 +63,9 @@ import java.util.stream.Stream;
 public abstract class CxxTest extends AbstractBuildRuleWithDeclaredAndExtraDeps
     implements TestRule, HasRuntimeDeps, BinaryBuildRule {
 
-  @AddToRuleKey private final ImmutableMap<String, Arg> env;
-  @AddToRuleKey private final ImmutableList<Arg> args;
-  @AddToRuleKey private final Tool executable;
+  private final ImmutableMap<String, Arg> env;
+  private final ImmutableList<Arg> args;
+  private final Tool executable;
 
   @AddToRuleKey
   @SuppressWarnings("PMD.UnusedPrivateField")


### PR DESCRIPTION
Buck does not cache results of tests anymore

This change removes all the args that affect the runtime behavior of tests (since the test rules run always anyway)