### PR TITLE
 Add per target environent to apple_test

### DIFF
--- a/src/com/facebook/buck/apple/AppleTestDescription.java
+++ b/src/com/facebook/buck/apple/AppleTestDescription.java
@@ -346,7 +346,7 @@ public class AppleTestDescription
             .orElse(appleConfig.getDelegate().getDefaultTestRuleTimeoutMs()),
         args.getIsUiTest(),
         args.getSnapshotReferenceImagesPath(),
-        args.getEnvironment());
+        args.getEnv());
   }
 
   private Optional<SourcePath> getXctool(
@@ -657,8 +657,8 @@ public class AppleTestDescription
     // Bundle related fields.
     ImmutableMap<String, String> getDestinationSpecifier();
 
-    // Bundle related fields.
-    Optional<ImmutableMap<String, String>> getEnvironment();
+    // Environment variables to set during the test run
+    Optional<ImmutableMap<String, String>> getEnv();
 
     @Override
     default Either<AppleBundleExtension, String> getExtension() {

--- a/src/com/facebook/buck/apple/AppleTestDescription.java
+++ b/src/com/facebook/buck/apple/AppleTestDescription.java
@@ -345,7 +345,8 @@ public class AppleTestDescription
             .map(Optional::of)
             .orElse(appleConfig.getDelegate().getDefaultTestRuleTimeoutMs()),
         args.getIsUiTest(),
-        args.getSnapshotReferenceImagesPath());
+        args.getSnapshotReferenceImagesPath(),
+        args.getEnvironment());
   }
 
   private Optional<SourcePath> getXctool(
@@ -655,6 +656,9 @@ public class AppleTestDescription
 
     // Bundle related fields.
     ImmutableMap<String, String> getDestinationSpecifier();
+
+    // Bundle related fields.
+    Optional<ImmutableMap<String, String>> getEnvironment();
 
     @Override
     default Either<AppleBundleExtension, String> getExtension() {

--- a/test/com/facebook/buck/apple/AppleTestIntegrationTest.java
+++ b/test/com/facebook/buck/apple/AppleTestIntegrationTest.java
@@ -602,6 +602,28 @@ public class AppleTestIntegrationTest {
   }
 
   @Test
+  public void targetspecificEnvironmentOverrideAffectsXctestTest() throws Exception {
+    ProjectWorkspace workspace =
+        TestDataHelper.createProjectWorkspaceForScenario(this, "apple_test_env", tmp);
+    workspace.setUp();
+    ProcessResult result;
+    result =
+        workspace.runBuckCommand(
+            "test", "--config", "apple.xctest_platforms=macosx", "//:foo#macosx-x86_64");
+    result.assertTestFailure("normally the test should fail");
+    workspace.resetBuildLogFile();
+    result =
+        workspace.runBuckCommand(
+            "test",
+            "--config",
+            "apple.xctest_platforms=macosx",
+            "--config",
+            "testcase.set_targetspecific_env=True",
+            "//:foo#macosx-x86_64");
+    result.assertSuccess("should pass when I pass correct environment");
+  }
+
+  @Test
   public void appleTestWithoutTestHostShouldSupportMultiarch() throws Exception {
     ProjectWorkspace workspace =
         TestDataHelper.createProjectWorkspaceForScenario(this, "apple_test_xctest", tmp);

--- a/test/com/facebook/buck/apple/XctoolRunTestsStepTest.java
+++ b/test/com/facebook/buck/apple/XctoolRunTestsStepTest.java
@@ -665,7 +665,7 @@ public class XctoolRunTestsStepTest {
         new XctoolRunTestsStep(
             projectFilesystem,
             Paths.get("/path/to/xctool"),
-            ImmutableMap.of(),
+            ImmutableMap.of("LLVM_PROFILE_FILE", "/tmp/some.profraw"),
             Optional.empty(),
             "iphonesimulator",
             Optional.empty(),
@@ -702,7 +702,8 @@ public class XctoolRunTestsStepTest {
                     "DEVELOPER_DIR", "/path/to/developer/dir",
                     "XCTOOL_TEST_ENV_TEST_LOG_PATH", "/path/to/test-logs",
                     "XCTOOL_TEST_ENV_TEST_LOG_LEVEL", "verbose",
-                    "XCTOOL_TEST_ENV_FB_REFERENCE_IMAGE_DIR", "/path/to/snapshotimages"))
+                    "XCTOOL_TEST_ENV_FB_REFERENCE_IMAGE_DIR", "/path/to/snapshotimages",
+                    "LLVM_PROFILE_FILE", "/tmp/some.profraw"))
             .setDirectory(projectFilesystem.getRootPath().toAbsolutePath())
             .setRedirectOutput(ProcessBuilder.Redirect.PIPE)
             .build();

--- a/test/com/facebook/buck/apple/testdata/apple_test_env/BUCK.fixture
+++ b/test/com/facebook/buck/apple/testdata/apple_test_env/BUCK.fixture
@@ -1,3 +1,7 @@
+kwargs = {}
+if read_config("testcase", "set_targetspecific_env", False):
+	kwargs['environment'] = {"FOO": "bar"}
+
 apple_test(
     name = "foo",
     srcs = ["FooXCTest.m"],
@@ -6,4 +10,5 @@ apple_test(
         "$SDKROOT/System/Library/Frameworks/Foundation.framework",
     ],
     info_plist = "Test.plist",
+    **kwargs
 )

--- a/test/com/facebook/buck/apple/testdata/apple_test_env/BUCK.fixture
+++ b/test/com/facebook/buck/apple/testdata/apple_test_env/BUCK.fixture
@@ -1,6 +1,6 @@
 kwargs = {}
 if read_config("testcase", "set_targetspecific_env", False):
-	kwargs['environment'] = {"FOO": "bar"}
+	kwargs['env'] = {"FOO": "bar"}
 
 apple_test(
     name = "foo",


### PR DESCRIPTION
Enable target specific environment variables to be set for apple_test
rules. This is for example useful to set variables like
LLVM_PROFILE_FILE and get a per test target file with profile data.