### PR TITLE
Refactor apple rules to pass CxxPlatformsProvider instead of flavor and domain

### DIFF
--- a/src/com/facebook/buck/apple/AppleBinaryDescription.java
+++ b/src/com/facebook/buck/apple/AppleBinaryDescription.java
@@ -311,8 +311,7 @@ public class AppleBinaryDescription
         strippedBinaryRule,
         unstrippedBinaryRule,
         AppleDebugFormat.FLAVOR_DOMAIN.getRequiredValue(buildTarget),
-        cxxPlatformsProvider.getCxxPlatforms(),
-        cxxPlatformsProvider.getDefaultCxxPlatform().getFlavor(),
+        cxxPlatformsProvider,
         appleCxxPlatformsFlavorDomain);
   }
 
@@ -357,8 +356,7 @@ public class AppleBinaryDescription
     }
     BuildTarget binaryTarget = buildTarget.withoutFlavors(APP_FLAVOR);
     return AppleDescriptions.createAppleBundle(
-        cxxPlatforms,
-        defaultCxxFlavor,
+        getCxxPlatformsProvider(),
         appleCxxPlatformsFlavorDomain,
         targetGraph,
         buildTarget,

--- a/src/com/facebook/buck/apple/AppleBundleDescription.java
+++ b/src/com/facebook/buck/apple/AppleBundleDescription.java
@@ -148,8 +148,7 @@ public class AppleBundleDescription
     CxxPlatformsProvider cxxPlatformsProvider = getCxxPlatformsProvider();
 
     return AppleDescriptions.createAppleBundle(
-        cxxPlatformsProvider.getCxxPlatforms(),
-        cxxPlatformsProvider.getDefaultCxxPlatform().getFlavor(),
+        cxxPlatformsProvider,
         getAppleCxxPlatformFlavorDomain(),
         context.getTargetGraph(),
         buildTarget,
@@ -206,11 +205,7 @@ public class AppleBundleDescription
       AppleCxxPlatform appleCxxPlatform = fatBinaryInfo.get().getRepresentativePlatform();
       cxxPlatform = appleCxxPlatform.getCxxPlatform();
     } else {
-      cxxPlatform =
-          ApplePlatforms.getCxxPlatformForBuildTarget(
-              cxxPlatformsProvider.getCxxPlatforms(),
-              cxxPlatformsProvider.getDefaultCxxPlatform().getFlavor(),
-              buildTarget);
+      cxxPlatform = ApplePlatforms.getCxxPlatformForBuildTarget(cxxPlatformsProvider, buildTarget);
     }
 
     String platformName = cxxPlatform.getFlavor().getName();
@@ -307,8 +302,7 @@ public class AppleBundleDescription
     FlavorDomain<AppleCxxPlatform> appleCxxPlatforms = getAppleCxxPlatformFlavorDomain();
     AppleCxxPlatform appleCxxPlatform =
         ApplePlatforms.getAppleCxxPlatformForBuildTarget(
-            cxxPlatformsProvider.getCxxPlatforms(),
-            cxxPlatformsProvider.getDefaultCxxPlatform().getFlavor(),
+            cxxPlatformsProvider,
             appleCxxPlatforms,
             buildTarget,
             MultiarchFileInfos.create(appleCxxPlatforms, buildTarget));

--- a/src/com/facebook/buck/apple/AppleLibraryDescription.java
+++ b/src/com/facebook/buck/apple/AppleLibraryDescription.java
@@ -404,8 +404,7 @@ public class AppleLibraryDescription
     CxxPlatformsProvider cxxPlatformsProvider = getCxxPlatformsProvider();
 
     return AppleDescriptions.createAppleBundle(
-        cxxPlatformsProvider.getCxxPlatforms(),
-        cxxPlatformsProvider.getDefaultCxxPlatform().getFlavor(),
+        cxxPlatformsProvider,
         getAppleCxxPlatformDomain(),
         targetGraph,
         buildTarget,
@@ -511,8 +510,7 @@ public class AppleLibraryDescription
         AppleDebugFormat.FLAVOR_DOMAIN
             .getValue(buildTarget)
             .orElse(appleConfig.getDefaultDebugInfoFormatForLibraries()),
-        cxxPlatforms,
-        defaultCxxFlavor,
+        cxxPlatformsProvider,
         getAppleCxxPlatformDomain());
   }
 

