### PR TITLE
Add system_include parameter for cxx_library to use -isystem for includes

### DIFF
--- a/buck.iml
+++ b/buck.iml
@@ -13,6 +13,7 @@
       <sourceFolder url="file://$MODULE_DIR$/test/com/facebook/buck/apple/toolchain/impl/testdata" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/test/com/facebook/buck/android/toolchain/ndk/impl/testdata" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/test/com/facebook/buck/cli/testdata" type="java-test-resource" relativeOutputPath="com/facebook/buck/cli/testdata" />
+      <sourceFolder url="file://$MODULE_DIR$/build/gen" isTestSource="false" generated="true" />
       <excludeFolder url="file://$MODULE_DIR$/.buckd" />
       <excludeFolder url="file://$MODULE_DIR$/buck-out" />
       <excludeFolder url="file://$MODULE_DIR$/build" />

--- a/buck.iml
+++ b/buck.iml
@@ -13,7 +13,6 @@
       <sourceFolder url="file://$MODULE_DIR$/test/com/facebook/buck/apple/toolchain/impl/testdata" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/test/com/facebook/buck/android/toolchain/ndk/impl/testdata" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/test/com/facebook/buck/cli/testdata" type="java-test-resource" relativeOutputPath="com/facebook/buck/cli/testdata" />
-      <sourceFolder url="file://$MODULE_DIR$/build/gen" isTestSource="false" generated="true" />
       <excludeFolder url="file://$MODULE_DIR$/.buckd" />
       <excludeFolder url="file://$MODULE_DIR$/buck-out" />
       <excludeFolder url="file://$MODULE_DIR$/build" />

--- a/src/com/facebook/buck/cxx/CxxLibraryDescription.java
+++ b/src/com/facebook/buck/cxx/CxxLibraryDescription.java
@@ -467,6 +467,11 @@ public class CxxLibraryDescription
     Optional<Boolean> isReexportAllHeaderDependencies();
 
     /**
+     * Whether consumers should include this target's headers with -isystem instead of -I.
+     */
+    Optional<Boolean> isSystemInclude();
+
+    /**
      * These fields are passed through to SwiftLibrary for mixed C/Swift targets; they are not used
      * otherwise.
      */

--- a/src/com/facebook/buck/cxx/CxxLibraryDescription.java
+++ b/src/com/facebook/buck/cxx/CxxLibraryDescription.java
@@ -466,9 +466,7 @@ public class CxxLibraryDescription
      */
     Optional<Boolean> isReexportAllHeaderDependencies();
 
