### PR TITLE
Update createProjectWorkspaceForScenario to create testing jar cell by default

### DIFF
--- a/test/com/facebook/buck/android/AndroidPrebuiltAarIntegrationTest.java
+++ b/test/com/facebook/buck/android/AndroidPrebuiltAarIntegrationTest.java
@@ -43,8 +43,7 @@ public class AndroidPrebuiltAarIntegrationTest extends AbiCompilationModeTest {
   @Before
   public void setUp() throws InterruptedException, IOException {
     AssumeAndroidPlatform.assumeSdkIsAvailable();
-    workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "android_prebuilt_aar", tmp, true);
+    workspace = TestDataHelper.createProjectWorkspaceForScenario(this, "android_prebuilt_aar", tmp);
     workspace.setUp();
     setWorkspaceCompilationMode(workspace);
   }

--- a/test/com/facebook/buck/android/NdkLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/android/NdkLibraryIntegrationTest.java
@@ -39,12 +39,12 @@ public class NdkLibraryIntegrationTest {
     AssumeAndroidPlatform.assumeNdkIsAvailable();
 
     ProjectWorkspace workspace1 =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "cxx_deps", tmp1);
+        TestDataHelper.createProjectWorkspaceForScenarioWithoutDefaultCell(this, "cxx_deps", tmp1);
     workspace1.setUp();
     workspace1.runBuckBuild("//jni:foo").assertSuccess();
 
     ProjectWorkspace workspace2 =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "cxx_deps", tmp2);
+        TestDataHelper.createProjectWorkspaceForScenarioWithoutDefaultCell(this, "cxx_deps", tmp2);
     workspace2.setUp();
     workspace2.runBuckBuild("//jni:foo").assertSuccess();
 

