### PR TITLE
Fixed link from csharp_library to Visibility

### DIFF
--- a/docs/__common.soy
+++ b/docs/__common.soy
@@ -889,7 +889,7 @@ docsearch({
   this rule as a dependency, for example, by listing it in
   their <code>deps</code> or <code>exported_deps</code> attributes.
   For more information,
-  see {call buck.concept_link}{param page: 'visibility' /}{param name: 'Visibility' /}{/call}.
+  see {call buck.concept_link}{param page: 'visibility' /}{param name: 'visibility' /}{/call}.
   {/param}
 {/call}
 {/template}

--- a/docs/__common.soy
+++ b/docs/__common.soy
@@ -886,10 +886,10 @@ docsearch({
   {param desc}
   List of <a href="{ROOT}concept/build_target_pattern.html">build
   target patterns</a> that identify the build rules that can include
-  this rule as a dependency, for example, by listing it in 
+  this rule as a dependency, for example, by listing it in
   their <code>deps</code> or <code>exported_deps</code> attributes.
-  For more information, 
-  see {call buck.concept_link}{param page: 'Visibility' /}{param name: 'Visibility' /}{/call}.
+  For more information,
+  see {call buck.concept_link}{param page: 'visibility' /}{param name: 'Visibility' /}{/call}.
   {/param}
 {/call}
 {/template}


### PR DESCRIPTION
The link from the csharp_library rule page to the visibility page is broken because of a capitalization. Fixed that.