### PR TITLE
Fixing Machos file scrubbers to correctly handle cgo binaries

### DIFF
--- a/src/com/facebook/buck/cxx/toolchain/objectfile/LcUuidContentsScrubber.java
+++ b/src/com/facebook/buck/cxx/toolchain/objectfile/LcUuidContentsScrubber.java
@@ -38,7 +38,7 @@ public class LcUuidContentsScrubber implements FileContentsScrubber {
     MappedByteBuffer map = file.map(FileChannel.MapMode.READ_WRITE, 0, size);
 
     try {
-      Machos.setUuid(map, ZERO_UUID);
+      Machos.setUuidIfPresent(map, ZERO_UUID);
     } catch (Machos.MachoException e) {
       throw new ScrubException(e.getMessage());
     }
@@ -51,7 +51,7 @@ public class LcUuidContentsScrubber implements FileContentsScrubber {
 
     map.rewind();
     try {
-      Machos.setUuid(map, Arrays.copyOf(hasher.hash().asBytes(), 16));
+      Machos.setUuidIfPresent(map, Arrays.copyOf(hasher.hash().asBytes(), 16));
     } catch (Machos.MachoException e) {
       throw new ScrubException(e.getMessage());
     }

--- a/src/com/facebook/buck/cxx/toolchain/objectfile/Machos.java
+++ b/src/com/facebook/buck/cxx/toolchain/objectfile/Machos.java
@@ -67,7 +67,6 @@ public class Machos {
         /* Command body */ ObjectFileScrubbers.getBytes(map, commandSize - 8);
       }
     }
-
   }
 
   static boolean isMacho(FileChannel file) throws IOException {
@@ -147,7 +146,6 @@ public class Machos {
             }
             segmentSizePosition = segmentFileSizePosition;
             segmentSize = segmentFileSize;
-
           }
           break;
         case LC_SEGMENT_64:
@@ -173,7 +171,6 @@ public class Machos {
               throw new MachoException("map segment file size too big");
             }
             segmentSize = (int) segment64FileSize;
-
           }
           break;
       }
