### PR TITLE
Better go test coverage reporting

### DIFF
--- a/docs/__go_common.soy
+++ b/docs/__go_common.soy
@@ -2,7 +2,7 @@
 
 /***/
 {template .supported_language_version}
-Note: Buck is currently tested with (and therefore supports) version 1.5 of Go.
+Note: Buck is currently tested with (and therefore supports) version 1.10 of Go.
 {/template}
 
 /***/

--- a/src/com/facebook/buck/features/go/GoTest.java
+++ b/src/com/facebook/buck/features/go/GoTest.java
@@ -122,8 +122,8 @@ public class GoTest extends NoopBuildRuleWithDeclaredAndExtraDeps
         testMain.getExecutableCommand().getCommandPrefix(buildContext.getSourcePathResolver()));
     args.add("-test.v");
     if (coverageMode != Mode.NONE) {
-      Path coverProfile = getProjectFilesystem().resolve(getPathToTestOutputDirectory())
-          .resolve("coverage");
+      Path coverProfile =
+          getProjectFilesystem().resolve(getPathToTestOutputDirectory()).resolve("coverage");
       args.add("-test.coverprofile", coverProfile.toString());
     }
     if (testRuleTimeoutMs.isPresent()) {

--- a/src/com/facebook/buck/features/go/GoTest.java
+++ b/src/com/facebook/buck/features/go/GoTest.java
@@ -275,8 +275,8 @@ public class GoTest extends AbstractBuildRuleWithDeclaredAndExtraDeps
   }
 
   @Override
