### PR TITLE
Add unified headers support

### DIFF
--- a/src/com/facebook/buck/android/AndroidBuckConfig.java
+++ b/src/com/facebook/buck/android/AndroidBuckConfig.java
@@ -97,7 +97,7 @@ public class AndroidBuckConfig {
     return delegate.getListWithoutComments("ndk", "extra_ldflags", ' ');
   }
 
-  public boolean getNdkUnifiedHeaders() {
+  public boolean isNdkUnifiedHeaders() {
     return delegate.getBooleanValue("ndk", "unified_headers", false);
   }
 

--- a/src/com/facebook/buck/android/AndroidBuckConfig.java
+++ b/src/com/facebook/buck/android/AndroidBuckConfig.java
@@ -97,6 +97,10 @@ public class AndroidBuckConfig {
     return delegate.getListWithoutComments("ndk", "extra_ldflags", ' ');
   }
 
+  public boolean getNdkUnifiedHeaders() {
+    return delegate.getBooleanValue("ndk", "unified_headers", false);
+  }
+
   public boolean isGrayscaleImageProcessingEnabled() {
     return delegate.getBooleanValue("resources", "resource_grayscale_enabled", false);
   }

--- a/src/com/facebook/buck/android/toolchain/ndk/AbstractNdkCxxPlatformTargetConfiguration.java
+++ b/src/com/facebook/buck/android/toolchain/ndk/AbstractNdkCxxPlatformTargetConfiguration.java
@@ -28,6 +28,11 @@ abstract class AbstractNdkCxxPlatformTargetConfiguration {
 
   public abstract String getTargetAppPlatform();
 
+  @Value.Derived
+  public int getTargetAppPlatformLevel() {
+    return Integer.parseInt(getTargetAppPlatform().substring("android-".length()));
+  }
+
   public abstract NdkCxxPlatformCompiler getCompiler();
 
   @Value.Derived

--- a/src/com/facebook/buck/android/toolchain/ndk/impl/NdkCxxPlatforms.java
+++ b/src/com/facebook/buck/android/toolchain/ndk/impl/NdkCxxPlatforms.java
@@ -749,9 +749,12 @@ public class NdkCxxPlatforms {
 
   private static ImmutableList<String> getCommonIncludes(NdkCxxToolchainPaths toolchainPaths) {
     ImmutableList.Builder<String> flags = new Builder<String>().add(
-        "-isystem", toolchainPaths.getNdkToolRoot().resolve("include").toString(),
-        "-isystem", toolchainPaths.getLibPath().resolve("include").toString(),
-        "-isystem", toolchainPaths.getIncludeSysroot().resolve("usr").resolve("include").toString(),
+        "-isystem",
+        toolchainPaths.getNdkToolRoot().resolve("include").toString(),
+        "-isystem",
+        toolchainPaths.getLibPath().resolve("include").toString(),
+        "-isystem",
+        toolchainPaths.getIncludeSysroot().resolve("usr").resolve("include").toString(),
         "-isystem",
         toolchainPaths.getIncludeSysroot().resolve("usr").resolve("include").resolve("linux")
             .toString());

--- a/src/com/facebook/buck/android/toolchain/ndk/impl/NdkCxxPlatforms.java
+++ b/src/com/facebook/buck/android/toolchain/ndk/impl/NdkCxxPlatforms.java
@@ -417,7 +417,7 @@ public class NdkCxxPlatforms {
             host.toString(),
             cxxRuntime,
             strictToolchainPaths,
-            androidConfig.getNdkUnifiedHeaders());
+            androidConfig.isNdkUnifiedHeaders());
     // Sanitized paths will have magic placeholders for parts of the paths that
     // are machine/host-specific. See comments on ANDROID_NDK_ROOT and
     // BUILD_HOST_SUBST above.
@@ -742,7 +742,9 @@ public class NdkCxxPlatforms {
     // NDK builds enable stack protector and debug symbols by default.
     flags.add("-fstack-protector", "-g3");
 
-    flags.add("-D__ANDROID_API__=" + targetConfiguration.getTargetAppPlatformLevel());
+    if (toolchainPaths.isUnifiedHeaders()) {
+      flags.add("-D__ANDROID_API__=" + targetConfiguration.getTargetAppPlatformLevel());
+    }
 
     return flags.build();
   }


### PR DESCRIPTION
See #1730. Spec: https://android.googlesource.com/platform/ndk/+/ndk-release-r16/docs/UnifiedHeaders.md

NDK 15 only support android api 14+, so I think there's a number of tests that break because of this. I also haven't added any tests for this PR yet, but it does compile a sample project.