### PR TITLE
Allow modular mixed apple_library

### DIFF
--- a/src/com/facebook/buck/apple/AppleDescriptions.java
+++ b/src/com/facebook/buck/apple/AppleDescriptions.java
@@ -99,6 +99,8 @@ public class AppleDescriptions {
       InternalFlavor.of("apple-swift-objc-generated-header");
   public static final Flavor SWIFT_OBJC_GENERATED_HEADER_SYMLINK_TREE_FLAVOR =
       InternalFlavor.of("apple-swift-private-objc-generated-header");
+  public static final Flavor SWIFT_UNDERLYING_MODULE_FLAVOR =
+      InternalFlavor.of("apple-swift-underlying-module");
 
   public static final Flavor INCLUDE_FRAMEWORKS_FLAVOR = InternalFlavor.of("include-frameworks");
   public static final Flavor NO_INCLUDE_FRAMEWORKS_FLAVOR =

--- a/src/com/facebook/buck/apple/AppleLibraryDescriptionSwiftEnhancer.java
+++ b/src/com/facebook/buck/apple/AppleLibraryDescriptionSwiftEnhancer.java
@@ -47,6 +47,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
 
 public class AppleLibraryDescriptionSwiftEnhancer {
   @SuppressWarnings("unused")
@@ -117,8 +118,11 @@ public class AppleLibraryDescriptionSwiftEnhancer {
 
     ImmutableSet.Builder<CxxPreprocessorInput> builder = ImmutableSet.builder();
     builder.addAll(transitiveMap.values());
-    if (arg.isModular()) { // NOPMD PMD.EmptyIfStmt till stacked PR lands
-      // TODO(robbert): Need to query for objc_module headers here
+    if (arg.isModular()) {
+      Optional<CxxPreprocessorInput> underlyingModule =
+          AppleLibraryDescription.underlyingModuleCxxPreprocessorInput(
+              target, graphBuilder, platform);
+      underlyingModule.ifPresent(builder::add);
     } else {
       builder.add(lib.getPublicCxxPreprocessorInputExcludingDelegate(platform, graphBuilder));
     }

--- a/src/com/facebook/buck/apple/AppleLibraryDescriptionSwiftEnhancer.java
+++ b/src/com/facebook/buck/apple/AppleLibraryDescriptionSwiftEnhancer.java
@@ -87,6 +87,9 @@ public class AppleLibraryDescriptionSwiftEnhancer {
     inputs.forEach(input -> flagsBuilder.addAllFrameworkPaths(input.getFrameworks()));
     PreprocessorFlags preprocessorFlags = flagsBuilder.build();
 
+    Optional<CxxPreprocessorInput> underlyingModule =
+        AppleLibraryDescription.underlyingModuleCxxPreprocessorInput(target, graphBuilder, platform);
+
     return SwiftLibraryDescription.createSwiftCompileRule(
         platform,
         applePlatform.getSwiftPlatform().get(),
@@ -99,7 +102,8 @@ public class AppleLibraryDescriptionSwiftEnhancer {
         filesystem,
         swiftArgs,
         preprocessor,
-        preprocessorFlags);
+        preprocessorFlags,
+        underlyingModule.isPresent());
   }
 
   /**

--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -99,6 +99,8 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
 
   @AddToRuleKey private final PreprocessorFlags cxxDeps;
 
+  @AddToRuleKey private final boolean importUnderlyingModule;
+
   SwiftCompile(
       CxxPlatform cxxPlatform,
       SwiftBuckConfig swiftBuckConfig,
@@ -115,13 +117,15 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
       Optional<Boolean> enableObjcInterop,
       Optional<SourcePath> bridgingHeader,
       Preprocessor preprocessor,
-      PreprocessorFlags cxxDeps) {
+      PreprocessorFlags cxxDeps,
+      boolean importUnderlyingModule) {
     super(buildTarget, projectFilesystem, params);
     this.cxxPlatform = cxxPlatform;
     this.frameworks = frameworks;
     this.swiftBuckConfig = swiftBuckConfig;
     this.swiftCompiler = swiftCompiler;
     this.outputPath = outputPath;
+    this.importUnderlyingModule = importUnderlyingModule;
     this.headerPath = outputPath.resolve(SwiftDescriptions.toSwiftHeaderName(moduleName) + ".h");
 
     String escapedModuleName = CxxDescriptionEnhancer.normalizeModuleName(moduleName);
@@ -174,6 +178,9 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
     if (bridgingHeader.isPresent()) {
       compilerCommand.add(
           "-import-objc-header", resolver.getRelativePath(bridgingHeader.get()).toString());
+    }
+    if (importUnderlyingModule) {
+      compilerCommand.add("-import-underlying-module");
     }
 
     Function<FrameworkPath, Path> frameworkPathToSearchPath =

--- a/src/com/facebook/buck/swift/SwiftLibraryDescription.java
+++ b/src/com/facebook/buck/swift/SwiftLibraryDescription.java
@@ -304,7 +304,8 @@ public class SwiftLibraryDescription
           args.getEnableObjcInterop(),
           args.getBridgingHeader(),
           preprocessor,
-          cxxDeps);
+          cxxDeps,
+          false);
     }
 
     // Otherwise, we return the generic placeholder of this library.
@@ -432,7 +433,8 @@ public class SwiftLibraryDescription
       ProjectFilesystem projectFilesystem,
       SwiftLibraryDescriptionArg args,
       Preprocessor preprocessor,
-      PreprocessorFlags preprocessFlags) {
+      PreprocessorFlags preprocessFlags,
+      boolean importUnderlyingModule) {
 
     DepsBuilder srcsDepsBuilder = new DepsBuilder(ruleFinder);
     args.getSrcs().forEach(src -> srcsDepsBuilder.add(src));
@@ -460,7 +462,8 @@ public class SwiftLibraryDescription
         args.getEnableObjcInterop(),
         args.getBridgingHeader(),
         preprocessor,
-        preprocessFlags);
+        preprocessFlags,
+        importUnderlyingModule);
   }
 
   public static boolean isSwiftTarget(BuildTarget buildTarget) {

--- a/test/com/facebook/buck/apple/AppleLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/apple/AppleLibraryIntegrationTest.java
@@ -911,6 +911,11 @@ public class AppleLibraryIntegrationTest {
     testModularScenario("apple_library_modular_swift_uses_objc_diff_lib", "Bar");
   }
 
+  @Test
+  public void testBuildAppleLibraryWhereModularSwiftUsesObjcSameLib() throws Exception {
+    testModularScenario("apple_library_modular_swift_uses_objc_same_lib", "Mixed");
+  }
+
   private void testModularScenario(String scenario, String targetName) throws Exception {
     assumeTrue(Platform.detect() == Platform.MACOS);
     assumeTrue(AppleNativeIntegrationTestUtils.isApplePlatformAvailable(ApplePlatform.MACOSX));

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_same_lib/BUCK.fixture
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_same_lib/BUCK.fixture
@@ -1,0 +1,13 @@
+apple_library(
+    name = "Mixed",
+    srcs = [
+        "Hello.m",
+        "dummy.swift",
+    ],
+    exported_headers = ["Hello.h"],
+    frameworks = [
+        "$SDKROOT/System/Library/Frameworks/Foundation.framework",
+    ],
+    modular = True,
+    swift_version = "4",
+)

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_same_lib/Hello.h
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_same_lib/Hello.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Hello: NSObject
+  - (NSString *)hello;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_same_lib/Hello.m
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_same_lib/Hello.m
@@ -1,0 +1,9 @@
+#import "Hello.h"
+
+@implementation Hello
+
+- (NSString *)hello {
+  return @"hello";
+}
+
+@end

--- a/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_same_lib/dummy.swift
+++ b/test/com/facebook/buck/apple/testdata/apple_library_modular_swift_uses_objc_same_lib/dummy.swift
@@ -1,0 +1,6 @@
+class Dummy {
+  func test() {
+    let hello = Hello()
+    Swift.print(hello.hello())
+  }
+}


### PR DESCRIPTION
This pr adds the functionality to support modular mixed objective-c/swift librariesusing the `-import-underlying-module` flag. The new swift metadata type `SWIFT_UNDERLYING_MODULE` refers to a build rule for a headersymlinktree that exposes the public Objective-C headers through a module with the same name, so that the swift compiler can read this using the import-underlying-module flag when compiling the swift sources for the library.

Based on having support for modular libraries in #1874.