### PR TITLE
[TravisCI] Fix Go integration tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,8 @@ before_install:
   # Set up the Android environment.
   - export NDK_HOME=${HOME}/android-ndk-linux
   - ./scripts/travisci_install_android_ndk.sh
-  # Install go 1.5
-  - eval "$(gimme 1.5)"
+  # Install go 1.8, required for cgo -srcdir flag to work
+  - eval "$(gimme 1.8)"
   - echo -e "[go]\n  root = ${GOROOT}" >> .buckconfig.local
   # Set up the Groovy environment
   - export GROOVY_HOME=/usr/share/groovy/


### PR DESCRIPTION
cgo `-srcdir` flag was introduced in go 1.8, so this change
bumps the installed version of Go to 1.8.