### PR TITLE
[TravisCI] Do not install unnecessary packages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,6 @@ sudo: false
 
 addons:
   apt:
-    sources:
-      # For newer gcc than precise supports out of the box.
-      - ubuntu-toolchain-r-test
-      # For newer ghc than precise supports out of the box.
-      - hvr-ghc
     packages:
       # Travis is on 64bit and there will be a cryptic aapt error w/o these libs.
       # For native code tests, we need some additional libraries if we are in a 64-bit environment.
@@ -29,19 +24,14 @@ addons:
       - zlib1g:i386
       - groovy
         # We rely on -gno-record-gcc-switches which was added in 4.7.
-      - gcc-4.7
-      - g++-4.7
+      - gcc
+      - g++
       # Getting compile errors on javac 1.8.0_31-b13
       - oracle-java8-installer
       # Haskell tests require GHC (and at least version 7.6).
-      - ghc-8.0.2
+      - ghc
 
 before_install:
-  - rm -rf ${HOME}/travis-cxx
-  - mkdir ${HOME}/travis-cxx
-  - ln -s /usr/bin/gcc-4.7 ${HOME}/travis-cxx/gcc
-  - ln -s /usr/bin/g++-4.7 ${HOME}/travis-cxx/g++
-  - export PATH=${HOME}/travis-cxx:$PATH
   # Limit Ant's and Buck's memory usage to avoid the OOM killer.
   - export ANT_OPTS='-Xmx500m'
   - echo '-Xmx500m' > .buckjavaargs.local
@@ -55,8 +45,6 @@ before_install:
   - echo -e "[go]\n  root = ${GOROOT}" >> .buckconfig.local
   # Set up the Groovy environment
   - export GROOVY_HOME=/usr/share/groovy/
-  # Haskell setup:
-  - export PATH=/opt/ghc/8.0.2/bin:$PATH
 
 # Buck dependencies are checked in, so no need to download dependencies
 install: true


### PR DESCRIPTION
Trusty now has a GCC 4.8 and a GHC 7.6 packages available by default, so there is not need to install them from external sources. Also, default version of GCC is most likely already pulled in by some other dependencies, so in the end we should end up pulling in fewer packages.