### PR TITLE
Add CFBundleIdentifier key when looking for toolchains.

### DIFF
--- a/test/com/facebook/buck/apple/testdata/toolchain-discovery/Toolchains/baz.xctoolchain/Info.plist
+++ b/test/com/facebook/buck/apple/testdata/toolchain-discovery/Toolchains/baz.xctoolchain/Info.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Aliases</key>
+  <array>
+    <string>Local</string>
+  </array>
+  <key>CFBundleIdentifier</key>
+  <string>tc-03_21-2018_05_10.swift.20180510</string>
+  <key>CompatibilityVersion</key>
+  <integer>2</integer>
+  <key>CompatibilityVersionDisplayString</key>
+  <string>Xcode 8.0</string>
+  <key>CreatedDate</key>
+  <date>2018-05-10T16:37:53Z</date>
+  <key>DisplayName</key>
+  <string>Local Swift Development Snapshot 2018-05-10</string>
+  <key>OverrideBuildSettings</key>
+  <dict>
+    <key>ENABLE_BITCODE</key>
+    <string>NO</string>
+    <key>SWIFT_DISABLE_REQUIRED_ARCLITE</key>
+    <string>YES</string>
+    <key>SWIFT_LINK_OBJC_RUNTIME</key>
+    <string>YES</string>
+  </dict>
+  <key>ReportProblemURL</key>
+  <string>https://bugs.swift.org/</string>
+  <key>ShortDisplayName</key>
+  <string>Local Swift Development Snapshot</string>
+  <key>Version</key>
+  <string>swift-LOCAL-2018-05-10-a</string>
+</dict>
+</plist>

