### PR TITLE
Ignore unhandled metadata in cxx library

### DIFF
--- a/src/com/facebook/buck/cxx/CxxLibraryDescription.java
+++ b/src/com/facebook/buck/cxx/CxxLibraryDescription.java
@@ -273,8 +273,14 @@ public class CxxLibraryDescription
       CxxLibraryDescriptionArg args,
       Optional<ImmutableMap<BuildTarget, Version>> selectedVersions,
       Class<U> metadataClass) {
-    return cxxLibraryMetadataFactory.createMetadata(
-        buildTarget, graphBuilder, cellRoots, args, metadataClass);
+    Optional<Map.Entry<Flavor, CxxLibraryDescription.MetadataType>> type =
+        CxxLibraryDescription.METADATA_TYPE.getFlavorAndValue(buildTarget);
+    if (type.isPresent()) {
+      return cxxLibraryMetadataFactory.createMetadata(
+          buildTarget, graphBuilder, cellRoots, args, metadataClass);
+    } else {
+      return Optional.empty();
+    }
   }
 
   @Override


### PR DESCRIPTION
cxx_library raises if it gets unknow metadata creation requests.  Changing it to ignore them instead.