### PR TITLE
[TravisCI] Use latest version of Google format.

### DIFF
--- a/scripts/travisci_test_java_file_format
+++ b/scripts/travisci_test_java_file_format
@@ -11,8 +11,9 @@ trap finish EXIT
 
 REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 
-FORMAT_JAR_URL="https://github.com/google/google-java-format/releases/download/google-java-format-1.4/google-java-format-1.4-all-deps.jar"
-FORMAT_JAR_LOCATION="${HOME}/google-java-format-1.4-all-deps.jar"
+FORMAT_JAR_NAME="google-java-format-1.5-all-deps.jar"
+FORMAT_JAR_URL="https://github.com/google/google-java-format/releases/download/google-java-format-1.5/${FORMAT_JAR_NAME}"
+FORMAT_JAR_LOCATION="${HOME}/${FORMAT_JAR_NAME}"
 
 wget -O "${FORMAT_JAR_LOCATION}" "${FORMAT_JAR_URL}"
 


### PR DESCRIPTION
Entire Buck codebase is formatted with google-format version 1.5.