### PR TITLE
[TravisCI] Remove no longer needed Ubuntu package.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,6 @@ addons:
         # We rely on -gno-record-gcc-switches which was added in 4.7.
       - gcc
       - g++
-      # Getting compile errors on javac 1.8.0_31-b13
-      - oracle-java8-installer
       # Haskell tests require GHC (and at least version 7.6).
       - ghc
       # base ghc package does not include dynamic libraries


### PR DESCRIPTION
This package was only needed for the older version of Ubuntu and
is no longer required for Trusty and later.