### PR TITLE
Remove stdout/stderr headers when there is nothing in it

### DIFF
--- a/src/com/facebook/buck/event/listener/TestResultFormatter.java
+++ b/src/com/facebook/buck/event/listener/TestResultFormatter.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.TimeZone;
+import org.testng.util.Strings;
 
 public class TestResultFormatter {
 
@@ -218,16 +219,19 @@ public class TestResultFormatter {
       }
     }
 
-    if (summaryVerbosity.getIncludeStdOut()
-        && testResult.getStdOut() != null
-        && testResult.getStdOut().length() > 0) {
+    if (summaryVerbosity.getIncludeStdOut() && Strings.isNullOrEmpty(testResult.getStdOut())) {
       addTo.add("====STANDARD OUT====", testResult.getStdOut());
     }
 
-    if (summaryVerbosity.getIncludeStdErr()
-        && testResult.getStdErr() != null
-        && testResult.getStdErr().length() > 0) {
+    if (summaryVerbosity.getIncludeStdErr() && Strings.isNullOrEmpty(testResult.getStdErr())) {
       addTo.add("====STANDARD ERR====", testResult.getStdErr());
+    }
+
+    if (Strings.isNullOrEmpty(testResult.getMessage())
+        && Strings.isNullOrEmpty(testResult.getStacktrace())
+        && Strings.isNullOrEmpty(testResult.getStdOut())
+        && Strings.isNullOrEmpty(testResult.getStdErr())) {
+      addTo.add("Test did not produce any output.");
     }
   }
 

--- a/src/com/facebook/buck/event/listener/TestResultFormatter.java
+++ b/src/com/facebook/buck/event/listener/TestResultFormatter.java
@@ -29,6 +29,7 @@ import com.facebook.buck.util.Verbosity;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -43,7 +44,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.TimeZone;
-import org.testng.util.Strings;
 
 public class TestResultFormatter {
 
@@ -116,6 +116,7 @@ public class TestResultFormatter {
   public void reportResult(ImmutableList.Builder<String> addTo, TestResults results) {
     if (verbosity.shouldPrintBinaryRunInformation() && results.getTotalNumberOfTests() > 1) {
       addTo.add("");
+
       addTo.add(
           String.format(
               locale,

--- a/src/com/facebook/buck/event/listener/TestResultFormatter.java
+++ b/src/com/facebook/buck/event/listener/TestResultFormatter.java
@@ -218,11 +218,15 @@ public class TestResultFormatter {
       }
     }
 
-    if (summaryVerbosity.getIncludeStdOut() && testResult.getStdOut() != null) {
+    if (summaryVerbosity.getIncludeStdOut()
+        && testResult.getStdOut() != null
+        && testResult.getStdOut().length() > 0) {
       addTo.add("====STANDARD OUT====", testResult.getStdOut());
     }
 
-    if (summaryVerbosity.getIncludeStdErr() && testResult.getStdErr() != null) {
+    if (summaryVerbosity.getIncludeStdErr()
+        && testResult.getStdErr() != null
+        && testResult.getStdErr().length() > 0) {
       addTo.add("====STANDARD ERR====", testResult.getStdErr());
     }
   }

--- a/src/com/facebook/buck/event/listener/TestResultFormatter.java
+++ b/src/com/facebook/buck/event/listener/TestResultFormatter.java
@@ -116,7 +116,6 @@ public class TestResultFormatter {
   public void reportResult(ImmutableList.Builder<String> addTo, TestResults results) {
     if (verbosity.shouldPrintBinaryRunInformation() && results.getTotalNumberOfTests() > 1) {
       addTo.add("");
-
       addTo.add(
           String.format(
               locale,

--- a/src/com/facebook/buck/event/listener/TestResultFormatter.java
+++ b/src/com/facebook/buck/event/listener/TestResultFormatter.java
@@ -219,11 +219,11 @@ public class TestResultFormatter {
       }
     }
 
-    if (summaryVerbosity.getIncludeStdOut() && Strings.isNullOrEmpty(testResult.getStdOut())) {
+    if (summaryVerbosity.getIncludeStdOut() && !Strings.isNullOrEmpty(testResult.getStdOut())) {
       addTo.add("====STANDARD OUT====", testResult.getStdOut());
     }
 
-    if (summaryVerbosity.getIncludeStdErr() && Strings.isNullOrEmpty(testResult.getStdErr())) {
+    if (summaryVerbosity.getIncludeStdErr() && !Strings.isNullOrEmpty(testResult.getStdErr())) {
       addTo.add("====STANDARD ERR====", testResult.getStdErr());
     }
 

--- a/src/com/facebook/buck/features/go/GoTest.java
+++ b/src/com/facebook/buck/features/go/GoTest.java
@@ -229,7 +229,7 @@ public class GoTest extends AbstractBuildRuleWithDeclaredAndExtraDeps
                   "",
                   Joiner.on(System.lineSeparator()).join(stackTrace),
                   Joiner.on(System.lineSeparator()).join(stdout),
-                  null));
+                  ""));
 
           currentTests.remove(matcher.group("name"));
           stdout.clear();

--- a/src/com/facebook/buck/features/go/GoTest.java
+++ b/src/com/facebook/buck/features/go/GoTest.java
@@ -229,7 +229,7 @@ public class GoTest extends AbstractBuildRuleWithDeclaredAndExtraDeps
                   "",
                   Joiner.on(System.lineSeparator()).join(stackTrace),
                   Joiner.on(System.lineSeparator()).join(stdout),
-                  ""));
+                  null));
 
           currentTests.remove(matcher.group("name"));
           stdout.clear();


### PR DESCRIPTION
When a test failed and there nothing in stdout/stderror, buck should not print out headers with empty body like the one below:

```
====STANDARD OUT====

====STANDARD ERR====

```
This PR fixed that.