### PR TITLE
Inherit base linker flags when platform linker flags are present

### DIFF
--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -1593,7 +1593,8 @@ public class ProjectGenerator {
               generateConfigKey("OTHER_LDFLAGS", platform),
               Streams.stream(
                       Iterables.transform(
-                          Iterables.concat(platformLinkerFlags.get(platform)),
+                          Iterables.concat(
+                              otherLdFlags, Iterables.concat(platformLinkerFlags.get(platform))),
                           Escaper.BASH_ESCAPER::apply))
                   .collect(Collectors.joining(" ")));
         }

--- a/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
@@ -2716,7 +2716,7 @@ public class ProjectGeneratorTest {
             + "-Wundeclared-selector -Wno-objc-designated-initializers -ffoo-iphone -fbar-iphone",
         settings.get("OTHER_CPLUSPLUSFLAGS[sdk=iphonesimulator*][arch=x86_64]"));
     assertEquals(
-        "-lbaz-iphone -lbaz-iphone",
+        "-fatal_warnings -ObjC -lbaz-iphone -fatal_warnings -ObjC -lbaz-iphone",
         settings.get("OTHER_LDFLAGS[sdk=iphonesimulator*][arch=x86_64]"));
   }
 


### PR DESCRIPTION
Currently any target with dependencies that specify platform linker flags will have its linker flags overridden by those flags rather than appended. This diff changes the behaviour to match how c flags are handled, by appending the platform flags to the existing base flags.