@@ -182,7 +179,7 @@ public class Machos {
 
     if (!linkEditSegmentFound) {
       /*The OSO entries are identified in segments named __LINKEDIT. If no segment is found with
-       that name, there is nothing to scrub.*/
+      that name, there is nothing to scrub.*/
       return;
     }
 

--- a/src/com/facebook/buck/cxx/toolchain/objectfile/Machos.java
+++ b/src/com/facebook/buck/cxx/toolchain/objectfile/Machos.java
@@ -108,6 +108,10 @@ public class Machos {
     int segmentSizePosition = 0;
     int segmentSize = 0;
     boolean linkEditSegmentFound = false;
+    int segmentFileSizePosition = 0;
+    int segmentFileSize = 0;
+    int segment64FileSizePosition = 0;
+    long segment64FileSize = 0;
 
     int commandsCount = header.getCommandsCount();
     for (int i = 0; i < commandsCount; i++) {
@@ -131,8 +135,8 @@ public class Machos {
             /* vm address */ ObjectFileScrubbers.getLittleEndianInt(map);
             /* vm size */ ObjectFileScrubbers.getLittleEndianInt(map);
             /* segment file offset */ ObjectFileScrubbers.getLittleEndianInt(map);
-            int segmentFileSizePosition = map.position();
-            int segmentFileSize = ObjectFileScrubbers.getLittleEndianInt(map);
+            segmentFileSizePosition = map.position();
+            segmentFileSize = ObjectFileScrubbers.getLittleEndianInt(map);
             /* maximum vm protection */ ObjectFileScrubbers.getLittleEndianInt(map);
             /* initial vm protection */ ObjectFileScrubbers.getLittleEndianInt(map);
             /* number of sections */ ObjectFileScrubbers.getLittleEndianInt(map);
@@ -154,8 +158,8 @@ public class Machos {
             /* vm address */ ObjectFileScrubbers.getLittleEndianLong(map);
             /* vm size */ ObjectFileScrubbers.getLittleEndianLong(map);
             /* segment file offset */ ObjectFileScrubbers.getLittleEndianLong(map);
-            int segment64FileSizePosition = map.position();
-            long segment64FileSize = ObjectFileScrubbers.getLittleEndianLong(map);
+            segment64FileSizePosition = map.position();
+            segment64FileSize = ObjectFileScrubbers.getLittleEndianLong(map);
             /* maximum vm protection */ ObjectFileScrubbers.getLittleEndianInt(map);
             /* initial vm protection */ ObjectFileScrubbers.getLittleEndianInt(map);
             /* number of sections */ ObjectFileScrubbers.getLittleEndianInt(map);

--- a/src/com/facebook/buck/cxx/toolchain/objectfile/Machos.java
+++ b/src/com/facebook/buck/cxx/toolchain/objectfile/Machos.java
@@ -54,7 +54,7 @@ public class Machos {
 
   private Machos() {}
 
-  static void setUuid(MappedByteBuffer map, byte[] uuid) throws MachoException {
+  static void setUuidIfPresent(MappedByteBuffer map, byte[] uuid) throws MachoException {
     int commandsCount = getHeader(map).getCommandsCount();
 
     for (int i = 0; i < commandsCount; i++) {

--- a/src/com/facebook/buck/cxx/toolchain/objectfile/Machos.java
+++ b/src/com/facebook/buck/cxx/toolchain/objectfile/Machos.java
@@ -130,7 +130,7 @@ public class Machos {
             linkEditSegmentFound = true;
             /* vm address */ ObjectFileScrubbers.getLittleEndianInt(map);
             /* vm size */ ObjectFileScrubbers.getLittleEndianInt(map);
-            int segmentFileOffset = ObjectFileScrubbers.getLittleEndianInt(map);
+            /* segment file offset */ ObjectFileScrubbers.getLittleEndianInt(map);
             int segmentFileSizePosition = map.position();
             int segmentFileSize = ObjectFileScrubbers.getLittleEndianInt(map);
             /* maximum vm protection */ ObjectFileScrubbers.getLittleEndianInt(map);
@@ -153,7 +153,7 @@ public class Machos {
             linkEditSegmentFound = true;
             /* vm address */ ObjectFileScrubbers.getLittleEndianLong(map);
             /* vm size */ ObjectFileScrubbers.getLittleEndianLong(map);
-            long segment64FileOffset = ObjectFileScrubbers.getLittleEndianLong(map);
+            /* segment file offset */ ObjectFileScrubbers.getLittleEndianLong(map);
             int segment64FileSizePosition = map.position();
             long segment64FileSize = ObjectFileScrubbers.getLittleEndianLong(map);
             /* maximum vm protection */ ObjectFileScrubbers.getLittleEndianInt(map);

--- a/src/com/facebook/buck/step/fs/FileScrubberStep.java
+++ b/src/com/facebook/buck/step/fs/FileScrubberStep.java
@@ -64,6 +64,7 @@ public class FileScrubberStep implements Step {
       }
     } catch (FileContentsScrubber.ScrubException e) {
       context.logError(e, "Error scrubbing non-deterministic metadata from %s", filePath);
+      return StepExecutionResults.ERROR;
     }
     return StepExecutionResults.SUCCESS;
   }

--- a/src/com/facebook/buck/step/fs/FileScrubberStep.java
+++ b/src/com/facebook/buck/step/fs/FileScrubberStep.java
@@ -64,7 +64,6 @@ public class FileScrubberStep implements Step {
       }
     } catch (FileContentsScrubber.ScrubException e) {
       context.logError(e, "Error scrubbing non-deterministic metadata from %s", filePath);
-      return StepExecutionResults.ERROR;
     }
     return StepExecutionResults.SUCCESS;
   }


### PR DESCRIPTION
This addresses the bug logged in https://github.com/facebook/buck/issues/1717.

When a FileScrubberStep fails, it currently causes the entire build to fail. This shouldn't be critical behavior as the scrubber merely increases the effectiveness of the cache between builds.

This is a problem because the scrubbing methods used in com.facebook.buck.cxx.toolchain.objectfile.Machos currently do not work on Mach-O object files created from cgo files. You can see the behavior by running the test binaryWithCgo in com.facebook.buck.go.GoBinaryIntegrationTest on Mac.

I'll create another issue about the scrubbers not handling cgo object files.