### PR TITLE
Convert integer entries to hex decimal entries during RDotTxtEntry initialization.

### DIFF
--- a/src/com/facebook/buck/android/aapt/RDotTxtEntry.java
+++ b/src/com/facebook/buck/android/aapt/RDotTxtEntry.java
@@ -176,9 +176,24 @@ public class RDotTxtEntry implements Comparable<RDotTxtEntry> {
     this.idType = idType;
     this.type = type;
     this.name = name;
-    this.idValue = idValue;
+    this.idValue = hexDecimalStringValue(idType, type, idValue);
     this.customType = customType;
     this.parent = parent != null ? parent : name;
+  }
+
+  /*
+   * Convert integer string values to hex decimal string for
+   * non integer arrays and non styleable entries.
+   */
+  private static String hexDecimalStringValue(IdType idType, RType type, String idValue) {
+    if (idType == IdType.INT_ARRAY || type == RType.STYLEABLE) {
+      return idValue;
+    }
+    if (idValue.length() == 0 || idValue.startsWith("0x")) {
+      return idValue;
+    } else {
+      return String.format("0x%08x", Integer.parseInt(idValue));
+    }
   }
 
   public int getNumArrayValues() {

--- a/test/com/facebook/buck/android/MergeAndroidResourcesStepTest.java
+++ b/test/com/facebook/buck/android/MergeAndroidResourcesStepTest.java
@@ -139,6 +139,7 @@ public class MergeAndroidResourcesStepTest {
             sharedPackageName,
             "a-R.txt",
             ImmutableList.of(
+                "int attr android_layout 0x010100f2",
                 "int attr buttonPanelSideLayout 0x7f01003a",
                 "int attr listLayout 0x7f01003b",
                 "int[] styleable AlertDialog { 0x7f01003a, 0x7f01003b, 0x010100f2 }",
@@ -214,7 +215,7 @@ public class MergeAndroidResourcesStepTest {
             new FakeRDotTxtEntryWithID(INT, STYLEABLE, "AlertDialog_buttonPanelSideLayout", "1"),
             new FakeRDotTxtEntryWithID(INT, STYLEABLE, "AlertDialog_multiChoiceItemLayout", "2"),
             new FakeRDotTxtEntryWithID(
-                INT_ARRAY, STYLEABLE, "PercentLayout_Layout", "{ 0,0x07f01009 }"),
+                INT_ARRAY, STYLEABLE, "PercentLayout_Layout", "{ 0x00000000,0x07f01009 }"),
             new FakeRDotTxtEntryWithID(
                 INT, STYLEABLE, "PercentLayout_Layout_layout_aspectRatio", "0"),
             new FakeRDotTxtEntryWithID(


### PR DESCRIPTION
__Problem:__
Android attributes are being populated to R.java created by mini aapt like `android_font`. This causes robolectric test failures. ([fails to construct Robolectric resource table](https://github.com/robolectric/robolectric/blob/b019ccaad2ab76a632306956c71c4bcdc730e95b/resources/src/main/java/org/robolectric/res/PackageResourceTable.java#L109))
```
java.lang.IllegalArgumentException: Incompatible package for com.uber:attr/android_font with resId 1 to ResourceIndex with packageIdentifier 7
    at org.robolectric.res.PackageResourceTable.addResource(PackageResourceTable.java:109)
    at org.robolectric.res.ResourceTableFactory.addRClassValues(ResourceTableFactory.java:71)
    at org.robolectric.res.ResourceTableFactory.lambda$newResourceTable$1(ResourceTableFactory.java:45)
    at org.robolectric.util.PerfStatsCollector.measure(PerfStatsCollector.java:50)
    at org.robolectric.res.ResourceTableFactory.newResourceTable(ResourceTableFactory.java:38)
    at org.robolectric.res.ResourceMerger.buildResourceTable(ResourceMerger.java:20)
    at org.robolectric.RobolectricTestRunner.getAppResourceTable(RobolectricTestRunner.java:529)
    ...
```    

__RootCause:__
This is happening because a third party library is including `android_font` in its R.txt with an integer value. The attribute is then included in the dependee's R.java generated by miniaapt. 

__Solution:__
Don't include any attributes which starts with `"0x01"`, since those should come from the android framework. Also need make `RDotTxtEntry` initialization convert integers into hexdecimal strings so that the check is effective.


This only affects R.java files generated for robolectric tests and intermediatray libraries.


