### PR TITLE
Add support for <public> Android resources

### DIFF
--- a/test/com/facebook/buck/android/aapt/MiniAaptTest.java
+++ b/test/com/facebook/buck/android/aapt/MiniAaptTest.java
@@ -757,4 +757,196 @@ public class MiniAaptTest {
             new FakeRDotTxtEntry(IdType.INT, RType.ATTR, "attr2_3")),
         resources);
   }
+
+  @Test
+  public void ignoresValidPublicResourceType() throws IOException, ResourceParseException {
+    ImmutableList<String> lines =
+        ImmutableList.<String>builder()
+            .add(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+                "<resources>",
+                "<public name=\"some_resource_name\" type=\"string\"/>",
+                "</resources>")
+            .build();
+
+    filesystem.writeLinesToPath(lines, Paths.get("public.xml"));
+
+    MiniAapt aapt =
+        new MiniAapt(
+            resolver,
+            filesystem,
+            FakeSourcePath.of(filesystem, "res"),
+            Paths.get("R.txt"),
+            ImmutableSet.of());
+
+    aapt.processValuesFile(filesystem, Paths.get("public.xml"));
+  }
+
+  @Test
+  public void invalidPublicResourceWithNoName() throws IOException, ResourceParseException {
+    thrown.expect(ResourceParseException.class);
+    thrown.expectMessage(
+        "Error parsing file 'public.xml', expected a 'name' attribute in \n" + "'[public: null]'");
+
+    ImmutableList<String> lines =
+        ImmutableList.<String>builder()
+            .add(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+                "<resources>",
+                "<public type=\"string\"/>",
+                "</resources>")
+            .build();
+
+    filesystem.writeLinesToPath(lines, Paths.get("public.xml"));
+
+    MiniAapt aapt =
+        new MiniAapt(
+            resolver,
+            filesystem,
+            FakeSourcePath.of(filesystem, "res"),
+            Paths.get("R.txt"),
+            ImmutableSet.of());
+
+    aapt.processValuesFile(filesystem, Paths.get("public.xml"));
+  }
+
+  @Test
+  public void invalidPublicResourceWithEmptyName() throws IOException, ResourceParseException {
+    thrown.expect(ResourceParseException.class);
+    thrown.expectMessage(
+        "Error parsing file 'public.xml', expected a 'name' attribute in \n" + "'[public: null]'");
+
+    ImmutableList<String> lines =
+        ImmutableList.<String>builder()
+            .add(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+                "<resources>",
+                "<public name=\"\" type=\"string\"/>",
+                "</resources>")
+            .build();
+
+    filesystem.writeLinesToPath(lines, Paths.get("public.xml"));
+
+    MiniAapt aapt =
+        new MiniAapt(
+            resolver,
+            filesystem,
+            FakeSourcePath.of(filesystem, "res"),
+            Paths.get("R.txt"),
+            ImmutableSet.of());
+
+    aapt.processValuesFile(filesystem, Paths.get("public.xml"));
+  }
+
+  @Test
+  public void invalidPublicResourceWithNoType() throws IOException, ResourceParseException {
+    thrown.expect(ResourceParseException.class);
+    thrown.expectMessage(
+        "Error parsing file 'public.xml', expected a 'type' attribute in: \n" + "'[public: null]'");
+
+    ImmutableList<String> lines =
+        ImmutableList.<String>builder()
+            .add(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+                "<resources>",
+                "<public name=\"some_resource_name\"/>",
+                "</resources>")
+            .build();
+
+    filesystem.writeLinesToPath(lines, Paths.get("public.xml"));
+
+    MiniAapt aapt =
+        new MiniAapt(
+            resolver,
+            filesystem,
+            FakeSourcePath.of(filesystem, "res"),
+            Paths.get("R.txt"),
+            ImmutableSet.of());
+
+    aapt.processValuesFile(filesystem, Paths.get("public.xml"));
+  }
+
+  @Test
+  public void invalidPublicResourceWithEmptyType() throws IOException, ResourceParseException {
+    thrown.expect(ResourceParseException.class);
+    thrown.expectMessage(
+        "Error parsing file 'public.xml', expected a 'type' attribute in: \n" + "'[public: null]'");
+
+    ImmutableList<String> lines =
+        ImmutableList.<String>builder()
+            .add(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+                "<resources>",
+                "<public name=\"some_resource_name\" type=\"\"/>",
+                "</resources>")
+            .build();
+
+    filesystem.writeLinesToPath(lines, Paths.get("public.xml"));
+
+    MiniAapt aapt =
+        new MiniAapt(
+            resolver,
+            filesystem,
+            FakeSourcePath.of(filesystem, "res"),
+            Paths.get("R.txt"),
+            ImmutableSet.of());
+
+    aapt.processValuesFile(filesystem, Paths.get("public.xml"));
+  }
+
+  @Test
+  public void invalidPublicResourceWithUnknownType() throws IOException, ResourceParseException {
+    thrown.expect(ResourceParseException.class);
+    thrown.expectMessage(
+        "Invalid resource type 'unknown_type' in <public> resource 'some_resource_name' in file 'public.xml'");
+
+    ImmutableList<String> lines =
+        ImmutableList.<String>builder()
+            .add(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+                "<resources>",
+                "<public name=\"some_resource_name\" type=\"unknown_type\"/>",
+                "</resources>")
+            .build();
+
+    filesystem.writeLinesToPath(lines, Paths.get("public.xml"));
+
+    MiniAapt aapt =
+        new MiniAapt(
+            resolver,
+            filesystem,
+            FakeSourcePath.of(filesystem, "res"),
+            Paths.get("R.txt"),
+            ImmutableSet.of());
+
+    aapt.processValuesFile(filesystem, Paths.get("public.xml"));
+  }
+
+  @Test
+  public void validPublicResourceTypeInInvalidFile() throws IOException, ResourceParseException {
+    thrown.expect(ResourceParseException.class);
+    thrown.expectMessage(
+        "<public> resource 'some_resource_name' must be declared in res/values/public.xml, but was declared in 'non-public.xml'");
+
+    ImmutableList<String> lines =
+        ImmutableList.<String>builder()
+            .add(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+                "<resources>",
+                "<public name=\"some_resource_name\" type=\"string\"/>",
+                "</resources>")
+            .build();
+
+    filesystem.writeLinesToPath(lines, Paths.get("non-public.xml"));
+
+    MiniAapt aapt =
+        new MiniAapt(
+            resolver,
+            filesystem,
+            FakeSourcePath.of(filesystem, "res"),
+            Paths.get("R.txt"),
+            ImmutableSet.of());
+
+    aapt.processValuesFile(filesystem, Paths.get("non-public.xml"));
+  }
 }


