### PR TITLE
Publish lone build targets

### DIFF
--- a/src/com/facebook/buck/cli/PublishCommand.java
+++ b/src/com/facebook/buck/cli/PublishCommand.java
@@ -22,14 +22,18 @@ import static com.facebook.buck.jvm.java.Javadoc.DOC_JAR;
 
 import com.facebook.buck.config.BuckConfig;
 import com.facebook.buck.core.model.BuildTarget;
+import com.facebook.buck.core.rules.ActionGraphBuilder;
 import com.facebook.buck.core.rules.BuildRule;
 import com.facebook.buck.core.rules.SourcePathRuleFinder;
 import com.facebook.buck.core.sourcepath.resolver.impl.DefaultSourcePathResolver;
+import com.facebook.buck.event.BuckEventBus;
 import com.facebook.buck.event.ConsoleEvent;
+import com.facebook.buck.file.OutputFilePublisher;
 import com.facebook.buck.jvm.java.MavenPublishable;
 import com.facebook.buck.maven.Publisher;
 import com.facebook.buck.parser.BuildTargetSpec;
 import com.facebook.buck.parser.TargetNodeSpec;
+import com.facebook.buck.step.ExecutorPool;
 import com.facebook.buck.util.CommandLineException;
 import com.facebook.buck.util.ExitCode;
 import com.google.common.base.Joiner;
@@ -39,10 +43,16 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import okhttp3.Credentials;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.deployment.DeployResult;
 import org.eclipse.aether.deployment.DeploymentException;
@@ -51,11 +61,11 @@ import org.kohsuke.args4j.Option;
 public class PublishCommand extends BuildCommand {
   public static final String REMOTE_REPO_LONG_ARG = "--remote-repo";
   public static final String REMOTE_REPO_SHORT_ARG = "-r";
+  public static final String TO_MAVEN_LONG_ARG = "--to-maven";
   public static final String INCLUDE_SOURCE_LONG_ARG = "--include-source";
   public static final String INCLUDE_SOURCE_SHORT_ARG = "-s";
   public static final String INCLUDE_DOCS_LONG_ARG = "--include-docs";
   public static final String INCLUDE_DOCS_SHORT_ARG = "-w";
-  public static final String TO_MAVEN_CENTRAL_LONG_ARG = "--to-maven-central";
   public static final String DRY_RUN_LONG_ARG = "--dry-run";
 
   private static final String PUBLISH_GEN_PATH = "publish";
@@ -68,20 +78,25 @@ public class PublishCommand extends BuildCommand {
   private URL remoteRepo = null;
 
   @Option(
-      name = TO_MAVEN_CENTRAL_LONG_ARG,
-      usage = "Same as \"" + REMOTE_REPO_LONG_ARG + " " + Publisher.MAVEN_CENTRAL_URL + "\"")
-  private boolean toMavenCentral = false;
+      name = TO_MAVEN_LONG_ARG,
+      usage =
+          "Indicate that the remote repository is a maven repository and automatically set "
+              + REMOTE_REPO_LONG_ARG
+              + " to "
+              + Publisher.MAVEN_CENTRAL_URL
+              + " unless it is provided otherwise.")
+  private boolean toMaven = false;
 
   @Option(
       name = INCLUDE_SOURCE_LONG_ARG,
       aliases = INCLUDE_SOURCE_SHORT_ARG,
-      usage = "Publish source code as well")
+      usage = "Publish source code as well. Only valid for Maven repositories")
   private boolean includeSource = false;
 
   @Option(
       name = INCLUDE_DOCS_LONG_ARG,
       aliases = INCLUDE_DOCS_SHORT_ARG,
-      usage = "Publish docs as well")
+      usage = "Publish docs as well. Only valid for Maven repositories")
   private boolean includeDocs = false;
 
   @Option(name = DRY_RUN_LONG_ARG, usage = "Just print the artifacts to be published")
