### PR TITLE
Fix global use of `@echo off` within chocolatey BAT file

### DIFF
--- a/tools/release/platforms/chocolatey/buck.bat
+++ b/tools/release/platforms/chocolatey/buck.bat
@@ -1,3 +1,4 @@
+@setlocal
 @echo off
 REM Invoke buck.pex in the same directory as this script with python
 REM We try to find a python2 installation first because python3 can


### PR DESCRIPTION
# Discussion

`@echo off` is a global setting, changing the caller's state, and shouldn't be used without a preceding `setlocal`. Alternatively, if you want to pass environmental state back up to the caller, both `setlocal` and `echo off` can be removed, and commands in the BAT/CMD file prefixed with an "@" to suppress display, eg:

``` batch
@REM Invoke buck.pex in the same directory as this script with python
@REM We try to find a python2 installation first because python3 can
@REM install itself as 'python.exe' on the path, and we don't want that
@REM just yet
@if exist "C:\Python27\python.exe" @(
  C:\Python27\python.exe %~dp0\buck.pex %*
) else @(
  python %~dp0\buck.pex %*
)
```

But I don't see that you need that, so this would be the simpler fix.