### PR TITLE
Add error for combining modular and bridging header

### DIFF
--- a/src/com/facebook/buck/apple/AppleNativeTargetDescriptionArg.java
+++ b/src/com/facebook/buck/apple/AppleNativeTargetDescriptionArg.java
@@ -16,6 +16,7 @@
 
 package com.facebook.buck.apple;
 
+import com.facebook.buck.core.exceptions.HumanReadableException;
 import com.facebook.buck.cxx.CxxLibraryDescription;
 import com.facebook.buck.swift.SwiftCommonArg;
 import com.google.common.collect.ImmutableMap;
@@ -34,5 +35,13 @@ public interface AppleNativeTargetDescriptionArg
   @Value.Default
   default boolean isModular() {
     return false;
+  }
+
+  @Value.Check
+  default void checkModularUsage() {
+    if (isModular() && getBridgingHeader().isPresent()) {
+      throw new HumanReadableException(
+          "Cannot be modular=True and have a bridging_header in the same rule");
+    }
   }
 }

--- a/test/com/facebook/buck/apple/AppleLibraryDescriptionTest.java
+++ b/test/com/facebook/buck/apple/AppleLibraryDescriptionTest.java
@@ -52,9 +52,13 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.Optional;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class AppleLibraryDescriptionTest {
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void linkerFlagsLocationMacro() {
@@ -151,5 +155,15 @@ public class AppleLibraryDescriptionTest {
         containsInAnyOrder(
             StringWithMacrosUtils.format("-fmodule-name=library"),
             StringWithMacrosUtils.format("-DDEBUG=1")));
+  }
+
+  @Test
+  public void noModularBridgingHeader() {
+    thrown.expectMessage("Cannot be modular=True and have a bridging_header in the same rule");
+    AppleLibraryDescriptionArg.builder()
+        .setName("fake")
+        .setModular(true)
+        .setBridgingHeader(FakeSourcePath.of("header.h"))
+        .build();
   }
 }


### PR DESCRIPTION
For apple targets containig swift setting modular to true and a bridging header is not a valid build setup. Add an error to fail immediately if this is set. Based on https://github.com/facebook/buck/issues/1918#issuecomment-398401059.