### PR TITLE
Fixed #1714 and #1791

### DIFF
--- a/src/com/facebook/buck/go/CGoGenerateImportStep.java
+++ b/src/com/facebook/buck/go/CGoGenerateImportStep.java
@@ -53,7 +53,7 @@ public class CGoGenerateImportStep extends ShellStep {
   protected ImmutableList<String> getShellCommandInternal(ExecutionContext context) {
     return ImmutableList.<String>builder()
         .addAll(cgoCommandPrefix)
-        .add("-dynpackage", packageName.toString())
+        .add("-dynpackage", packageName.getFileName().toString())
         .add("-dynimport", bin.toString())
         .add("-dynout", outputFile.toString())
         .build();

--- a/src/com/facebook/buck/go/GoTestDescription.java
+++ b/src/com/facebook/buck/go/GoTestDescription.java
@@ -421,7 +421,10 @@ public class GoTestDescription
                   .stream()
                   .map(BuildRule::getBuildTarget)
                   .collect(ImmutableList.toImmutableList()),
-              args.getCgoDeps());
+              ImmutableSortedSet.<BuildTarget>naturalOrder()
+                  .addAll(libraryArg.getCgoDeps())
+                  .addAll(args.getCgoDeps())
+                  .build());
     } else {
       testLibrary =
           GoDescriptors.createGoCompileRule(

--- a/test/com/facebook/buck/go/GoAssumptions.java
+++ b/test/com/facebook/buck/go/GoAssumptions.java
@@ -43,9 +43,9 @@ import org.junit.Assume;
 
 abstract class GoAssumptions {
   // e.g., "go version go1.9.2 darwin/amd64", "go version go1.9.2 windows/amd64",
-  // "go version go1.2.1 linux/amd64"
+  // "go version go1.8 linux/amd64"
   private static final Pattern VERSION_PATTERN =
-      Pattern.compile("^go version go(\\d+)\\.(\\d+)\\.(\\d+).*$");
+      Pattern.compile("^go version go(\\d+)\\.(\\d+).*$");
 
   public static void assumeGoCompilerAvailable() throws IOException {
     Throwable exception = null;
@@ -86,8 +86,8 @@ abstract class GoAssumptions {
             .map(Integer::valueOf)
             .collect(Collectors.toList());
     Assume.assumeTrue(
-        "Expect minimum version string in the form of x.y.z, got: " + minimumVersion,
-        minimumVersionNumbers.size() == 3);
+        "Expect minimum version string in the form of x.y, got: " + minimumVersion,
+        minimumVersionNumbers.size() >= 2);
     Throwable exception = null;
     List<Integer> actualVersionNumbers = null;
     ProcessExecutor processExecutor = new DefaultProcessExecutor(new TestConsole());
@@ -104,7 +104,7 @@ abstract class GoAssumptions {
         Matcher matcher = VERSION_PATTERN.matcher(versionOut);
         if (matcher.matches()) {
           actualVersionNumbers =
-              IntStream.range(1, 4)
+              IntStream.range(1, 3)
                   .mapToObj(matcher::group)
                   .map(Integer::valueOf)
                   .collect(Collectors.toList());
@@ -119,7 +119,7 @@ abstract class GoAssumptions {
     }
     assumeNoException(exception);
     boolean versionSatisfied = true;
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < 2; i++) {
       if (actualVersionNumbers.get(i) < minimumVersionNumbers.get(i)) {
         versionSatisfied = false;
         break;

--- a/test/com/facebook/buck/go/GoTestIntegrationTest.java
+++ b/test/com/facebook/buck/go/GoTestIntegrationTest.java
@@ -126,5 +126,4 @@ public class GoTestIntegrationTest {
     ProcessResult result = workspace.runBuckCommand("test", "//cgo/lib:all_tests");
     result.assertSuccess();
   }
-
 }

--- a/test/com/facebook/buck/go/GoTestIntegrationTest.java
+++ b/test/com/facebook/buck/go/GoTestIntegrationTest.java
@@ -120,4 +120,11 @@ public class GoTestIntegrationTest {
     ProcessResult result = workspace.runBuckCommand("test", "//add:test-add13");
     result.assertSuccess();
   }
+
+  @Test
+  public void testLibWithCgoDeps() throws IOException {
+    ProcessResult result = workspace.runBuckCommand("test", "//cgo/lib:all_tests");
+    result.assertSuccess();
+  }
+
 }

--- a/test/com/facebook/buck/go/testdata/go_test/cgo/lib/BUCK.fixture
+++ b/test/com/facebook/buck/go/testdata/go_test/cgo/lib/BUCK.fixture
@@ -1,0 +1,17 @@
+cgo_library(
+  name="cgo_lib",
+  srcs=['double_cgo.go']
+)
+
+go_library(
+  name="lib",
+  srcs=["quad_lib.go"],
+  tests=[":all_tests"],
+  cgo_deps=[":cgo_lib"]
+)
+
+go_test(
+  name="all_tests",
+  library=":lib",
+  srcs=["double_test.go"]
+)

--- a/test/com/facebook/buck/go/testdata/go_test/cgo/lib/double_cgo.go
+++ b/test/com/facebook/buck/go/testdata/go_test/cgo/lib/double_cgo.go
@@ -1,0 +1,12 @@
+package lib
+
+/*
+int multiply2(int i) {
+	return i << 1;
+}
+*/
+import "C"
+
+func Double(i int) int {
+	return int(C.multiply2(C.int(i)))
+}

--- a/test/com/facebook/buck/go/testdata/go_test/cgo/lib/double_test.go
+++ b/test/com/facebook/buck/go/testdata/go_test/cgo/lib/double_test.go
@@ -1,0 +1,11 @@
+package lib
+
+import "testing"
+
+func TestDouble(t *testing.T) {
+	if Quad(17) == 68 {
+		t.Log("Success!")
+	} else {
+		t.Error("Wrong answer!")
+	}
+}

--- a/test/com/facebook/buck/go/testdata/go_test/cgo/lib/quad_lib.go
+++ b/test/com/facebook/buck/go/testdata/go_test/cgo/lib/quad_lib.go
@@ -1,0 +1,5 @@
+package lib
+
+func Quad(i int) int {
+	return Double(Double(i))
+}


### PR DESCRIPTION
Issues and solutions:

#1714: the `cgo_deps` parameter of a `go_library` rule was not copied to the `go_test` rules targeting at the `go_library` rule. So when the `go_test` rules were built, the `cgo_library` rules needed by the `go_library` were not built.

Solution: Copy `cgo_deps` from `go_library` to `go_test`

#1791: When Buck was calling cgo to generate the import file, it sets the package name to be the full package name with paths. As a result, the `package` statement in the resulting Go file has the full package name with `/` and `.` in it, causing syntax error when the Go file is compiled.

Solution: Only use the last part of the package name in the cgo-generated go source