--- a/test/com/facebook/buck/apple/toolchain/impl/AppleToolchainDiscoveryTest.java
+++ b/test/com/facebook/buck/apple/toolchain/impl/AppleToolchainDiscoveryTest.java
@@ -66,17 +66,23 @@ public class AppleToolchainDiscoveryTest {
     Path root = Paths.get("test/com/facebook/buck/apple/testdata/toolchain-discovery");
     ImmutableMap<String, AppleToolchain> expected =
         ImmutableMap.of(
-            "com.facebook.foo.toolchain.XcodeDefault",
-            AppleToolchain.builder()
-                .setIdentifier("com.facebook.foo.toolchain.XcodeDefault")
-                .setVersion("23B456")
-                .setPath(root.resolve("Toolchains/foo.xctoolchain"))
-                .build(),
             "com.facebook.bar.toolchain.XcodeDefault",
             AppleToolchain.builder()
                 .setIdentifier("com.facebook.bar.toolchain.XcodeDefault")
                 .setVersion("23B456")
                 .setPath(root.resolve("Toolchains/bar.xctoolchain"))
+                .build(),
+            "tc-03_21-2018_05_10.swift.20180510",
+            AppleToolchain.builder()
+                .setIdentifier("tc-03_21-2018_05_10.swift.20180510")
+                // .setVersion("swift-LOCAL-2018-05-10-a")
+                .setPath(root.resolve("Toolchains/baz.xctoolchain"))
+                .build(),
+            "com.facebook.foo.toolchain.XcodeDefault",
+            AppleToolchain.builder()
+                .setIdentifier("com.facebook.foo.toolchain.XcodeDefault")
+                .setVersion("23B456")
+                .setPath(root.resolve("Toolchains/foo.xctoolchain"))
                 .build());
 
     assertThat(
@@ -91,17 +97,23 @@ public class AppleToolchainDiscoveryTest {
     Path root = Paths.get("test/com/facebook/buck/apple/testdata/toolchain-discovery");
     ImmutableMap<String, AppleToolchain> expected =
         ImmutableMap.of(
-            "com.facebook.foo.toolchain.XcodeDefault",
-            AppleToolchain.builder()
-                .setIdentifier("com.facebook.foo.toolchain.XcodeDefault")
-                .setVersion("23B456")
-                .setPath(root.resolve("Toolchains/foo.xctoolchain"))
-                .build(),
             "com.facebook.bar.toolchain.XcodeDefault",
             AppleToolchain.builder()
                 .setIdentifier("com.facebook.bar.toolchain.XcodeDefault")
                 .setVersion("23B456")
                 .setPath(root.resolve("Toolchains/bar.xctoolchain"))
+                .build(),
+            "tc-03_21-2018_05_10.swift.20180510",
+            AppleToolchain.builder()
+                .setIdentifier("tc-03_21-2018_05_10.swift.20180510")
+                // .setVersion("swift-LOCAL-2018-05-10-a")
+                .setPath(root.resolve("Toolchains/baz.xctoolchain"))
+                .build(),
+            "com.facebook.foo.toolchain.XcodeDefault",
+            AppleToolchain.builder()
+                .setIdentifier("com.facebook.foo.toolchain.XcodeDefault")
+                .setVersion("23B456")
+                .setPath(root.resolve("Toolchains/foo.xctoolchain"))
                 .build());
 
     assertThat(
@@ -115,17 +127,23 @@ public class AppleToolchainDiscoveryTest {
     Path root = Paths.get("test/com/facebook/buck/apple/testdata/toolchain-discovery");
     ImmutableMap<String, AppleToolchain> expected =
         ImmutableMap.of(
-            "com.facebook.foo.toolchain.XcodeDefault",
-            AppleToolchain.builder()
-                .setIdentifier("com.facebook.foo.toolchain.XcodeDefault")
-                .setVersion("23B456")
-                .setPath(root.resolve("Toolchains/foo.xctoolchain"))
-                .build(),
             "com.facebook.bar.toolchain.XcodeDefault",
             AppleToolchain.builder()
                 .setIdentifier("com.facebook.bar.toolchain.XcodeDefault")
                 .setVersion("23B456")
                 .setPath(root.resolve("Toolchains/bar.xctoolchain"))
+                .build(),
+            "tc-03_21-2018_05_10.swift.20180510",
+            AppleToolchain.builder()
+                .setIdentifier("tc-03_21-2018_05_10.swift.20180510")
+                // .setVersion("swift-LOCAL-2018-05-10-a")
+                .setPath(root.resolve("Toolchains/baz.xctoolchain"))
+                .build(),
+            "com.facebook.foo.toolchain.XcodeDefault",
+            AppleToolchain.builder()
+                .setIdentifier("com.facebook.foo.toolchain.XcodeDefault")
+                .setVersion("23B456")
+                .setPath(root.resolve("Toolchains/foo.xctoolchain"))
                 .build());
 
     assertThat(
@@ -141,6 +159,7 @@ public class AppleToolchainDiscoveryTest {
     Path tempRoot = temp.getRoot().toPath();
     MostFiles.copyRecursively(root, tempRoot);
     Files.delete(tempRoot.resolve("Toolchains/foo.xctoolchain/ToolchainInfo.plist"));
+    Files.delete(tempRoot.resolve("Toolchains/baz.xctoolchain/Info.plist"));
     Files.write(
         tempRoot.resolve("Toolchains/bar.xctoolchain/Info.plist"),
         ImmutableList.of("Not a valid plist"),
@@ -191,17 +210,22 @@ public class AppleToolchainDiscoveryTest {
 
     ImmutableMap<String, AppleToolchain> expected =
         ImmutableMap.of(
-            "com.facebook.foo.toolchain.XcodeDefault",
-            AppleToolchain.builder()
-                .setIdentifier("com.facebook.foo.toolchain.XcodeDefault")
-                .setVersion("23B456")
-                .setPath(root.resolve("Toolchains/foo.xctoolchain").toAbsolutePath())
-                .build(),
             "com.facebook.bar.toolchain.XcodeDefault",
             AppleToolchain.builder()
                 .setIdentifier("com.facebook.bar.toolchain.XcodeDefault")
                 .setVersion("23B456")
                 .setPath(root.resolve("Toolchains/bar.xctoolchain").toAbsolutePath())
+                .build(),
+            "tc-03_21-2018_05_10.swift.20180510",
+            AppleToolchain.builder()
+                .setIdentifier("tc-03_21-2018_05_10.swift.20180510")
+                .setPath(root.resolve("Toolchains/baz.xctoolchain").toAbsolutePath())
+                .build(),
+            "com.facebook.foo.toolchain.XcodeDefault",
+            AppleToolchain.builder()
+                .setIdentifier("com.facebook.foo.toolchain.XcodeDefault")
+                .setVersion("23B456")
+                .setPath(root.resolve("Toolchains/foo.xctoolchain").toAbsolutePath())
                 .build());
 
     try {


### PR DESCRIPTION
This will allow us to look for both "Identifier" and "CFBundleIdentifier" in
the toolchains plist file. This is needed because the official Xcode
toolchain uses the "Identifier" key but the open-source Swift toolchains only
set the "CFBundleIdentifier" key.