### PR TITLE
Add processor_classes argument to java_annotation_processor rule

### DIFF
--- a/src/com/facebook/buck/jvm/java/JavaAnnotationProcessorDescription.java
+++ b/src/com/facebook/buck/jvm/java/JavaAnnotationProcessorDescription.java
@@ -30,6 +30,8 @@ import com.facebook.buck.rules.SourcePathRuleFinder;
 import com.facebook.buck.util.HumanReadableException;
 import com.facebook.buck.util.immutables.BuckStyleImmutable;
 import com.facebook.buck.versions.VersionPropagator;
+import com.google.common.collect.ImmutableSet;
+import java.util.Optional;
 import org.immutables.value.Value;
 
 /**
@@ -51,7 +53,16 @@ public class JavaAnnotationProcessorDescription
       BuildRuleParams params,
       JavaAnnotationProcessorDescriptionArg args) {
     JavacPluginProperties.Builder propsBuilder = JavacPluginProperties.builder();
-    propsBuilder.addProcessorNames(args.getProcessorClass());
+
+    Optional<String> processorClass = args.getProcessorClass();
+    if (processorClass.isPresent()) {
+      propsBuilder.addProcessorNames(processorClass.get());
+    } else {
+      for (String pClass : args.getProcessorClasses()) {
+        propsBuilder.addProcessorNames(pClass);
+      }
+    }
+
     for (BuildRule dep : params.getBuildDeps()) {
       if (!(dep instanceof JavaLibrary)) {
         throw new HumanReadableException(
@@ -82,7 +93,13 @@ public class JavaAnnotationProcessorDescription
   @Value.Immutable
   interface AbstractJavaAnnotationProcessorDescriptionArg
       extends CommonDescriptionArg, HasDeclaredDeps {
-    String getProcessorClass();
+
+    @Value.Default
+    default Optional<String> getProcessorClass() {
+      return Optional.empty();
+    }
+
+    ImmutableSet<String> getProcessorClasses();
 
     @Value.Default
     default boolean isIsolateClassLoader() {

--- a/src/com/facebook/buck/jvm/java/JavaAnnotationProcessorDescription.java
+++ b/src/com/facebook/buck/jvm/java/JavaAnnotationProcessorDescription.java
@@ -55,6 +55,12 @@ public class JavaAnnotationProcessorDescription
     JavacPluginProperties.Builder propsBuilder = JavacPluginProperties.builder();
 
     Optional<String> processorClass = args.getProcessorClass();
+
+    if (!processorClass.isPresent() && args.getProcessorClasses().isEmpty()) {
+      throw new HumanReadableException(
+          String.format("%s: must specify a processor class, none specified;", buildTarget));
+    }
+
     if (processorClass.isPresent()) {
       propsBuilder.addProcessorNames(processorClass.get());
     } else {

--- a/src/com/facebook/buck/jvm/java/JavaAnnotationProcessorDescription.java
+++ b/src/com/facebook/buck/jvm/java/JavaAnnotationProcessorDescription.java
@@ -52,17 +52,15 @@ public class JavaAnnotationProcessorDescription
       BuildTarget buildTarget,
       BuildRuleParams params,
       JavaAnnotationProcessorDescriptionArg args) {
-    JavacPluginProperties.Builder propsBuilder = JavacPluginProperties.builder();
-
-    Optional<String> processorClass = args.getProcessorClass();
-
-    if (!processorClass.isPresent() && args.getProcessorClasses().isEmpty()) {
+    if (!args.getProcessorClass().isPresent() && args.getProcessorClasses().isEmpty()) {
       throw new HumanReadableException(
           String.format("%s: must specify a processor class, none specified;", buildTarget));
     }
 
-    if (processorClass.isPresent()) {
-      propsBuilder.addProcessorNames(processorClass.get());
+    JavacPluginProperties.Builder propsBuilder = JavacPluginProperties.builder();
+
+    if (args.getProcessorClass().isPresent()) {
+      propsBuilder.addProcessorNames(args.getProcessorClass().get());
     } else {
       for (String pClass : args.getProcessorClasses()) {
         propsBuilder.addProcessorNames(pClass);

--- a/test/com/facebook/buck/jvm/java/JavaAnnotationProcessorDescriptionTest.java
+++ b/test/com/facebook/buck/jvm/java/JavaAnnotationProcessorDescriptionTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2014-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.jvm.java;
+
+import static org.junit.Assert.assertEquals;
+
+import com.facebook.buck.io.filesystem.ProjectFilesystem;
+import com.facebook.buck.model.BuildTarget;
+import com.facebook.buck.model.BuildTargetFactory;
+import com.facebook.buck.rules.BuildRuleParams;
+import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.TestBuildRuleCreationContextFactory;
+import com.facebook.buck.rules.TestBuildRuleParams;
+import com.facebook.buck.rules.TestBuildRuleResolver;
+import com.facebook.buck.testutil.FakeProjectFilesystem;
+import com.facebook.buck.util.HumanReadableException;
+import com.google.common.collect.ImmutableSet;
+import java.util.Optional;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class JavaAnnotationProcessorDescriptionTest {
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testProcessorClassIsPassedToJavaAnnotationProcessor() {
+    // Given
+    JavaAnnotationProcessorDescriptionArg arg =
+        JavaAnnotationProcessorDescriptionArg.builder()
+            .setName("annotation_processor")
+            .setIsolateClassLoader(false)
+            .setDoesNotAffectAbi(true)
+            .setSupportsAbiGenerationFromSource(true)
+            .setProcessorClass(Optional.of("Foo.Bar"))
+            .build();
+
+    BuildRuleResolver buildRuleResolver = new TestBuildRuleResolver();
+    ProjectFilesystem projectFilesystem = new FakeProjectFilesystem();
+
+    BuildTarget buildTarget = BuildTargetFactory.newInstance("//foo:baz");
+
+    BuildRuleParams params =
+        TestBuildRuleParams.create().withDeclaredDeps(buildRuleResolver.getAllRules(arg.getDeps()));
+
+    // When
+    JavaAnnotationProcessor javaAnnotationProcessor =
+        (JavaAnnotationProcessor)
+            new JavaAnnotationProcessorDescription()
+                .createBuildRule(
+                    TestBuildRuleCreationContextFactory.create(
+                        buildRuleResolver, projectFilesystem),
+                    buildTarget,
+                    params,
+                    arg);
+
+    // Verify
+    JavacPluginProperties props =
+        JavacPluginProperties.builder()
+            .setCanReuseClassLoader(true)
+            .setDoesNotAffectAbi(true)
+            .setSupportsAbiGenerationFromSource(true)
+            .addProcessorNames("Foo.Bar")
+            .build();
+
+    assertEquals(javaAnnotationProcessor.getUnresolvedProperties(), props);
+  }
+
+  @Test
+  public void testProcessorClassesIsPassedToJavaAnnotationProcessor() {
+    // Given
+    JavaAnnotationProcessorDescriptionArg arg =
+        JavaAnnotationProcessorDescriptionArg.builder()
+            .setName("annotation_processor")
+            .setIsolateClassLoader(false)
+            .setDoesNotAffectAbi(true)
+            .setSupportsAbiGenerationFromSource(true)
+            .setProcessorClasses(ImmutableSet.of("Foo.Bar", "Bar.Foo"))
+            .build();
+
+    BuildRuleResolver buildRuleResolver = new TestBuildRuleResolver();
+    ProjectFilesystem projectFilesystem = new FakeProjectFilesystem();
+
+    BuildTarget buildTarget = BuildTargetFactory.newInstance("//foo:baz");
+
+    BuildRuleParams params =
+        TestBuildRuleParams.create().withDeclaredDeps(buildRuleResolver.getAllRules(arg.getDeps()));
+
+    // When
+    JavaAnnotationProcessor javaAnnotationProcessor =
+        (JavaAnnotationProcessor)
+            new JavaAnnotationProcessorDescription()
+                .createBuildRule(
+                    TestBuildRuleCreationContextFactory.create(
+                        buildRuleResolver, projectFilesystem),
+                    buildTarget,
+                    params,
+                    arg);
+
+    // Verify
+    JavacPluginProperties props =
+        JavacPluginProperties.builder()
+            .setCanReuseClassLoader(true)
+            .setDoesNotAffectAbi(true)
+            .setSupportsAbiGenerationFromSource(true)
+            .addProcessorNames("Foo.Bar", "Bar.Foo")
+            .build();
+
+    assertEquals(javaAnnotationProcessor.getUnresolvedProperties(), props);
+  }
+
+  @Test
+  public void testOnlyProcessorClassIsPassedToJavaAnnotationProcessor() {
+    // Given
+    JavaAnnotationProcessorDescriptionArg arg =
+        JavaAnnotationProcessorDescriptionArg.builder()
+            .setName("annotation_processor")
+            .setIsolateClassLoader(false)
+            .setDoesNotAffectAbi(true)
+            .setSupportsAbiGenerationFromSource(true)
+            .setProcessorClass(Optional.of("Needle.HayStack"))
+            .setProcessorClasses(ImmutableSet.of("Foo.Bar", "Bar.Foo"))
+            .build();
+
+    BuildRuleResolver buildRuleResolver = new TestBuildRuleResolver();
+    ProjectFilesystem projectFilesystem = new FakeProjectFilesystem();
+
+    BuildTarget buildTarget = BuildTargetFactory.newInstance("//foo:baz");
+
+    BuildRuleParams params =
+        TestBuildRuleParams.create().withDeclaredDeps(buildRuleResolver.getAllRules(arg.getDeps()));
+
+    // When
+    JavaAnnotationProcessor javaAnnotationProcessor =
+        (JavaAnnotationProcessor)
+            new JavaAnnotationProcessorDescription()
+                .createBuildRule(
+                    TestBuildRuleCreationContextFactory.create(
+                        buildRuleResolver, projectFilesystem),
+                    buildTarget,
+                    params,
+                    arg);
+
+    // Verify
+    JavacPluginProperties props =
+        JavacPluginProperties.builder()
+            .setCanReuseClassLoader(true)
+            .setDoesNotAffectAbi(true)
+            .setSupportsAbiGenerationFromSource(true)
+            .addProcessorNames("Needle.HayStack")
+            .build();
+
+    assertEquals(javaAnnotationProcessor.getUnresolvedProperties(), props);
+  }
+
+  @Test
+  public void testRaisesExceptionWhenNoProcessorClassIsSpecified() {
+    // Given
+    JavaAnnotationProcessorDescriptionArg arg =
+        JavaAnnotationProcessorDescriptionArg.builder()
+            .setName("annotation_processor")
+            .setIsolateClassLoader(false)
+            .setDoesNotAffectAbi(true)
+            .setSupportsAbiGenerationFromSource(true)
+            .build();
+
+    BuildRuleResolver buildRuleResolver = new TestBuildRuleResolver();
+    ProjectFilesystem projectFilesystem = new FakeProjectFilesystem();
+
+    BuildTarget buildTarget = BuildTargetFactory.newInstance("//foo:baz");
+
+    BuildRuleParams params =
+        TestBuildRuleParams.create().withDeclaredDeps(buildRuleResolver.getAllRules(arg.getDeps()));
+
+    // Verify
+    thrown.expect(HumanReadableException.class);
+    thrown.expectMessage("//foo:baz: must specify a processor class, none specified;");
+
+    // When
+    JavaAnnotationProcessor javaAnnotationProcessor =
+        (JavaAnnotationProcessor)
+            new JavaAnnotationProcessorDescription()
+                .createBuildRule(
+                    TestBuildRuleCreationContextFactory.create(
+                        buildRuleResolver, projectFilesystem),
+                    buildTarget,
+                    params,
+                    arg);
+  }
+}

--- a/test/com/facebook/buck/jvm/java/JavaAnnotationProcessorDescriptionTest.java
+++ b/test/com/facebook/buck/jvm/java/JavaAnnotationProcessorDescriptionTest.java
@@ -192,14 +192,11 @@ public class JavaAnnotationProcessorDescriptionTest {
     thrown.expectMessage("//foo:baz: must specify a processor class, none specified;");
 
     // When
-    JavaAnnotationProcessor javaAnnotationProcessor =
-        (JavaAnnotationProcessor)
-            new JavaAnnotationProcessorDescription()
-                .createBuildRule(
-                    TestBuildRuleCreationContextFactory.create(
-                        buildRuleResolver, projectFilesystem),
-                    buildTarget,
-                    params,
-                    arg);
+    new JavaAnnotationProcessorDescription()
+        .createBuildRule(
+            TestBuildRuleCreationContextFactory.create(buildRuleResolver, projectFilesystem),
+            buildTarget,
+            params,
+            arg);
   }
 }


### PR DESCRIPTION
Single annotation processors can have multiple processor classes.
for eg: AutoValue has these
```
'com.google.auto.value.processor.AutoAnnotationProcessor',
'com.google.auto.value.processor.AutoValueBuilderProcessor',
'com.google.auto.value.extension.memoized.MemoizedValidator',
'com.google.auto.value.processor.AutoValueProcessor',
```

This now requires creating multiple `java_annotation_processor` rule.
Adding `processor_classes` argument so multiple processor classes can be specified in the same `java_annotation_processor` rule.
propsBuilder already supports adding multiple processor classes.

Ref: https://github.com/facebook/buck/issues/1831