### PR TITLE
Fixing typo in remote execution test BUCK file

### DIFF
--- a/test/com/facebook/buck/remoteexecution/BUCK
+++ b/test/com/facebook/buck/remoteexecution/BUCK
@@ -1,7 +1,7 @@
 load("//tools/build_rules:java_rules.bzl", "java_test")
 
 java_test(
-    name = "remotexeecution",
+    name = "remoteexecution",
     srcs = glob([
         "*.java",
     ]),


### PR DESCRIPTION
Fixes the target name typo in `test/com/facebook/buck/remoteexecution/BUCK` from `remotexeecution --> remoteexecution`