### PR TITLE
Ignore buck-out

### DIFF
--- a/src/com/facebook/buck/parser/AbstractBuildFileSpec.java
+++ b/src/com/facebook/buck/parser/AbstractBuildFileSpec.java
@@ -23,6 +23,7 @@ import com.facebook.buck.core.util.immutables.BuckStyleImmutable;
 import com.facebook.buck.io.ProjectWatch;
 import com.facebook.buck.io.Watchman;
 import com.facebook.buck.io.WatchmanClient;
+import com.facebook.buck.io.filesystem.PathOrGlobMatcher;
 import com.facebook.buck.io.filesystem.ProjectFilesystem;
 import com.facebook.buck.log.Logger;
 import com.google.common.base.Preconditions;
@@ -204,7 +205,7 @@ abstract class AbstractBuildFileSpec {
 
     for (String file : files) {
       Path relativePath = Paths.get(file);
-      if (!filesystem.isIgnored(relativePath)) {
+      if (!isIgnored(filesystem, relativePath)) {
         // To avoid an extra stat() and realpath(), we assume we have no symlinks here
         // (since Watchman doesn't follow them anyway), and directly resolve the path
         // instead of using ProjectFilesystem.resolve().
@@ -230,7 +231,7 @@ abstract class AbstractBuildFileSpec {
           @Override
           public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
             // Skip sub-dirs that we should ignore.
-            if (filesystem.isIgnored(dir)) {
+            if (isIgnored(filesystem, dir)) {
               return FileVisitResult.SKIP_SUBTREE;
             }
             return FileVisitResult.CONTINUE;
@@ -239,7 +240,7 @@ abstract class AbstractBuildFileSpec {
           @Override
           public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
             if (buildFileName.equals(file.getFileName().toString())
-                && !filesystem.isIgnored(file)) {
+                && !isIgnored(filesystem, file)) {
               function.accept(filesystem.resolve(file));
             }
             return FileVisitResult.CONTINUE;
@@ -274,5 +275,11 @@ abstract class AbstractBuildFileSpec {
         buildFiles::add);
 
     return buildFiles.build();
+  }
+
+  static boolean isIgnored(ProjectFilesystem filesystem, Path path) {
+    // Ignoring buck-out in addition to the blacklist paths
+    return filesystem.isIgnored(path)
+        || new PathOrGlobMatcher(filesystem.getBuckPaths().getBuckOut()).matches(path);
   }
 }

--- a/test/com/facebook/buck/parser/BuildFileSpecTest.java
+++ b/test/com/facebook/buck/parser/BuildFileSpecTest.java
@@ -17,6 +17,7 @@
 package com.facebook.buck.parser;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.facebook.buck.core.cell.Cell;
 import com.facebook.buck.core.cell.TestCellBuilder;
@@ -237,6 +238,13 @@ public class BuildFileSpecTest {
     thrown.expect(HumanReadableException.class);
     thrown.expectMessage("could not be found");
     recursiveSpec.findBuildFiles(cell, ParserConfig.BuildFileSearchMethod.FILESYSTEM_CRAWL);
+  }
+
+  @Test
+  public void testBuckOutIsIgnored() {
+    FakeProjectFilesystem filesystem = new FakeProjectFilesystem();
+    Path buildFile = Paths.get("buck-out", "gen", "a", "BUCK");
+    assertTrue(BuildFileSpec.isIgnored(filesystem, buildFile));
   }
 
   private static Watchman createWatchman(


### PR DESCRIPTION
According to the [doc](https://buckbuild.com/concept/buckconfig.html#project.ignore), `buck-out` should be automatically ignored. This PR implements that, to avoid crashes when running `buck build //...`

```
java.lang.IllegalStateException: Target '//buck-out/gen/protobuf/google/google:google' refers to file 'buck-out/gen/protobuf/google/google', which doesn't belong to any package
	at com.facebook.buck.parser.ThrowingPackageBoundaryChecker.enforceBuckPackageBoundaries(ThrowingPackageBoundaryChecker.java:60)
	at com.facebook.buck.parser.DefaultParserTargetNodeFactory.createTargetNodeFromObject(DefaultParserTargetNodeFactory.java:210)
	at com.facebook.buck.parser.DefaultParserTargetNodeFactory.createTargetNode(DefaultParserTargetNodeFactory.java:166)
	at com.facebook.buck.parser.DefaultParserTargetNodeFactory.createTargetNode(DefaultParserTargetNodeFactory.java:1)
	at com.facebook.buck.parser.TargetNodeParsePipeline.computeNodeInScope(TargetNodeParsePipeline.java:106)
	at com.facebook.buck.parser.TargetNodeParsePipeline.computeNodeInScope(TargetNodeParsePipeline.java:1)
	at com.facebook.buck.parser.ConvertingPipelineWithPerfEventScope.computeNode(ConvertingPipelineWithPerfEventScope.java:68)
	at com.facebook.buck.parser.ConvertingPipeline.dispatchComputeNode(ConvertingPipeline.java:143)
	at com.facebook.buck.parser.ConvertingPipeline.lambda$1(ConvertingPipeline.java:81)
	at com.facebook.buck.parser.PipelineNodeCache.getJobWithCacheLookup(PipelineNodeCache.java:73)
	at com.facebook.buck.parser.ConvertingPipeline.lambda$0(ConvertingPipeline.java:74)
	at com.google.common.util.concurrent.AbstractTransformFuture$AsyncTransformFuture.doTransform(AbstractTransformFuture.java:206)
	at com.google.common.util.concurrent.AbstractTransformFuture$AsyncTransformFuture.doTransform(AbstractTransformFuture.java:195)
	at com.google.common.util.concurrent.AbstractTransformFuture.run(AbstractTransformFuture.java:115)
	at com.google.common.util.concurrent.MoreExecutors$5$1.run(MoreExecutors.java:999)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)

```

@ttsugriy @mkaczanowski Please take a look. Thanks!