### PR TITLE
Add new types to maven url decoder

### DIFF
--- a/src/com/facebook/buck/file/downloader/impl/MavenUrlDecoder.java
+++ b/src/com/facebook/buck/file/downloader/impl/MavenUrlDecoder.java
@@ -130,6 +130,12 @@ public class MavenUrlDecoder {
       case "aar":
         return ".aar";
 
+      case "exe":
+        return ".exe";
+
+      case "pex":
+        return ".pex";
+
       case "tar.gz":
         return ".tar.gz";
 

--- a/test/com/facebook/buck/file/downloader/impl/MavenUrlDecoderTest.java
+++ b/test/com/facebook/buck/file/downloader/impl/MavenUrlDecoderTest.java
@@ -83,6 +83,30 @@ public class MavenUrlDecoderTest {
   }
 
   @Test
+  public void parseMvnUrlWithDefaultDomainAndExeType() throws URISyntaxException {
+    URI seen =
+        MavenUrlDecoder.toHttpUrl(
+            Optional.of("http://foo.bar"), new URI("mvn:org.apache.karaf:apache-karaf:exe:3.0.8"));
+
+    URI expected =
+        new URI("http://foo.bar/org/apache/karaf/apache-karaf/3.0.8/apache-karaf-3.0.8.exe");
+
+    assertEquals(expected, seen);
+  }
+
+  @Test
+  public void parseMvnUrlWithDefaultDomainAndPexType() throws URISyntaxException {
+    URI seen =
+        MavenUrlDecoder.toHttpUrl(
+            Optional.of("http://foo.bar"), new URI("mvn:org.apache.karaf:apache-karaf:pex:3.0.8"));
+
+    URI expected =
+        new URI("http://foo.bar/org/apache/karaf/apache-karaf/3.0.8/apache-karaf-3.0.8.pex");
+
+    assertEquals(expected, seen);
+  }
+
+  @Test
   public void parseMvnUrlWithCustomDomain() throws URISyntaxException {
     URI seen =
         MavenUrlDecoder.toHttpUrl(


### PR DESCRIPTION
- `exe` is used by protoc binaries - https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.6.0/
- `pex` is used by buck binaries - https://github.com/facebook/buck#prebuilt-buck-binaries