### PR TITLE
Add tests for modular swift libraries

### DIFF
--- a/test/com/facebook/buck/apple/AppleLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/apple/AppleLibraryIntegrationTest.java
@@ -870,6 +870,43 @@ public class AppleLibraryIntegrationTest {
     result.assertSuccess();
   }
 
+  @Test
+  public void testBuildAppleLibraryWhereModularObjcUsesSwiftDiffLib() throws Exception {
+    testModularScenario("apple_library_modular_objc_uses_swift_diff_lib", "Bar");
+  }
+
+  @Test
+  public void testBuildAppleLibraryWhereModularObjcUsesSwiftSameLib() throws Exception {
+    testModularScenario("apple_library_modular_objc_uses_swift_same_lib", "Mixed");
+  }
+
+  @Test
+  public void testBuildAppleLibraryWhereModularSwiftUsesObjcDiffLib() throws Exception {
+    testModularScenario("apple_library_modular_swift_uses_objc_diff_lib", "Bar");
+  }
+
+  @Test
+  public void testBuildAppleLibraryWhereModularSwiftUsesObjcSameLib() throws Exception {
+    testModularScenario("apple_library_modular_swift_uses_objc_same_lib", "Mixed");
+  }
+
+  private void testModularScenario(String scenario, String targetName) throws Exception {
+    assumeTrue(Platform.detect() == Platform.MACOS);
+    assumeTrue(AppleNativeIntegrationTestUtils.isApplePlatformAvailable(ApplePlatform.MACOSX));
+
+    ProjectWorkspace workspace =
+        TestDataHelper.createProjectWorkspaceForScenario(this, scenario, tmp);
+    workspace.setUp();
+    workspace.addBuckConfigLocalOption("apple", "use_swift_delegate", "false");
+    workspace.addBuckConfigLocalOption("cxx", "cflags", "-fmodules");
+    BuildTarget dylibTarget =
+        workspace
+            .newBuildTarget(String.format("//:%s#iphonesimulator-x86_64", targetName))
+            .withAppendedFlavors(CxxDescriptionEnhancer.SHARED_FLAVOR);
+    ProcessResult result = workspace.runBuckCommand("build", dylibTarget.getFullyQualifiedName());
+    result.assertSuccess();
+  }
+
   private static void assertIsSymbolicLink(Path link, Path target) throws IOException {
     assertTrue(Files.isSymbolicLink(link));
     assertEquals(target, Files.readSymbolicLink(link));

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_diff_lib/BUCK.fixture
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_diff_lib/BUCK.fixture
@@ -1,0 +1,22 @@
+apple_library(
+    name = "Foo",
+    srcs = ["dummy.swift"],
+    frameworks = [
+        "$SDKROOT/System/Library/Frameworks/Foundation.framework",
+    ],
+    modular = True,
+    swift_version = "4",
+)
+
+apple_library(
+    name = "Bar",
+    srcs = ["Hello.m"],
+    exported_headers = ["Hello.h"],
+    frameworks = [
+        "$SDKROOT/System/Library/Frameworks/Foundation.framework",
+    ],
+    modular = True,
+    deps = [
+        ":Foo",
+    ],
+)

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_diff_lib/Hello.h
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_diff_lib/Hello.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Hello: NSObject
+- (void)test;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_diff_lib/Hello.m
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_diff_lib/Hello.m
@@ -1,0 +1,12 @@
+#import "Hello.h"
+
+// #import <Foo/Foo-Swift.h>
+@import Foo;
+
+@implementation Hello
+
+- (void)test {
+  [Dummy hello];
+}
+
+@end

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_diff_lib/dummy.swift
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_diff_lib/dummy.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+@objc public class Dummy: NSObject {
+  @objc public class func hello() {
+    Swift.print("hello")
+  }
+}

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_same_lib/BUCK.fixture
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_same_lib/BUCK.fixture
@@ -1,0 +1,13 @@
+apple_library(
+    name = "Mixed",
+    srcs = [
+        "Hello.m",
+        "dummy.swift",
+    ],
+    exported_headers = ["Hello.h"],
+    frameworks = [
+        "$SDKROOT/System/Library/Frameworks/Foundation.framework",
+    ],
+    modular = True,
+    swift_version = "4",
+)

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_same_lib/Hello.h
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_same_lib/Hello.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Hello: NSObject
+- (void)test;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_same_lib/Hello.m
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_same_lib/Hello.m
@@ -1,0 +1,11 @@
+#import "Hello.h"
+
+#import <Mixed/Mixed-Swift.h>
+
+@implementation Hello
+
+- (void)test {
+  [Dummy hello];
+}
+
+@end

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_same_lib/dummy.swift
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_same_lib/dummy.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+@objc public class Dummy: NSObject {
+  @objc public class func hello() {
+    Swift.print("hello")
+  }
+}

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_diff_lib/BUCK.fixture
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_diff_lib/BUCK.fixture
@@ -1,0 +1,22 @@
+apple_library(
+    name = "Foo",
+    srcs = ["Hello.m"],
+    exported_headers = ["Hello.h"],
+    modular = True,
+    frameworks = [
+        "$SDKROOT/System/Library/Frameworks/Foundation.framework",
+    ],
+)
+
+apple_library(
+    name = "Bar",
+    srcs = ["dummy.swift"],
+    frameworks = [
+        "$SDKROOT/System/Library/Frameworks/Foundation.framework",
+    ],
+    swift_version = "4",
+    modular = True,
+    deps = [
+        ":Foo",
+    ],
+)

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_diff_lib/Hello.h
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_diff_lib/Hello.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Hello: NSObject
+  - (NSString *)hello;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_diff_lib/Hello.m
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_diff_lib/Hello.m
@@ -1,0 +1,9 @@
+#import "Hello.h"
+
+@implementation Hello
+
+- (NSString *)hello {
+  return @"hello";
+}
+
+@end

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_diff_lib/dummy.swift
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_diff_lib/dummy.swift
@@ -1,0 +1,8 @@
+import Foo
+
+class Dummy {
+  func test() {
+    let hello = Hello()
+    Swift.print(hello.hello())
+  }
+}

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_same_lib/BUCK.fixture
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_same_lib/BUCK.fixture
@@ -1,0 +1,13 @@
+apple_library(
+    name = "Mixed",
+    srcs = [
+        "Hello.m",
+        "dummy.swift",
+    ],
+    exported_headers = ["Hello.h"],
+    frameworks = [
+        "$SDKROOT/System/Library/Frameworks/Foundation.framework",
+    ],
+    modular = True,
+    swift_version = "4",
+)

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_same_lib/Hello.h
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_same_lib/Hello.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Hello: NSObject
+  - (NSString *)hello;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_same_lib/Hello.m
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_same_lib/Hello.m
@@ -1,0 +1,9 @@
+#import "Hello.h"
+
+@implementation Hello
+
+- (NSString *)hello {
+  return @"hello";
+}
+
+@end

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_same_lib/dummy.swift
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_same_lib/dummy.swift
@@ -1,0 +1,6 @@
+class Dummy {
+  func test() {
+    let hello = Hello()
+    Swift.print(hello.hello())
+  }
+}

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_swift_diff_lib/BUCK.fixture
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_swift_diff_lib/BUCK.fixture
@@ -1,0 +1,14 @@
+apple_library(
+    name = "Foo",
+    srcs = ["Foo.swift"],
+    modular = True,
+    swift_version = "4",
+)
+
+apple_library(
+    name = "Bar",
+    srcs = ["Bar.swift"],
+    swift_version = "4",
+    modular = True,
+    deps = [":Foo"],
+)

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_swift_diff_lib/Bar.swift
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_swift_diff_lib/Bar.swift
@@ -1,0 +1,8 @@
+import Foo
+
+class Bar {
+  func bar() {
+    let foo = Foo()
+    foo.hello()
+  }
+}

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_swift_diff_lib/Foo.swift
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_swift_diff_lib/Foo.swift
@@ -1,0 +1,6 @@
+public class Foo {
+  public init() {}
+  public func hello() {
+    Swift.print("hello")
+  }
+}


### PR DESCRIPTION
These tests currently fail, but should serve as a reference implementation for what is expected to work of modular `apple_libraries`. I'm working towards all the PR's that will make these work and will ping this PR as soon as it can be merged and expected to pass.