### PR TITLE
Add FrameworkPaths from dependencies to SwiftCompile

### DIFF
--- a/src/com/facebook/buck/apple/AppleLibraryDescriptionSwiftEnhancer.java
+++ b/src/com/facebook/buck/apple/AppleLibraryDescriptionSwiftEnhancer.java
@@ -83,6 +83,7 @@ public class AppleLibraryDescriptionSwiftEnhancer {
 
     PreprocessorFlags.Builder flagsBuilder = PreprocessorFlags.builder();
     inputs.forEach(input -> flagsBuilder.addAllIncludes(input.getIncludes()));
+    inputs.forEach(input -> flagsBuilder.addAllFrameworkPaths(input.getFrameworks()));
     PreprocessorFlags preprocessorFlags = flagsBuilder.build();
 
     return SwiftLibraryDescription.createSwiftCompileRule(

--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -57,6 +57,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Streams;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -179,8 +180,7 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
         CxxDescriptionEnhancer.frameworkPathToSearchPath(cxxPlatform, resolver);
 
     compilerCommand.addAll(
-        frameworks
-            .stream()
+        Streams.concat(frameworks.stream(), cxxDeps.getFrameworkPaths().stream())
             .filter(x -> !x.isSDKROOTFrameworkPath())
             .map(frameworkPathToSearchPath)
             .flatMap(searchPath -> ImmutableSet.of("-F", searchPath.toString()).stream())

--- a/test/com/facebook/buck/apple/PrebuiltAppleFrameworkIntegrationTest.java
+++ b/test/com/facebook/buck/apple/PrebuiltAppleFrameworkIntegrationTest.java
@@ -250,4 +250,13 @@ public class PrebuiltAppleFrameworkIntegrationTest {
                   Pattern.DOTALL)));
     }
   }
+
+  @Test
+  public void frameworkPathsPassedIntoSwiftc() throws Exception {
+    ProjectWorkspace workspace =
+        TestDataHelper.createProjectWorkspaceForScenario(
+            this, "prebuilt_apple_framework_static_swift", tmp);
+    workspace.setUp();
+    workspace.runBuckBuild("//:Foo#macosx-x86_64,static").assertSuccess();
+  }
 }

--- a/test/com/facebook/buck/apple/testdata/prebuilt_apple_framework_static_swift/.buckconfig
+++ b/test/com/facebook/buck/apple/testdata/prebuilt_apple_framework_static_swift/.buckconfig
@@ -1,0 +1,4 @@
+[cxx]
+  default_platform = macosx-x86_64
+[apple]
+  use_swift_delegate = false

--- a/test/com/facebook/buck/apple/testdata/prebuilt_apple_framework_static_swift/BUCK.fixture
+++ b/test/com/facebook/buck/apple/testdata/prebuilt_apple_framework_static_swift/BUCK.fixture
@@ -1,0 +1,15 @@
+apple_library(
+    name = "Foo",
+    srcs = ["foo.swift"],
+    frameworks = [
+        "$SDKROOT/System/Library/Frameworks/Foundation.framework",
+    ],
+    swift_version = "4",
+    deps = [':Dummy'],
+)
+
+prebuilt_apple_framework(
+    name = "Dummy",
+    framework = "Dummy.framework",
+    preferred_linkage = "static",
+)

--- a/test/com/facebook/buck/apple/testdata/prebuilt_apple_framework_static_swift/Dummy.framework/Headers/Dummy.h
+++ b/test/com/facebook/buck/apple/testdata/prebuilt_apple_framework_static_swift/Dummy.framework/Headers/Dummy.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+
+@interface HelloWorldClass : NSObject
++ (void)hello;
+- (nonnull instancetype)init;
+@end

--- a/test/com/facebook/buck/apple/testdata/prebuilt_apple_framework_static_swift/Dummy.framework/Modules/module.modulemap
+++ b/test/com/facebook/buck/apple/testdata/prebuilt_apple_framework_static_swift/Dummy.framework/Modules/module.modulemap
@@ -1,0 +1,3 @@
+framework module Dummy {
+	umbrella header "Dummy.h" 
+}

--- a/test/com/facebook/buck/apple/testdata/prebuilt_apple_framework_static_swift/foo.swift
+++ b/test/com/facebook/buck/apple/testdata/prebuilt_apple_framework_static_swift/foo.swift
@@ -1,0 +1,7 @@
+import Foundation
+import Dummy
+
+func addTwo(to i: Int) -> Int {
+	let _ = HelloWorldClass()
+	return 1
+}


### PR DESCRIPTION
The dependency flags passed to SwiftCompile by the `AppleLibraryDescriptionSwiftEnhancer` currently only include "include" flags. This is not sufficient as some rules export frameworks as part of the rule, and the framework search paths for those need to be visible to use the framework.

This change adds the FrameworkPaths to the PreprocessorFlags that are passed when creating the swiftcompile rule. Those are included in the compile command in `getSwiftIncludeArgs`, but unfortunately this prefixes them with `-Xcc` to only make them visible to the clang importer. The frameworks search paths need to be seen visible to both the clang and swift compiler, which is why the paths are also added without `-Xcc`. This duplication is unfortunate but does not cause problems.