### PR TITLE
Tolerate hyphens in go file names

### DIFF
--- a/src/com/facebook/buck/features/go/GoTestCoverSource.java
+++ b/src/com/facebook/buck/features/go/GoTestCoverSource.java
@@ -25,7 +25,6 @@ import com.facebook.buck.core.sourcepath.SourcePath;
 import com.facebook.buck.core.sourcepath.resolver.SourcePathResolver;
 import com.facebook.buck.core.toolchain.tool.Tool;
 import com.facebook.buck.io.BuildCellRelativePath;
-import com.facebook.buck.io.file.MorePaths;
 import com.facebook.buck.io.filesystem.ProjectFilesystem;
 import com.facebook.buck.model.BuildTargets;
 import com.facebook.buck.rules.AbstractBuildRule;
@@ -137,11 +136,7 @@ public class GoTestCoverSource extends AbstractBuildRule {
   }
 
   static String getVarName(Path path) {
-    return "Var_"
-        + Hashing.sha256()
-            .hashString(MorePaths.pathWithUnixSeparators(path.getFileName()), Charsets.UTF_8)
-            .toString()
-            .substring(0, 10);
+    return "Var_" + Hashing.sha256().hashString(path.getFileName().toString(), Charsets.UTF_8);
   }
 
   public ImmutableSet<SourcePath> getCoveredSources() {

--- a/src/com/facebook/buck/features/go/GoTestCoverSource.java
+++ b/src/com/facebook/buck/features/go/GoTestCoverSource.java
@@ -133,8 +133,8 @@ public class GoTestCoverSource extends AbstractBuildRule {
     return resolver.getSourcePathName(buildTarget, path).endsWith("_test.go");
   }
 
-  private String getVarName(Path path) {
-    return "Var_" + path.getFileName().toString().replace(".go", "");
+  static String getVarName(Path path) {
+    return "Var_" + path.getFileName().toString().replace(".go", "").replace("-", "_");
   }
 
   public ImmutableSet<SourcePath> getCoveredSources() {

--- a/src/com/facebook/buck/features/go/GoTestCoverSource.java
+++ b/src/com/facebook/buck/features/go/GoTestCoverSource.java
@@ -25,6 +25,7 @@ import com.facebook.buck.core.sourcepath.SourcePath;
 import com.facebook.buck.core.sourcepath.resolver.SourcePathResolver;
 import com.facebook.buck.core.toolchain.tool.Tool;
 import com.facebook.buck.io.BuildCellRelativePath;
+import com.facebook.buck.io.file.MorePaths;
 import com.facebook.buck.io.filesystem.ProjectFilesystem;
 import com.facebook.buck.model.BuildTargets;
 import com.facebook.buck.rules.AbstractBuildRule;
@@ -33,10 +34,12 @@ import com.facebook.buck.rules.BuildableSupport;
 import com.facebook.buck.rules.SourcePathRuleFinder;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.fs.MakeCleanDirectoryStep;
+import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.hash.Hashing;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.SortedSet;
@@ -134,7 +137,11 @@ public class GoTestCoverSource extends AbstractBuildRule {
   }
 
   static String getVarName(Path path) {
-    return "Var_" + path.getFileName().toString().replace(".go", "").replace('-', '_');
+    return "Var_"
+        + Hashing.sha256()
+            .hashString(MorePaths.pathWithUnixSeparators(path.getFileName()), Charsets.UTF_8)
+            .toString()
+            .substring(0, 10);
   }
 
   public ImmutableSet<SourcePath> getCoveredSources() {

--- a/src/com/facebook/buck/features/go/GoTestCoverSource.java
+++ b/src/com/facebook/buck/features/go/GoTestCoverSource.java
@@ -134,7 +134,7 @@ public class GoTestCoverSource extends AbstractBuildRule {
   }
 
   static String getVarName(Path path) {
-    return "Var_" + path.getFileName().toString().replace(".go", "").replace("-", "_");
+    return "Var_" + path.getFileName().toString().replace(".go", "").replace('-', '_');
   }
 
   public ImmutableSet<SourcePath> getCoveredSources() {

--- a/src/com/facebook/buck/features/go/GoTestCoverStep.java
+++ b/src/com/facebook/buck/features/go/GoTestCoverStep.java
@@ -71,7 +71,9 @@ public class GoTestCoverStep extends ShellStep {
         ImmutableList.<String>builder()
             .addAll(generatorCommandPrefix)
             .add("-mode", coverageMode.getMode())
-            .add("-var", "Var_" + targetFile.getFileName().toString().replace(".go", ""))
+            .add(
+                "-var",
+                GoTestCoverSource.getVarName(targetFile))
             .add("-o", targetFile.toString())
             .add(sourceFile.toString());
     return command.build();

--- a/src/com/facebook/buck/features/go/GoTestCoverStep.java
+++ b/src/com/facebook/buck/features/go/GoTestCoverStep.java
@@ -71,9 +71,7 @@ public class GoTestCoverStep extends ShellStep {
         ImmutableList.<String>builder()
             .addAll(generatorCommandPrefix)
             .add("-mode", coverageMode.getMode())
-            .add(
-                "-var",
-                GoTestCoverSource.getVarName(targetFile))
+            .add("-var", GoTestCoverSource.getVarName(targetFile))
             .add("-o", targetFile.toString())
             .add(sourceFile.toString());
     return command.build();

--- a/test/com/facebook/buck/features/go/GoTestIntegrationTest.java
+++ b/test/com/facebook/buck/features/go/GoTestIntegrationTest.java
@@ -139,4 +139,11 @@ public class GoTestIntegrationTest {
     ProcessResult result = workspace.runBuckCommand("test", "//genrule_wtih_lib_as_src:test");
     result.assertSuccess();
   }
+
+  @Test
+  public void testHyphen() throws IOException {
+    // This test should pass.
+    ProcessResult result = workspace.runBuckCommand("test", "//:test-hyphen");
+    result.assertSuccess();
+  }
 }

--- a/test/com/facebook/buck/features/go/testdata/go_test/BUCK.fixture
+++ b/test/com/facebook/buck/features/go/testdata/go_test/BUCK.fixture
@@ -66,3 +66,13 @@ go_test(
     name = "subtests",
     srcs = ["subtests.go"],
 )
+
+go_test(
+    name = "test-hyphen",
+    package_name = "lib",
+    srcs = [
+        "power-driven.go",
+        "power-driven_test.go",
+    ],
+    coverage_mode='set',
+)

--- a/test/com/facebook/buck/features/go/testdata/go_test/BUCK.fixture
+++ b/test/com/facebook/buck/features/go/testdata/go_test/BUCK.fixture
@@ -74,5 +74,5 @@ go_test(
         "power-driven.go",
         "power-driven_test.go",
     ],
-    coverage_mode='set',
+    coverage_mode = "set",
 )

--- a/test/com/facebook/buck/features/go/testdata/go_test/power-driven.go
+++ b/test/com/facebook/buck/features/go/testdata/go_test/power-driven.go
@@ -1,0 +1,5 @@
+package lib
+
+func Drive(i int) int {
+  return i + 1
+}

--- a/test/com/facebook/buck/features/go/testdata/go_test/power-driven_test.go
+++ b/test/com/facebook/buck/features/go/testdata/go_test/power-driven_test.go
@@ -1,0 +1,9 @@
+package lib
+
+import "testing"
+
+func TestDrive(t *testing.T) {
+	if Drive(1) != 2 {
+		t.Errorf("1 + 1 != 2")
+	}
+}


### PR DESCRIPTION
There may be hyphens in Go file names. They need to be replaced before using the file names as variable names, otherwise the hyphens will be treated as minus signs by Go compiler

@ttsugriy @styurin Please take a look

cc @VitalyArbuzov