@@ -106,23 +121,25 @@ public class PublishCommand extends BuildCommand {
       throws IOException, InterruptedException {
 
     // Input validation
-    if (remoteRepo != null && toMavenCentral) {
+    if (!toMaven && (includeDocs || includeSource)) {
       throw new CommandLineException(
-          "please specify only a single remote repository to publish to.\n"
-              + "Use "
-              + REMOTE_REPO_LONG_ARG
-              + " <URL> or "
-              + TO_MAVEN_CENTRAL_LONG_ARG
-              + " but not both.");
+          INCLUDE_DOCS_LONG_ARG
+              + " and "
+              + INCLUDE_SOURCE_LONG_ARG
+              + " are only available when publishing to a Maven repository");
     }
 
-    if (remoteRepo == null && !toMavenCentral) {
-      throw new CommandLineException(
-          "please specify a remote repository to publish to.\n"
-              + "Use "
-              + REMOTE_REPO_LONG_ARG
-              + " <URL> or "
-              + TO_MAVEN_CENTRAL_LONG_ARG);
+    if (remoteRepo == null) {
+      if (toMaven) {
+        remoteRepo = Publisher.MAVEN_CENTRAL;
+      } else {
+        throw new CommandLineException(
+            "please specify a remote repository to publish to.\n"
+                + "Use "
+                + REMOTE_REPO_LONG_ARG
+                + " <URL> or "
+                + TO_MAVEN_LONG_ARG);
+      }
     }
 
     // Build the specified target(s).
@@ -141,12 +158,62 @@ public class PublishCommand extends BuildCommand {
     }
 
     // Publish starting with the given targets.
-    return publishTargets(buildRunResult.getBuildTargets(), params)
-        ? ExitCode.SUCCESS
-        : ExitCode.RUN_ERROR;
+    boolean success;
+    if (toMaven) {
+      success = publishMavenTargets(buildRunResult.getBuildTargets(), params);
+    } else {
+      success = publishFileTargets(buildRunResult.getBuildTargets(), params);
+    }
+    return success ? ExitCode.SUCCESS : ExitCode.RUN_ERROR;
   }
 
-  private boolean publishTargets(
+  private boolean publishFileTargets(
+      ImmutableSet<BuildTarget> buildTargets, CommandRunnerParams params) {
+    Deque<CompletableFuture<Integer>> futures = new ArrayDeque<>();
+    boolean success = true;
+    ActionGraphBuilder graphBuilder = getBuild().getGraphBuilder();
+    DefaultSourcePathResolver pathResolver =
+        DefaultSourcePathResolver.from(new SourcePathRuleFinder(graphBuilder));
+    BuckEventBus buckEventBus = params.getBuckEventBus();
+    for (BuildTarget target : buildTargets) {
+      BuildRule buildRule = graphBuilder.requireRule(target);
+      Preconditions.checkNotNull(buildRule);
+      futures.add(
+          CompletableFuture.supplyAsync(
+              new OutputFilePublisher(
+                  buildRule,
+                  pathResolver,
+                  buckEventBus,
+                  remoteRepo,
+                  Credentials.basic(username, password)),
+              getExecutionContext().getExecutors().get(ExecutorPool.NETWORK)));
+    }
+    while (!futures.isEmpty()) {
+      CompletableFuture<Integer> future = futures.pop();
+      try {
+        if (future.isDone()) {
+          int resposeCode = future.get();
+          if (resposeCode >= 300 || resposeCode < 200) {
+            success = false;
+            if (resposeCode != -1) {
+              buckEventBus.post(
+                  ConsoleEvent.severe(
+                      "Publishing to " + remoteRepo + " returned a response code " + resposeCode));
+            }
+          }
+        } else {
+          futures.push(future);
+          TimeUnit.SECONDS.sleep(1);
+        }
+      } catch (InterruptedException | ExecutionException e) {
+        buckEventBus.post(ConsoleEvent.warning(e.getMessage()));
+        success = false;
+      }
+    }
+    return success;
+  }
+
+  private boolean publishMavenTargets(
       ImmutableSet<BuildTarget> buildTargets, CommandRunnerParams params) {
     ImmutableSet.Builder<MavenPublishable> publishables = ImmutableSet.builder();
     boolean success = true;
@@ -178,13 +245,10 @@ public class PublishCommand extends BuildCommand {
       publishables.add(publishable);
     }
 
-    // Assume validation passed.
-    URL repoUrl = toMavenCentral ? Publisher.MAVEN_CENTRAL : Preconditions.checkNotNull(remoteRepo);
-
     Publisher publisher =
         new Publisher(
             params.getCell().getFilesystem().getBuckPaths().getTmpDir().resolve(PUBLISH_GEN_PATH),
-            repoUrl,
+            remoteRepo,
             Optional.ofNullable(username),
             Optional.ofNullable(password),
             dryRun);
@@ -229,31 +293,36 @@ public class PublishCommand extends BuildCommand {
     ImmutableList<TargetNodeSpec> specs =
         super.parseArgumentsAsTargetNodeSpecs(config, targetsAsArgs);
 
-    Map<BuildTarget, TargetNodeSpec> uniqueSpecs = new HashMap<>();
-    for (TargetNodeSpec spec : specs) {
-      if (!(spec instanceof BuildTargetSpec)) {
-        throw new IllegalArgumentException(
-            "Need to specify build targets explicitly when publishing. " + "Cannot modify " + spec);
+    if (toMaven) {
+      Map<BuildTarget, TargetNodeSpec> uniqueSpecs = new HashMap<>();
+      for (TargetNodeSpec spec : specs) {
+        if (!(spec instanceof BuildTargetSpec)) {
+          throw new IllegalArgumentException(
+              "Need to specify build targets explicitly when publishing. "
+                  + "Cannot modify "
+                  + spec);
+        }
+
+        BuildTargetSpec targetSpec = (BuildTargetSpec) spec;
+        Preconditions.checkNotNull(targetSpec.getBuildTarget());
+
+        BuildTarget mavenTarget = targetSpec.getBuildTarget().withFlavors(MAVEN_JAR);
+        uniqueSpecs.put(mavenTarget, targetSpec.withBuildTarget(mavenTarget));
+
+        if (includeSource) {
+          BuildTarget sourceTarget = targetSpec.getBuildTarget().withFlavors(MAVEN_JAR, SRC_JAR);
+          uniqueSpecs.put(sourceTarget, targetSpec.withBuildTarget(sourceTarget));
+        }
+
+        if (includeDocs) {
+          BuildTarget docsTarget = targetSpec.getBuildTarget().withFlavors(MAVEN_JAR, DOC_JAR);
+          uniqueSpecs.put(docsTarget, targetSpec.withBuildTarget(docsTarget));
+        }
       }
-
-      BuildTargetSpec targetSpec = (BuildTargetSpec) spec;
-      Preconditions.checkNotNull(targetSpec.getBuildTarget());
-
-      BuildTarget mavenTarget = targetSpec.getBuildTarget().withFlavors(MAVEN_JAR);
-      uniqueSpecs.put(mavenTarget, targetSpec.withBuildTarget(mavenTarget));
-
-      if (includeSource) {
-        BuildTarget sourceTarget = targetSpec.getBuildTarget().withFlavors(MAVEN_JAR, SRC_JAR);
-        uniqueSpecs.put(sourceTarget, targetSpec.withBuildTarget(sourceTarget));
-      }
-
-      if (includeDocs) {
-        BuildTarget docsTarget = targetSpec.getBuildTarget().withFlavors(MAVEN_JAR, DOC_JAR);
-        uniqueSpecs.put(docsTarget, targetSpec.withBuildTarget(docsTarget));
-      }
+      return ImmutableList.copyOf(uniqueSpecs.values());
+    } else {
+      return specs;
     }
-
-    return ImmutableList.copyOf(uniqueSpecs.values());
   }
 
   @Override

--- a/src/com/facebook/buck/file/BUCK
+++ b/src/com/facebook/buck/file/BUCK
@@ -12,6 +12,7 @@ java_library_with_plugins(
         "HttpFile.java",
         "HttpFileBinary.java",
         "HttpFileDescription.java",
+        "OutputFilePublisher.java",
         "RemoteFile.java",
         "RemoteFileBinary.java",
         "RemoteFileDescription.java",
@@ -51,6 +52,7 @@ java_library_with_plugins(
         "//src/com/facebook/buck/zip:zip",
         "//third-party/java/guava:guava",
         "//third-party/java/infer-annotations:infer-annotations",
+        "//third-party/java/okhttp:okhttp",
     ],
 )
 

--- a/src/com/facebook/buck/file/OutputFilePublisher.java
+++ b/src/com/facebook/buck/file/OutputFilePublisher.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2018-present Facebook, Inc. and Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.file;
+
+import com.facebook.buck.core.model.BuildTarget;
+import com.facebook.buck.core.rules.BuildRule;
+import com.facebook.buck.core.sourcepath.resolver.SourcePathResolver;
+import com.facebook.buck.event.BuckEventBus;
+import com.facebook.buck.event.ConsoleEvent;
+import com.google.common.hash.Hashing;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Supplier;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+public class OutputFilePublisher implements Supplier<Integer> {
+  private final BuildRule buildRule;
+  private final SourcePathResolver pathResolver;
+  private final BuckEventBus buckEventBus;
+  private final URL repoBase;
+  private final String authorizationHeader;
+
+  public OutputFilePublisher(
+      BuildRule buildRule,
+      SourcePathResolver pathResolver,
+      BuckEventBus buckEventBus,
+      URL repoBase,
+      String authorizationHeader) {
+    this.buildRule = buildRule;
+    this.pathResolver = pathResolver;
+    this.buckEventBus = buckEventBus;
+    this.repoBase = repoBase;
+    this.authorizationHeader = authorizationHeader;
+  }
+
+  @Override
+  public Integer get() {
+    Path output = pathResolver.getAbsolutePath(buildRule.getSourcePathToOutput());
+    BuildTarget target = buildRule.getBuildTarget();
+    if (Files.isDirectory(output)) {
+      buckEventBus.post(
+          ConsoleEvent.severe(
+              "The output of "
+                  + target.getFullyQualifiedName()
+                  + " is a directory. Buck can only publish files."));
+      return -1;
+    }
+    byte[] content;
+    try {
+      content = Files.readAllBytes(output);
+    } catch (IOException e) {
+      buckEventBus.post(
+          ConsoleEvent.severe("Failed to read from " + output + ":\n" + e.getMessage()));
+      return -1;
+    }
+    String sha = Hashing.sha256().hashBytes(content).toString();
+    HttpUrl url = buildUrl(target, sha, output.getFileName().toString());
+    Request request =
+        new Request.Builder()
+            .url(url)
+            .header("Authorization", authorizationHeader)
+            .header("X-Checksum-Sha256", sha)
+            .put(RequestBody.create(MediaType.parse("application/octet-stream"), content))
+            .build();
+    try {
+      OkHttpClient client = new OkHttpClient();
+      Response response = client.newCall(request).execute();
+      return response.code();
+    } catch (IOException e) {
+      buckEventBus.post(
+          ConsoleEvent.severe("Failed to send " + output + " to " + url + ":\n" + e.getMessage()));
+      return -1;
+    }
+  }
+
+  HttpUrl buildUrl(BuildTarget target, String sha, String fileName) {
+    return new HttpUrl.Builder()
+        .scheme(repoBase.getProtocol())
+        .host(repoBase.getHost())
+        .port(repoBase.getPort())
+        .addPathSegments(repoBase.getPath())
+        .addPathSegments(target.getBasePath().toString())
+        .addPathSegment(sha)
+        .addPathSegment(fileName)
+        .build();
+  }
+}

--- a/src/com/facebook/buck/file/OutputFilePublisher.java
+++ b/src/com/facebook/buck/file/OutputFilePublisher.java
@@ -95,11 +95,8 @@ public class OutputFilePublisher implements Supplier<Integer> {
   }
 
   HttpUrl buildUrl(BuildTarget target, String sha, String fileName) {
-    return new HttpUrl.Builder()
-        .scheme(repoBase.getProtocol())
-        .host(repoBase.getHost())
-        .port(repoBase.getPort())
-        .addPathSegments(repoBase.getPath())
+    return HttpUrl.get(repoBase)
+        .newBuilder()
         .addPathSegments(target.getBasePath().toString())
         .addPathSegment(sha)
         .addPathSegment(fileName)

--- a/test/com/facebook/buck/cli/PublishCommandIntegrationTest.java
+++ b/test/com/facebook/buck/cli/PublishCommandIntegrationTest.java
@@ -176,12 +176,11 @@ public class PublishCommandIntegrationTest {
             getMockRepoUrl(),
             "//src/foo:src-archive");
     result.assertSuccess();
-//    assertTrue(result.getStderr().contains("buck-out/gen/src/foo/src-archive__/src-archive.zip"));
-//    assertTrue(
-//        result
-//            .getStderr()
-//            .contains(
-//                "src/foo/90ca326e8172d39b0e1920c3047eb58952a206f1e796a132ff107aa83e3e1c32/src-archive.zip"));
+    List<String> putRequestsPaths = requestsHandler.getPutRequestsPaths();
+    assertThat(
+        putRequestsPaths,
+        hasItem(
+            "/src/foo/90ca326e8172d39b0e1920c3047eb58952a206f1e796a132ff107aa83e3e1c32/src-archive.zip"));
   }
 
   @Test

--- a/test/com/facebook/buck/cli/PublishCommandIntegrationTest.java
+++ b/test/com/facebook/buck/cli/PublishCommandIntegrationTest.java
@@ -75,7 +75,7 @@ public class PublishCommandIntegrationTest {
 
   @Test
   public void testDependenciesTriggerPomGeneration() throws IOException {
-    ProcessResult result = runValidBuckPublish("publish_fatjar");
+    ProcessResult result = runValidBuckPublishMaven("publish_fatjar");
     result.assertSuccess();
     List<String> putRequestsPaths = requestsHandler.getPutRequestsPaths();
     assertThat(putRequestsPaths, hasItem(EXPECTED_PUT_URL_PATH_BASE + POM));
@@ -84,16 +84,18 @@ public class PublishCommandIntegrationTest {
 
   @Test
   public void testBasicCase() throws IOException {
-    ProcessResult result = runValidBuckPublish("publish");
+    ProcessResult result = runValidBuckPublishMaven("publish");
     result.assertSuccess();
   }
 
-  private ProcessResult runValidBuckPublish(String workspaceName) throws IOException {
+  private ProcessResult runValidBuckPublishMaven(String workspaceName) throws IOException {
     ProjectWorkspace workspace =
         TestDataHelper.createProjectWorkspaceForScenario(this, workspaceName, tmp);
     workspace.setUp();
 
-    ProcessResult result = runBuckPublish(workspace, PublishCommand.INCLUDE_SOURCE_LONG_ARG);
+    ProcessResult result =
+        runBuckPublish(
+            workspace, PublishCommand.TO_MAVEN_LONG_ARG, PublishCommand.INCLUDE_SOURCE_LONG_ARG);
     result.assertSuccess();
     List<String> putRequestsPaths = requestsHandler.getPutRequestsPaths();
     assertThat(putRequestsPaths, hasItem(EXPECTED_PUT_URL_PATH_BASE + JAR));
@@ -115,17 +117,21 @@ public class PublishCommandIntegrationTest {
   }
 
   @Test
-  public void testErrorOnMultiplePublishDest() throws IOException {
+  public void testIncludeSrcNoMaven() throws IOException {
     ProjectWorkspace workspace =
         TestDataHelper.createProjectWorkspaceForScenario(this, "publish", tmp);
     workspace.setUp();
 
     ProcessResult result =
         workspace.runBuckCommand(
-            "publish", "//:foo", "--remote-repo=http://foo.bar", "--to-maven-central");
-    result.assertExitCode("please specify only a single remote", ExitCode.COMMANDLINE_ERROR);
-    assertTrue(result.getStderr().contains(PublishCommand.REMOTE_REPO_LONG_ARG));
-    assertTrue(result.getStderr().contains(PublishCommand.TO_MAVEN_CENTRAL_LONG_ARG));
+            "publish",
+            "//:foo",
+            "--remote-repo=http://foo.bar",
+            PublishCommand.INCLUDE_SOURCE_LONG_ARG);
+    result.assertExitCode(
+        "only available when publishing to a Maven repository", ExitCode.COMMANDLINE_ERROR);
+    assertTrue(result.getStderr().contains(PublishCommand.INCLUDE_SOURCE_LONG_ARG));
+    assertTrue(result.getStderr().contains(PublishCommand.INCLUDE_DOCS_LONG_ARG));
   }
 
   @Test
@@ -136,7 +142,10 @@ public class PublishCommandIntegrationTest {
 
     ProcessResult result =
         runBuckPublish(
-            workspace, PublishCommand.INCLUDE_SOURCE_LONG_ARG, PublishCommand.DRY_RUN_LONG_ARG);
+            workspace,
+            PublishCommand.TO_MAVEN_LONG_ARG,
+            PublishCommand.INCLUDE_SOURCE_LONG_ARG,
+            PublishCommand.DRY_RUN_LONG_ARG);
     result.assertSuccess();
 
     assertTrue(requestsHandler.getPutRequestsPaths().isEmpty());
@@ -152,7 +161,27 @@ public class PublishCommandIntegrationTest {
 
   @Test
   public void testScalaPublish() throws IOException {
-    runValidBuckPublish("publish_scala");
+    runValidBuckPublishMaven("publish_scala");
+  }
+
+  @Test
+  public void testPublishFile() throws IOException {
+    ProjectWorkspace workspace =
+        TestDataHelper.createProjectWorkspaceForScenario(this, "publish_zip", tmp);
+    workspace.setUp();
+    ProcessResult result =
+        workspace.runBuckCommand(
+            "publish",
+            PublishCommand.REMOTE_REPO_SHORT_ARG,
+            getMockRepoUrl(),
+            "//src/foo:src-archive");
+    result.assertSuccess();
+//    assertTrue(result.getStderr().contains("buck-out/gen/src/foo/src-archive__/src-archive.zip"));
+//    assertTrue(
+//        result
+//            .getStderr()
+//            .contains(
+//                "src/foo/90ca326e8172d39b0e1920c3047eb58952a206f1e796a132ff107aa83e3e1c32/src-archive.zip"));
   }
 
   @Test
@@ -166,6 +195,7 @@ public class PublishCommandIntegrationTest {
     ProcessResult result =
         workspace.runBuckCommand(
             FluentIterable.from(new String[] {"publish"})
+                .append(PublishCommand.TO_MAVEN_LONG_ARG)
                 .append(PublishCommand.INCLUDE_SOURCE_LONG_ARG)
                 .append(PublishCommand.REMOTE_REPO_SHORT_ARG, publishPath.toUri().toString())
                 .append(TARGET)

--- a/test/com/facebook/buck/cli/testdata/publish_zip/src/foo/BUCK.fixture
+++ b/test/com/facebook/buck/cli/testdata/publish_zip/src/foo/BUCK.fixture
@@ -1,0 +1,4 @@
+zip_file(
+  name = 'src-archive',
+  srcs = glob(['*.go', '*.s', '*.h'])
+)

--- a/test/com/facebook/buck/cli/testdata/publish_zip/src/foo/local.h
+++ b/test/com/facebook/buck/cli/testdata/publish_zip/src/foo/local.h
@@ -1,0 +1,1 @@
+#define PLUS(a, b) a+b

--- a/test/com/facebook/buck/cli/testdata/publish_zip/src/foo/main.go
+++ b/test/com/facebook/buck/cli/testdata/publish_zip/src/foo/main.go
@@ -1,0 +1,9 @@
+package foo
+
+import "fmt"
+
+func Sum(xs []int64) int64
+
+func main() {
+    fmt.Printf("Sum is %d", Sum([]int64{1, 2, 3}))
+}

--- a/test/com/facebook/buck/cli/testdata/publish_zip/src/foo/sum.go
+++ b/test/com/facebook/buck/cli/testdata/publish_zip/src/foo/sum.go
@@ -1,0 +1,11 @@
+// +build !amd64
+
+package foo
+
+func Sum(xs []int64) int64 {
+  var n int64
+  for _, v := range xs {
+    n += v
+  }
+  return n
+}

--- a/test/com/facebook/buck/cli/testdata/publish_zip/src/foo/sum_amd64.s
+++ b/test/com/facebook/buck/cli/testdata/publish_zip/src/foo/sum_amd64.s
@@ -1,0 +1,21 @@
+#include "go_asm.h"
+#include "textflag.h"
+#include "local.h"
+
+// func Sum(xs []int64) int64
+TEXT ·Sum(SB),7,$0
+    MOVQ    $0, SI       // n
+    MOVQ    PLUS(xs,0)(FP), BX // BX = &xs[0]
+    MOVQ    PLUS(xs_len,8)(FP), CX // len(xs)
+    INCQ    CX           // CX++
+
+start:
+    DECQ    CX           // CX--
+    JZ done              // jump if CX = 0
+    ADDQ    (BX), SI     // n += *BX
+    ADDQ    $8, BX       // BX += 8
+    JMP start
+
+done:
+    MOVQ    SI, ret+24(FP) // return n
+    RET

--- a/test/com/facebook/buck/testutil/integration/HttpdForTests.java
+++ b/test/com/facebook/buck/testutil/integration/HttpdForTests.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
+import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
@@ -167,6 +168,13 @@ public class HttpdForTests implements AutoCloseable {
 
     // Prefer a loopback device to going out over the NIC.
     if (!candidateLoopbacks.isEmpty()) {
+      for (InetAddress addr : candidateLoopbacks) {
+        if (addr instanceof Inet4Address) {
+          // Prefer IPv4 addresses, as IPv6 may have have loop back addresses like
+          // fe80:0:0:0:0:0:0:1%lo0, which is not supported by okhttp
+          return addr;
+        }
+      }
       return candidateLoopbacks.iterator().next();
     }
     return candidateLocal.iterator().next();


### PR DESCRIPTION
This PR allows `buck publish` to upload the output of lone build target (whose output is a single file) to an HTTP address.

@styurin Please review.

cc @kageiit @romanoid 