### PR TITLE
[buck] Allow implicit native functions in skylark extension files

### DIFF
--- a/docs/concept/buckconfig.soy
+++ b/docs/concept/buckconfig.soy
@@ -2879,6 +2879,7 @@ your <code>.buckjavaargs</code> file</a>:
   {param section: 'parser' /}
   {param name: 'disable_implicit_native_rules' /}
   {param example_value: 'true' /}
+  {param default_value: 'false' /}
   {param description}
     If set, native rules (cxx_library, android_library, etc) cannot be used in BUCK files. This
     can be useful if your team has a common set of macros that should be loaded, and one desires
@@ -2886,6 +2887,21 @@ your <code>.buckjavaargs</code> file</a>:
     native rules can only be accessed via the 'native' object within an extension file that is
     evaluated with {call buck.fn_load /} or {call buck.fn_include_defs /}.
     This flag is disabled by default (native rules can be used in build files).
+  {/param}
+{/call}
+
+{call buckconfig.entry}
+  {param section: 'parser' /}
+  {param name: 'enable_implicit_native_rules_in_extensions' /}
+  {param example_value: 'true' /}
+  {param default_value: 'false' /}
+  {param description}
+    If set, native rules (cxx_library, android_library, etc) can be used in extension files
+    without the 'native.' prefix when using the skylark parser. This is useful when migrating 
+    from the python based parser, but it is suggested users try to migrate their files to use
+    the native. syntax so as to make it absolutely clear where rule definitions are coming from.
+    This flag is disabled by default (native rules cannot be used without the native. prefix in 
+    extension files in skylark).
   {/param}
 {/call}
 

--- a/src/com/facebook/buck/parser/AbstractParserConfig.java
+++ b/src/com/facebook/buck/parser/AbstractParserConfig.java
@@ -244,6 +244,16 @@ abstract class AbstractParserConfig implements ConfigView<BuckConfig> {
     return getDelegate().getBooleanValue("parser", "disable_implicit_native_rules", false);
   }
 
+  /**
+   * @return whether native build rules are available for users in extension files. If not, they are
+   *     only accessible in extension files under the 'native' object
+   */
+  @Value.Lazy
+  public boolean getEnableImplicitNativeRulesInExtensions() {
+    return getDelegate()
+        .getBooleanValue("parser", "enable_implicit_native_rules_in_extensions", false);
+  }
+
   /** @return whether Buck should warn about deprecated syntax. */
   @Value.Lazy
   public boolean isWarnAboutDeprecatedSyntax() {

--- a/src/com/facebook/buck/parser/ProjectBuildFileParserFactory.java
+++ b/src/com/facebook/buck/parser/ProjectBuildFileParserFactory.java
@@ -102,6 +102,8 @@ public class ProjectBuildFileParserFactory {
             .setBuildFileImportWhitelist(parserConfig.getBuildFileImportWhitelist())
             .setDisableImplicitNativeRules(parserConfig.getDisableImplicitNativeRules())
             .setWarnAboutDeprecatedSyntax(parserConfig.isWarnAboutDeprecatedSyntax())
+            .setEnableImplicitNativeRulesInExtensions(
+                parserConfig.getEnableImplicitNativeRulesInExtensions())
             .build();
     return EventReportingProjectBuildFileParser.of(
         createProjectBuildFileParser(

--- a/src/com/facebook/buck/parser/options/AbstractProjectBuildFileParserOptions.java
+++ b/src/com/facebook/buck/parser/options/AbstractProjectBuildFileParserOptions.java
@@ -91,6 +91,11 @@ abstract class AbstractProjectBuildFileParserOptions {
   }
 
   @Value.Default
+  public boolean getEnableImplicitNativeRulesInExtensions() {
+    return false;
+  }
+
+  @Value.Default
   public boolean isWarnAboutDeprecatedSyntax() {
     return true;
   }

--- a/src/com/facebook/buck/skylark/parser/SkylarkProjectBuildFileParser.java
+++ b/src/com/facebook/buck/skylark/parser/SkylarkProjectBuildFileParser.java
@@ -144,7 +144,7 @@ public class SkylarkProjectBuildFileParser implements ProjectBuildFileParser {
 
   /** Always disable implicit native imports in skylark rules, they should utilize native.foo */
   private Environment.Frame getBuckLoadContextGlobals() {
-    return getBuckGlobals(true);
+    return getBuckGlobals(!options.getEnableImplicitNativeRulesInExtensions());
   }
 
   /** Disable implicit native rules depending on configuration */

--- a/test/com/facebook/buck/parser/ParserIntegrationTest.java
+++ b/test/com/facebook/buck/parser/ParserIntegrationTest.java
@@ -435,9 +435,6 @@ public class ParserIntegrationTest {
     workspace.runBuckBuild("//python/native_in_extension_bzl:main").assertSuccess();
 
     // Skylark interpreter, true / false / default for disabling implicit native rules
-    // TODO: Specific error messages are disabled until we hook up the skylark parser to the
-    // general buck event bus, since that's how we get messages in integration tests (and how
-    // the python parser is hooked up)
 
     assertParseFailedWithSubstrings(
         workspace.runBuckBuild(
@@ -518,6 +515,24 @@ public class ParserIntegrationTest {
             "parser.polyglot_parsing_enabled=true",
             "-c",
             "parser.default_build_file_syntax=SKYLARK")
+        .assertSuccess();
+  }
+
+  @Test
+  public void enablingImplicitNativeRulesMakesThemAvailableInExtensionFiles() throws IOException {
+    ProjectWorkspace workspace =
+        TestDataHelper.createProjectWorkspaceForScenario(
+            this, "disable_implicit_native_rules", temporaryFolder);
+    workspace.setUp();
+    workspace
+        .runBuckBuild(
+            "//skylark/implicit_in_extension_bzl:main",
+            "-c",
+            "parser.polyglot_parsing_enabled=true",
+            "-c",
+            "parser.default_build_file_syntax=SKYLARK",
+            "-c",
+            "parser.enable_implicit_native_rules_in_extensions=true")
         .assertSuccess();
   }
 


### PR DESCRIPTION
With skylark, we're trying to enforce that 'native' should be used to access native rules. However, when migrating from python_dsl -> skylark, it can be useful to have the native rules exposed in the global scope. This allows it to be configured, but by default we disallow it to encourage new projects to not follow the globals practice. 