### PR TITLE
Implemented precompiled header support for Visual C++

### DIFF
--- a/src/com/facebook/buck/cxx/toolchain/WindowsPreprocessor.java
+++ b/src/com/facebook/buck/cxx/toolchain/WindowsPreprocessor.java
@@ -20,6 +20,7 @@ import com.facebook.buck.core.toolchain.tool.DelegatingTool;
 import com.facebook.buck.core.toolchain.tool.Tool;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.io.Files;
 import java.nio.file.Path;
 
 /** Preprocessor implementation for the Windows toolchain. */
@@ -65,7 +66,7 @@ public class WindowsPreprocessor extends DelegatingTool implements Preprocessor 
   @Override
   public Iterable<String> precompiledHeaderArgs(Path pchOutputPath) {
     String hFilename = pchOutputPath.getFileName().toString();
-    String pchFilename = hFilename.substring(0, hFilename.length() - 4) + ".pch";
+    String pchFilename = Files.getNameWithoutExtension(hFilename) + ".pch";
     return ImmutableList.of("/Yu", pchFilename);
   }
 }

--- a/src/com/facebook/buck/cxx/toolchain/WindowsPreprocessor.java
+++ b/src/com/facebook/buck/cxx/toolchain/WindowsPreprocessor.java
@@ -18,6 +18,7 @@ package com.facebook.buck.cxx.toolchain;
 
 import com.facebook.buck.core.toolchain.tool.DelegatingTool;
 import com.facebook.buck.core.toolchain.tool.Tool;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import java.nio.file.Path;
 
@@ -34,10 +35,7 @@ public class WindowsPreprocessor extends DelegatingTool implements Preprocessor 
 
   @Override
   public boolean supportsPrecompiledHeaders() {
-    // TODO(steveo) Should be easy to add support; will try @ later time,
-    // when I can test w/ Windows.
-    // https://msdn.microsoft.com/en-us/library/z0atkd6c.aspx
-    return false;
+    return true;
   }
 
   private static String prependIncludeFlag(String includeRoot) {
@@ -61,22 +59,13 @@ public class WindowsPreprocessor extends DelegatingTool implements Preprocessor 
 
   @Override
   public Iterable<String> prefixHeaderArgs(Path prefixHeader) {
-    throw new UnsupportedOperationException("prefix header not supported by " + getClass());
-    // TODO(steveo) Should be easy to add support; will try @ later time,
-    // when I can test w/ Windows.
-    // "Forced Include": https://msdn.microsoft.com/en-us/library/8c5ztk84.aspx
-    // Space is allowed between flag and its pathname argument.
-    // E.g. something like this (space allowed between flag and its argument):
-    // return ImmutableList.of("/FI", resolver.getAbsolutePath(prefixHeader).toString());
+    return ImmutableList.of("/Yc", prefixHeader.toString());
   }
 
   @Override
   public Iterable<String> precompiledHeaderArgs(Path pchOutputPath) {
-    throw new UnsupportedOperationException("precompiled header not supported by " + getClass());
-    // TODO(steveo) Should be easy to add support; will try @ later time,
-    // when I can test w/ Windows.
-    // https://msdn.microsoft.com/en-us/library/z0atkd6c.aspx
-    // E.g. something like this flag (no space between "/Yu" and its argument):
-    // return ImmutableList.of("/Yu" + pchOutputPath);
+    String hFilename = pchOutputPath.getFileName().toString();
+    String pchFilename = hFilename.substring(0, hFilename.length() - 4) + ".pch";
+    return ImmutableList.of("/Yu", pchFilename);
   }
 }

--- a/test/com/facebook/buck/cxx/toolchain/BUCK
+++ b/test/com/facebook/buck/cxx/toolchain/BUCK
@@ -62,5 +62,6 @@ standard_java_test(
         "//third-party/java/guava:guava",
         "//third-party/java/hamcrest:hamcrest-junit",
         "//third-party/java/junit:junit",
+        "//third-party/java/easymock:easymock",
     ],
 )

--- a/test/com/facebook/buck/cxx/toolchain/WindowsPreprocessorTest.java
+++ b/test/com/facebook/buck/cxx/toolchain/WindowsPreprocessorTest.java
@@ -16,14 +16,18 @@
 
 package com.facebook.buck.cxx.toolchain;
 
