### PR TITLE
Add option to configure custom package exclusions in android binaries

### DIFF
--- a/src/com/facebook/buck/android/AabBuilderStep.java
+++ b/src/com/facebook/buck/android/AabBuilderStep.java
@@ -66,6 +66,7 @@ public class AabBuilderStep implements Step {
   private final ImmutableSet<ModuleInfo> modulesInfo;
   private final AppBuilderBase appBuilderBase;
   private final ImmutableSet<String> moduleNames;
+  private final ImmutableSet<String> packagingExcludePatterns;
 
   /**
    * @param modulesInfo A set of ModuleInfo containing information about modules to be built within
@@ -81,6 +82,7 @@ public class AabBuilderStep implements Step {
       Supplier<KeystoreProperties> keystorePropertiesSupplier,
       boolean debugMode,
       int apkCompressionLevel,
+      ImmutableSet<String> packagingExcludePatterns,
       Path tempBundleConfig,
       ImmutableSet<ModuleInfo> modulesInfo,
       ImmutableSet<String> moduleNames) {
@@ -91,6 +93,7 @@ public class AabBuilderStep implements Step {
     this.tempBundleConfig = tempBundleConfig;
     this.modulesInfo = modulesInfo;
     this.moduleNames = moduleNames;
+    this.packagingExcludePatterns = packagingExcludePatterns;
     this.appBuilderBase =
         new AppBuilderBase(filesystem, keystorePropertiesSupplier, pathToKeystore);
   }
@@ -117,7 +120,8 @@ public class AabBuilderStep implements Step {
               privateKeyAndCertificate.privateKey,
               privateKeyAndCertificate.certificate,
               output,
-              apkCompressionLevel);
+              apkCompressionLevel,
+              packagingExcludePatterns);
       builder.setDebugMode(debugMode);
       Set<String> addedFiles = new HashSet<>();
       Set<Path> addedSourceFiles = new HashSet<>();

--- a/src/com/facebook/buck/android/AndroidBinary.java
+++ b/src/com/facebook/buck/android/AndroidBinary.java
@@ -151,7 +151,8 @@ public class AndroidBinary extends AbstractBuildRule
       ResourceFilesInfo resourceFilesInfo,
       ImmutableSortedSet<APKModule> apkModules,
       Optional<ExopackageInfo> exopackageInfo,
-      int apkCompressionLevel) {
+      int apkCompressionLevel,
+      ImmutableSet<String> packagingExcludePatterns) {
     super(buildTarget, projectFilesystem);
     Preconditions.checkArgument(params.getExtraDeps().get().isEmpty());
     this.ruleFinder = ruleFinder;
@@ -223,6 +224,7 @@ public class AndroidBinary extends AbstractBuildRule
             apkModules,
             enhancementResult.getModuleResourceApkPaths(),
             apkCompressionLevel,
+            packagingExcludePatterns,
             true);
     this.exopackageInfo = exopackageInfo;
 

--- a/src/com/facebook/buck/android/AndroidBinaryBuildable.java
+++ b/src/com/facebook/buck/android/AndroidBinaryBuildable.java
@@ -118,6 +118,8 @@ class AndroidBinaryBuildable implements AddsToRuleKey {
 
   @AddToRuleKey private final ImmutableMap<APKModule, SourcePath> moduleResourceApkPaths;
 
+  @AddToRuleKey private final ImmutableSet<String> packagingExcludePatterns;
+
   private final boolean isApk;
 
   // These should be the only things not added to the rulekey.
@@ -148,6 +150,7 @@ class AndroidBinaryBuildable implements AddsToRuleKey {
       ImmutableSortedSet<APKModule> apkModules,
       ImmutableMap<APKModule, SourcePath> moduleResourceApkPaths,
       int apkCompressionLevel,
+      ImmutableSet<String> packagingExcludePatterns,
       boolean isApk) {
     this.filesystem = filesystem;
     this.buildTarget = buildTarget;
@@ -170,6 +173,7 @@ class AndroidBinaryBuildable implements AddsToRuleKey {
     this.compressAssetLibraries = compressAssetLibraries;
     this.resourceFilesInfo = resourceFilesInfo;
     this.apkCompressionLevel = apkCompressionLevel;
+    this.packagingExcludePatterns = packagingExcludePatterns;
     this.isApk = isApk;
   }
 
@@ -279,7 +283,8 @@ class AndroidBinaryBuildable implements AddsToRuleKey {
               keystoreProperties,
               false,
               javaRuntimeLauncher.getCommandPrefix(pathResolver),
-              apkCompressionLevel));
+              apkCompressionLevel,
+              packagingExcludePatterns));
     } else {
       Path tempBundleConfig =
           BuildTargetPaths.getGenPath(
@@ -350,6 +355,7 @@ class AndroidBinaryBuildable implements AddsToRuleKey {
               keystoreProperties,
               false,
               apkCompressionLevel,
+              packagingExcludePatterns,
               tempBundleConfig,
               modulesInfo.build(),
               moduleNames));

--- a/src/com/facebook/buck/android/AndroidBinaryDescription.java
+++ b/src/com/facebook/buck/android/AndroidBinaryDescription.java
@@ -306,5 +306,7 @@ public class AndroidBinaryDescription
     abstract Optional<SourcePath> getRedexConfig();
 
     abstract ImmutableList<StringWithMacros> getRedexExtraArgs();
+
+    abstract ImmutableSet<String> getPackagingExcludePatterns();
   }
 }

--- a/src/com/facebook/buck/android/AndroidBinaryFactory.java
+++ b/src/com/facebook/buck/android/AndroidBinaryFactory.java
@@ -143,6 +143,7 @@ public class AndroidBinaryFactory {
         filesInfo.getResourceFilesInfo(),
         ImmutableSortedSet.copyOf(result.getAPKModuleGraph().getAPKModules()),
         filesInfo.getExopackageInfo(),
-        apkConfig.getCompressionLevel());
+        apkConfig.getCompressionLevel(),
+        args.getPackagingExcludePatterns());
   }
 }

--- a/src/com/facebook/buck/android/AndroidBundle.java
+++ b/src/com/facebook/buck/android/AndroidBundle.java
@@ -151,7 +151,8 @@ public class AndroidBundle extends AbstractBuildRule
       ResourceFilesInfo resourceFilesInfo,
       ImmutableSortedSet<APKModule> apkModules,
       Optional<ExopackageInfo> exopackageInfo,
-      int apkCompressionLevel) {
+      int apkCompressionLevel,
+      ImmutableSet<String> packagingExcludePatterns) {
     super(buildTarget, projectFilesystem);
     Preconditions.checkArgument(params.getExtraDeps().get().isEmpty());
     this.ruleFinder = ruleFinder;
@@ -223,6 +224,7 @@ public class AndroidBundle extends AbstractBuildRule
             apkModules,
             enhancementResult.getModuleResourceApkPaths(),
             apkCompressionLevel,
+            packagingExcludePatterns,
             false);
     this.exopackageInfo = exopackageInfo;
 

--- a/src/com/facebook/buck/android/AndroidBundleDescription.java
+++ b/src/com/facebook/buck/android/AndroidBundleDescription.java
@@ -318,5 +318,7 @@ public class AndroidBundleDescription
     public AaptMode getAaptMode() {
       return AaptMode.AAPT2;
     }
+
+    abstract ImmutableSet<String> getPackagingExcludePatterns();
   }
 }

--- a/src/com/facebook/buck/android/AndroidBundleFactory.java
+++ b/src/com/facebook/buck/android/AndroidBundleFactory.java
@@ -143,6 +143,7 @@ public class AndroidBundleFactory {
         filesInfo.getResourceFilesInfo(),
         ImmutableSortedSet.copyOf(result.getAPKModuleGraph().getAPKModules()),
         filesInfo.getExopackageInfo(),
-        apkConfig.getCompressionLevel());
+        apkConfig.getCompressionLevel(),
+        args.getPackagingExcludePatterns());
   }
 }

--- a/src/com/facebook/buck/android/AndroidInstrumentationApk.java
+++ b/src/com/facebook/buck/android/AndroidInstrumentationApk.java
@@ -63,7 +63,8 @@ public class AndroidInstrumentationApk extends AndroidBinary {
       NativeFilesInfo nativeFilesInfo,
       ResourceFilesInfo resourceFilesInfo,
       Optional<ExopackageInfo> exopackageInfo,
-      int apkCompressionLevel) {
+      int apkCompressionLevel,
+      ImmutableSet<String> packagingExcludePatterns) {
     super(
         buildTarget,
         projectFilesystem,
@@ -100,7 +101,7 @@ public class AndroidInstrumentationApk extends AndroidBinary {
         ImmutableSortedSet.copyOf(enhancementResult.getAPKModuleGraph().getAPKModules()),
         exopackageInfo,
         apkCompressionLevel,
-        ImmutableSet.of());
+        packagingExcludePatterns);
     this.apkUnderTest = apkUnderTest;
   }
 

--- a/src/com/facebook/buck/android/AndroidInstrumentationApk.java
+++ b/src/com/facebook/buck/android/AndroidInstrumentationApk.java
@@ -26,6 +26,7 @@ import com.facebook.buck.core.rules.SourcePathRuleFinder;
 import com.facebook.buck.io.filesystem.ProjectFilesystem;
 import com.facebook.buck.jvm.core.JavaLibrary;
 import com.facebook.buck.util.RichStream;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.EnumSet;
 import java.util.Optional;
@@ -98,7 +99,8 @@ public class AndroidInstrumentationApk extends AndroidBinary {
         resourceFilesInfo,
         ImmutableSortedSet.copyOf(enhancementResult.getAPKModuleGraph().getAPKModules()),
         exopackageInfo,
-        apkCompressionLevel);
+        apkCompressionLevel,
+        ImmutableSet.of());
     this.apkUnderTest = apkUnderTest;
   }
 

--- a/src/com/facebook/buck/android/AndroidInstrumentationApkDescription.java
+++ b/src/com/facebook/buck/android/AndroidInstrumentationApkDescription.java
@@ -240,7 +240,8 @@ public class AndroidInstrumentationApkDescription
         filesInfo.getNativeFilesInfo(),
         filesInfo.getResourceFilesInfo(),
         filesInfo.getExopackageInfo(),
-        apkConfig.getCompressionLevel());
+        apkConfig.getCompressionLevel(),
+        args.getPackagingExcludePatterns());
   }
 
   @BuckStyleImmutable
@@ -252,6 +253,8 @@ public class AndroidInstrumentationApkDescription
     Optional<SourcePath> getManifestSkeleton();
 
     BuildTarget getApk();
+
+    abstract ImmutableSet<String> getPackagingExcludePatterns();
 
     @Value.Default
     default AaptMode getAaptMode() {

--- a/src/com/facebook/buck/android/ApkBuilderStep.java
+++ b/src/com/facebook/buck/android/ApkBuilderStep.java
@@ -58,6 +58,7 @@ public class ApkBuilderStep implements Step {
   private final boolean debugMode;
   private final ImmutableList<String> javaRuntimeLauncher;
   private final int apkCompressionLevel;
+  private final ImmutableSet<String> packagingExcludePatterns;
   private final AppBuilderBase appBuilderBase;
 
   /**
@@ -83,7 +84,8 @@ public class ApkBuilderStep implements Step {
       Supplier<KeystoreProperties> keystorePropertiesSupplier,
       boolean debugMode,
       ImmutableList<String> javaRuntimeLauncher,
-      int apkCompressionLevel) {
+      int apkCompressionLevel,
+      ImmutableSet<String> packagingExcludePatterns) {
     this.filesystem = filesystem;
     this.resourceApk = resourceApk;
     this.pathToOutputApkFile = pathToOutputApkFile;
@@ -95,6 +97,7 @@ public class ApkBuilderStep implements Step {
     this.debugMode = debugMode;
     this.javaRuntimeLauncher = javaRuntimeLauncher;
     this.apkCompressionLevel = apkCompressionLevel;
+    this.packagingExcludePatterns = packagingExcludePatterns;
     this.appBuilderBase =
         new AppBuilderBase(filesystem, keystorePropertiesSupplier, pathToKeystore);
   }
@@ -118,7 +121,8 @@ public class ApkBuilderStep implements Step {
               privateKeyAndCertificate.privateKey,
               privateKeyAndCertificate.certificate,
               output,
-              apkCompressionLevel);
+              apkCompressionLevel,
+              packagingExcludePatterns);
       builder.setDebugMode(debugMode);
       for (Path nativeLibraryDirectory : nativeLibraryDirectories) {
         builder.addNativeLibraries(


### PR DESCRIPTION
This allows users of buck to configure additional patterns of archive paths to exclude from the apk (Analogous to https://google.github.io/android-gradle-dsl/current/com.android.build.gradle.internal.dsl.PackagingOptions.html). This is very useful to remove things like metadata that comes from kotlin standard libraries that just add bloat to the apk