### PR TITLE
Add modulemap to headers for modular apple_library

### DIFF
--- a/src/com/facebook/buck/apple/AppleLibraryDescription.java
+++ b/src/com/facebook/buck/apple/AppleLibraryDescription.java
@@ -67,6 +67,7 @@ import com.facebook.buck.cxx.HasAppleDebugSymbolDeps;
 import com.facebook.buck.cxx.HeaderSymlinkTreeWithHeaderMap;
 import com.facebook.buck.cxx.toolchain.CxxPlatform;
 import com.facebook.buck.cxx.toolchain.CxxPlatformsProvider;
+import com.facebook.buck.cxx.toolchain.HeaderMode;
 import com.facebook.buck.cxx.toolchain.HeaderSymlinkTree;
 import com.facebook.buck.cxx.toolchain.HeaderVisibility;
 import com.facebook.buck.cxx.toolchain.LinkerMapMode;
@@ -90,10 +91,14 @@ import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
@@ -601,6 +606,19 @@ public class AppleLibraryDescription
       unstrippedTarget = unstrippedTarget.withoutFlavors(LinkerMapMode.NO_LINKER_MAP.getFlavor());
     }
 
+    Optional<CxxPlatform> platform =
+        getCxxPlatformsProvider().getCxxPlatforms().getValue(buildTarget);
+    Optional<Type> libType = LIBRARY_TYPE.getValue(buildTarget);
+    Optional<HeaderMode> headerMode = CxxLibraryDescription.HEADER_MODE.getValue(buildTarget);
+    if (platform.isPresent()
+        && libType.isPresent()
+        && libType.get().equals(Type.EXPORTED_HEADERS)
+        && headerMode.isPresent()
+        && headerMode.get().equals(HeaderMode.SYMLINK_TREE_WITH_MODULEMAP)) {
+      return createExportedModuleSymlinkTreeBuildRule(
+          buildTarget, context.getProjectFilesystem(), graphBuilder, args);
+    }
+
     return graphBuilder.computeIfAbsent(
         unstrippedTarget,
         unstrippedTarget1 -> {
@@ -634,6 +652,32 @@ public class AppleLibraryDescription
     return AppleDebuggableBinary.isBuildRuleDebuggable(buildRule);
   }
 
+  /** @return a {@link HeaderSymlinkTree} for the exported headers of this C/C++ library. */
+  private HeaderSymlinkTree createExportedModuleSymlinkTreeBuildRule(
+      BuildTarget buildTarget,
+      ProjectFilesystem projectFilesystem,
+      ActionGraphBuilder graphBuilder,
+      AppleNativeTargetDescriptionArg args) {
+    SourcePathRuleFinder ruleFinder = new SourcePathRuleFinder(graphBuilder);
+    SourcePathResolver pathResolver = DefaultSourcePathResolver.from(ruleFinder);
+
+    Path headerPathPrefix = AppleDescriptions.getHeaderPathPrefix(args, buildTarget);
+    ImmutableSortedMap<String, SourcePath> headers =
+        AppleDescriptions.parseAppleHeadersForUseFromOtherTargets(
+            buildTarget,
+            pathResolver::getRelativePath,
+            headerPathPrefix,
+            args.getExportedHeaders());
+
+    return CxxDescriptionEnhancer.createHeaderSymlinkTree(
+        buildTarget,
+        projectFilesystem,
+        ruleFinder,
+        HeaderMode.SYMLINK_TREE_WITH_MODULEMAP,
+        CxxPreprocessables.resolveHeaderMap(Paths.get(""), headers),
+        HeaderVisibility.PUBLIC);
+  }
+
   <U> Optional<U> createMetadataForLibrary(
       BuildTarget buildTarget,
       ActionGraphBuilder graphBuilder,
@@ -644,13 +688,27 @@ public class AppleLibraryDescription
     SourcePathResolver pathResolver =
         DefaultSourcePathResolver.from(new SourcePathRuleFinder(graphBuilder));
 
-    // Forward to C/C++ library description.
     if (CxxLibraryDescription.METADATA_TYPE.containsAnyOf(buildTarget.getFlavors())) {
-      CxxLibraryDescriptionArg.Builder delegateArg = CxxLibraryDescriptionArg.builder().from(args);
-      AppleDescriptions.populateCxxLibraryDescriptionArg(
-          pathResolver, delegateArg, args, buildTarget);
-      return cxxLibraryMetadataFactory.createMetadata(
-          buildTarget, graphBuilder, cellRoots, delegateArg.build(), metadataClass);
+      // Modules are always platform specific so we need to only have one platform specific
+      // headersymlinktree with a modulemap. We cannot forward the metadata to a cxxlibrary
+      // description as it makes an optimization of having multiple header symlinktrees (platform
+      // specific and general). This also gives us more control over exposing the correct swift
+      // header modularly for mixed targets
+      if (args.isModular()) {
+        Map.Entry<Flavor, CxxLibraryDescription.MetadataType> cxxMetaDataType =
+            CxxLibraryDescription.METADATA_TYPE.getFlavorAndValue(buildTarget).get();
+        switch (cxxMetaDataType.getValue()) {
+          case CXX_PREPROCESSOR_INPUT:
+            return createCxxPreprocessorInputMetadata(
+                buildTarget, graphBuilder, cellRoots, args, metadataClass, cxxMetaDataType);
+          case CXX_HEADERS:
+            throw new IllegalStateException(
+                "Modular apple_library should provide a unified modular CXX_PREPROCESSOR_INPUT and not pass individual CXX_HEADERS");
+        }
+      } else {
+        return forwardMetadataToCxxLibraryDescription(
+            buildTarget, graphBuilder, cellRoots, args, metadataClass, pathResolver);
+      }
     }
 
     if (metadataClass.isAssignableFrom(FrameworkDependencies.class)
@@ -683,7 +741,6 @@ public class AppleLibraryDescription
 
     Optional<Map.Entry<Flavor, MetadataType>> metaType =
         METADATA_TYPE.getFlavorAndValue(buildTarget);
-
     if (metaType.isPresent()) {
       BuildTarget baseTarget = buildTarget.withoutFlavors(metaType.get().getKey());
       switch (metaType.get().getValue()) {
@@ -770,6 +827,64 @@ public class AppleLibraryDescription
     }
 
     return Optional.empty();
+  }
+
+  private <U> Optional<U> createCxxPreprocessorInputMetadata(
+      BuildTarget buildTarget,
+      ActionGraphBuilder graphBuilder,
+      CellPathResolver cellRoots,
+      AppleNativeTargetDescriptionArg args,
+      Class<U> metadataClass,
+      Entry<Flavor, CxxLibraryDescription.MetadataType> cxxMetaDataType) {
+    Entry<Flavor, CxxPlatform> platform =
+        getCxxPlatformsProvider()
+            .getCxxPlatforms()
+            .getFlavorAndValue(buildTarget)
+            .orElseThrow(IllegalArgumentException::new);
+    Entry<Flavor, HeaderVisibility> visibility =
+        CxxLibraryDescription.HEADER_VISIBILITY
+            .getFlavorAndValue(buildTarget)
+            .orElseThrow(IllegalArgumentException::new);
+    BuildTarget baseTarget =
+        buildTarget.withoutFlavors(
+            cxxMetaDataType.getKey(), platform.getKey(), visibility.getKey());
+
+    CxxPreprocessorInput.Builder cxxPreprocessorInputBuilder = CxxPreprocessorInput.builder();
+    CxxLibraryMetadataFactory.addCxxPreprocessorInputFromArgs(
+        cxxPreprocessorInputBuilder,
+        args,
+        platform,
+        f ->
+            CxxDescriptionEnhancer.toStringWithMacrosArgs(
+                buildTarget, cellRoots, graphBuilder, platform.getValue(), f));
+
+    HeaderSymlinkTree symlinkTree =
+        (HeaderSymlinkTree)
+            graphBuilder.requireRule(
+                baseTarget
+                    .withoutFlavors(LIBRARY_TYPE.getFlavors())
+                    .withAppendedFlavors(
+                        CxxLibraryDescription.Type.EXPORTED_HEADERS.getFlavor(),
+                        platform.getKey(),
+                        HeaderMode.SYMLINK_TREE_WITH_MODULEMAP.getFlavor()));
+    cxxPreprocessorInputBuilder.addIncludes(
+        CxxSymlinkTreeHeaders.from(symlinkTree, CxxPreprocessables.IncludeType.LOCAL));
+    CxxPreprocessorInput cxxPreprocessorInput = cxxPreprocessorInputBuilder.build();
+    return Optional.of(cxxPreprocessorInput).map(metadataClass::cast);
+  }
+
+  private <U> Optional<U> forwardMetadataToCxxLibraryDescription(
+      BuildTarget buildTarget,
+      ActionGraphBuilder graphBuilder,
+      CellPathResolver cellRoots,
+      AppleNativeTargetDescriptionArg args,
+      Class<U> metadataClass,
+      SourcePathResolver pathResolver) {
+    CxxLibraryDescriptionArg.Builder delegateArg = CxxLibraryDescriptionArg.builder().from(args);
+    AppleDescriptions.populateCxxLibraryDescriptionArg(
+        pathResolver, delegateArg, args, buildTarget);
+    return cxxLibraryMetadataFactory.createMetadata(
+        buildTarget, graphBuilder, cellRoots, delegateArg.build(), metadataClass);
   }
 
   @Override

--- a/src/com/facebook/buck/apple/AppleLibraryDescriptionSwiftEnhancer.java
+++ b/src/com/facebook/buck/apple/AppleLibraryDescriptionSwiftEnhancer.java
@@ -117,7 +117,7 @@ public class AppleLibraryDescriptionSwiftEnhancer {
 
     ImmutableSet.Builder<CxxPreprocessorInput> builder = ImmutableSet.builder();
     builder.addAll(transitiveMap.values());
-    if (arg.isModular()) {
+    if (arg.isModular()) { // NOPMD PMD.EmptyIfStmt till stacked PR lands
       // TODO(robbert): Need to query for objc_module headers here
     } else {
       builder.add(lib.getPublicCxxPreprocessorInputExcludingDelegate(platform, graphBuilder));

--- a/src/com/facebook/buck/apple/AppleLibraryDescriptionSwiftEnhancer.java
+++ b/src/com/facebook/buck/apple/AppleLibraryDescriptionSwiftEnhancer.java
@@ -106,7 +106,10 @@ public class AppleLibraryDescriptionSwiftEnhancer {
    * CxxLibrary.
    */
   public static ImmutableSet<CxxPreprocessorInput> getPreprocessorInputsForAppleLibrary(
-      BuildTarget target, ActionGraphBuilder graphBuilder, CxxPlatform platform) {
+      BuildTarget target,
+      ActionGraphBuilder graphBuilder,
+      CxxPlatform platform,
+      AppleNativeTargetDescriptionArg arg) {
     CxxLibrary lib = (CxxLibrary) graphBuilder.requireRule(target.withFlavors());
     ImmutableMap<BuildTarget, CxxPreprocessorInput> transitiveMap =
         TransitiveCxxPreprocessorInputCache.computeTransitiveCxxToPreprocessorInputMap(
@@ -114,7 +117,11 @@ public class AppleLibraryDescriptionSwiftEnhancer {
 
     ImmutableSet.Builder<CxxPreprocessorInput> builder = ImmutableSet.builder();
     builder.addAll(transitiveMap.values());
-    builder.add(lib.getPublicCxxPreprocessorInputExcludingDelegate(platform, graphBuilder));
+    if (arg.isModular()) {
+      // TODO(robbert): Need to query for objc_module headers here
+    } else {
+      builder.add(lib.getPublicCxxPreprocessorInputExcludingDelegate(platform, graphBuilder));
+    }
 
     return builder.build();
   }
@@ -126,6 +133,22 @@ public class AppleLibraryDescriptionSwiftEnhancer {
       ActionGraphBuilder graphBuilder,
       CxxPlatform cxxPlatform,
       HeaderVisibility headerVisibility) {
+    ImmutableMap<Path, SourcePath> headers =
+        getObjCGeneratedHeader(buildTarget, graphBuilder, cxxPlatform, headerVisibility);
+
+    Path outputPath = BuildTargets.getGenPath(projectFilesystem, buildTarget, "%s");
+    HeaderSymlinkTreeWithHeaderMap headerMapRule =
+        HeaderSymlinkTreeWithHeaderMap.create(
+            buildTarget, projectFilesystem, outputPath, headers, ruleFinder);
+
+    return headerMapRule;
+  }
+
+  public static ImmutableMap<Path, SourcePath> getObjCGeneratedHeader(
+      BuildTarget buildTarget,
+      ActionGraphBuilder graphBuilder,
+      CxxPlatform cxxPlatform,
+      HeaderVisibility headerVisibility) {
     BuildTarget swiftCompileTarget = createBuildTargetForSwiftCompile(buildTarget, cxxPlatform);
     SwiftCompile compile = (SwiftCompile) graphBuilder.requireRule(swiftCompileTarget);
 
@@ -134,13 +157,7 @@ public class AppleLibraryDescriptionSwiftEnhancer {
 
     ImmutableMap.Builder<Path, SourcePath> headerLinks = ImmutableMap.builder();
     headerLinks.put(objCImportPath, objCGeneratedPath);
-
-    Path outputPath = BuildTargets.getGenPath(projectFilesystem, buildTarget, "%s");
-    HeaderSymlinkTreeWithHeaderMap headerMapRule =
-        HeaderSymlinkTreeWithHeaderMap.create(
-            buildTarget, projectFilesystem, outputPath, headerLinks.build(), ruleFinder);
-
-    return headerMapRule;
+    return headerLinks.build();
   }
 
   private static Path getObjCGeneratedHeaderSourceIncludePath(

--- a/src/com/facebook/buck/cxx/CxxLibraryDescription.java
+++ b/src/com/facebook/buck/cxx/CxxLibraryDescription.java
@@ -118,10 +118,10 @@ public class CxxLibraryDescription
   public static final FlavorDomain<MetadataType> METADATA_TYPE =
       FlavorDomain.from("C/C++ Metadata Type", MetadataType.class);
 
-  static final FlavorDomain<HeaderVisibility> HEADER_VISIBILITY =
+  public static final FlavorDomain<HeaderVisibility> HEADER_VISIBILITY =
       FlavorDomain.from("C/C++ Header Visibility", HeaderVisibility.class);
 
-  static final FlavorDomain<HeaderMode> HEADER_MODE =
+  public static final FlavorDomain<HeaderMode> HEADER_MODE =
       FlavorDomain.from("C/C++ Header Mode", HeaderMode.class);
 
   private final CxxLibraryImplicitFlavors cxxLibraryImplicitFlavors;

--- a/test/com/facebook/buck/apple/AppleLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/apple/AppleLibraryIntegrationTest.java
@@ -896,6 +896,38 @@ public class AppleLibraryIntegrationTest {
     result.assertSuccess();
   }
 
+  @Test
+  public void testBuildAppleLibraryWhereModularObjcUsesSwiftDiffLib() throws Exception {
+    testModularScenario("apple_library_modular_objc_uses_swift_diff_lib", "Bar");
+  }
+
+  @Test
+  public void testBuildAppleLibraryWhereModularObjcUsesSwiftSameLib() throws Exception {
+    testModularScenario("apple_library_modular_objc_uses_swift_same_lib", "Mixed");
+  }
+
+  @Test
+  public void testBuildAppleLibraryWhereModularSwiftUsesObjcDiffLib() throws Exception {
+    testModularScenario("apple_library_modular_swift_uses_objc_diff_lib", "Bar");
+  }
+
+  private void testModularScenario(String scenario, String targetName) throws Exception {
+    assumeTrue(Platform.detect() == Platform.MACOS);
+    assumeTrue(AppleNativeIntegrationTestUtils.isApplePlatformAvailable(ApplePlatform.MACOSX));
+
+    ProjectWorkspace workspace =
+        TestDataHelper.createProjectWorkspaceForScenario(this, scenario, tmp);
+    workspace.setUp();
+    workspace.addBuckConfigLocalOption("apple", "use_swift_delegate", "false");
+    workspace.addBuckConfigLocalOption("cxx", "cflags", "-fmodules");
+    BuildTarget dylibTarget =
+        workspace
+            .newBuildTarget(String.format("//:%s#iphonesimulator-x86_64", targetName))
+            .withAppendedFlavors(CxxDescriptionEnhancer.SHARED_FLAVOR);
+    ProcessResult result = workspace.runBuckCommand("build", dylibTarget.getFullyQualifiedName());
+    result.assertSuccess();
+  }
+
   private static void assertIsSymbolicLink(Path link, Path target) throws IOException {
     assertTrue(Files.isSymbolicLink(link));
     assertEquals(target, Files.readSymbolicLink(link));

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_diff_lib/BUCK.fixture
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_diff_lib/BUCK.fixture
@@ -1,0 +1,22 @@
+apple_library(
+    name = "Foo",
+    srcs = ["dummy.swift"],
+    frameworks = [
+        "$SDKROOT/System/Library/Frameworks/Foundation.framework",
+    ],
+    modular = True,
+    swift_version = "4",
+)
+
+apple_library(
+    name = "Bar",
+    srcs = ["Hello.m"],
+    exported_headers = ["Hello.h"],
+    frameworks = [
+        "$SDKROOT/System/Library/Frameworks/Foundation.framework",
+    ],
+    modular = True,
+    deps = [
+        ":Foo",
+    ],
+)

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_diff_lib/Hello.h
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_diff_lib/Hello.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Hello: NSObject
+- (void)test;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_diff_lib/Hello.m
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_diff_lib/Hello.m
@@ -1,0 +1,12 @@
+#import "Hello.h"
+
+// #import <Foo/Foo-Swift.h>
+@import Foo;
+
+@implementation Hello
+
+- (void)test {
+  [Dummy hello];
+}
+
+@end

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_diff_lib/dummy.swift
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_diff_lib/dummy.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+@objc public class Dummy: NSObject {
+  @objc public class func hello() {
+    Swift.print("hello")
+  }
+}

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_same_lib/BUCK.fixture
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_same_lib/BUCK.fixture
@@ -1,0 +1,13 @@
+apple_library(
+    name = "Mixed",
+    srcs = [
+        "Hello.m",
+        "dummy.swift",
+    ],
+    exported_headers = ["Hello.h"],
+    frameworks = [
+        "$SDKROOT/System/Library/Frameworks/Foundation.framework",
+    ],
+    modular = True,
+    swift_version = "4",
+)

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_same_lib/Hello.h
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_same_lib/Hello.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Hello: NSObject
+- (void)test;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_same_lib/Hello.m
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_same_lib/Hello.m
@@ -1,0 +1,11 @@
+#import "Hello.h"
+
+#import <Mixed/Mixed-Swift.h>
+
+@implementation Hello
+
+- (void)test {
+  [Dummy hello];
+}
+
+@end

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_same_lib/dummy.swift
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_objc_uses_swift_same_lib/dummy.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+@objc public class Dummy: NSObject {
+  @objc public class func hello() {
+    Swift.print("hello")
+  }
+}

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_diff_lib/BUCK.fixture
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_diff_lib/BUCK.fixture
@@ -1,0 +1,22 @@
+apple_library(
+    name = "Foo",
+    srcs = ["Hello.m"],
+    exported_headers = ["Hello.h"],
+    modular = True,
+    frameworks = [
+        "$SDKROOT/System/Library/Frameworks/Foundation.framework",
+    ],
+)
+
+apple_library(
+    name = "Bar",
+    srcs = ["dummy.swift"],
+    frameworks = [
+        "$SDKROOT/System/Library/Frameworks/Foundation.framework",
+    ],
+    swift_version = "4",
+    modular = True,
+    deps = [
+        ":Foo",
+    ],
+)

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_diff_lib/Hello.h
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_diff_lib/Hello.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Hello: NSObject
+  - (NSString *)hello;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_diff_lib/Hello.m
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_diff_lib/Hello.m
@@ -1,0 +1,9 @@
+#import "Hello.h"
+
+@implementation Hello
+
+- (NSString *)hello {
+  return @"hello";
+}
+
+@end

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_diff_lib/dummy.swift
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_diff_lib/dummy.swift
@@ -1,0 +1,8 @@
+import Foo
+
+class Dummy {
+  func test() {
+    let hello = Hello()
+    Swift.print(hello.hello())
+  }
+}

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_swift_diff_lib/BUCK.fixture
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_swift_diff_lib/BUCK.fixture
@@ -1,0 +1,14 @@
+apple_library(
+    name = "Foo",
+    srcs = ["Foo.swift"],
+    modular = True,
+    swift_version = "4",
+)
+
+apple_library(
+    name = "Bar",
+    srcs = ["Bar.swift"],
+    swift_version = "4",
+    modular = True,
+    deps = [":Foo"],
+)

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_swift_diff_lib/Bar.swift
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_swift_diff_lib/Bar.swift
@@ -1,0 +1,8 @@
+import Foo
+
+class Bar {
+  func bar() {
+    let foo = Foo()
+    foo.hello()
+  }
+}

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_swift_diff_lib/Foo.swift
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_swift_diff_lib/Foo.swift
@@ -1,0 +1,6 @@
+public class Foo {
+  public init() {}
+  public func hello() {
+    Swift.print("hello")
+  }
+}


### PR DESCRIPTION
When an `apple_library` is marked as modular, add a modulemap to the generated headersymlinktree so other rules can import this library modularly.

Modules are always platform specific so we need to only have one platform specific headersymlinktree with a modulemap. We cannot forward the metadata to a CxxLibraryDescription as it will create two trees (platform specific and platform agnostic). This PR makes sure that if a library is modular, AppleLibraryDescription doesn't forward the `CxxLibraryDescription.MetadataType.CXX_PREPROCESSOR_INPUT` to a CxxLibraryDelegate but instead creates it itself.