### PR TITLE
Fixed `buck publish` to stop incorrectly packaging direct dep srcs

### DIFF
--- a/src/com/facebook/buck/jvm/java/MavenUberJar.java
+++ b/src/com/facebook/buck/jvm/java/MavenUberJar.java
@@ -42,6 +42,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -182,7 +183,8 @@ public class MavenUberJar extends AbstractBuildRuleWithDeclaredAndExtraDeps
         ImmutableSortedSet<SourcePath> topLevelSrcs,
         Optional<String> mavenCoords,
         Optional<SourcePath> mavenPomTemplate) {
-      TraversedDeps traversedDeps = TraversedDeps.traverse(params.getBuildDeps());
+      // Do not package deps by default.
+      TraversedDeps traversedDeps = TraversedDeps.traverse(params.getBuildDeps(), false);
 
       params = adjustParams(params, traversedDeps);
 
@@ -229,6 +231,11 @@ public class MavenUberJar extends AbstractBuildRuleWithDeclaredAndExtraDeps
     }
 
     private static TraversedDeps traverse(Set<? extends BuildRule> roots) {
+      return traverse(roots, true);
+    }
+
+    private static TraversedDeps traverse(
+        Set<? extends BuildRule> roots, boolean alwaysPackageRoots) {
       ImmutableSortedSet.Builder<HasMavenCoordinates> depsCollector =
           ImmutableSortedSet.naturalOrder();
 
@@ -239,7 +246,7 @@ public class MavenUberJar extends AbstractBuildRuleWithDeclaredAndExtraDeps
             ((HasClasspathEntries) root)
                 .getTransitiveClasspathDeps()
                 .stream()
-                .filter(buildRule -> !root.equals(buildRule))
+                .filter(buildRule -> !(alwaysPackageRoots && root.equals(buildRule)))
                 .iterator());
       }
       ImmutableSortedSet.Builder<JavaLibrary> removals = ImmutableSortedSet.naturalOrder();
@@ -250,10 +257,11 @@ public class MavenUberJar extends AbstractBuildRuleWithDeclaredAndExtraDeps
         }
       }
 
+      Set<JavaLibrary> difference = Sets.difference(candidates.build(), removals.build());
+      Set<? extends BuildRule> mandatoryRules = alwaysPackageRoots ? roots : Collections.emptySet();
       return new TraversedDeps(
           /* mavenDeps */ depsCollector.build(),
-          /* packagedDeps */ Sets.union(
-              roots, Sets.difference(candidates.build(), removals.build())));
+          /* packagedDeps */ Sets.union(mandatoryRules, difference));
     }
   }
 }

--- a/test/com/facebook/buck/jvm/java/FakeJavaLibrary.java
+++ b/test/com/facebook/buck/jvm/java/FakeJavaLibrary.java
@@ -20,7 +20,6 @@ import com.facebook.buck.android.packageable.AndroidPackageable;
 import com.facebook.buck.android.packageable.AndroidPackageableCollector;
 import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.sourcepath.ExplicitBuildTargetSourcePath;
-import com.facebook.buck.core.sourcepath.PathSourcePath;
 import com.facebook.buck.core.sourcepath.SourcePath;
 import com.facebook.buck.io.filesystem.ProjectFilesystem;
 import com.facebook.buck.jvm.core.JavaLibrary;
@@ -28,13 +27,10 @@ import com.facebook.buck.model.BuildTargets;
 import com.facebook.buck.rules.BuildRule;
 import com.facebook.buck.rules.BuildRuleResolver;
 import com.facebook.buck.rules.FakeBuildRule;
