### PR TITLE
Fixed BUCK default test runner sometimes skipping test failures if delegate (junit) test runner fails with error.

### DIFF
--- a/src/com/facebook/buck/testrunner/JUnitRunner.java
+++ b/src/com/facebook/buck/testrunner/JUnitRunner.java
@@ -370,6 +370,17 @@ public final class JUnitRunner extends BaseRunner {
               stdErr.length() == 0 ? null : stdErr.toString()));
     }
 
+    @Override
+    public void testRunFinished(Result runResult) {
+      if (resultListener != null) {
+        // testStarted was called for latest test, but not the testFinished
+        // report all failures as unbounded
+        for (Failure failure : result.getFailures()) {
+          recordUnpairedResult(failure, ResultType.FAILURE);
+        }
+      }
+    }
+
     /**
      * The regular listener we created from the singular result, in this class, will not by default
      * treat assumption failures as regular failures, and will not store them. As a consequence, we


### PR DESCRIPTION
Fixes https://github.com/facebook/buck/issues/2007

Unfortunately the case where I were able to consistently reproduce the problem involves heavy amount of 3rd-party dependencies and I were unable to condense the problem to a simple reproduction case. 