### PR TITLE
Added ability to control java duplicate entries log verbosity.

### DIFF
--- a/docs/concept/buckconfig.soy
+++ b/docs/concept/buckconfig.soy
@@ -2443,6 +2443,22 @@ cxx_library(
   {/param}
 {/call}
 
+{call buckconfig.entry}
+  {param section: 'java' /}
+  {param name: 'duplicates_log_level' /}
+  {param example_value: 'info' /}
+  {param description}
+     <p>Verbosity of logs emitted on duplicates when building binary.</p>
+     <p>The valid values are:
+       <ul>
+         <li><code>info</code> (default): emit an info to the console,</li>
+         <li><code>warn</code>: emit a warning to the console,</li>
+         <li><code>fine</code>: emit a fine info to the console, visible only at high verbosity levels.</li>
+       </ul>
+     </p>
+  {/param}
+{/call}
+
 {call buckconfig.section}
   {param name: 'kotlin' /}
   {param description}

--- a/src/com/facebook/buck/jvm/java/AbstractJarParameters.java
+++ b/src/com/facebook/buck/jvm/java/AbstractJarParameters.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.logging.Level;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -53,4 +54,9 @@ abstract class AbstractJarParameters {
   public abstract Optional<String> getMainClass();
 
   public abstract Optional<Path> getManifestFile();
+
+  @Value.Default
+  public Level getDuplicatesLogLevel() {
+    return Level.INFO;
+  }
 }

--- a/src/com/facebook/buck/jvm/java/JarDirectoryStep.java
+++ b/src/com/facebook/buck/jvm/java/JarDirectoryStep.java
@@ -75,9 +75,11 @@ public class JarDirectoryStep implements Step {
 
     JavacEventSinkToBuckEventBusBridge eventSink =
         new JavacEventSinkToBuckEventBusBridge(context.getBuckEventBus());
+    LoggingJarBuilderObserver loggingObserver =
+        new LoggingJarBuilderObserver(eventSink, parameters.getDuplicatesLogLevel());
     return StepExecutionResult.of(
         new JarBuilder()
-            .setObserver(new LoggingJarBuilderObserver(eventSink))
+            .setObserver(loggingObserver)
             .setEntriesToJar(parameters.getEntriesToJar().stream().map(filesystem::resolve))
             .setMainClass(parameters.getMainClass().orElse(null))
             .setManifestFile(parameters.getManifestFile().map(filesystem::resolve).orElse(null))

--- a/src/com/facebook/buck/jvm/java/JavaBinary.java
+++ b/src/com/facebook/buck/jvm/java/JavaBinary.java
@@ -46,6 +46,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
+import java.util.logging.Level;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import javax.annotation.Nullable;
@@ -76,6 +77,7 @@ public class JavaBinary extends AbstractBuildRuleWithDeclaredAndExtraDeps
   private final ImmutableSet<SourcePath> transitiveClasspaths;
 
   private final boolean cache;
+  private Level duplicatesLogLevel;
 
   public JavaBinary(
       BuildTarget buildTarget,
@@ -90,7 +92,8 @@ public class JavaBinary extends AbstractBuildRuleWithDeclaredAndExtraDeps
       ImmutableSet<Pattern> blacklist,
       ImmutableSet<JavaLibrary> transitiveClasspathDeps,
       ImmutableSet<SourcePath> transitiveClasspaths,
-      boolean cache) {
+      boolean cache,
+      Level duplicatesLogLevel) {
     super(buildTarget, projectFilesystem, params);
     this.javaRuntimeLauncher = javaRuntimeLauncher;
     this.mainClass = mainClass;
@@ -106,6 +109,7 @@ public class JavaBinary extends AbstractBuildRuleWithDeclaredAndExtraDeps
     this.transitiveClasspathDeps = transitiveClasspathDeps;
     this.transitiveClasspaths = transitiveClasspaths;
     this.cache = cache;
+    this.duplicatesLogLevel = duplicatesLogLevel;
   }
 
   @Override
@@ -161,6 +165,7 @@ public class JavaBinary extends AbstractBuildRuleWithDeclaredAndExtraDeps
                 .setManifestFile(Optional.ofNullable(manifestPath))
                 .setMergeManifests(mergeManifests)
                 .setDisallowAllDuplicates(disallowAllDuplicates)
+                .setDuplicatesLogLevel(duplicatesLogLevel)
                 .setRemoveEntryPredicate(
                     entry ->
                         blacklistPatternsMatcher.hasPatterns()

--- a/src/com/facebook/buck/jvm/java/JavaBinaryDescription.java
+++ b/src/com/facebook/buck/jvm/java/JavaBinaryDescription.java
@@ -131,7 +131,8 @@ public class JavaBinaryDescription
             args.getBlacklist(),
             transitiveClasspathDeps,
             transitiveClasspaths,
-            javaBuckConfig.shouldCacheBinaries());
+            javaBuckConfig.shouldCacheBinaries(),
+            javaBuckConfig.getDuplicatesLogLevel());
 
     // If we're packaging native libraries, construct the rule to build the fat JAR, which packages
     // up the original binary JAR and any required native libraries.

--- a/src/com/facebook/buck/jvm/java/JavaBuckConfig.java
+++ b/src/com/facebook/buck/jvm/java/JavaBuckConfig.java
@@ -38,6 +38,7 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.logging.Level;
 
 /** A java-specific "view" of BuckConfig. */
 public class JavaBuckConfig implements ConfigView<BuckConfig> {
@@ -241,6 +242,13 @@ public class JavaBuckConfig implements ConfigView<BuckConfig> {
         .orElse(UnusedDependenciesAction.IGNORE);
   }
 
+  public Level getDuplicatesLogLevel() {
+    return delegate
+        .getEnum(SECTION, "duplicates_log_level", DuplicatesLogLevel.class)
+        .orElse(DuplicatesLogLevel.INFO)
+        .getLevel();
+  }
+
   public enum SourceAbiVerificationMode {
     /** Don't verify ABI jars. */
     OFF,
@@ -255,5 +263,23 @@ public class JavaBuckConfig implements ConfigView<BuckConfig> {
     FAIL,
     WARN,
     IGNORE
+  }
+
+  /** Logging level duplicates are reported at */
+  public enum DuplicatesLogLevel {
+    WARN(Level.WARNING),
+    INFO(Level.INFO),
+    FINE(Level.FINE),
+    ;
+
+    private final Level level;
+
+    DuplicatesLogLevel(Level level) {
+      this.level = level;
+    }
+
+    public Level getLevel() {
+      return level;
+    }
   }
 }

--- a/src/com/facebook/buck/jvm/java/LoggingJarBuilderObserver.java
+++ b/src/com/facebook/buck/jvm/java/LoggingJarBuilderObserver.java
@@ -24,9 +24,15 @@ import java.util.zip.ZipEntry;
 
 public class LoggingJarBuilderObserver implements JarBuilder.Observer {
   private final JavacEventSink eventSink;
+  private Level duplicatesLogLevel;
 
   public LoggingJarBuilderObserver(JavacEventSink eventSink) {
+    this(eventSink, Level.INFO);
+  }
+
+  public LoggingJarBuilderObserver(JavacEventSink eventSink, Level duplicatesLogLevel) {
     this.eventSink = eventSink;
+    this.duplicatesLogLevel = duplicatesLogLevel;
   }
 
   @Override
@@ -48,6 +54,6 @@ public class LoggingJarBuilderObserver implements JarBuilder.Observer {
   }
 
   private Level determineSeverity(ZipEntry entry) {
-    return entry.isDirectory() ? Level.FINE : Level.INFO;
+    return entry.isDirectory() ? Level.FINE : duplicatesLogLevel;
   }
 }

--- a/test/com/facebook/buck/jvm/java/JavaBinaryTest.java
+++ b/test/com/facebook/buck/jvm/java/JavaBinaryTest.java
@@ -40,6 +40,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.logging.Level;
 import org.junit.Test;
 
 public class JavaBinaryTest {
@@ -96,7 +97,8 @@ public class JavaBinaryTest {
                 /* blacklist */ ImmutableSet.of(),
                 ImmutableSet.of(),
                 ImmutableSet.of(),
-                /* cache */ true));
+                /* cache */ true,
+                Level.INFO));
 
     // Strip the trailing "." from the absolute path to the current directory.
     final String basePath = new File(".").getAbsolutePath().replaceFirst("\\.$", "");


### PR DESCRIPTION
This is useful for 2 use cases:
- Increase log level to WARN when duplicates are not desired in the codebase.
- Log at Fine to reduce clutter in build logs.