-    /**
-     * Whether consumers should include this target's headers with -isystem instead of -I.
-     */
+    /** Whether consumers should include this target's headers with -isystem instead of -I. */
     Optional<Boolean> isSystemInclude();
 
     /**

--- a/src/com/facebook/buck/cxx/CxxLibraryMetadataFactory.java
+++ b/src/com/facebook/buck/cxx/CxxLibraryMetadataFactory.java
@@ -63,6 +63,7 @@ public class CxxLibraryMetadataFactory {
           if (!args.getExportedHeaders().isEmpty()) {
             HeaderMode mode = CxxLibraryDescription.HEADER_MODE.getRequiredValue(buildTarget);
             baseTarget = baseTarget.withoutFlavors(mode.getFlavor());
+            CxxPreprocessables.IncludeType includeType = args.isSystemInclude().orElse(false) ? CxxPreprocessables.IncludeType.SYSTEM : CxxPreprocessables.IncludeType.LOCAL;
             symlinkTree =
                 Optional.of(
                     CxxSymlinkTreeHeaders.from(
@@ -73,7 +74,7 @@ public class CxxLibraryMetadataFactory {
                                     .withAppendedFlavors(
                                         CxxLibraryDescription.Type.EXPORTED_HEADERS.getFlavor(),
                                         mode.getFlavor())),
-                        CxxPreprocessables.IncludeType.LOCAL));
+                        includeType));
           }
           return symlinkTree.map(metadataClass::cast);
         }

--- a/src/com/facebook/buck/cxx/CxxLibraryMetadataFactory.java
+++ b/src/com/facebook/buck/cxx/CxxLibraryMetadataFactory.java
@@ -63,8 +63,10 @@ public class CxxLibraryMetadataFactory {
           if (!args.getExportedHeaders().isEmpty()) {
             HeaderMode mode = CxxLibraryDescription.HEADER_MODE.getRequiredValue(buildTarget);
             baseTarget = baseTarget.withoutFlavors(mode.getFlavor());
-            CxxPreprocessables.IncludeType includeType = args.isSystemInclude().orElse(false) ?
-                CxxPreprocessables.IncludeType.SYSTEM : CxxPreprocessables.IncludeType.LOCAL;
+            CxxPreprocessables.IncludeType includeType =
+                args.isSystemInclude().orElse(false)
+                    ? CxxPreprocessables.IncludeType.SYSTEM
+                    : CxxPreprocessables.IncludeType.LOCAL;
             symlinkTree =
                 Optional.of(
                     CxxSymlinkTreeHeaders.from(

--- a/src/com/facebook/buck/cxx/CxxLibraryMetadataFactory.java
+++ b/src/com/facebook/buck/cxx/CxxLibraryMetadataFactory.java
@@ -63,7 +63,8 @@ public class CxxLibraryMetadataFactory {
           if (!args.getExportedHeaders().isEmpty()) {
             HeaderMode mode = CxxLibraryDescription.HEADER_MODE.getRequiredValue(buildTarget);
             baseTarget = baseTarget.withoutFlavors(mode.getFlavor());
-            CxxPreprocessables.IncludeType includeType = args.isSystemInclude().orElse(false) ? CxxPreprocessables.IncludeType.SYSTEM : CxxPreprocessables.IncludeType.LOCAL;
+            CxxPreprocessables.IncludeType includeType = args.isSystemInclude().orElse(false) ?
+                CxxPreprocessables.IncludeType.SYSTEM : CxxPreprocessables.IncludeType.LOCAL;
             symlinkTree =
                 Optional.of(
                     CxxSymlinkTreeHeaders.from(

--- a/test/com/facebook/buck/cxx/CxxLibraryBuilder.java
+++ b/test/com/facebook/buck/cxx/CxxLibraryBuilder.java
@@ -103,6 +103,11 @@ public class CxxLibraryBuilder
     return this;
   }
 
+  public CxxLibraryBuilder setSystemInclude(boolean systemInclude) {
+    getArgForPopulating().setSystemInclude(systemInclude);
+    return this;
+  }
+
   public CxxLibraryBuilder setExportedPreprocessorFlags(
       ImmutableList<String> exportedPreprocessorFlags) {
     getArgForPopulating()

--- a/test/com/facebook/buck/cxx/CxxLibraryDescriptionTest.java
+++ b/test/com/facebook/buck/cxx/CxxLibraryDescriptionTest.java
@@ -354,9 +354,7 @@ public class CxxLibraryDescriptionTest {
             .setSystemInclude(true);
 
     // Build target graph.
-    TargetGraph targetGraph =
-        TargetGraphFactory.newInstance(
-            cxxLibraryBuilder.build());
+    TargetGraph targetGraph = TargetGraphFactory.newInstance(cxxLibraryBuilder.build());
 
     // Construct C/C++ library build rules.
     ActionGraphBuilder graphBuilder = new TestActionGraphBuilder(targetGraph);


### PR DESCRIPTION
Fixes https://github.com/facebook/buck/issues/1906

Adds a system_include parameter to cxx_library that defaults to false. When set to true, that library's exported headers will be included with "-isystem" instead of "-I" by consumers. The practical effect of this is to ignore warnings from those header files.

prebuilt_cxx_library includes its headers with -isystem, but it's common to copy the entire source of a project into the repo and build it with cxx_library, in which case system_include=True comes in handy when you want to avoid making edits to the source.