### PR TITLE
Adds kapt apoptions to kotlin_library

### DIFF
--- a/docs/rule/android_library.soy
+++ b/docs/rule/android_library.soy
@@ -186,6 +186,20 @@ compiled class files and resources.
   {/param}
 {/call}
 
+{call buck.arg}
+  {param name: 'kapt_apoptions' /}
+  {param default : '{}' /}
+  {param desc}
+  Map of annotation processor options to pass into kapt via the apoptions plugin option. Each entry
+  should be a key value pair of the processor option and its value.
+  E.g.
+  kapt_apoptions = {
+    'someAnnotationOption': 'someValue'
+  }
+  More information here: https://kotlinlang.org/docs/reference/kapt.html
+  {/param}
+{/call}
+
 {call jvm_common.exported_deps}
   {param library: 'android_library' /}
 {/call}

--- a/docs/rule/android_library.soy
+++ b/docs/rule/android_library.soy
@@ -188,10 +188,9 @@ compiled class files and resources.
 
 {call buck.arg}
   {param name: 'kapt_ap_options' /}
-  {param default : '{}' /}
   {param desc}
   Map of annotation processor options to pass into kapt via the apoptions plugin option. Each entry
-  should be a key value pair of the processor option and its value.
+  should be a key value pair of the processor option and its value. Default is an empty map.
   E.g.
   kapt_ap_options = {
     'someAnnotationOption': 'someValue'

--- a/docs/rule/android_library.soy
+++ b/docs/rule/android_library.soy
@@ -187,13 +187,13 @@ compiled class files and resources.
 {/call}
 
 {call buck.arg}
-  {param name: 'kapt_apoptions' /}
+  {param name: 'kapt_ap_options' /}
   {param default : '{}' /}
   {param desc}
   Map of annotation processor options to pass into kapt via the apoptions plugin option. Each entry
   should be a key value pair of the processor option and its value.
   E.g.
-  kapt_apoptions = {
+  kapt_ap_options = {
     'someAnnotationOption': 'someValue'
   }
   More information here: https://kotlinlang.org/docs/reference/kapt.html

--- a/docs/rule/android_library.soy
+++ b/docs/rule/android_library.soy
@@ -188,14 +188,14 @@ compiled class files and resources.
 
 {call buck.arg}
   {param name: 'kapt_ap_options' /}
-  {param desc}
+  {param desc}{literal}
   Map of annotation processor options to pass into kapt via the apoptions plugin option. Each entry
   should be a key value pair of the processor option and its value. Default is an empty map.
   E.g.
   kapt_ap_options = {
     'someAnnotationOption': 'someValue'
   }
-  More information here: https://kotlinlang.org/docs/reference/kapt.html
+  More information here: https://kotlinlang.org/docs/reference/kapt.html{/literal}
   {/param}
 {/call}
 

--- a/docs/rule/kotlin_library.soy
+++ b/docs/rule/kotlin_library.soy
@@ -99,9 +99,9 @@ the <code>resources</code> argument.
 
 {call buck.arg}
   {param name: 'kapt_ap_options' /}
-  {param default : '{}' /}
   {param desc}
-  Map of annotation processor options to pass into kapt via the apoptions plugin option.
+  Map of annotation processor options to pass into kapt via the apoptions plugin option. Each entry
+  should be a key value pair of the processor option and its value. Default is an empty map.
   E.g.
   kapt_ap_options = {
     'someAnnotationOption': 'someValue'

--- a/docs/rule/kotlin_library.soy
+++ b/docs/rule/kotlin_library.soy
@@ -48,7 +48,7 @@ the <code>resources</code> argument.
 
 {call buck.arg}
   {param name: 'srcs' /}
-  {param default: '[]' /}
+  {param default: '{}' /}
   {param desc}
   The set of <code>.kt</code>, <code>.java</code> or <code>.kts</code> files to compile for this rule.
   If any of the files in this list end in <code>.src.zip</code>,
@@ -94,6 +94,20 @@ the <code>resources</code> argument.
   it for Java sources too.
   "javac" works only against Java sources, Kotlin sources won't have access to generated
   classes at compile time.
+  {/param}
+{/call}
+
+{call buck.arg}
+  {param name: 'kapt_apoptions' /}
+  {param default : '[]' /}
+  {param desc}
+  Map of annotation processor options to pass into kapt via the apoptions plugin option.
+  E.g.
+  kapt_apoptions = {
+    'someAnnotationOption': 'someValue'
+  }
+  They will be encoded and passed into kapt as documented here:
+  https://kotlinlang.org/docs/reference/kapt.html
   {/param}
 {/call}
 

--- a/docs/rule/kotlin_library.soy
+++ b/docs/rule/kotlin_library.soy
@@ -98,12 +98,12 @@ the <code>resources</code> argument.
 {/call}
 
 {call buck.arg}
-  {param name: 'kapt_apoptions' /}
+  {param name: 'kapt_ap_options' /}
   {param default : '{}' /}
   {param desc}
   Map of annotation processor options to pass into kapt via the apoptions plugin option.
   E.g.
-  kapt_apoptions = {
+  kapt_ap_options = {
     'someAnnotationOption': 'someValue'
   }
   They will be encoded and passed into kapt as documented here:

--- a/docs/rule/kotlin_library.soy
+++ b/docs/rule/kotlin_library.soy
@@ -48,7 +48,7 @@ the <code>resources</code> argument.
 
 {call buck.arg}
   {param name: 'srcs' /}
-  {param default: '{}' /}
+  {param default: '[]' /}
   {param desc}
   The set of <code>.kt</code>, <code>.java</code> or <code>.kts</code> files to compile for this rule.
   If any of the files in this list end in <code>.src.zip</code>,
@@ -99,7 +99,7 @@ the <code>resources</code> argument.
 
 {call buck.arg}
   {param name: 'kapt_apoptions' /}
-  {param default : '[]' /}
+  {param default : '{}' /}
   {param desc}
   Map of annotation processor options to pass into kapt via the apoptions plugin option.
   E.g.

--- a/docs/rule/kotlin_library.soy
+++ b/docs/rule/kotlin_library.soy
@@ -99,15 +99,14 @@ the <code>resources</code> argument.
 
 {call buck.arg}
   {param name: 'kapt_ap_options' /}
-  {param desc}
+  {param desc}{literal}
   Map of annotation processor options to pass into kapt via the apoptions plugin option. Each entry
   should be a key value pair of the processor option and its value. Default is an empty map.
   E.g.
   kapt_ap_options = {
     'someAnnotationOption': 'someValue'
   }
-  They will be encoded and passed into kapt as documented here:
-  https://kotlinlang.org/docs/reference/kapt.html
+  More information here: https://kotlinlang.org/docs/reference/kapt.html{/literal}
   {/param}
 {/call}
 

--- a/src/com/facebook/buck/jvm/kotlin/KotlinConfiguredCompilerFactory.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinConfiguredCompilerFactory.java
@@ -66,6 +66,7 @@ public class KotlinConfiguredCompilerFactory extends ConfiguredCompilerFactory {
         kotlinArgs.getExtraKotlincArguments(),
         kotlinArgs.getFriendPaths(),
         kotlinArgs.getAnnotationProcessingTool().orElse(AnnotationProcessingTool.KAPT),
+        kotlinArgs.getKaptApoptions(),
         extraClasspathProviderSupplier.apply(toolchainProvider),
         getJavac(buildRuleResolver, args),
         javacOptions);

--- a/src/com/facebook/buck/jvm/kotlin/KotlinConfiguredCompilerFactory.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinConfiguredCompilerFactory.java
@@ -66,7 +66,7 @@ public class KotlinConfiguredCompilerFactory extends ConfiguredCompilerFactory {
         kotlinArgs.getExtraKotlincArguments(),
         kotlinArgs.getFriendPaths(),
         kotlinArgs.getAnnotationProcessingTool().orElse(AnnotationProcessingTool.KAPT),
-        kotlinArgs.getKaptApoptions(),
+        kotlinArgs.getKaptApOptions(),
         extraClasspathProviderSupplier.apply(toolchainProvider),
         getJavac(buildRuleResolver, args),
         javacOptions);

--- a/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
@@ -201,7 +201,7 @@ public class KotlinLibraryDescription
 
     ImmutableList<SourcePath> getFriendPaths();
     
-    ImmutableMap<String, String> getKaptApoptions();
+    ImmutableMap<String, String> getKaptApOptions();
   }
 
   @BuckStyleImmutable

--- a/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
@@ -45,6 +45,7 @@ import com.facebook.buck.jvm.java.toolchain.JavacOptionsProvider;
 import com.facebook.buck.maven.aether.AetherUtil;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.Objects;
@@ -199,6 +200,8 @@ public class KotlinLibraryDescription
     Optional<AnnotationProcessingTool> getAnnotationProcessingTool();
 
     ImmutableList<SourcePath> getFriendPaths();
+    
+    ImmutableMap<String, String> getKaptApoptions();
   }
 
   @BuckStyleImmutable

--- a/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
@@ -71,7 +71,7 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
   @AddToRuleKey private final ImmutableList<String> extraKotlincArguments;
   @AddToRuleKey private final ImmutableList<SourcePath> friendPaths;
   @AddToRuleKey private final AnnotationProcessingTool annotationProcessingTool;
-  @AddToRuleKey private final ImmutableMap<String, String> kaptApoptions;
+  @AddToRuleKey private final ImmutableMap<String, String> kaptApOptions;
   @AddToRuleKey private final ExtraClasspathProvider extraClassPath;
   @AddToRuleKey private final Javac javac;
   @AddToRuleKey private final JavacOptions javacOptions;
@@ -110,7 +110,7 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
       ImmutableList<String> extraKotlincArguments,
       ImmutableList<SourcePath> friendPaths,
       AnnotationProcessingTool annotationProcessingTool,
-      ImmutableMap<String, String> kaptApoptions,
+      ImmutableMap<String, String> kaptApOptions,
       ExtraClasspathProvider extraClassPath,
       Javac javac,
       JavacOptions javacOptions) {
@@ -119,7 +119,7 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
     this.extraKotlincArguments = extraKotlincArguments;
     this.friendPaths = friendPaths;
     this.annotationProcessingTool = annotationProcessingTool;
-    this.kaptApoptions = kaptApoptions;
+    this.kaptApOptions = kaptApOptions;
     this.extraClassPath = extraClassPath;
     this.javac = javac;
     this.javacOptions = Objects.requireNonNull(javacOptions);
@@ -199,9 +199,9 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
             sourceFilePaths,
             pathToSrcsList,
             allClasspaths,
-            kaptApoptions,
             extraKotlincArguments,
             friendPathsArg,
+            kaptApOptions,
             kaptGeneratedOutput,
             stubsOutput,
             incrementalDataOutput,
@@ -318,9 +318,9 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
       ImmutableSortedSet<Path> sourceFilePaths,
       Path pathToSrcsList,
       Iterable<? extends Path> declaredClasspathEntries,
-      ImmutableMap<String, String> kaptApoptions,
       ImmutableList<String> extraKotlincArguments,
       String friendPathsArg,
+      ImmutableMap<String, String> kaptApOptions,
       Path kaptGenerated,
       Path stubsOutput,
       Path incrementalData,
@@ -355,9 +355,8 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
             .add(STUBS_ARG + filesystem.resolve(stubsOutput))
             .add(
                 AP_OPTIONS
-                    + encodeKaptApoptions(
-                        kaptApoptions,
-                        filesystem.resolve(kaptGenerated).toString()))
+                    + encodeKaptApOptions(
+                        kaptApOptions, filesystem.resolve(kaptGenerated).toString()))
             .add(JAVAC_ARG + encodeOptions(Collections.emptyMap()))
             .add(LIGHT_ANALYSIS + "true") // TODO: Provide value as argument
             .add(CORRECT_ERROR_TYPES + "false") // TODO: Provide value as argument
@@ -429,15 +428,12 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
     return javacOptions.withBootclasspathFromContext(extraClassPath).getBootclasspath();
   }
 
