### PR TITLE
Add prebuilt frameworks to tests without bundle loader in xcode projects

### DIFF
--- a/test/com/facebook/buck/apple/testdata/prebuilt_apple_framework_links/test/BUCK.fixture
+++ b/test/com/facebook/buck/apple/testdata/prebuilt_apple_framework_links/test/BUCK.fixture
@@ -1,0 +1,16 @@
+apple_test(
+    name = "test",
+    srcs = ["FooXCTest.m"],
+    info_plist = "Test.plist",
+    frameworks = [
+        "$PLATFORM_DIR/Developer/Library/Frameworks/XCTest.framework",
+        "$SDKROOT/System/Library/Frameworks/Foundation.framework",
+    ],
+    deps = ["//prebuilt:BuckTest"],
+)
+
+xcode_workspace_config(
+    name = "workspace",
+    workspace_name = "testworkspace",
+    extra_tests = [":test"],
+)

--- a/test/com/facebook/buck/apple/testdata/prebuilt_apple_framework_links/test/FooXCTest.m
+++ b/test/com/facebook/buck/apple/testdata/prebuilt_apple_framework_links/test/FooXCTest.m
@@ -1,0 +1,13 @@
+#import <XCTest/XCTest.h>
+#import <BuckTest/BuckTest.h>
+
+@interface FooXCTest : XCTestCase
+@end
+
+@implementation FooXCTest
+
+- (void)testTwoPlusTwoEqualsFour {
+  XCTAssertEqual([Hello sayHello], @"Hello", @"Must say hello");
+}
+
+@end

--- a/test/com/facebook/buck/apple/testdata/prebuilt_apple_framework_links/test/Test.plist
+++ b/test/com/facebook/buck/apple/testdata/prebuilt_apple_framework_links/test/Test.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>CFBundleExecutable</key>
+        <string>${EXECUTABLE_NAME}</string>
+        <key>CFBundleIdentifier</key>
+        <string>com.facebook.${PRODUCT_NAME:rfc1034identifier}</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundlePackageType</key>
+        <string>BNDL</string>
+        <key>CFBundleShortVersionString</key>
+        <string>1.0</string>
+        <key>CFBundleSignature</key>
+        <string>????</string>
+        <key>CFBundleVersion</key>
+        <string>1</string>
+</dict>
+</plist>


### PR DESCRIPTION
When a test has no bundle loader, it should include all its frameworks in the test bundle and have `@loader_path/Frameworks` set in `LD_RUNPATH_SEARCH_PATHS`.