### PR TITLE
Kotlinc Step: Don't add generated code to javac sources if we aren't generating code.

### DIFF
--- a/test/com/facebook/buck/android/AndroidLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/android/AndroidLibraryIntegrationTest.java
@@ -95,7 +95,8 @@ public class AndroidLibraryIntegrationTest extends AbiCompilationModeTest {
   public void testAndroidKotlinLibraryNoKotlinSourcesCompilation() throws Exception {
     AssumeAndroidPlatform.assumeSdkIsAvailable();
     KotlinTestAssumptions.assumeCompilerAvailable(workspace.asCell().getBuckConfig());
-    ProcessResult result = workspace.runBuckBuild("//kotlin/com/sample/lib:lib_mixed_no_kotlin_sources");
+    ProcessResult result =
+        workspace.runBuckBuild("//kotlin/com/sample/lib:lib_mixed_no_kotlin_sources");
     result.assertSuccess();
   }
 

--- a/test/com/facebook/buck/android/AndroidLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/android/AndroidLibraryIntegrationTest.java
@@ -91,6 +91,14 @@ public class AndroidLibraryIntegrationTest extends AbiCompilationModeTest {
     result.assertSuccess();
   }
 
+  @Test
+  public void testAndroidKotlinLibraryNoKotlinSourcesCompilation() throws Exception {
+    AssumeAndroidPlatform.assumeSdkIsAvailable();
+    KotlinTestAssumptions.assumeCompilerAvailable(workspace.asCell().getBuckConfig());
+    ProcessResult result = workspace.runBuckBuild("//kotlin/com/sample/lib:lib_mixed_no_kotlin_sources");
+    result.assertSuccess();
+  }
+
   @Test(timeout = (3 * 60 * 1000))
   public void testAndroidScalaLibraryDoesNotUseTransitiveResources()
       throws InterruptedException, IOException {

--- a/test/com/facebook/buck/android/testdata/android_project/kotlin/com/sample/lib/BUCK.fixture
+++ b/test/com/facebook/buck/android/testdata/android_project/kotlin/com/sample/lib/BUCK.fixture
@@ -82,6 +82,21 @@ android_library(
     ],
 )
 
+android_library(
+    name = "lib_mixed_no_kotlin_sources",
+    srcs = glob([
+        "EmptyJavaClass.java",
+    ]),
+    language = "KOTLIN",
+    visibility = [
+        "PUBLIC",
+    ],
+    deps = [
+        "//res/com/sample/title:title",
+        "//res/com/sample/top:top",
+    ],
+)
+
 robolectric_test(
     name = "test",
     srcs = glob([

--- a/test/com/facebook/buck/android/testdata/android_project/kotlin/com/sample/lib/EmptyJavaClass.java
+++ b/test/com/facebook/buck/android/testdata/android_project/kotlin/com/sample/lib/EmptyJavaClass.java
@@ -1,0 +1,5 @@
+package com.sample.lib;
+
+class EmptyJavaClass {
+  void foo() {}
+}


### PR DESCRIPTION
When using `language= 'kotlin'` in an `android_library` rule without any kotlin source code, it jumps straight into passing the non-existent generated source zip to javac. This results in `__src_debug_gen_sources__/generated.src.zip (No such file or directory)`.