### PR TITLE
Prevent frameworks being copied to appex targets

### DIFF
--- a/src/com/facebook/buck/apple/AppleBundle.java
+++ b/src/com/facebook/buck/apple/AppleBundle.java
@@ -966,7 +966,8 @@ public class AppleBundle extends AbstractBuildRuleWithDeclaredAndExtraDeps
       boolean isForPackaging) {
     // It's apparently safe to run this even on a non-swift bundle (in that case, no libs
     // are copied over).
-    if (swiftStdlibTool.isPresent()) {
+    boolean shouldCopySwiftStdlib = !extension.equals(AppleBundleExtension.APPEX.toFileExtension());
+    if (swiftStdlibTool.isPresent() && shouldCopySwiftStdlib) {
       ImmutableList.Builder<String> swiftStdlibCommand = ImmutableList.builder();
       swiftStdlibCommand.addAll(swiftStdlibTool.get().getCommandPrefix(resolver));
       swiftStdlibCommand.add(


### PR DESCRIPTION
Using @zayhero's fix to prevent  the swift std lib files from being copied over when the target is an extension. 

Extensions can not contain a `Frameworks` folder in them and must instead rely on their parent app's frameworks. 

Using the following build settings, Xcode was able to build without the inclusion of `MyExtension.appex/Framewworks`, however when built with buck the `MyExtension.appex/Framewworks` existed with the copied swift libs. 


`MyExtension.appex` build settings
```
  'ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES': 'NO',
    'EMBEDDED_CONTENT_CONTAINS_SWIFT': 'NO',
    'RUNPATH_SEARCH_PATHS': '@executable_path/../../Frameworks'
```

If a `Frameworks` folder is found in an `.appex` the itunes connect validation will give the following error:

```
ERROR ITMS-90206: "Invalid Bundle. The bundle at 'Yarn.app/PlugIns/Notification.appex' contains disallowed file 'Frameworks'."
```

This PR resolves the above issue by skipping the copy step if the target is an APPEX extension