### PR TITLE
Add support for bazel-like short build target names

### DIFF
--- a/src/com/facebook/buck/parser/BuildTargetParser.java
+++ b/src/com/facebook/buck/parser/BuildTargetParser.java
@@ -92,15 +92,15 @@ public class BuildTargetParser {
     }
 
     List<String> parts = BUILD_RULE_SEPARATOR_SPLITTER.splitToList(targetAfterCell);
-    if (parts.size() != 2) {
+    if (parts.size() > 2) {
       throw new BuildTargetParseException(
           String.format(
-              "%s must contain exactly one colon (found %d)", buildTargetName, parts.size() - 1));
+              "%s must contain at most one colon (found %d)", buildTargetName, parts.size() - 1));
     }
 
     String baseName =
         parts.get(0).isEmpty() ? buildTargetPatternParser.getBaseName() : parts.get(0);
-    String shortName = parts.get(1);
+    String shortName = ((parts.size() == 2) ? parts.get(1) : parts.get(0).substring(parts.get(0).lastIndexOf("/")+1));
     Iterable<String> flavorNames = new HashSet<>();
     int hashIndex = shortName.indexOf('#');
     if (hashIndex != -1 && hashIndex < shortName.length()) {

--- a/test/com/facebook/buck/parser/BuildTargetParserTest.java
+++ b/test/com/facebook/buck/parser/BuildTargetParserTest.java
@@ -126,6 +126,14 @@ public class BuildTargetParserTest {
   }
 
   @Test
+  public void testParseNoColon() {
+    BuildTarget buildTarget =
+        parser.parse("//facebook/orca", fullyQualifiedParser, createCellRoots(null));
+    assertEquals("//facebook/orca", buildTarget.getBaseName());
+    assertEquals("orca", buildTarget.getShortNameAndFlavorPostfix());
+  }
+
+  @Test
   public void testParseMultipleColons() {
     try {
       parser.parse("//facebook:orca:assets", fullyQualifiedParser, createCellRoots(null));

--- a/test/com/facebook/buck/parser/BuildTargetParserTest.java
+++ b/test/com/facebook/buck/parser/BuildTargetParserTest.java
@@ -126,24 +126,13 @@ public class BuildTargetParserTest {
   }
 
   @Test
-  public void testParseNoColon() {
-    try {
-      parser.parse("//facebook/orca/assets", fullyQualifiedParser, createCellRoots(null));
-      fail("parse() should throw an exception");
-    } catch (BuildTargetParseException e) {
-      assertEquals(
-          "//facebook/orca/assets must contain exactly one colon (found 0)", e.getMessage());
-    }
-  }
-
-  @Test
   public void testParseMultipleColons() {
     try {
       parser.parse("//facebook:orca:assets", fullyQualifiedParser, createCellRoots(null));
       fail("parse() should throw an exception");
     } catch (BuildTargetParseException e) {
       assertEquals(
-          "//facebook:orca:assets must contain exactly one colon (found 2)", e.getMessage());
+          "//facebook:orca:assets must contain at most one colon (found 2)", e.getMessage());
     }
   }
 


### PR DESCRIPTION
Bazel omits the part after colon in target names
if that part is equal to the part after last slash.
e.g. bazel converts //foo/bar:bar to //foo/bar
Though both bazel and buck use Skylark, this creates
confusion in some tools like
https://github.com/bazelbuild/buildtools/tree/master/buildifier
There has been a discussion going on
https://github.com/bazelbuild/buildtools/pull/339