-  private String encodeKaptApoptions(
-      Map<String, String> kaptApoptions,
-      String kaptGeneratedPath) {
+  private String encodeKaptApOptions(Map<String, String> kaptApOptions, String kaptGeneratedPath) {
+    Map<String, String> kaptApOptionsToEncode = new HashMap<>();
+    kaptApOptionsToEncode.put(KAPT_GENERATED, kaptGeneratedPath);
+    kaptApOptionsToEncode.putAll(kaptApOptions);
 
-    Map<String, String> kaptApoptionsToEncode = new HashMap<>();
-    kaptApoptionsToEncode.put(KAPT_GENERATED, kaptGeneratedPath);
-    kaptApoptionsToEncode.putAll(kaptApoptions);
-
-    return encodeOptions(kaptApoptionsToEncode);
+    return encodeOptions(kaptApOptionsToEncode);
   }
 
   private void addCreateFolderStep(

--- a/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
@@ -49,6 +49,7 @@ import com.facebook.buck.zip.ZipStep;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import java.io.ByteArrayOutputStream;
@@ -57,6 +58,7 @@ import java.io.ObjectOutputStream;
 import java.nio.file.Path;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -69,6 +71,7 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
   @AddToRuleKey private final ImmutableList<String> extraKotlincArguments;
   @AddToRuleKey private final ImmutableList<SourcePath> friendPaths;
   @AddToRuleKey private final AnnotationProcessingTool annotationProcessingTool;
+  @AddToRuleKey private final ImmutableMap<String, String> kaptApoptions;
   @AddToRuleKey private final ExtraClasspathProvider extraClassPath;
   @AddToRuleKey private final Javac javac;
   @AddToRuleKey private final JavacOptions javacOptions;
@@ -107,6 +110,7 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
       ImmutableList<String> extraKotlincArguments,
       ImmutableList<SourcePath> friendPaths,
       AnnotationProcessingTool annotationProcessingTool,
+      ImmutableMap<String, String> kaptApoptions,
       ExtraClasspathProvider extraClassPath,
       Javac javac,
       JavacOptions javacOptions) {
@@ -115,6 +119,7 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
     this.extraKotlincArguments = extraKotlincArguments;
     this.friendPaths = friendPaths;
     this.annotationProcessingTool = annotationProcessingTool;
+    this.kaptApoptions = kaptApoptions;
     this.extraClassPath = extraClassPath;
     this.javac = javac;
     this.javacOptions = Objects.requireNonNull(javacOptions);
@@ -194,6 +199,7 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
             sourceFilePaths,
             pathToSrcsList,
             allClasspaths,
+            kaptApoptions,
             extraKotlincArguments,
             friendPathsArg,
             kaptGeneratedOutput,
@@ -312,6 +318,7 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
       ImmutableSortedSet<Path> sourceFilePaths,
       Path pathToSrcsList,
       Iterable<? extends Path> declaredClasspathEntries,
+      ImmutableMap<String, String> kaptApoptions,
       ImmutableList<String> extraKotlincArguments,
       String friendPathsArg,
       Path kaptGenerated,
@@ -348,9 +355,9 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
             .add(STUBS_ARG + filesystem.resolve(stubsOutput))
             .add(
                 AP_OPTIONS
-                    + encodeOptions(
-                        Collections.singletonMap(
-                            KAPT_GENERATED, filesystem.resolve(kaptGenerated).toString())))
+                    + encodeKaptApoptions(
+                        kaptApoptions,
+                        filesystem.resolve(kaptGenerated).toString()))
             .add(JAVAC_ARG + encodeOptions(Collections.emptyMap()))
             .add(LIGHT_ANALYSIS + "true") // TODO: Provide value as argument
             .add(CORRECT_ERROR_TYPES + "false") // TODO: Provide value as argument
@@ -420,6 +427,17 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
   @Override
   protected Optional<String> getBootClasspath(BuildContext context) {
     return javacOptions.withBootclasspathFromContext(extraClassPath).getBootclasspath();
+  }
+
+  private String encodeKaptApoptions(
+      Map<String, String> kaptApoptions,
+      String kaptGeneratedPath) {
+
+    Map<String, String> kaptApoptionsToEncode = new HashMap<>();
+    kaptApoptionsToEncode.put(KAPT_GENERATED, kaptGeneratedPath);
+    kaptApoptionsToEncode.putAll(kaptApoptions);
+
+    return encodeOptions(kaptApoptionsToEncode);
   }
 
   private void addCreateFolderStep(

--- a/test/com/facebook/buck/jvm/kotlin/KotlinLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/kotlin/KotlinLibraryIntegrationTest.java
@@ -172,4 +172,11 @@ public class KotlinLibraryIntegrationTest {
     ProcessResult buildResult = workspace.runBuckCommand("build", "//com/example/zip:zip");
     buildResult.assertSuccess("Build should have succeeded.");
   }
+
+  @Test
+  public void shouldPassApoptionsToKapt() throws Exception {
+    ProcessResult buildResult = workspace.runBuckCommand(
+        "build", "//com/example/ap/kapt-apoptions:kotlin");
+    buildResult.assertSuccess("Build should have succeeded.");
+  }
 }

--- a/test/com/facebook/buck/jvm/kotlin/KotlinLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/kotlin/KotlinLibraryIntegrationTest.java
@@ -175,8 +175,8 @@ public class KotlinLibraryIntegrationTest {
 
   @Test
   public void shouldPassApoptionsToKapt() throws Exception {
-    ProcessResult buildResult = workspace.runBuckCommand(
-        "build", "//com/example/ap/kapt-apoptions:kotlin");
+    ProcessResult buildResult =
+        workspace.runBuckCommand("build", "//com/example/ap/kapt-apoptions:kotlin");
     buildResult.assertSuccess("Build should have succeeded.");
   }
 }

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/ap/kapt-apoptions/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/ap/kapt-apoptions/BUCK.fixture
@@ -1,0 +1,22 @@
+kotlin_library(
+    name = "kotlin",
+    srcs = glob([
+        "*.kt",
+        "*.java",
+    ]),
+    annotation_processor_deps = [
+        "//com/example/ap/kotlinapwithapoption:ap-lib-apoption",
+    ],
+    annotation_processors = [
+        "com.example.ap.kotlinap.KotlinAnnotationProcessorWithApoption",
+    ],
+    kapt_apoptions = {
+      'someApoption' : 'someApoptionValue'
+    },
+    visibility = [
+        "PUBLIC",
+    ],
+    deps = [
+        "//com/example/ap/kotlinannotation:annotation-lib",
+    ],
+)

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/ap/kapt-apoptions/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/ap/kapt-apoptions/BUCK.fixture
@@ -10,7 +10,7 @@ kotlin_library(
     annotation_processors = [
         "com.example.ap.kotlinap.KotlinAnnotationProcessorWithApoption",
     ],
-    kapt_apoptions = {
+    kapt_ap_options = {
       'someApoption' : 'someApoptionValue'
     },
     visibility = [

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/ap/kapt-apoptions/KotlinClassWithKotlinAnnotation.kt
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/ap/kapt-apoptions/KotlinClassWithKotlinAnnotation.kt
@@ -1,0 +1,6 @@
+package com.example.ap
+
+import com.example.ap.kotlinannotation.KotlinAnnotation
+
+@KotlinAnnotation
+class KotlinClassWithKotlinAnnotation

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/ap/kotlinapwithapoption/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/ap/kotlinapwithapoption/BUCK.fixture
@@ -1,0 +1,16 @@
+kotlin_library(
+    name = "ap-lib-apoption",
+    srcs = [
+        "KotlinAnnotationProcessorWithApoption.kt",
+    ],
+    resources = glob([
+        "resources/**",
+    ]),
+    resources_root = "resources",
+    visibility = [
+        "PUBLIC",
+    ],
+    deps = [
+        "//com/example/ap/kotlinannotation:annotation-lib",
+    ],
+)

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/ap/kotlinapwithapoption/KotlinAnnotationProcessorWithApoption.kt
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/ap/kotlinapwithapoption/KotlinAnnotationProcessorWithApoption.kt
@@ -1,0 +1,26 @@
+package com.example.ap.kotlinap
+
+import javax.annotation.processing.*
+import javax.lang.model.SourceVersion
+import javax.lang.model.element.TypeElement
+
+import com.example.ap.kotlinannotation.KotlinAnnotation
+
+class KotlinAnnotationProcessorWithApoption : AbstractProcessor() {
+
+    override fun getSupportedAnnotationTypes(): MutableSet<String> {
+        return mutableSetOf(KotlinAnnotation::class.java.name)
+    }
+
+    override fun getSupportedSourceVersion(): SourceVersion {
+        return SourceVersion.latest()
+    }
+
+    override fun process(annotations: MutableSet<out TypeElement>, roundEnv: RoundEnvironment): Boolean {
+        if (!processingEnv.getOptions().get("someApoption").equals("someApoptionValue")) {
+            throw java.lang.IllegalStateException("KotlinAnnotationProcessorWithApoption could not retrieve the apoption")
+        }
+
+        return true
+    }
+}

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/ap/kotlinapwithapoption/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/ap/kotlinapwithapoption/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+com.example.ap.kotlinap.KotlinAnnotationProcessorWithApoption


### PR DESCRIPTION
This will allow users to pass in kapt annotation processor options to kapt.

Not sure if the way I wrote the docs is okay, but I don't think there are any examples of Hash type params so I wanted to be explicit.

Slack discussion here: https://buckbuild.slack.com/archives/C6N81MF55/p1537224378000100