### PR DESCRIPTION
Fixes #864.

This PR adds "support" for `<public>` Android resources: https://developer.android.com/studio/projects/android-library#PrivateResources

AGP seems to ignore `<public>` during resource processing https://android.googlesource.com/platform/tools/base/+/ec8e2b78ea42ac57d6e63bf88a3e09e1713bcc08/layoutlib-api/src/main/java/com/android/resources/ResourceType.java#59

and then lets Lint and Android Studio take care of that. 

Support I've added to Buck validates the declaration (it must have `name` and `type` and be declared in `public.xml`), usages should be validated by Lint and/or IDE.

---

Without this patch, Buck crashes with following stacktrace:

```java
Error parsing resources to generate resource IDs for Pair(…).
com.facebook.buck.android.aapt.MiniAapt.ResourceParseException: Invalid resource type '<public>' in '…/attributes/res_release#resources-symlink-tree/res/values/public.xml'.
com.facebook.buck.android.aapt.MiniAapt$ResourceParseException: Invalid resource type '<public>' in '…/attributes/res_release#resources-symlink-tree/res/values/public.xml'.
	at com.facebook.buck.android.aapt.MiniAapt.processValuesFile(MiniAapt.java:444)
	at com.facebook.buck.android.aapt.MiniAapt.processValues(MiniAapt.java:378)
	at com.facebook.buck.android.aapt.MiniAapt.collectResources(MiniAapt.java:298)
	at com.facebook.buck.android.aapt.MiniAapt.execute(MiniAapt.java:184)
	at com.facebook.buck.step.DefaultStepRunner.runStepForBuildTarget(DefaultStepRunner.java:45)
	at com.facebook.buck.rules.CachingBuildRuleBuilder$BuildRuleSteps.executeCommands(CachingBuildRuleBuilder.java:1320)
	at com.facebook.buck.rules.CachingBuildRuleBuilder$BuildRuleSteps.executeCommandsNowThatDepsAreBuilt(CachingBuildRuleBuilder.java:1288)
	at com.facebook.buck.rules.CachingBuildRuleBuilder$BuildRuleSteps.runWithExecutor(CachingBuildRuleBuilder.java:1247)
	at com.facebook.buck.rules.CachingBuildRuleBuilder$BuildRuleSteps.run(CachingBuildRuleBuilder.java:1236)
	at com.facebook.buck.rules.CachingBuildRuleBuilder$2.runWithDefaultExecutor(CachingBuildRuleBuilder.java:750)
	at com.facebook.buck.util.concurrent.WeightedListeningExecutorService.lambda$submit$2(WeightedListeningExecutorService.java:104)
	at com.facebook.buck.util.concurrent.WeightedListeningExecutorService.lambda$submitWithSemaphore$0(WeightedListeningExecutorService.java:78)
	at com.google.common.util.concurrent.AbstractTransformFuture$AsyncTransformFuture.doTransform(AbstractTransformFuture.java:206)
	at com.google.common.util.concurrent.AbstractTransformFuture$AsyncTransformFuture.doTransform(AbstractTransformFuture.java:195)
	at com.google.common.util.concurrent.AbstractTransformFuture.run(AbstractTransformFuture.java:115)
	at com.google.common.util.concurrent.MoreExecutors$5$1.run(MoreExecutors.java:999)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

cc @kageiit 