### PR TITLE
Allow for thread_core_ratio of above 1.0 if reserved_core isn't set

### DIFF
--- a/src/com/facebook/buck/core/config/BuckConfig.java
+++ b/src/com/facebook/buck/core/config/BuckConfig.java
@@ -607,15 +607,17 @@ public class BuckConfig {
 
     int scaledValue = (int) Math.ceil(ratio * detectedProcessorCount);
 
-    int threadLimit = detectedProcessorCount;
+
 
     Optional<Long> reservedCores = getNumberOfReservedCores();
     if (reservedCores.isPresent()) {
-      threadLimit -= reservedCores.get();
-    }
+      int threadLimit = detectedProcessorCount;
 
-    if (scaledValue > threadLimit) {
-      scaledValue = threadLimit;
+      threadLimit -= reservedCores.get();
+
+      if (scaledValue > threadLimit) {
+        scaledValue = threadLimit;
+      }
     }
 
     Optional<Long> minThreads = getThreadCoreRatioMinThreads();
@@ -630,11 +632,6 @@ public class BuckConfig {
       if (minThreads.isPresent() && minThreads.get() > maxThreadsValue) {
         throw new HumanReadableException(
             "thread_core_ratio_max_cores must be larger than thread_core_ratio_min_cores");
-      }
-
-      if (maxThreadsValue > threadLimit) {
-        throw new HumanReadableException(
-            "thread_core_ratio_max_cores is larger than thread_core_ratio_reserved_cores allows");
       }
 
       scaledValue = Math.min(scaledValue, (int) maxThreadsValue);

--- a/test/com/facebook/buck/core/config/BuckConfigTest.java
+++ b/test/com/facebook/buck/core/config/BuckConfigTest.java
@@ -209,6 +209,15 @@ public class BuckConfigTest {
   }
 
   @Test
+  public void testBuildThreadsRatioGreaterThanOne() {
+    BuckConfig buckConfig =
+        FakeBuckConfig.builder()
+            .setSections(ImmutableMap.of("build", ImmutableMap.of("thread_core_ratio", "2")))
+            .build();
+    assertThat(buckConfig.getDefaultMaximumNumberOfThreads(10), Matchers.equalTo(20));
+  }
+
+  @Test
   public void testBuildThreadsRatioGreaterThanZero() {
     BuckConfig buckConfig =
         FakeBuckConfig.builder()
@@ -274,6 +283,20 @@ public class BuckConfigTest {
                     "build",
                     ImmutableMap.of(
                         "thread_core_ratio", "1",
+                        "thread_core_ratio_reserved_cores", "2")))
+            .build();
+    assertThat(buckConfig.getDefaultMaximumNumberOfThreads(10), Matchers.equalTo(8));
+  }
+
+  @Test
+  public void testBuildThreadsRatioGreaterThanOneWithReservedCores() {
+    BuckConfig buckConfig =
+        FakeBuckConfig.builder()
+            .setSections(
+                ImmutableMap.of(
+                    "build",
+                    ImmutableMap.of(
+                        "thread_core_ratio", "2",
                         "thread_core_ratio_reserved_cores", "2")))
             .build();
     assertThat(buckConfig.getDefaultMaximumNumberOfThreads(10), Matchers.equalTo(8));


### PR DESCRIPTION
This changes the logic to make thread_core above 1 work

Previously we unconditionally ran:
if (scaledValue > threadLimit) {
     scaledValue = threadLimit;
}

Which eliminated values over 1.0.

Now we only run it if reserved_core is set

Also with the new logic
"thread_core_ratio_max_cores is larger than thread_core_ratio_reserved_cores allows");
is not necessary.