-import com.facebook.buck.testutil.FakeProjectFilesystem;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Ordering;
 import com.google.common.hash.HashCode;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -43,6 +39,7 @@ import java.util.Set;
 public class FakeJavaLibrary extends FakeBuildRule implements JavaLibrary, AndroidPackageable {
 
   private ImmutableSortedSet<SourcePath> srcs = ImmutableSortedSet.of();
+  private Optional<String> mavenCoords = Optional.empty();
 
   public FakeJavaLibrary(
       BuildTarget target, ProjectFilesystem filesystem, ImmutableSortedSet<BuildRule> deps) {
@@ -115,12 +112,9 @@ public class FakeJavaLibrary extends FakeBuildRule implements JavaLibrary, Andro
     return ImmutableSortedSet.of();
   }
 
-  public FakeJavaLibrary setJavaSrcs(ImmutableSortedSet<Path> srcs) {
+  public FakeJavaLibrary setJavaSrcs(ImmutableSortedSet<SourcePath> srcs) {
     Preconditions.checkNotNull(srcs);
-    this.srcs =
-        FluentIterable.from(srcs)
-            .transform(p -> (SourcePath) PathSourcePath.of(new FakeProjectFilesystem(), p))
-            .toSortedSet(Ordering.natural());
+    this.srcs = srcs;
     return this;
   }
 
@@ -151,6 +145,11 @@ public class FakeJavaLibrary extends FakeBuildRule implements JavaLibrary, Andro
 
   @Override
   public Optional<String> getMavenCoords() {
-    return Optional.empty();
+    return mavenCoords;
+  }
+
+  public FakeJavaLibrary setMavenCoords(String mavenCoords) {
+    this.mavenCoords = Optional.of(mavenCoords);
+    return this;
   }
 }

--- a/test/com/facebook/buck/jvm/java/MavenUberJarTest.java
+++ b/test/com/facebook/buck/jvm/java/MavenUberJarTest.java
@@ -16,21 +16,31 @@
 
 package com.facebook.buck.jvm.java;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import com.facebook.buck.core.model.BuildTarget;
+import com.facebook.buck.core.sourcepath.AbstractPathSourcePath;
 import com.facebook.buck.core.sourcepath.DefaultBuildTargetSourcePath;
+import com.facebook.buck.core.sourcepath.SourcePath;
 import com.facebook.buck.features.python.PythonLibrary;
 import com.facebook.buck.features.python.PythonLibraryBuilder;
 import com.facebook.buck.io.filesystem.ProjectFilesystem;
 import com.facebook.buck.jvm.core.JavaLibrary;
 import com.facebook.buck.model.BuildTargetFactory;
 import com.facebook.buck.parser.exceptions.NoSuchBuildTargetException;
+import com.facebook.buck.rules.BuildRule;
+import com.facebook.buck.rules.BuildRuleParams;
 import com.facebook.buck.rules.BuildRuleResolver;
+import com.facebook.buck.rules.FakeSourcePath;
 import com.facebook.buck.rules.TargetGraph;
+import com.facebook.buck.rules.TestBuildRuleParams;
 import com.facebook.buck.rules.TestBuildRuleResolver;
 import com.facebook.buck.testutil.FakeProjectFilesystem;
 import com.facebook.buck.testutil.TargetGraphFactory;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Lists;
+import java.util.List;
 import java.util.Optional;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -71,5 +81,49 @@ public class MavenUberJarTest {
             Optional.of("com.facebook.buck.jvm.java:java:jar:42"),
             Optional.empty());
     assertThat(buildRule.getBuildDeps(), Matchers.not(Matchers.hasItem(pythonLibrary)));
+  }
+
+  @Test
+  public void testOnlyCorrectSourcesIncluded() {
+    BuildTarget javaTarget = BuildTargetFactory.newInstance("//:java");
+
+    BuildTarget depWithCoords = BuildTargetFactory.newInstance("//:java_dep_1");
+    BuildTarget depWithoutCoords = BuildTargetFactory.newInstance("//:java_dep_2");
+
+    depWithCoords.compareTo(depWithoutCoords);
+
+    FakeJavaLibrary javaLibraryWithCoords =
+        new FakeJavaLibrary(depWithCoords)
+            .setMavenCoords("coord")
+            .setJavaSrcs(ImmutableSortedSet.of(FakeSourcePath.of("depWithCoords")));
+    FakeJavaLibrary javaLibraryWithoutCoords =
+        new FakeJavaLibrary(depWithoutCoords)
+            .setJavaSrcs(ImmutableSortedSet.of(FakeSourcePath.of("depWithoutCoords")));
+    ImmutableSortedSet<BuildRule> deps =
+        ImmutableSortedSet.of(javaLibraryWithCoords, javaLibraryWithoutCoords);
+
+    BuildRuleParams params = TestBuildRuleParams.create().withDeclaredDeps(deps);
+
+    MavenUberJar.SourceJar buildRule =
+        MavenUberJar.SourceJar.create(
+            javaTarget,
+            new FakeProjectFilesystem(),
+            params,
+            ImmutableSortedSet.of(FakeSourcePath.of("javaTarget")),
+            Optional.empty(),
+            Optional.empty());
+
+    List<BuildRule> packagedDeps = Lists.newArrayList(buildRule.getPackagedDependencies());
+
+    assertEquals(1, packagedDeps.size());
+    assertEquals(javaLibraryWithoutCoords, packagedDeps.get(0));
+
+    ImmutableSortedSet<SourcePath> sources = buildRule.getSources();
+    assertEquals(2, sources.size());
+    assertEquals(
+        "depWithoutCoords",
+        ((AbstractPathSourcePath) sources.first()).getRelativePath().toString());
+    assertEquals(
+        "javaTarget", ((AbstractPathSourcePath) sources.last()).getRelativePath().toString());
   }
 }


### PR DESCRIPTION
The problem was the difference between how TraversedDeps is initialized for sources jar versus regular jar.

For the sources jar java_library Build rule is not available yet and set of all classpath dependencies was used as root and auto-included in sources jar.

This led to sources jar including superset of what it is supposed to contain.