--- a/test/com/facebook/buck/android/RobolectricTestRuleIntegrationTest.java
+++ b/test/com/facebook/buck/android/RobolectricTestRuleIntegrationTest.java
@@ -35,7 +35,7 @@ public class RobolectricTestRuleIntegrationTest {
     AssumeAndroidPlatform.assumeSdkIsAvailable();
 
     workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "android_project", tmpFolder, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "android_project", tmpFolder);
     workspace.setUp();
     workspace.addBuckConfigLocalOption(
         "test",
@@ -50,7 +50,7 @@ public class RobolectricTestRuleIntegrationTest {
     AssumeAndroidPlatform.assumeSdkIsAvailable();
 
     workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "android_project", tmpFolder, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "android_project", tmpFolder);
     workspace.setUp();
     workspace.addBuckConfigLocalOption(
         "test",
@@ -65,7 +65,7 @@ public class RobolectricTestRuleIntegrationTest {
     AssumeAndroidPlatform.assumeSdkIsAvailable();
 
     workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "android_project", tmpFolder, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "android_project", tmpFolder);
     workspace.setUp();
     workspace.addBuckConfigLocalOption(
         "test",

--- a/test/com/facebook/buck/cli/AuditCellCommandIntegrationTest.java
+++ b/test/com/facebook/buck/cli/AuditCellCommandIntegrationTest.java
@@ -41,11 +41,11 @@ public class AuditCellCommandIntegrationTest {
   @Test
   public void testBuckCell() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
+        TestDataHelper.createProjectWorkspaceForScenarioWithoutDefaultCell(
             this, "crosscell_file_watching/primary", tmp.newFolder());
     workspace.setUp();
     ProjectWorkspace secondary =
-        TestDataHelper.createProjectWorkspaceForScenario(
+        TestDataHelper.createProjectWorkspaceForScenarioWithoutDefaultCell(
             this, "crosscell_file_watching/secondary", tmp.newFolder());
     secondary.setUp();
     TestDataHelper.overrideBuckconfig(
@@ -72,11 +72,11 @@ public class AuditCellCommandIntegrationTest {
   @Test
   public void testBuckCellJsonOutput() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
+        TestDataHelper.createProjectWorkspaceForScenarioWithoutDefaultCell(
             this, "crosscell_file_watching/primary", tmp.newFolder());
     workspace.setUp();
     ProjectWorkspace secondary =
-        TestDataHelper.createProjectWorkspaceForScenario(
+        TestDataHelper.createProjectWorkspaceForScenarioWithoutDefaultCell(
             this, "crosscell_file_watching/secondary", tmp.newFolder());
     secondary.setUp();
     TestDataHelper.overrideBuckconfig(

--- a/test/com/facebook/buck/cli/DaemonIntegrationTest.java
+++ b/test/com/facebook/buck/cli/DaemonIntegrationTest.java
@@ -90,7 +90,7 @@ public class DaemonIntegrationTest {
       throws IOException, InterruptedException, ExecutionException {
 
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "exclusive_execution", tmp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "exclusive_execution", tmp);
     workspace.setUp();
     Future<?> firstThread =
         executorService.schedule(
@@ -111,7 +111,7 @@ public class DaemonIntegrationTest {
       throws InterruptedException, IOException {
     long timeoutMillis = 100;
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "exclusive_execution", tmp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "exclusive_execution", tmp);
     workspace.setUp();
 
     // Build an NGContext connected to an NGInputStream reading from a stream that will timeout.
@@ -132,7 +132,7 @@ public class DaemonIntegrationTest {
   public void whenConcurrentReadOnlyCommandExecutedThenReadOnlyCommandSucceeds()
       throws IOException, InterruptedException, ExecutionException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "exclusive_execution", tmp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "exclusive_execution", tmp);
     workspace.setUp();
     Future<?> firstThread =
         executorService.schedule(
@@ -150,7 +150,7 @@ public class DaemonIntegrationTest {
       throws IOException, InterruptedException {
 
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "exclusive_execution", tmp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "exclusive_execution", tmp);
     workspace.setUp();
     executorService.invokeAll(
         ImmutableList.of(
@@ -197,7 +197,7 @@ public class DaemonIntegrationTest {
   @Test
   public void whenAppBuckFileRemovedThenRebuildFails() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "file_watching", tmp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "file_watching", tmp);
     workspace.setUp();
     ProcessResult result = workspace.runBuckdCommand("build", "app");
     result.assertSuccess();
@@ -211,7 +211,7 @@ public class DaemonIntegrationTest {
   @Test
   public void whenActivityBuckFileRemovedThenRebuildFails() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "file_watching", tmp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "file_watching", tmp);
     workspace.setUp();
     workspace.runBuckdCommand("build", "//java/com/example/activity:activity").assertSuccess();
 
@@ -226,7 +226,7 @@ public class DaemonIntegrationTest {
   @Test
   public void whenSourceInputRemovedThenRebuildFails() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "file_watching", tmp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "file_watching", tmp);
     workspace.setUp();
     workspace.runBuckdCommand("build", "//java/com/example/activity:activity").assertSuccess();
 
@@ -247,7 +247,7 @@ public class DaemonIntegrationTest {
   @Test
   public void whenSourceInputInvalidatedThenRebuildFails() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "file_watching", tmp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "file_watching", tmp);
     workspace.setUp();
     workspace.runBuckdCommand("build", "//java/com/example/activity:activity").assertSuccess();
 
@@ -263,7 +263,7 @@ public class DaemonIntegrationTest {
   @Test
   public void whenAppBuckFileInvalidatedThenRebuildFails() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "file_watching", tmp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "file_watching", tmp);
     workspace.setUp();
     workspace.runBuckdCommand("build", "app").assertSuccess();
 
@@ -281,7 +281,7 @@ public class DaemonIntegrationTest {
   @Test
   public void whenNativeBuckTargetInvalidatedThenRebuildFails() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "file_watching", tmp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "file_watching", tmp);
     workspace.setUp();
     ProcessResult result = workspace.runBuckdCommand("run", "//native/main:main");
     result.assertSuccess();
@@ -303,7 +303,7 @@ public class DaemonIntegrationTest {
   @Test
   public void whenNativeSourceInputInvalidatedThenRebuildFails() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "file_watching", tmp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "file_watching", tmp);
     workspace.setUp();
     ProcessResult result = workspace.runBuckdCommand("run", "//native/main:main");
     result.assertSuccess();
@@ -397,7 +397,7 @@ public class DaemonIntegrationTest {
   @Test
   public void whenBuckBuiltTwiceLogIsPresent() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "file_watching", tmp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "file_watching", tmp);
     workspace.setUp();
 
     workspace.runBuckdCommand("build", "//java/com/example/activity:activity").assertSuccess();

--- a/test/com/facebook/buck/cli/ExternalTestRunnerIntegrationTest.java
+++ b/test/com/facebook/buck/cli/ExternalTestRunnerIntegrationTest.java
@@ -40,8 +40,7 @@ public class ExternalTestRunnerIntegrationTest {
 
   @Before
   public void setUp() throws IOException {
-    workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "external_test_runner", tmp, true);
+    workspace = TestDataHelper.createProjectWorkspaceForScenario(this, "external_test_runner", tmp);
     workspace.setUp();
   }
 

--- a/test/com/facebook/buck/cli/TestCommandIntegrationTest.java
+++ b/test/com/facebook/buck/cli/TestCommandIntegrationTest.java
@@ -68,7 +68,7 @@ public class TestCommandIntegrationTest {
   @Test
   public void testCsvCodeCoverage() throws Exception {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "test_coverage", tmp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "test_coverage", tmp);
     workspace.setUp();
 
     try (PropertySaver saver = new PropertySaver(getCodeCoverageProperties())) {
@@ -84,7 +84,7 @@ public class TestCommandIntegrationTest {
   @Test
   public void testHtmlCodeCoverage() throws Exception {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "test_coverage", tmp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "test_coverage", tmp);
     workspace.setUp();
 
     try (PropertySaver saver = new PropertySaver(getCodeCoverageProperties())) {
@@ -103,7 +103,7 @@ public class TestCommandIntegrationTest {
   @Test
   public void testXmlCodeCoverage() throws Exception {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "test_coverage", tmp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "test_coverage", tmp);
     workspace.setUp();
 
     try (PropertySaver saver = new PropertySaver(getCodeCoverageProperties())) {

--- a/test/com/facebook/buck/config/BuckConfigTest.java
+++ b/test/com/facebook/buck/config/BuckConfigTest.java
@@ -349,7 +349,7 @@ public class BuckConfigTest {
   public void testBuckPyIgnorePaths() throws IOException {
     ProjectWorkspace workspace =
         TestDataHelper.createProjectWorkspaceForScenario(
-            this, "buck_py_ignore_paths", temporaryFolder, true);
+            this, "buck_py_ignore_paths", temporaryFolder);
     workspace.setUp();
 
     ProcessResult result = workspace.runBuckCommand("test", "--all");

--- a/test/com/facebook/buck/crosscell/InterCellIntegrationTest.java
+++ b/test/com/facebook/buck/crosscell/InterCellIntegrationTest.java
@@ -420,7 +420,8 @@ public class InterCellIntegrationTest {
   @Test
   public void circularCellReferencesAreAllowed() throws IOException {
     ProjectWorkspace mainRepo =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "inter-cell/circular", tmp);
+        TestDataHelper.createProjectWorkspaceForScenarioWithoutDefaultCell(
+            this, "inter-cell/circular", tmp);
     mainRepo.setUp();
     Path primary = mainRepo.getPath("primary");
 
@@ -910,7 +911,8 @@ public class InterCellIntegrationTest {
   private ProjectWorkspace createWorkspace(String scenarioName) throws IOException {
     Path tmpSubfolder = tmp.newFolder();
     ProjectWorkspace projectWorkspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, scenarioName, tmpSubfolder);
+        TestDataHelper.createProjectWorkspaceForScenarioWithoutDefaultCell(
+            this, scenarioName, tmpSubfolder);
     projectWorkspace.setUp();
     return projectWorkspace;
   }

--- a/test/com/facebook/buck/crosscell/SourcePathResolutionIntegrationTest.java
+++ b/test/com/facebook/buck/crosscell/SourcePathResolutionIntegrationTest.java
@@ -106,7 +106,8 @@ public class SourcePathResolutionIntegrationTest {
   private ProjectWorkspace createWorkspace(String scenarioName) throws IOException {
     Path tmpSubfolder = tmp.newFolder();
     ProjectWorkspace projectWorkspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, scenarioName, tmpSubfolder);
+        TestDataHelper.createProjectWorkspaceForScenarioWithoutDefaultCell(
+            this, scenarioName, tmpSubfolder);
     projectWorkspace.setUp();
     return projectWorkspace;
   }

--- a/test/com/facebook/buck/distributed/DistBuildIntegrationTest.java
+++ b/test/com/facebook/buck/distributed/DistBuildIntegrationTest.java
@@ -173,7 +173,7 @@ public class DistBuildIntegrationTest {
       throws IOException {
     Path cellPath = outputDir.resolve(cellSubDir);
     ProjectWorkspace sourceWorkspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
+        TestDataHelper.createProjectWorkspaceForScenarioWithoutDefaultCell(
             this, scenario + "/" + cellSubDir, cellPath);
     sourceWorkspace.setUp();
     return sourceWorkspace;

--- a/test/com/facebook/buck/ide/intellij/ProjectIntegrationTest.java
+++ b/test/com/facebook/buck/ide/intellij/ProjectIntegrationTest.java
@@ -110,7 +110,7 @@ public class ProjectIntegrationTest {
   public void testVersion2BuckProjectWithUnusedLibraries() throws IOException {
     ProjectWorkspace workspace =
         TestDataHelper.createProjectWorkspaceForScenario(
-            this, "project_with_unused_libraries", temporaryFolder, true);
+            this, "project_with_unused_libraries", temporaryFolder);
     workspace.setUp();
 
     ProcessResult result = workspace.runBuckCommand("project");
@@ -403,12 +403,12 @@ public class ProjectIntegrationTest {
     AssumeAndroidPlatform.assumeSdkIsAvailable();
 
     ProjectWorkspace primary =
-        TestDataHelper.createProjectWorkspaceForScenario(
+        TestDataHelper.createProjectWorkspaceForScenarioWithoutDefaultCell(
             this, "inter-cell/primary", temporaryFolder.newFolder());
     primary.setUp();
 
     ProjectWorkspace secondary =
-        TestDataHelper.createProjectWorkspaceForScenario(
+        TestDataHelper.createProjectWorkspaceForScenarioWithoutDefaultCell(
             this, "inter-cell/secondary", temporaryFolder.newFolder());
     secondary.setUp();
 
@@ -459,8 +459,7 @@ public class ProjectIntegrationTest {
     AssumeAndroidPlatform.assumeSdkIsAvailable();
 
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, folderWithTestData, temporaryFolder, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, folderWithTestData, temporaryFolder);
     workspace.setUp();
 
     ProcessResult result =

--- a/test/com/facebook/buck/jvm/groovy/GroovyTestIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/groovy/GroovyTestIntegrationTest.java
@@ -37,8 +37,7 @@ public class GroovyTestIntegrationTest {
     assumeTrue(System.getenv("GROOVY_HOME") != null);
 
     workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, "groovy_test_description", tmp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "groovy_test_description", tmp);
     workspace.setUp();
   }
 

--- a/test/com/facebook/buck/jvm/java/BuildTargetSourcePathAsSrcIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/java/BuildTargetSourcePathAsSrcIntegrationTest.java
@@ -40,7 +40,7 @@ public class BuildTargetSourcePathAsSrcIntegrationTest {
     Charset charsetForTest = StandardCharsets.UTF_8;
     ProjectWorkspace workspace =
         TestDataHelper.createProjectWorkspaceForScenario(
-            this, "build_rule_source_path_as_src_test", tmp, true);
+            this, "build_rule_source_path_as_src_test", tmp);
     workspace.setUp();
 
     // The test should pass out of the box.

--- a/test/com/facebook/buck/jvm/java/GenruleDepsIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/java/GenruleDepsIntegrationTest.java
@@ -39,7 +39,7 @@ public class GenruleDepsIntegrationTest {
   public void testUpdatingJarBuildByGenruleAffectDependentRebuild() throws IOException {
     Charset charsetForTest = StandardCharsets.UTF_8;
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "genrule_test", tmp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "genrule_test", tmp);
     workspace.setUp();
 
     // The test should pass out of the box.

--- a/test/com/facebook/buck/jvm/java/JavaTestIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/java/JavaTestIntegrationTest.java
@@ -45,7 +45,7 @@ public class JavaTestIntegrationTest {
   @Test
   public void shouldNotCompileIfDependsOnCompilerClasspath() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "missing_test_deps", temp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "missing_test_deps", temp);
     workspace.setUp();
 
     ProcessResult result = workspace.runBuckCommand("build", "//:no-jsr-305");
@@ -58,7 +58,7 @@ public class JavaTestIntegrationTest {
   @Test
   public void shouldRefuseToRunJUnitTestsIfHamcrestNotOnClasspath() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "missing_test_deps", temp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "missing_test_deps", temp);
     workspace.setUp();
 
     ProcessResult result = workspace.runBuckCommand("test", "//:no-hamcrest");
@@ -76,7 +76,7 @@ public class JavaTestIntegrationTest {
   @Test
   public void shouldRefuseToRunJUnitTestsIfJUnitNotOnClasspath() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "missing_test_deps", temp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "missing_test_deps", temp);
     workspace.setUp();
 
     ProcessResult result = workspace.runBuckCommand("test", "//:no-junit");
@@ -94,7 +94,7 @@ public class JavaTestIntegrationTest {
   @Test
   public void shouldRefuseToRunTestNgTestsIfTestNgNotOnClasspath() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "missing_test_deps", temp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "missing_test_deps", temp);
     workspace.setUp();
 
     ProcessResult result = workspace.runBuckCommand("test", "//:no-testng");
@@ -123,7 +123,7 @@ public class JavaTestIntegrationTest {
   @Test
   public void shouldNotDeadlock() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "deadlock", temp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "deadlock", temp);
     workspace.setUp();
 
     ProcessResult result = workspace.runBuckCommand("test", "//:suite");
@@ -135,7 +135,7 @@ public class JavaTestIntegrationTest {
   public void missingResultsFileIsTestFailure() throws IOException {
     ProjectWorkspace workspace =
         TestDataHelper.createProjectWorkspaceForScenario(
-            this, "java_test_missing_result_file", temp, true);
+            this, "java_test_missing_result_file", temp);
     workspace.setUp();
 
     ProcessResult result = workspace.runBuckCommand("test", "//:simple");
@@ -148,7 +148,7 @@ public class JavaTestIntegrationTest {
   @Test
   public void spinningTestTimesOutGlobalTimeout() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "slow_tests", temp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "slow_tests", temp);
     workspace.setUp();
     workspace.writeContentsToPath("[test]\n  rule_timeout = 250", ".buckconfig");
 
@@ -163,8 +163,7 @@ public class JavaTestIntegrationTest {
   @Test
   public void spinningTestTimesOutPerRuleTimeout() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, "slow_tests_per_rule_timeout", temp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "slow_tests_per_rule_timeout", temp);
     workspace.setUp();
 
     ProcessResult result = workspace.runBuckCommand("test", "//:spinning");
@@ -178,7 +177,7 @@ public class JavaTestIntegrationTest {
   @Test
   public void normalTestDoesNotTimeOut() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "slow_tests", temp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "slow_tests", temp);
     workspace.setUp();
     workspace.writeContentsToPath("[test]\n  rule_timeout = 10000", ".buckconfig");
 
@@ -188,7 +187,7 @@ public class JavaTestIntegrationTest {
   @Test
   public void brokenTestGivesFailedTestResult() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "java_test_broken_test", temp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "java_test_broken_test", temp);
     workspace.setUp();
     workspace.runBuckCommand("test", "//:simple").assertTestFailure();
   }
@@ -196,8 +195,7 @@ public class JavaTestIntegrationTest {
   @Test
   public void staticInitializationException() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, "static_initialization_test", temp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "static_initialization_test", temp);
     workspace.setUp();
     ProcessResult result = workspace.runBuckCommand("test", "//:npe");
     result.assertTestFailure();
@@ -208,8 +206,7 @@ public class JavaTestIntegrationTest {
   @Test
   public void dependencyOnAnotherTest() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, "depend_on_another_test", temp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "depend_on_another_test", temp);
     workspace.setUp();
     ProcessResult result = workspace.runBuckCommand("test", "//:a");
     result.assertSuccess();
@@ -257,7 +254,7 @@ public class JavaTestIntegrationTest {
   @Test
   public void testForkMode() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "slow_tests", temp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "slow_tests", temp);
     workspace.setUp();
     ProcessResult result = workspace.runBuckCommand("test", "//:fork-mode");
     result.assertSuccess();
@@ -266,7 +263,7 @@ public class JavaTestIntegrationTest {
   @Test
   public void testClasspath() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "test_rule_classpath", temp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "test_rule_classpath", temp);
     workspace.setUp();
     ProcessResult result = workspace.runBuckCommand("audit", "classpath", "//:top");
     result.assertSuccess();
@@ -286,7 +283,7 @@ public class JavaTestIntegrationTest {
   @Test
   public void testEnvLocationMacro() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "env_macros", temp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "env_macros", temp);
     workspace.setUp();
     workspace.runBuckCommand("test", "//:env").assertSuccess();
   }

--- a/test/com/facebook/buck/jvm/java/UnusedDependenciesFinderIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/java/UnusedDependenciesFinderIntegrationTest.java
@@ -38,7 +38,7 @@ public class UnusedDependenciesFinderIntegrationTest {
   public void setUp() throws InterruptedException, IOException {
     workspace =
         TestDataHelper.createProjectWorkspaceForScenario(
-            this, "unused_dependencies", temporaryFolder, true);
+            this, "unused_dependencies", temporaryFolder);
     workspace.setUp();
   }
 

--- a/test/com/facebook/buck/jvm/kotlin/KotlinTestIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/kotlin/KotlinTestIntegrationTest.java
@@ -36,8 +36,7 @@ public class KotlinTestIntegrationTest {
   @Before
   public void setUp() throws Exception {
     workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, "kotlin_test_description", tmp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "kotlin_test_description", tmp);
     workspace.setUp();
 
     Path kotlincPath = TestDataHelper.getTestDataScenario(this, "kotlinc");

--- a/test/com/facebook/buck/jvm/scala/ScalaTestIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/scala/ScalaTestIntegrationTest.java
@@ -37,7 +37,7 @@ public class ScalaTestIntegrationTest {
 
   @Before
   public void setUp() throws IOException {
-    workspace = TestDataHelper.createProjectWorkspaceForScenario(this, "scala_test", tmp, true);
+    workspace = TestDataHelper.createProjectWorkspaceForScenario(this, "scala_test", tmp);
     workspace.setUp();
   }
 

--- a/test/com/facebook/buck/rules/modern/ModernBuildRuleStrategyIntegrationTest.java
+++ b/test/com/facebook/buck/rules/modern/ModernBuildRuleStrategyIntegrationTest.java
@@ -223,7 +223,9 @@ public class ModernBuildRuleStrategyIntegrationTest {
   public void setUp() throws InterruptedException, IOException {
     // MBR strategies use a ContentAddressedStorage that doesn't work correctly on Windows.
     assumeFalse(Platform.detect().equals(Platform.WINDOWS));
-    workspace = TestDataHelper.createProjectWorkspaceForScenario(this, "strategies", tmpFolder);
+    workspace =
+        TestDataHelper.createProjectWorkspaceForScenarioWithoutDefaultCell(
+            this, "strategies", tmpFolder);
     workspace.setKnownBuildRuleTypesFactoryFactory(
         (processExecutor, pluginManager, sandboxExecutionStrategyFactory) ->
             cell ->

--- a/test/com/facebook/buck/test/labels/LabelsIntegrationTest.java
+++ b/test/com/facebook/buck/test/labels/LabelsIntegrationTest.java
@@ -35,8 +35,7 @@ public class LabelsIntegrationTest {
 
   @Before
   public void setUpWorkspace() throws IOException {
-    workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "labels", temporaryFolder, true);
+    workspace = TestDataHelper.createProjectWorkspaceForScenario(this, "labels", temporaryFolder);
     workspace.setUp();
   }
 

--- a/test/com/facebook/buck/testrunner/AssumptionViolationsTest.java
+++ b/test/com/facebook/buck/testrunner/AssumptionViolationsTest.java
@@ -40,7 +40,7 @@ public class AssumptionViolationsTest {
   public void setupWorkspace() throws IOException {
     workspace =
         TestDataHelper.createProjectWorkspaceForScenario(
-            this, "assumption_violations", temporaryFolder, true);
+            this, "assumption_violations", temporaryFolder);
     workspace.setUp();
   }
 

--- a/test/com/facebook/buck/testrunner/BuildThenTestIntegrationTest.java
+++ b/test/com/facebook/buck/testrunner/BuildThenTestIntegrationTest.java
@@ -41,8 +41,7 @@ public class BuildThenTestIntegrationTest {
   @Test
   public void testBuildThenTest() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, "build_then_test", temporaryFolder, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "build_then_test", temporaryFolder);
     workspace.setUp();
 
     ProcessResult buildResult = workspace.runBuckCommand("build", "//:example");
@@ -70,8 +69,7 @@ public class BuildThenTestIntegrationTest {
   @Test
   public void testRunningTestOnClassWithoutTestMethods() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, "build_then_test", temporaryFolder, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "build_then_test", temporaryFolder);
     workspace.setUp();
 
     ProcessResult testResult = workspace.runBuckCommand("test", "//:nontestclass");
@@ -85,8 +83,7 @@ public class BuildThenTestIntegrationTest {
   @Test
   public void testRunningTestInAbstractClass() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, "build_then_test", temporaryFolder, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "build_then_test", temporaryFolder);
     workspace.setUp();
 
     ProcessResult testResult = workspace.runBuckCommand("test", "//:abstractclass");

--- a/test/com/facebook/buck/testrunner/CallFlowIntegrationTest.java
+++ b/test/com/facebook/buck/testrunner/CallFlowIntegrationTest.java
@@ -34,8 +34,7 @@ public class CallFlowIntegrationTest {
   @Test
   public void testCallFlow() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, "test_call_flow", temporaryFolder, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "test_call_flow", temporaryFolder);
     workspace.setUp();
 
     // ExceedsAnnotationTimeoutTest should fail.

--- a/test/com/facebook/buck/testrunner/ClassStatementsTest.java
+++ b/test/com/facebook/buck/testrunner/ClassStatementsTest.java
@@ -41,8 +41,7 @@ public class ClassStatementsTest {
   @Test
   public void shouldFailWhenBeforeClassThrows() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, "class_statements", temporaryFolder, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "class_statements", temporaryFolder);
     workspace.setUp();
 
     ProcessResult result = workspace.runBuckCommand("test", "--all");

--- a/test/com/facebook/buck/testrunner/LoggingIntegrationTest.java
+++ b/test/com/facebook/buck/testrunner/LoggingIntegrationTest.java
@@ -36,7 +36,7 @@ public class LoggingIntegrationTest {
   @Test
   public void logOutputIsOnlyReportedForTestWhichFails() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "test_with_logging", temp, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "test_with_logging", temp);
     workspace.setUp();
 
     ProcessResult result = workspace.runBuckCommand("test", "//:logging");

--- a/test/com/facebook/buck/testrunner/RunWithAnnotationIntegrationTest.java
+++ b/test/com/facebook/buck/testrunner/RunWithAnnotationIntegrationTest.java
@@ -45,7 +45,7 @@ public class RunWithAnnotationIntegrationTest {
   @Test
   public void testSimpleSuiteRun2TestCases() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "runwith", temporaryFolder, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "runwith", temporaryFolder);
     workspace.setUp();
 
     ProcessResult suiteTestResult = workspace.runBuckCommand("test", "//:SimpleSuiteTest");
@@ -56,7 +56,7 @@ public class RunWithAnnotationIntegrationTest {
   @Test
   public void testFailingSuiteRun3TestCasesWith1Failure() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "runwith", temporaryFolder, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "runwith", temporaryFolder);
     workspace.setUp();
 
     ProcessResult suiteTestResult = workspace.runBuckCommand("test", "//:FailingSuiteTest");
@@ -68,7 +68,7 @@ public class RunWithAnnotationIntegrationTest {
   @Test
   public void testParametrizedTestRun4Cases() throws IOException, SAXException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "runwith", temporaryFolder, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "runwith", temporaryFolder);
     workspace.setUp();
 
     ProcessResult suiteTestResult = workspace.runBuckCommand("test", "//:ParametrizedTest");

--- a/test/com/facebook/buck/testrunner/RunWithDefaultTimeoutIntegrationTest.java
+++ b/test/com/facebook/buck/testrunner/RunWithDefaultTimeoutIntegrationTest.java
@@ -59,8 +59,7 @@ public class RunWithDefaultTimeoutIntegrationTest {
   public void testRunWithHonorsDefaultTimeoutOnTestThatRunsLong() throws IOException {
     assumeThat(Platform.detect(), not(Platform.WINDOWS));
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, "run_with_timeout", temporaryFolder, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "run_with_timeout", temporaryFolder);
     workspace.setUp();
 
     ProcessResult testResult = workspace.runBuckCommand("test", "//:TestThatTakesTooLong");
@@ -72,8 +71,7 @@ public class RunWithDefaultTimeoutIntegrationTest {
   public void testRunWithHonorsDefaultTimeoutOnTestThatRunsForever() throws IOException {
     assumeThat(Platform.detect(), not(Platform.WINDOWS));
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, "run_with_timeout", temporaryFolder, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "run_with_timeout", temporaryFolder);
     workspace.setUp();
 
     ProcessResult testResult = workspace.runBuckCommand("test", "//:TestThatRunsForever");
@@ -85,8 +83,7 @@ public class RunWithDefaultTimeoutIntegrationTest {
   public void testRunWithLetsTimeoutAnnotationOverrideDefaultTimeout() throws IOException {
     assumeThat(Platform.detect(), not(Platform.WINDOWS));
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, "run_with_timeout", temporaryFolder, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "run_with_timeout", temporaryFolder);
     workspace.setUp();
 
     ProcessResult testResult =
@@ -99,8 +96,7 @@ public class RunWithDefaultTimeoutIntegrationTest {
   public void testRunWithLetsTimeoutRuleOverrideDefaultTimeout() throws IOException {
     assumeThat(Platform.detect(), not(Platform.WINDOWS));
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, "run_with_timeout", temporaryFolder, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "run_with_timeout", temporaryFolder);
     workspace.setUp();
 
     ProcessResult testResult =
@@ -113,8 +109,7 @@ public class RunWithDefaultTimeoutIntegrationTest {
   public void testAllTestsForRunWithAreRunOnTheSameThread() throws IOException {
     assumeThat(Platform.detect(), not(Platform.WINDOWS));
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, "run_with_timeout", temporaryFolder, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "run_with_timeout", temporaryFolder);
     workspace.setUp();
 
     ProcessResult testResult =

--- a/test/com/facebook/buck/testrunner/TestNGIntegrationTest.java
+++ b/test/com/facebook/buck/testrunner/TestNGIntegrationTest.java
@@ -38,8 +38,7 @@ public class TestNGIntegrationTest {
   @Before
   public void setupSimpleTestNGWorkspace() throws IOException {
     workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, "simple_testng", temporaryFolder, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "simple_testng", temporaryFolder);
     workspace.setUp();
   }
 

--- a/test/com/facebook/buck/testrunner/TestNGLoggingIntegrationTest.java
+++ b/test/com/facebook/buck/testrunner/TestNGLoggingIntegrationTest.java
@@ -37,8 +37,7 @@ public class TestNGLoggingIntegrationTest {
 
   @Before
   public void setupWorkspace() throws IOException {
-    workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "testng_logging", temp, true);
+    workspace = TestDataHelper.createProjectWorkspaceForScenario(this, "testng_logging", temp);
     workspace.setUp();
   }
 

--- a/test/com/facebook/buck/testrunner/TestSelectorsDifferentRunnerIntegrationTest.java
+++ b/test/com/facebook/buck/testrunner/TestSelectorsDifferentRunnerIntegrationTest.java
@@ -40,7 +40,7 @@ public class TestSelectorsDifferentRunnerIntegrationTest {
   public void shouldSelectOneTest() throws IOException {
     ProjectWorkspace workspace =
         TestDataHelper.createProjectWorkspaceForScenario(
-            this, "test_selectors_annotated_with_runwith", temporaryFolder, true);
+            this, "test_selectors_annotated_with_runwith", temporaryFolder);
     workspace.setUp();
 
     Path file = workspace.getPath("AnotherRunnerLogger.log");

--- a/test/com/facebook/buck/testrunner/TestSelectorsIntegrationTest.java
+++ b/test/com/facebook/buck/testrunner/TestSelectorsIntegrationTest.java
@@ -41,8 +41,7 @@ public class TestSelectorsIntegrationTest {
   @Before
   public void setupWorkspace() throws IOException {
     workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(
-            this, "test_selectors", temporaryFolder, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "test_selectors", temporaryFolder);
     workspace.setUp();
   }
 

--- a/test/com/facebook/buck/testrunner/TestSelectorsJUnitVersionsIntegrationTest.java
+++ b/test/com/facebook/buck/testrunner/TestSelectorsJUnitVersionsIntegrationTest.java
@@ -43,7 +43,7 @@ public class TestSelectorsJUnitVersionsIntegrationTest {
   public void setupWorkspace() throws IOException {
     workspace =
         TestDataHelper.createProjectWorkspaceForScenario(
-            this, "test_selectors_junit_versions", temporaryFolder, true);
+            this, "test_selectors_junit_versions", temporaryFolder);
     workspace.setUp();
   }
 

--- a/test/com/facebook/buck/testrunner/TestSelectorsTestlessClassesTest.java
+++ b/test/com/facebook/buck/testrunner/TestSelectorsTestlessClassesTest.java
@@ -46,7 +46,7 @@ public class TestSelectorsTestlessClassesTest {
   public void setupWorkspace() throws IOException {
     workspace =
         TestDataHelper.createProjectWorkspaceForScenario(
-            this, "test_selectors_testless_classes", temporaryFolder, true);
+            this, "test_selectors_testless_classes", temporaryFolder);
     workspace.setUp();
   }
 

--- a/test/com/facebook/buck/testrunner/TimeoutIntegrationTest.java
+++ b/test/com/facebook/buck/testrunner/TimeoutIntegrationTest.java
@@ -43,7 +43,6 @@ import org.junit.Test;
  * <p>That said, this behavior of JUnit interacts badly with a default test timeout in {@code
  * .buckconfig} because it requires adding {@link org.junit.rules.Timeout} to the handful of tests
  * that exploit this behavior.
- *
  */
 public class TimeoutIntegrationTest {
 
@@ -54,7 +53,7 @@ public class TimeoutIntegrationTest {
   @Test
   public void testThatTimeoutsInTestsWorkAsExpected() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "timeouts", temporaryFolder, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "timeouts", temporaryFolder);
     workspace.setUp();
 
     // ExceedsAnnotationTimeoutTest should fail.
@@ -99,7 +98,7 @@ public class TimeoutIntegrationTest {
   public void individualTestCanOverrideTheDefaultTestTimeout() throws IOException {
     ProjectWorkspace workspace =
         TestDataHelper.createProjectWorkspaceForScenario(
-            this, "overridden_timeouts", temporaryFolder, true);
+            this, "overridden_timeouts", temporaryFolder);
     workspace.setUp();
 
     // The .buckconfig in that workspace sets the default timeout to 1000ms.
@@ -111,7 +110,7 @@ public class TimeoutIntegrationTest {
   @Test
   public void testThatTimeoutsDumpsThreadStacks() throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(this, "timeouts", temporaryFolder, true);
+        TestDataHelper.createProjectWorkspaceForScenario(this, "timeouts", temporaryFolder);
     workspace.setUp();
 
     ProcessResult testResult = workspace.runBuckCommand("test", "//:SleepTest");

--- a/test/com/facebook/buck/testutil/integration/InferHelper.java
+++ b/test/com/facebook/buck/testutil/integration/InferHelper.java
@@ -40,7 +40,8 @@ public class InferHelper {
   public static ProjectWorkspace setupWorkspace(
       Object testCase, Path workspaceRoot, String scenarioName) throws IOException {
     ProjectWorkspace projectWorkspace =
-        TestDataHelper.createProjectWorkspaceForScenario(testCase, scenarioName, workspaceRoot);
+        TestDataHelper.createProjectWorkspaceForScenarioWithoutDefaultCell(
+            testCase, scenarioName, workspaceRoot);
     projectWorkspace.setUp();
     return projectWorkspace;
   }
@@ -60,7 +61,8 @@ public class InferHelper {
       Optional<Path> fakeInferRootPathOpt)
       throws IOException {
     ProjectWorkspace workspace =
-        TestDataHelper.createProjectWorkspaceForScenario(testCase, scenarioName, temporaryFolder);
+        TestDataHelper.createProjectWorkspaceForScenarioWithoutDefaultCell(
+            testCase, scenarioName, temporaryFolder);
 
     Path fakeInferRootPath = fakeInferRootPathOpt.orElse(workspace.getPath("fake-infer"));
 

--- a/test/com/facebook/buck/testutil/integration/ProjectWorkspace.java
+++ b/test/com/facebook/buck/testutil/integration/ProjectWorkspace.java
@@ -156,7 +156,7 @@ public class ProjectWorkspace extends AbstractWorkspace {
 
   @VisibleForTesting
   ProjectWorkspace(Path templateDir, Path targetFolder) {
-    this(templateDir, targetFolder, false);
+    this(templateDir, targetFolder, true);
   }
 
   private ProjectFilesystemAndConfig getProjectFilesystemAndConfig()

--- a/test/com/facebook/buck/testutil/integration/TestDataHelper.java
+++ b/test/com/facebook/buck/testutil/integration/TestDataHelper.java
@@ -86,21 +86,21 @@ public class TestDataHelper {
   }
 
   public static ProjectWorkspace createProjectWorkspaceForScenario(
-      Object testCase, String scenario, TemporaryPaths temporaryRoot, boolean addBuckRepoCell) {
-    Path templateDir = TestDataHelper.getTestDataScenario(testCase, scenario);
-    return new ProjectWorkspace(templateDir, temporaryRoot.getRoot(), addBuckRepoCell);
-  }
-
-  public static ProjectWorkspace createProjectWorkspaceForScenario(
       Object testCase, String scenario, Path temporaryRoot) {
     Path templateDir = TestDataHelper.getTestDataScenario(testCase, scenario);
     return new ProjectWorkspace(templateDir, temporaryRoot);
   }
 
-  public static ProjectWorkspace createProjectWorkspaceForScenario(
-      Object testCase, String scenario, Path temporaryRoot, boolean addBuckRepoCell) {
+  public static ProjectWorkspace createProjectWorkspaceForScenarioWithoutDefaultCell(
+      Object testCase, String scenario, TemporaryPaths temporaryRoot) {
     Path templateDir = TestDataHelper.getTestDataScenario(testCase, scenario);
-    return new ProjectWorkspace(templateDir, temporaryRoot, addBuckRepoCell);
+    return new ProjectWorkspace(templateDir, temporaryRoot.getRoot(), false);
+  }
+
+  public static ProjectWorkspace createProjectWorkspaceForScenarioWithoutDefaultCell(
+      Object testCase, String scenario, Path temporaryRoot) {
+    Path templateDir = TestDataHelper.getTestDataScenario(testCase, scenario);
+    return new ProjectWorkspace(templateDir, temporaryRoot, false);
   }
 
   public static void overrideBuckconfig(


### PR DESCRIPTION
- Updated TestDataHelper.createProjectWorkspaceForScenario to always create default cell with 3rdpaty jars used by tests.
- Added createProjectWorkspaceForScenarioNoDefaultCell instead of bool parameter to be used by tests that need to set up their own cells.

This change was suggested by @styurin in https://github.com/facebook/buck/pull/1855