+import static com.facebook.buck.util.environment.Platform.WINDOWS;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import com.facebook.buck.rules.Tool;
+import com.facebook.buck.util.environment.Platform;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.easymock.EasyMock;
 import org.hamcrest.junit.ExpectedException;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,6 +46,8 @@ public class WindowsPreprocessorTest {
 
   @Test
   public void testPrefixHeaderArgsHandlesSimpleHeaderFilePaths() {
+    Assume.assumeThat(Platform.detect(), is(WINDOWS));
+
     String headerPathStr = "stdafx.h";
     Path headerPath = Paths.get(headerPathStr);
 
@@ -50,7 +56,9 @@ public class WindowsPreprocessorTest {
 
   @Test
   public void testPrefixHeaderArgsHandlesNestedHeaderFilePaths() {
-    String headerPathStr = "include/subdir/stdafx.h";
+    Assume.assumeThat(Platform.detect(), is(WINDOWS));
+
+    String headerPathStr = "include\\subdir\\stdafx.h";
     Path headerPath = Paths.get(headerPathStr);
 
     assertThat(windowsPreprocessor.prefixHeaderArgs(headerPath), contains("/Yc", headerPathStr));
@@ -58,6 +66,8 @@ public class WindowsPreprocessorTest {
 
   @Test
   public void testPrecompiledHeaderArgsHandlesSimpleHeaderFilePaths() {
+    Assume.assumeThat(Platform.detect(), is(WINDOWS));
+
     String headerPathStr = "stdafx.h";
     String pchPathStr = "stdafx.pch";
     Path headerPath = Paths.get(headerPathStr);
@@ -67,7 +77,9 @@ public class WindowsPreprocessorTest {
 
   @Test
   public void testPrecompiledHeaderArgsHandlesNestedHeaderFilePaths() {
-    String headerPathStr = "include/subdir/stdafx.h";
+    Assume.assumeThat(Platform.detect(), is(WINDOWS));
+
+    String headerPathStr = "include\\subdir\\stdafx.h";
     String pchPathStr = "stdafx.pch";
     Path headerPath = Paths.get(headerPathStr);
 

--- a/test/com/facebook/buck/cxx/toolchain/WindowsPreprocessorTest.java
+++ b/test/com/facebook/buck/cxx/toolchain/WindowsPreprocessorTest.java
@@ -46,15 +46,15 @@ public class WindowsPreprocessorTest {
     String pchPathStr = "stdafx.pch";
     Path headerPath = Paths.get(headerPathStr);
 
-    assertThat(windowsPreprocessor.prefixHeaderArgs(headerPath), contains("/Yu", pchPathStr));
+    assertThat(windowsPreprocessor.precompiledHeaderArgs(headerPath), contains("/Yu", pchPathStr));
   }
 
   @Test
   public void testPrecompiledHeaderArgsHandlesNestedHeaderFilePaths() {
     String headerPathStr = "include/subdir/stdafx.h";
-    String pchPathStr = "include/subdir/stdafx.pch";
+    String pchPathStr = "stdafx.pch";
     Path headerPath = Paths.get(headerPathStr);
 
-    assertThat(windowsPreprocessor.prefixHeaderArgs(headerPath), contains("/Yu", pchPathStr));
+    assertThat(windowsPreprocessor.precompiledHeaderArgs(headerPath), contains("/Yu", pchPathStr));
   }
 }

--- a/test/com/facebook/buck/cxx/toolchain/WindowsPreprocessorTest.java
+++ b/test/com/facebook/buck/cxx/toolchain/WindowsPreprocessorTest.java
@@ -21,7 +21,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-import com.facebook.buck.rules.Tool;
+import com.facebook.buck.core.toolchain.tool.Tool;
 import com.facebook.buck.util.environment.Platform;
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/test/com/facebook/buck/cxx/toolchain/WindowsPreprocessorTest.java
+++ b/test/com/facebook/buck/cxx/toolchain/WindowsPreprocessorTest.java
@@ -1,0 +1,60 @@
+package com.facebook.buck.cxx.toolchain;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+
+import com.facebook.buck.rules.Tool;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.easymock.EasyMock;
+import org.hamcrest.junit.ExpectedException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.testng.annotations.Test;
+
+public class WindowsPreprocessorTest {
+  @Rule public final ExpectedException expectedException = ExpectedException.none();
+
+  private WindowsPreprocessor windowsPreprocessor;
+
+  @Before
+  public void setUp() {
+    Tool tool = EasyMock.createMock(Tool.class);
+
+    this.windowsPreprocessor = new WindowsPreprocessor(tool);
+  }
+
+  @Test
+  public void testPrefixHeaderArgsHandlesSimpleHeaderFilePaths() {
+    String headerPathStr = "stdafx.h";
+    Path headerPath = Paths.get(headerPathStr);
+
+    assertThat(windowsPreprocessor.prefixHeaderArgs(headerPath), contains("/Yc", headerPathStr));
+  }
+
+  @Test
+  public void testPrefixHeaderArgsHandlesNestedHeaderFilePaths() {
+    String headerPathStr = "include/subdir/stdafx.h";
+    Path headerPath = Paths.get(headerPathStr);
+
+    assertThat(windowsPreprocessor.prefixHeaderArgs(headerPath), contains("/Yc", headerPathStr));
+  }
+
+  @Test
+  public void testPrecompiledHeaderArgsHandlesSimpleHeaderFilePaths() {
+    String headerPathStr = "stdafx.h";
+    String pchPathStr = "stdafx.pch";
+    Path headerPath = Paths.get(headerPathStr);
+
+    assertThat(windowsPreprocessor.prefixHeaderArgs(headerPath), contains("/Yu", pchPathStr));
+  }
+
+  @Test
+  public void testPrecompiledHeaderArgsHandlesNestedHeaderFilePaths() {
+    String headerPathStr = "include/subdir/stdafx.h";
+    String pchPathStr = "include/subdir/stdafx.pch";
+    Path headerPath = Paths.get(headerPathStr);
+
+    assertThat(windowsPreprocessor.prefixHeaderArgs(headerPath), contains("/Yu", pchPathStr));
+  }
+}

--- a/test/com/facebook/buck/cxx/toolchain/WindowsPreprocessorTest.java
+++ b/test/com/facebook/buck/cxx/toolchain/WindowsPreprocessorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.facebook.buck.cxx.toolchain;
 
 import static org.hamcrest.Matchers.contains;

--- a/test/com/facebook/buck/cxx/toolchain/WindowsPreprocessorTest.java
+++ b/test/com/facebook/buck/cxx/toolchain/WindowsPreprocessorTest.java
@@ -10,7 +10,7 @@ import org.easymock.EasyMock;
 import org.hamcrest.junit.ExpectedException;
 import org.junit.Before;
 import org.junit.Rule;
-import org.testng.annotations.Test;
+import org.junit.Test;
 
 public class WindowsPreprocessorTest {
   @Rule public final ExpectedException expectedException = ExpectedException.none();


### PR DESCRIPTION
As the summary says. Checked on Windows 10 with Visual Studio / C++ 2017 compiler.

**TODO:** is it worth using `/Yc` and `/Yu` together with `/Fp[PCH filename]` rather than relying on the default PCH path?