--- a/src/com/facebook/buck/apple/ApplePlatforms.java
+++ b/src/com/facebook/buck/apple/ApplePlatforms.java
@@ -19,10 +19,10 @@ package com.facebook.buck.apple;
 import com.facebook.buck.apple.toolchain.AppleCxxPlatform;
 import com.facebook.buck.core.exceptions.HumanReadableException;
 import com.facebook.buck.core.model.BuildTarget;
-import com.facebook.buck.core.model.Flavor;
 import com.facebook.buck.core.model.FlavorDomain;
 import com.facebook.buck.core.model.FlavorDomainException;
 import com.facebook.buck.cxx.toolchain.CxxPlatform;
+import com.facebook.buck.cxx.toolchain.CxxPlatformsProvider;
 import java.util.Optional;
 
 public class ApplePlatforms {
@@ -31,17 +31,15 @@ public class ApplePlatforms {
 
   /** Only works with thin binaries. */
   static CxxPlatform getCxxPlatformForBuildTarget(
-      FlavorDomain<CxxPlatform> cxxPlatformFlavorDomain,
-      Flavor defaultCxxFlavor,
-      BuildTarget target) {
-    return cxxPlatformFlavorDomain
+      CxxPlatformsProvider cxxPlatformsProvider, BuildTarget target) {
+    return cxxPlatformsProvider
+        .getCxxPlatforms()
         .getValue(target)
-        .orElse(cxxPlatformFlavorDomain.getValue(defaultCxxFlavor));
+        .orElse(cxxPlatformsProvider.getDefaultCxxPlatform());
   }
 
   public static AppleCxxPlatform getAppleCxxPlatformForBuildTarget(
-      FlavorDomain<CxxPlatform> cxxPlatformFlavorDomain,
-      Flavor defaultCxxFlavor,
+      CxxPlatformsProvider cxxPlatformsProvider,
       FlavorDomain<AppleCxxPlatform> appleCxxPlatformFlavorDomain,
       BuildTarget target,
       Optional<MultiarchFileInfo> fatBinaryInfo) {
@@ -49,8 +47,7 @@ public class ApplePlatforms {
     if (fatBinaryInfo.isPresent()) {
       appleCxxPlatform = fatBinaryInfo.get().getRepresentativePlatform();
     } else {
-      CxxPlatform cxxPlatform =
-          getCxxPlatformForBuildTarget(cxxPlatformFlavorDomain, defaultCxxFlavor, target);
+      CxxPlatform cxxPlatform = getCxxPlatformForBuildTarget(cxxPlatformsProvider, target);
       try {
         appleCxxPlatform = appleCxxPlatformFlavorDomain.getValue(cxxPlatform.getFlavor());
       } catch (FlavorDomainException e) {

--- a/src/com/facebook/buck/apple/AppleTestDescription.java
+++ b/src/com/facebook/buck/apple/AppleTestDescription.java
@@ -280,8 +280,7 @@ public class AppleTestDescription
 
     AppleBundle bundle =
         AppleDescriptions.createAppleBundle(
-            cxxPlatformFlavorDomain,
-            defaultCxxFlavor,
+            getCxxPlatformsProvider(),
             appleCxxPlatformFlavorDomain,
             context.getTargetGraph(),
             buildTarget.withAppendedFlavors(


### PR DESCRIPTION
Some apple rules pass `FlavorDomain<CxxPlatform> cxxPlatformFlavorDomain` as well as a 
`Flavor` for the default platform. Refactor this into passing a single `CxxPlatformsProvider`, which encapsulates these to reduce some argument passing complexity.