### PR TITLE
Add GoLand support for "buck project"

### DIFF
--- a/docs/command/project.soy
+++ b/docs/command/project.soy
@@ -87,6 +87,7 @@
 <ul>
   <li><a href="#intellij">IntelliJ</a></li>
   <li><a href="#xcode">Xcode</a></li>
+  <li>GoLand</li>
 </ul>
 
 <h3 id="intellij">IntelliJ</h3>

--- a/docs/concept/buckconfig.soy
+++ b/docs/concept/buckconfig.soy
@@ -3112,6 +3112,7 @@ your <code>.buckjavaargs</code> file</a>:
     <ul>
       <li><code>intellij</code></li>
       <li><code>xcode</code></li>
+      <li><code>goland</code></li>
     </ul>
   {/param}
 {/call}

--- a/src/com/facebook/buck/cli/ProjectCommand.java
+++ b/src/com/facebook/buck/cli/ProjectCommand.java
@@ -368,7 +368,8 @@ public class ProjectCommand extends BuildCommand {
             break;
           default:
             // unreachable
-            throw new IllegalStateException("'ide' should always be of type 'INTELLIJ' or 'XCODE' or 'GOLAND'");
+            throw new IllegalStateException(
+                "'ide' should always be of type 'INTELLIJ' or 'XCODE' or 'GOLAND'");
         }
         rc = runPostprocessScriptIfNeeded(params, projectIde);
         if (rc != 0) {

--- a/src/com/facebook/buck/cli/ProjectCommand.java
+++ b/src/com/facebook/buck/cli/ProjectCommand.java
@@ -60,7 +60,8 @@ public class ProjectCommand extends BuildCommand {
 
   public enum Ide {
     INTELLIJ,
-    XCODE;
+    XCODE,
+    GOLAND;
 
     public static Ide fromString(String string) {
       switch (Ascii.toLowerCase(string)) {
@@ -68,6 +69,8 @@ public class ProjectCommand extends BuildCommand {
           return Ide.INTELLIJ;
         case "xcode":
           return Ide.XCODE;
+        case "goland":
+          return Ide.GOLAND;
         default:
           throw new HumanReadableException("Invalid ide value %s.", string);
       }
@@ -359,9 +362,13 @@ public class ProjectCommand extends BuildCommand {
                     });
             result = xcodeProjectCommandHelper.parseTargetsAndRunXCodeGenerator(executor);
             break;
+          case GOLAND:
+            // Only running pre- and post-processing scripts for now
+            result = ExitCode.SUCCESS;
+            break;
           default:
             // unreachable
-            throw new IllegalStateException("'ide' should always be of type 'INTELLIJ' or 'XCODE'");
+            throw new IllegalStateException("'ide' should always be of type 'INTELLIJ' or 'XCODE' or 'GOLAND'");
         }
         rc = runPostprocessScriptIfNeeded(params, projectIde);
         if (rc != 0) {


### PR DESCRIPTION
Right now, we don't need to create any project files for GoLand, but we need to run a script to symlink generated code into GOPATH. This PR allow us to run that script using "buck project".

It may sound overkill now, but using "buck project" to initialize IDE workspace allows us to hide implementation details from users. At some point in the future when we need to create a project file later, user experience will not change.

@philipjameson @styurin @ttsugriy Please take a look