### PR TITLE
[TravisCI] Run google-java-format for all files affected by every PR …

### DIFF
--- a/scripts/travisci_test_java_file_format
+++ b/scripts/travisci_test_java_file_format
@@ -17,7 +17,7 @@ FORMAT_JAR_LOCATION="${HOME}/${FORMAT_JAR_NAME}"
 
 wget -O "${FORMAT_JAR_LOCATION}" "${FORMAT_JAR_URL}"
 
-for file_in_revision in $(git diff-tree --no-commit-id --name-only -r HEAD); do
+for file_in_revision in $(git diff --name-only --diff-filter=AM HEAD..${TRAVIS_BRANCH}); do
   echo "Checking ${file_in_revision}"
 
   [ -f "${file_in_revision}" ] || continue


### PR DESCRIPTION
Currently google format only runs for files that were modified by the very last PR commit, which does not work well when PR has many commits.