### PR TITLE
[Apple] Remove test args that do not affect the output from rulekeys

### DIFF
--- a/src/com/facebook/buck/apple/AppleTest.java
+++ b/src/com/facebook/buck/apple/AppleTest.java
@@ -72,36 +72,36 @@ import java.util.stream.Stream;
 public class AppleTest extends AbstractBuildRuleWithDeclaredAndExtraDeps
     implements TestRule, HasRuntimeDeps, ExternalTestRunnerRule {
 
-  @AddToRuleKey private final Optional<SourcePath> xctool;
+  private final Optional<SourcePath> xctool;
 
-  @AddToRuleKey private Optional<Long> xctoolStutterTimeout;
+  private Optional<Long> xctoolStutterTimeout;
 
-  @AddToRuleKey private final Tool xctest;
+  private final Tool xctest;
 
-  @AddToRuleKey private final boolean useXctest;
+  private final boolean useXctest;
 
-  @AddToRuleKey private final String platformName;
+  private final String platformName;
 
   private final Optional<String> defaultDestinationSpecifier;
   private final Optional<ImmutableMap<String, String>> destinationSpecifier;
 
-  @AddToRuleKey private final AppleBundle testBundle;
+  private final AppleBundle testBundle;
 
   @AddToRuleKey private final Optional<AppleBundle> testHostApp;
 
-  @AddToRuleKey private final Optional<AppleBundle> uiTestTargetApp;
+  private final Optional<AppleBundle> uiTestTargetApp;
 
   private final ImmutableSet<String> contacts;
   private final ImmutableSet<String> labels;
 
-  @AddToRuleKey private final boolean runTestSeparately;
+  private final boolean runTestSeparately;
 
   @AddToRuleKey private final boolean isUiTest;
 
   private final Path testOutputPath;
   private final Path testLogsPath;
 
-  @AddToRuleKey private final Optional<Either<SourcePath, String>> snapshotReferenceImagesPath;
+  private final Optional<Either<SourcePath, String>> snapshotReferenceImagesPath;
 
   private Optional<Long> testRuleTimeoutMs;
 


### PR DESCRIPTION
Buck does not cache results of tests anymore

This change removes all the args that affect the runtime behavior of tests (since the test rules run always anyway)