### PR TITLE
[Android] Fix primary dex scenario file usage when progaurd is enabled.

### DIFF
--- a/src/com/facebook/buck/android/SplitZipStep.java
+++ b/src/com/facebook/buck/android/SplitZipStep.java
@@ -265,8 +265,8 @@ public class SplitZipStep implements Step {
       String internalClassName =
           Preconditions.checkNotNull(deobfuscate.apply(classFileName.replaceAll("\\.class$", "")));
 
-      return primaryDexClassNames.contains(internalClassName) ||
-          primaryDexFilter.matches(internalClassName);
+      return primaryDexClassNames.contains(internalClassName)
+          || primaryDexFilter.matches(internalClassName);
     };
   }
 
@@ -394,7 +394,8 @@ public class SplitZipStep implements Step {
       throws IOException {
 
     Function<String, String> obfuscationFunction = translatorFactory.createObfuscationFunction();
-    Function<String, String> deObfuscationFunction = translatorFactory.createDeobfuscationFunction();
+    Function<String, String> deObfuscationFunction =
+        translatorFactory.createDeobfuscationFunction();
 
     ImmutableList<Type> scenarioClasses =
         filesystem
@@ -410,10 +411,7 @@ public class SplitZipStep implements Step {
     FirstOrderHelper.addTypesAndDependencies(scenarioClasses, classesSupplier.get(), classBuilder);
 
     builder.addAll(
-        classBuilder.build()
-            .stream()
-            .map(deObfuscationFunction)
-            .collect(Collectors.toSet()));
+        classBuilder.build().stream().map(deObfuscationFunction).collect(Collectors.toSet()));
   }
 
   @VisibleForTesting

--- a/src/com/facebook/buck/android/dalvik/firstorder/FirstOrderHelper.java
+++ b/src/com/facebook/buck/android/dalvik/firstorder/FirstOrderHelper.java
@@ -43,7 +43,7 @@ public class FirstOrderHelper {
     helper.addDependencies(allClasses);
   }
 
-  private ImmutableSet<String> addDependencies(Iterable<ClassNode> allClasses) {
+  private void addDependencies(Iterable<ClassNode> allClasses) {
     for (ClassNode classNode : allClasses) {
       FirstOrderVisitorContext context = new FirstOrderVisitorContext();
       classNode.accept(context.classVisitor);
@@ -62,8 +62,6 @@ public class FirstOrderHelper {
     for (Type type : scenarioTypes) {
       addFirstOrderTypes(type);
     }
-
-    return resultBuilder.build();
   }
 
   private void addFirstOrderTypes(Type type) {


### PR DESCRIPTION
While computing the scenario classes, input scenario classes were being
obfuscated to get the dependent classes, but the dependent classes which
were not being de-obfuscated.

Since `createRequiredInPrimaryZipPredicate` needs to de-obfuscate the 
input classFileName primary dex scenario file wouldn’t work with proguard.