### PR TITLE
Reduce repo size for simple installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Since Buck is used to build Buck, the initial build process involves 2 phases:
 
 ##### 1. Bootstrap Buck with ant
 
-    git clone https://github.com/facebook/buck.git
+    git clone --depth 1 https://github.com/facebook/buck.git
     cd buck
     ant
 

--- a/scripts/packages/debian/Dockerfile
+++ b/scripts/packages/debian/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get install -y --no-install-recommends curl ca-certificates \
       equivs && \
       apt-get clean
 
-RUN git clone https://github.com/facebook/buck.git src
+RUN git clone --depth 1 https://github.com/facebook/buck.git src
 
 WORKDIR /src
 


### PR DESCRIPTION
When installing `buck` from source, a user doesn't necessarily need to clone the entire history, which currency weighs hundreds of megabytes.
