### PR TITLE
Cleaned up `buck publish`:

### DIFF
--- a/src/com/facebook/buck/cli/PublishCommand.java
+++ b/src/com/facebook/buck/cli/PublishCommand.java
@@ -58,6 +58,8 @@ public class PublishCommand extends BuildCommand {
   public static final String TO_MAVEN_CENTRAL_LONG_ARG = "--to-maven-central";
   public static final String DRY_RUN_LONG_ARG = "--dry-run";
 
+  private static final String PUBLISH_GEN_PATH = "publish";
+
   @Option(
     name = REMOTE_REPO_LONG_ARG,
     aliases = REMOTE_REPO_SHORT_ARG,
@@ -110,6 +112,16 @@ public class PublishCommand extends BuildCommand {
       throws IOException, InterruptedException {
 
     // Input validation
+    if (remoteRepo != null && toMavenCentral) {
+      throw new CommandLineException(
+          "please specify only a single remote repository to publish to.\n"
+              + "Use "
+              + REMOTE_REPO_LONG_ARG
+              + " <URL> or "
+              + TO_MAVEN_CENTRAL_LONG_ARG
+              + " but not both.");
+    }
+
     if (remoteRepo == null && !toMavenCentral) {
       throw new CommandLineException(
           "please specify a remote repository to publish to.\n"
@@ -172,10 +184,13 @@ public class PublishCommand extends BuildCommand {
       publishables.add(publishable);
     }
 
+    // Assume validation passed.
+    URL repoUrl = toMavenCentral ? Publisher.MAVEN_CENTRAL : Preconditions.checkNotNull(remoteRepo);
+
     Publisher publisher =
         new Publisher(
-            params.getCell().getFilesystem(),
-            Optional.ofNullable(remoteRepo),
+            params.getCell().getFilesystem().getBuckPaths().getTmpDir().resolve(PUBLISH_GEN_PATH),
+            repoUrl,
             Optional.ofNullable(username),
             Optional.ofNullable(password),
             dryRun);

--- a/src/com/facebook/buck/maven/Publisher.java
+++ b/src/com/facebook/buck/maven/Publisher.java
@@ -57,7 +57,7 @@ import org.eclipse.aether.util.artifact.SubArtifact;
 public class Publisher {
 
   public static final String MAVEN_CENTRAL_URL = "https://repo1.maven.org/maven2";
-  private static final URL MAVEN_CENTRAL;
+  public static final URL MAVEN_CENTRAL;
 
   static {
     try {
@@ -74,15 +74,6 @@ public class Publisher {
   private final RemoteRepository remoteRepo;
   private final boolean dryRun;
 
-  public Publisher(
-      ProjectFilesystem repositoryFilesystem,
-      Optional<URL> remoteRepoUrl,
-      Optional<String> username,
-      Optional<String> password,
-      boolean dryRun) {
-    this(repositoryFilesystem.getRootPath(), remoteRepoUrl, username, password, dryRun);
-  }
-
   /**
    * @param localRepoPath Typically obtained as {@link ProjectFilesystem#getRootPath}
    * @param remoteRepoUrl Canonically {@link #MAVEN_CENTRAL_URL}
@@ -91,13 +82,12 @@ public class Publisher {
    */
   public Publisher(
       Path localRepoPath,
-      Optional<URL> remoteRepoUrl,
+      URL remoteRepoUrl,
       Optional<String> username,
       Optional<String> password,
       boolean dryRun) {
     this.localRepo = new LocalRepository(localRepoPath.toFile());
-    this.remoteRepo =
-        AetherUtil.toRemoteRepository(remoteRepoUrl.orElse(MAVEN_CENTRAL), username, password);
+    this.remoteRepo = AetherUtil.toRemoteRepository(remoteRepoUrl, username, password);
     this.locator = AetherUtil.initServiceLocator();
     this.dryRun = dryRun;
   }

--- a/test/com/facebook/buck/cli/PublishCommandIntegrationTest.java
+++ b/test/com/facebook/buck/cli/PublishCommandIntegrationTest.java
@@ -100,6 +100,20 @@ public class PublishCommandIntegrationTest {
   }
 
   @Test
+  public void testErrorOnMultiplePublishDest() throws IOException {
+    ProjectWorkspace workspace =
+        TestDataHelper.createProjectWorkspaceForScenario(this, "publish", tmp);
+    workspace.setUp();
+
+    ProcessResult result =
+        workspace.runBuckCommand(
+            "publish", "//:foo", "--remote-repo=http://foo.bar", "--to-maven-central");
+    result.assertExitCode("please specify only a single remote", ExitCode.COMMANDLINE_ERROR);
+    assertTrue(result.getStderr().contains(PublishCommand.REMOTE_REPO_LONG_ARG));
+    assertTrue(result.getStderr().contains(PublishCommand.TO_MAVEN_CENTRAL_LONG_ARG));
+  }
+
+  @Test
   public void testDryDun() throws IOException {
     ProjectWorkspace workspace =
         TestDataHelper.createProjectWorkspaceForScenario(this, "publish", tmp);

--- a/test/com/facebook/buck/maven/PublisherTest.java
+++ b/test/com/facebook/buck/maven/PublisherTest.java
@@ -56,8 +56,8 @@ public class PublisherTest {
     ProjectFilesystem filesystem = new FakeProjectFilesystem();
     publisher =
         new Publisher(
-            filesystem,
-            /* remoteRepoUrl */ Optional.empty(),
+            filesystem.getRootPath(),
+            /* remoteRepoUrl */ Publisher.MAVEN_CENTRAL,
             /* username */ Optional.empty(),
             /* password */ Optional.empty(),
             /* dryRun */ true);

--- a/test/com/facebook/buck/maven/TestPublisher.java
+++ b/test/com/facebook/buck/maven/TestPublisher.java
@@ -54,7 +54,7 @@ public class TestPublisher extends Publisher implements AutoCloseable {
       throws Exception {
     super(
         pseudoLocalRepo,
-        Optional.of(httpd.getRootUri().toURL()),
+        httpd.getRootUri().toURL(),
         /* username */ Optional.empty(),
         /* password */ Optional.empty(),
         /* dryRun */ false);


### PR DESCRIPTION
1. Added validation case for where user both passes the repo and toMavenCentral (previously toMavenCentral was simply ignored)
2. Replaced implicit default of maven Central in Publisher with explicit logic.
3. Switched temp folder location from root of the repo to buck-out/tmp/publish to avoid adding clutter to the repo root.