### PR TITLE
[TravisCI] Enable tests on openjdk8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: android
 jdk:
+  - openjdk8
   - oraclejdk8
 env:
   - CI_ACTION=build


### PR DESCRIPTION
Most Linux distributions use OpenJDK8 instead of proprietary Oracle JDK,
so it's important to keep it in a good shape. This change adds a JDK
dimension to Buck's test matrix.