### PR TITLE
Allow non-test function name to start with "Test"

### DIFF
--- a/src/com/facebook/buck/features/go/testmaingen.go.in
+++ b/src/com/facebook/buck/features/go/testmaingen.go.in
@@ -338,11 +338,7 @@ func (t *testFuncs) load(filename, pkg string, doImport, seen *bool) error {
 			}
 			t.TestMain = &testFunc{pkg, name, "", false}
 			*doImport, *seen = true, true
-		case isTest(name, "Test"):
-			err := checkTestFunc(n, "T")
-			if err != nil {
-				return err
-			}
+		case isTest(name, "Test") && isTestFunc(n, "T"):
 			t.Tests = append(t.Tests, testFunc{pkg, name, "", false})
 			*doImport, *seen = true, true
 		case isTest(name, "Benchmark"):

--- a/test/com/facebook/buck/features/go/GoTestIntegrationTest.java
+++ b/test/com/facebook/buck/features/go/GoTestIntegrationTest.java
@@ -179,6 +179,12 @@ public class GoTestIntegrationTest {
     result.assertSuccess();
   }
 
+  @Test
+  public void testFuncWithPrefixTest() throws IOException {
+    ProcessResult result = workspace.runBuckCommand("test", "//:test-scores");
+    result.assertSuccess();
+  }
+
   private static void assertIsSymbolicLink(Path link, Path target) throws IOException {
     assertTrue(Files.isSymbolicLink(link));
     assertTrue(Files.isSameFile(target, Files.readSymbolicLink(link)));

--- a/test/com/facebook/buck/features/go/testdata/go_test/BUCK.fixture
+++ b/test/com/facebook/buck/features/go/testdata/go_test/BUCK.fixture
@@ -76,3 +76,12 @@ go_test(
     ],
     coverage_mode = "set",
 )
+
+go_test(
+    name = "test-scores",
+    package_name = "lib",
+    srcs = [
+        "test_scores.go",
+        "test_scores_test.go"
+    ]
+)

--- a/test/com/facebook/buck/features/go/testdata/go_test/test_scores.go
+++ b/test/com/facebook/buck/features/go/testdata/go_test/test_scores.go
@@ -1,0 +1,5 @@
+package lib
+
+func TestScores() int {
+  return 99
+}

--- a/test/com/facebook/buck/features/go/testdata/go_test/test_scores_test.go
+++ b/test/com/facebook/buck/features/go/testdata/go_test/test_scores_test.go
@@ -1,0 +1,9 @@
+package lib
+
+import "testing"
+
+func TestTestScores(t *testing.T) {
+	if TestScores() < 60 {
+		t.Errorf("What a Loser!")
+	}
+}


### PR DESCRIPTION
Buck assumed functions with names starting with "Test" are test functions, and tried to verify their signatures, which would crash on regular functions happen to have names starting with "Test".

This PR fixed that.

@philipjameson @styurin @ttsugriy Please review.