### PR TITLE
Filtering platform-dependent files before generating test main

### DIFF
--- a/src/com/facebook/buck/features/go/GoCompile.java
+++ b/src/com/facebook/buck/features/go/GoCompile.java
@@ -272,8 +272,7 @@ public class GoCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
     return steps.build();
   }
 
-  private static List<Path> getSourceFiles(
-      ImmutableSet<SourcePath> srcPaths, BuildContext context) {
+  static List<Path> getSourceFiles(ImmutableSet<SourcePath> srcPaths, BuildContext context) {
     List<Path> srcFiles = new ArrayList<>();
     for (SourcePath path : srcPaths) {
       Path srcPath = context.getSourcePathResolver().getAbsolutePath(path);

--- a/src/com/facebook/buck/features/go/GoTestDescription.java
+++ b/src/com/facebook/buck/features/go/GoTestDescription.java
@@ -164,6 +164,7 @@ public class GoTestDescription
             testMainGenerator,
             srcs,
             packageName,
+            platform,
             coverVariables,
             coverageMode);
     resolver.addToIndex(generatedTestMain);

--- a/src/com/facebook/buck/features/go/GoTestMainStep.java
+++ b/src/com/facebook/buck/features/go/GoTestMainStep.java
@@ -21,7 +21,7 @@ import com.facebook.buck.shell.ShellStep;
 import com.facebook.buck.step.ExecutionContext;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Streams;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
@@ -66,9 +66,8 @@ public class GoTestMainStep extends ShellStep {
             .add("--import-path", packageName.toString())
             .add("--cover-mode", coverageMode.getMode());
 
-    ImmutableSet<Path> filteredFiles = ImmutableSet.<Path>builder().addAll(testFiles).build();
     Set<Path> filteredFileNames =
-        filteredFiles.stream().map(Path::getFileName).collect(Collectors.toSet());
+        Streams.stream(testFiles).map(Path::getFileName).collect(Collectors.toSet());
     for (Map.Entry<Path, ImmutableMap<String, Path>> pkg : coverageVariables.entrySet()) {
       if (pkg.getValue().isEmpty()) {
         continue;
@@ -93,7 +92,11 @@ public class GoTestMainStep extends ShellStep {
 
       command.add("--cover-pkgs", pkgFlag.toString());
     }
-    command.addAll(filteredFiles.stream().map(Path::toString).collect(Collectors.toList()));
+
+    for (Path source : testFiles) {
+      command.add(source.toString());
+    }
+
     return command.build();
   }
 

--- a/src/com/facebook/buck/features/go/GoTestMainStep.java
+++ b/src/com/facebook/buck/features/go/GoTestMainStep.java
@@ -21,9 +21,12 @@ import com.facebook.buck.shell.ShellStep;
 import com.facebook.buck.step.ExecutionContext;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class GoTestMainStep extends ShellStep {
   private final ImmutableMap<String, String> environment;
@@ -31,7 +34,7 @@ public class GoTestMainStep extends ShellStep {
   private final GoTestCoverStep.Mode coverageMode;
   private final ImmutableMap<Path, ImmutableMap<String, Path>> coverageVariables;
   private final Path packageName;
-  private final ImmutableList<Path> testFiles;
+  private final Iterable<Path> testFiles;
   private final Path output;
 
   public GoTestMainStep(
@@ -42,7 +45,7 @@ public class GoTestMainStep extends ShellStep {
       GoTestCoverStep.Mode coverageMode,
       ImmutableMap<Path, ImmutableMap<String, Path>> coverageVariables,
       Path packageName,
-      ImmutableList<Path> testFiles,
+      Iterable<Path> testFiles,
       Path output) {
     super(Optional.of(buildTarget), workingDirectory);
     this.environment = environment;
@@ -63,6 +66,9 @@ public class GoTestMainStep extends ShellStep {
             .add("--import-path", packageName.toString())
             .add("--cover-mode", coverageMode.getMode());
 
+    ImmutableSet<Path> filteredFiles = ImmutableSet.<Path>builder().addAll(testFiles).build();
+    Set<Path> filteredFileNames =
+        filteredFiles.stream().map(Path::getFileName).collect(Collectors.toSet());
     for (Map.Entry<Path, ImmutableMap<String, Path>> pkg : coverageVariables.entrySet()) {
       if (pkg.getValue().isEmpty()) {
         continue;
@@ -74,23 +80,20 @@ public class GoTestMainStep extends ShellStep {
 
       boolean first = true;
       for (Map.Entry<String, Path> pkgVars : pkg.getValue().entrySet()) {
-        if (!first) {
-          pkgFlag.append(',');
+        if (filteredFileNames.contains(pkgVars.getValue())) {
+          if (!first) {
+            pkgFlag.append(',');
+          }
+          first = false;
+          pkgFlag.append(pkgVars.getKey());
+          pkgFlag.append('=');
+          pkgFlag.append(pkgVars.getValue());
         }
-        first = false;
-
-        pkgFlag.append(pkgVars.getKey());
-        pkgFlag.append('=');
-        pkgFlag.append(pkgVars.getValue());
       }
 
       command.add("--cover-pkgs", pkgFlag.toString());
     }
-
-    for (Path source : testFiles) {
-      command.add(source.toString());
-    }
-
+    command.addAll(filteredFiles.stream().map(Path::toString).collect(Collectors.toList()));
     return command.build();
   }
 


### PR DESCRIPTION
While generating test main for Go tests, Go files need to be filtered so test main doesn't contain coverage variables for Go files of other platforms, which are ignored before passing to Go compiler.

cc @ChinmayR