-  public ImmutableList<? extends Step> getBuildSteps(BuildContext context,
-      BuildableContext buildableContext) {
+  public ImmutableList<? extends Step> getBuildSteps(
+      BuildContext context, BuildableContext buildableContext) {
     return ImmutableList.of();
   }
 

--- a/src/com/facebook/buck/features/go/GoTest.java
+++ b/src/com/facebook/buck/features/go/GoTest.java
@@ -26,6 +26,7 @@ import com.facebook.buck.rules.BinaryBuildRule;
 import com.facebook.buck.rules.BuildContext;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleParams;
+import com.facebook.buck.rules.ExplicitBuildTargetSourcePath;
 import com.facebook.buck.rules.ExternalTestRunnerRule;
 import com.facebook.buck.rules.ExternalTestRunnerTestSpec;
 import com.facebook.buck.rules.HasRuntimeDeps;
@@ -270,6 +271,11 @@ public class GoTest extends NoopBuildRuleWithDeclaredAndExtraDeps
   @Override
   public Path getPathToTestOutputDirectory() {
     return BuildTargets.getGenPath(getProjectFilesystem(), getBuildTarget(), "__test_%s_output__");
+  }
+
+  @Override
+  public SourcePath getSourcePathToOutput() {
+    return ExplicitBuildTargetSourcePath.of(getBuildTarget(), getPathToTestOutputDirectory());
   }
 
   protected Path getPathToTestResults() {

--- a/src/com/facebook/buck/features/go/GoTest.java
+++ b/src/com/facebook/buck/features/go/GoTest.java
@@ -17,6 +17,7 @@
 package com.facebook.buck.features.go;
 
 import com.facebook.buck.core.model.BuildTarget;
+import com.facebook.buck.core.sourcepath.ExplicitBuildTargetSourcePath;
 import com.facebook.buck.core.sourcepath.SourcePath;
 import com.facebook.buck.features.go.GoTestCoverStep.Mode;
 import com.facebook.buck.io.BuildCellRelativePath;
@@ -26,7 +27,6 @@ import com.facebook.buck.rules.BinaryBuildRule;
 import com.facebook.buck.rules.BuildContext;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleParams;
-import com.facebook.buck.rules.ExplicitBuildTargetSourcePath;
 import com.facebook.buck.rules.ExternalTestRunnerRule;
 import com.facebook.buck.rules.ExternalTestRunnerTestSpec;
 import com.facebook.buck.rules.HasRuntimeDeps;

--- a/src/com/facebook/buck/features/go/GoTest.java
+++ b/src/com/facebook/buck/features/go/GoTest.java
@@ -18,6 +18,7 @@ package com.facebook.buck.features.go;
 
 import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.sourcepath.SourcePath;
+import com.facebook.buck.features.go.GoTestCoverStep.Mode;
 import com.facebook.buck.io.BuildCellRelativePath;
 import com.facebook.buck.io.filesystem.ProjectFilesystem;
 import com.facebook.buck.model.BuildTargets;
@@ -82,6 +83,7 @@ public class GoTest extends NoopBuildRuleWithDeclaredAndExtraDeps
   private final ImmutableSet<String> contacts;
   private final boolean runTestsSeparately;
   private final ImmutableSortedSet<SourcePath> resources;
+  private final Mode coverageMode;
 
   public GoTest(
       BuildTarget buildTarget,
@@ -92,7 +94,8 @@ public class GoTest extends NoopBuildRuleWithDeclaredAndExtraDeps
       ImmutableSet<String> contacts,
       Optional<Long> testRuleTimeoutMs,
       boolean runTestsSeparately,
-      ImmutableSortedSet<SourcePath> resources) {
+      ImmutableSortedSet<SourcePath> resources,
+      Mode coverageMode) {
     super(buildTarget, projectFilesystem, buildRuleParams);
     this.testMain = testMain;
     this.labels = labels;
@@ -100,6 +103,7 @@ public class GoTest extends NoopBuildRuleWithDeclaredAndExtraDeps
     this.testRuleTimeoutMs = testRuleTimeoutMs;
     this.runTestsSeparately = runTestsSeparately;
     this.resources = resources;
+    this.coverageMode = coverageMode;
   }
 
   @Override
@@ -117,6 +121,11 @@ public class GoTest extends NoopBuildRuleWithDeclaredAndExtraDeps
     args.addAll(
         testMain.getExecutableCommand().getCommandPrefix(buildContext.getSourcePathResolver()));
     args.add("-test.v");
+    if (coverageMode != Mode.NONE) {
+      Path coverProfile = getProjectFilesystem().resolve(getPathToTestOutputDirectory())
+          .resolve("coverage");
+      args.add("-test.coverprofile", coverProfile.toString());
+    }
     if (testRuleTimeoutMs.isPresent()) {
       args.add("-test.timeout", testRuleTimeoutMs.get() + "ms");
     }

--- a/src/com/facebook/buck/features/go/GoTest.java
+++ b/src/com/facebook/buck/features/go/GoTest.java
@@ -23,14 +23,15 @@ import com.facebook.buck.features.go.GoTestCoverStep.Mode;
 import com.facebook.buck.io.BuildCellRelativePath;
 import com.facebook.buck.io.filesystem.ProjectFilesystem;
 import com.facebook.buck.model.BuildTargets;
+import com.facebook.buck.rules.AbstractBuildRuleWithDeclaredAndExtraDeps;
 import com.facebook.buck.rules.BinaryBuildRule;
 import com.facebook.buck.rules.BuildContext;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleParams;
+import com.facebook.buck.rules.BuildableContext;
 import com.facebook.buck.rules.ExternalTestRunnerRule;
 import com.facebook.buck.rules.ExternalTestRunnerTestSpec;
 import com.facebook.buck.rules.HasRuntimeDeps;
-import com.facebook.buck.rules.NoopBuildRuleWithDeclaredAndExtraDeps;
 import com.facebook.buck.rules.SourcePathResolver;
 import com.facebook.buck.rules.SourcePathRuleFinder;
 import com.facebook.buck.rules.TestRule;
@@ -68,7 +69,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 @SuppressWarnings("PMD.TestClassWithoutTestCases")
-public class GoTest extends NoopBuildRuleWithDeclaredAndExtraDeps
+public class GoTest extends AbstractBuildRuleWithDeclaredAndExtraDeps
     implements TestRule, HasRuntimeDeps, ExternalTestRunnerRule, BinaryBuildRule {
   private static final Pattern TEST_START_PATTERN = Pattern.compile("^=== RUN\\s+(?<name>.*)$");
   private static final Pattern TEST_FINISHED_PATTERN =
@@ -271,6 +272,12 @@ public class GoTest extends NoopBuildRuleWithDeclaredAndExtraDeps
   @Override
   public Path getPathToTestOutputDirectory() {
     return BuildTargets.getGenPath(getProjectFilesystem(), getBuildTarget(), "__test_%s_output__");
+  }
+
+  @Override
+  public ImmutableList<? extends Step> getBuildSteps(BuildContext context,
+      BuildableContext buildableContext) {
+    return ImmutableList.of();
   }
 
   @Override

--- a/src/com/facebook/buck/features/go/GoTestDescription.java
+++ b/src/com/facebook/buck/features/go/GoTestDescription.java
@@ -260,7 +260,8 @@ public class GoTestDescription
             .map(Optional::of)
             .orElse(goBuckConfig.getDelegate().getDefaultTestRuleTimeoutMs()),
         args.getRunTestSeparately(),
-        args.getResources());
+        args.getResources(),
+        coverageMode);
   }
 
   private GoBinary createTestMainRule(

--- a/src/com/facebook/buck/features/go/GoTestDescription.java
+++ b/src/com/facebook/buck/features/go/GoTestDescription.java
@@ -185,9 +185,17 @@ public class GoTestDescription
 
     GoTestCoverStep.Mode coverageMode;
     ImmutableSortedSet.Builder<BuildRule> extraDeps = ImmutableSortedSet.naturalOrder();
-    ImmutableSet.Builder<SourcePath> srcs = ImmutableSet.builder();
+    ImmutableSet.Builder<SourcePath> srcs;
     ImmutableMap<String, Path> coverVariables;
 
+    ImmutableSet.Builder<SourcePath> rawSrcs = ImmutableSet.builder();
+    rawSrcs.addAll(args.getSrcs());
+    if (args.getLibrary().isPresent()) {
+      GoLibraryDescriptionArg libraryArg =
+          resolver.requireMetadata(args.getLibrary().get(), GoLibraryDescriptionArg.class).get();
+
+      rawSrcs.addAll(libraryArg.getSrcs());
+    }
     if (args.getCoverageMode().isPresent()) {
       coverageMode = args.getCoverageMode().get();
       GoTestCoverStep.Mode coverage = coverageMode;
@@ -203,15 +211,16 @@ public class GoTestDescription
                           ruleFinder,
                           pathResolver,
                           platform,
-                          args.getSrcs(),
+                          rawSrcs.build(),
                           platform.getCover(),
                           coverage));
 
       coverVariables = coverSource.getVariables();
+      srcs = ImmutableSet.builder();
       srcs.addAll(coverSource.getCoveredSources()).addAll(coverSource.getTestSources());
       extraDeps.add(coverSource);
     } else {
-      srcs.addAll(args.getSrcs());
+      srcs = rawSrcs;
       coverVariables = ImmutableMap.of();
       coverageMode = GoTestCoverStep.Mode.NONE;
     }
@@ -380,7 +389,7 @@ public class GoTestDescription
               resolver,
               goBuckConfig,
               packageName,
-              ImmutableSet.<SourcePath>builder().addAll(libraryArg.getSrcs()).addAll(srcs).build(),
+              ImmutableSet.<SourcePath>builder().addAll(srcs).build(),
               ImmutableList.<String>builder()
                   .addAll(libraryArg.getCompilerFlags())
                   .addAll(args.getCompilerFlags())


### PR DESCRIPTION
The source files in the `library` param were not added to the covered source, making `coverSource.getCoveredSources()` returns empty. This PR fixed it.

This PR also makes Buck save the coverage profile when `coverage_mode` is not null.