### PR TITLE
Download statically built python for jitpack builds

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,9 @@
 install:
    - set -exo pipefail
+   - mkdir python_tmp
+   - wget https://github.com/kageiit/jitpack-python/releases/download/2.7/python-2.7.tar.gz -O python_tmp/python.tar.gz
+   - tar -C python_tmp -xf python_tmp/python.tar.gz --strip-components=1
+   - export PATH="$PATH:python_tmp/bin"
    - ant
    - PEX=$(bin/buck build buck --show-output | awk '{print $2}')
    - SHA=$(git rev-parse HEAD)


### PR DESCRIPTION
Jitpack recently changed their build environment to no longer have python installed (See https://github.com/jitpack/jitpack.io/issues/3200)

This PR downloads a statically built version of python with no system dependencies from https://github.com/kageiit/jitpack-python for use inside jitpack builds. This lets users of buck continue to download and install buck built at any sha from jitpack.