### PR TITLE
[TravisCI] Fix Haskell integration tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,9 @@ addons:
       - oracle-java8-installer
       # Haskell tests require GHC (and at least version 7.6).
       - ghc
+      # base ghc package does not include dynamic libraries
+      # https://stackoverflow.com/a/11711501/1548477
+      - ghc-dynamic
 
 before_install:
   # Limit Ant's and Buck's memory usage to avoid the OOM killer.


### PR DESCRIPTION
Ubuntu's base `ghc` package does not include dynamic libraries, which leads to
runtime errors like:
```
    Could not find module `Prelude'
    Perhaps you haven't installed the "dyn" libraries for package `base'?
    Use -v to see a list of the files searched for.
```
`ghc-dynamic` package provides dynamic libraries and as such fixes failing integration tests.