### PR TITLE
[TravisCI] Run integration tests on MacOS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,71 +1,150 @@
 language: android
-jdk:
-  - openjdk8
-  - oraclejdk8
-env:
-  - CI_ACTION=build
-  - CI_ACTION=unit
-  - CI_ACTION=integration
-  - CI_ACTION=heavy_integration
-  - CI_ACTION=ant
 
-dist: trusty
+matrix:
+  include:
+  - os: linux
+    jdk: oraclejdk8
+    dist: trusty
+    addons:
+      apt:
+        packages:
+          - ant
+    env: CI_ACTION=build
+    # ANDROID_SDK is required for build.
+    android:
+      components:
+        - tools
+        - platform-tools
+        - build-tools-23.0.2
+        - android-23
+  - os: linux
+    jdk: openjdk8
+    dist: trusty
+    addons:
+      apt:
+        packages:
+          - ant
+    env: CI_ACTION=build
+    # ANDROID_SDK is required for build.
+    android:
+      components:
+        - tools
+        - platform-tools
+        - build-tools-23.0.2
+        - android-23
+  - os: linux
+    jdk: openjdk8
+    dist: trusty
+    addons:
+      apt:
+        packages:
+          - ant
+          - groovy
+    env: CI_ACTION=unit GROOVY_HOME=/usr/share/groovy/
+    # ANDROID_SDK is required for build.
+    android:
+      components:
+        - tools
+        - platform-tools
+        - build-tools-23.0.2
+        - android-23
+  - os: linux
+    jdk: openjdk8
+    dist: trusty
+    addons:
+      apt:
+        packages:
+          - ant
+    env: CI_ACTION=ant
+    # ANDROID_HOME required for javadoc verification.
+    android:
+      components:
+        - tools
+        - platform-tools
+        - build-tools-23.0.2
+        - android-23
+  - os: linux
+    jdk: openjdk8
+    dist: trusty
+    addons:
+      apt:
+        packages:
+          - ant
+          - groovy
+            # We rely on -gno-record-gcc-switches which was added in 4.7.
+          - gcc
+          - g++
+          # Haskell tests require GHC (and at least version 7.6).
+          - ghc
+          # base ghc package does not include dynamic libraries
+          # https://stackoverflow.com/a/11711501/1548477
+          - ghc-dynamic
+    env: CI_ACTION=integration GROOVY_HOME=/usr/share/groovy/
+    # ANDROID_SDK is required for build.
+    android:
+      components:
+        - tools
+        - platform-tools
+        - build-tools-23.0.2
+        - android-23
+  - os: linux
+    jdk: openjdk8
+    android:
+      components:
+        - tools
+        - platform-tools
+        - build-tools-23.0.2
+        - android-23
+        - addon-google_apis-google-23
+        - android-21
+        - addon-google_apis-google-21
+        - extra-android-support
+    dist: trusty
+    addons:
+      apt:
+        packages:
+          - ant
+          # Travis is on 64bit and there will be a cryptic aapt error w/o these libs.
+          # For native code tests, we need some additional libraries if we are in a 64-bit environment.
+          - libgd2-xpm-dev
+          - libc6:i386
+          - libstdc++6:i386
+          - zlib1g:i386
+            # We rely on -gno-record-gcc-switches which was added in 4.7.
+          - gcc
+          - g++
+          # Haskell tests require GHC (and at least version 7.6).
+          - ghc
+          # base ghc package does not include dynamic libraries
+          # https://stackoverflow.com/a/11711501/1548477
+          - ghc-dynamic
+    # https://docs.travis-ci.com/user/caching#Things-not-to-cache
+    # https://docs.travis-ci.com/user/caching#Explicitly-disabling-caching
+    cache:
+      directories:
+        - $HOME/ndk_cache
+    env: CI_ACTION=heavy_integration
 
 # Enable container-based architecture.
 sudo: false
 
-android:
-  components:
-  - tools
-  - platform-tools
-  - build-tools-23.0.2
-  - android-23
-  - addon-google_apis-google-23
-  - android-21
-  - addon-google_apis-google-21
-  - extra-android-support
-
-addons:
-  apt:
-    packages:
-      - ant
-      # Travis is on 64bit and there will be a cryptic aapt error w/o these libs.
-      # For native code tests, we need some additional libraries if we are in a 64-bit environment.
-      - libgd2-xpm-dev
-      - libc6:i386
-      - libstdc++6:i386
-      - zlib1g:i386
-      - groovy
-        # We rely on -gno-record-gcc-switches which was added in 4.7.
-      - gcc
-      - g++
-      # Haskell tests require GHC (and at least version 7.6).
-      - ghc
-      # base ghc package does not include dynamic libraries
-      # https://stackoverflow.com/a/11711501/1548477
-      - ghc-dynamic
-
 before_install:
+  # Install ant on MacOS
+  - if \[ ${TRAVIS_OS_NAME} == "osx" \]; then brew install ant; fi
   # Limit Ant's and Buck's memory usage to avoid the OOM killer.
   - export ANT_OPTS='-Xmx500m'
   - echo '-Xmx500m' > .buckjavaargs.local
-  # Set up the Android environment.
-  - export NDK_HOME=${HOME}/android-ndk-linux
-  - ./scripts/travisci_install_android_ndk.sh
+  # Set up the Android environment. Only for Linux.
+  - if \[ ${TRAVIS_OS_NAME} == "linux" \] && \[ "${CI_ACTION}" == "heavy_integration" \]; then
+      export NDK_HOME="${HOME}/android-ndk-linux" ;
+      ./scripts/travisci_install_android_ndk.sh ;
+    fi
   # Install go 1.8, required for cgo -srcdir flag to work
   - eval "$(gimme 1.8)"
   - echo -e "[go]\n  root = ${GOROOT}" >> .buckconfig.local
-  # Set up the Groovy environment
-  - export GROOVY_HOME=/usr/share/groovy/
 
 # Buck dependencies are checked in, so no need to download dependencies
 install: true
-
-# https://docs.travis-ci.com/user/caching#Things-not-to-cache
-# https://docs.travis-ci.com/user/caching#Explicitly-disabling-caching
-cache:
-  directories:
-    - $HOME/ndk_cache
 
 notifications:
   slack:


### PR DESCRIPTION
Buck has a number of Apple integration tests which are skipped on
Linux OS. Apple test health is extremely important for Buck, so this
change includes integration tests on OSX into test matrix.