### PR TITLE
Add common debug default settings for xcode project

### DIFF
--- a/src/com/facebook/buck/features/apple/project/CxxPlatformXcodeConfigGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/CxxPlatformXcodeConfigGenerator.java
@@ -43,9 +43,23 @@ class CxxPlatformXcodeConfigGenerator {
 
   private CxxPlatformXcodeConfigGenerator() {}
 
-  public static ImmutableMap<String, ImmutableMap<String, String>>
-      getDefaultXcodeBuildConfigurationsFromCxxPlatform(
-          CxxPlatform cxxPlatform, Map<String, String> appendedConfig) {
+  public static ImmutableMap<String, String> getAppleXcodeTargetBuildConfigurationsFromCxxPlatform(
+      CxxPlatform cxxPlatform, Map<String, String> appendedConfig) {
+
+    ArrayList<String> notProcessedCxxFlags = new ArrayList<String>(cxxPlatform.getCxxflags());
+    LinkedHashMap<String, String> notProcessedAppendedConfig =
+        new LinkedHashMap<String, String>(appendedConfig);
+
+    ImmutableMap.Builder<String, String> configBuilder = ImmutableMap.builder();
+    setSdkRootAndDeploymentTargetValues(
+        configBuilder, cxxPlatform, notProcessedCxxFlags, notProcessedAppendedConfig);
+    removeArchsValue(notProcessedCxxFlags, notProcessedAppendedConfig);
+
+    return configBuilder.build();
+  }
+
+  public static ImmutableMap<String, String> getCxxXcodeTargetBuildConfigurationsFromCxxPlatform(
+      CxxPlatform cxxPlatform, Map<String, String> appendedConfig) {
 
     ArrayList<String> notProcessedCxxFlags = new ArrayList<String>(cxxPlatform.getCxxflags());
     LinkedHashMap<String, String> notProcessedAppendedConfig =
@@ -60,7 +74,15 @@ class CxxPlatformXcodeConfigGenerator {
     setOtherCplusplusFlagsValue(configBuilder, notProcessedCxxFlags, notProcessedAppendedConfig);
     setFlagsFromNotProcessedAppendedConfig(configBuilder, notProcessedAppendedConfig);
 
-    ImmutableMap<String, String> config = configBuilder.build();
+    return configBuilder.build();
+  }
+
+  public static ImmutableMap<String, ImmutableMap<String, String>>
+      getDefaultXcodeBuildConfigurationsFromCxxPlatform(
+          CxxPlatform cxxPlatform, Map<String, String> appendedConfig) {
+
+    ImmutableMap<String, String> config =
+        getCxxXcodeTargetBuildConfigurationsFromCxxPlatform(cxxPlatform, appendedConfig);
     return new ImmutableMap.Builder<String, ImmutableMap<String, String>>()
         .put(DEBUG_BUILD_CONFIGURATION_NAME, config)
         .put(PROFILE_BUILD_CONFIGURATION_NAME, config)

--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -659,13 +659,14 @@ public class ProjectGenerator {
     defaultSettingsBuilder.put(PRODUCT_NAME, productName);
 
     Optional<ImmutableSortedMap<String, ImmutableMap<String, String>>> configs =
-        getXcodeBuildConfigurationsForTargetNode(targetNode, appendedConfig);
+        getXcodeBuildConfigurationsForTargetNode(targetNode);
     PBXNativeTarget target = targetBuilderResult.target;
     setTargetBuildConfigurations(
         buildTarget,
         target,
         project.getMainGroup(),
         configs.get(),
+        getTargetCxxBuildConfigurationForTargetNode(targetNode, appendedConfig),
         extraSettings,
         defaultSettingsBuilder.build(),
         appendedConfig);
@@ -1810,12 +1811,13 @@ public class ProjectGenerator {
         ImmutableMap<String, String> appendedConfig = appendConfigsBuilder.build();
 
         Optional<ImmutableSortedMap<String, ImmutableMap<String, String>>> configs =
-            getXcodeBuildConfigurationsForTargetNode(targetNode, appendedConfig);
+            getXcodeBuildConfigurationsForTargetNode(targetNode);
         setTargetBuildConfigurations(
             buildTarget,
             target,
             project.getMainGroup(),
             configs.get(),
+            getTargetCxxBuildConfigurationForTargetNode(targetNode, appendedConfig),
             extraSettingsBuilder.build(),
             defaultSettingsBuilder.build(),
             appendedConfig);
@@ -2421,8 +2423,7 @@ public class ProjectGenerator {
   }
 
   private Optional<ImmutableSortedMap<String, ImmutableMap<String, String>>>
-      getXcodeBuildConfigurationsForTargetNode(
-          TargetNode<?> targetNode, ImmutableMap<String, String> appendedConfig) {
+      getXcodeBuildConfigurationsForTargetNode(TargetNode<?> targetNode) {
     Optional<ImmutableSortedMap<String, ImmutableMap<String, String>>> configs = Optional.empty();
     Optional<TargetNode<AppleNativeTargetDescriptionArg>> appleTargetNode =
         TargetNodes.castArg(targetNode, AppleNativeTargetDescriptionArg.class);
@@ -2433,15 +2434,61 @@ public class ProjectGenerator {
     } else if (halideTargetNode.isPresent()) {
       configs = Optional.of(halideTargetNode.get().getConstructorArg().getConfigs());
     }
-    if (!configs.isPresent()
-        || (configs.isPresent() && configs.get().isEmpty())
-        || targetNode.getDescription() instanceof CxxLibraryDescription) {
-      ImmutableMap<String, ImmutableMap<String, String>> defaultConfig =
-          CxxPlatformXcodeConfigGenerator.getDefaultXcodeBuildConfigurationsFromCxxPlatform(
-              defaultCxxPlatform, appendedConfig);
-      configs = Optional.of(ImmutableSortedMap.copyOf(defaultConfig));
+
+    HashMap<String, HashMap<String, String>> combinedConfig =
+        new HashMap<String, HashMap<String, String>>();
+    combinedConfig.put(
+        CxxPlatformXcodeConfigGenerator.DEBUG_BUILD_CONFIGURATION_NAME,
+        new HashMap<String, String>(getDefaultDebugBuildConfiguration()));
+    combinedConfig.put(
+        CxxPlatformXcodeConfigGenerator.PROFILE_BUILD_CONFIGURATION_NAME,
+        new HashMap<String, String>());
+    combinedConfig.put(
+        CxxPlatformXcodeConfigGenerator.RELEASE_BUILD_CONFIGURATION_NAME,
+        new HashMap<String, String>());
+
+    if (configs.isPresent()
+        && !configs.get().isEmpty()
+        && !(targetNode.getDescription() instanceof CxxLibraryDescription)) {
+      for (Map.Entry<String, ImmutableMap<String, String>> targetLevelConfig :
+          configs.get().entrySet()) {
+        HashMap<String, String> pendingConfig =
+            new HashMap<String, String>(targetLevelConfig.getValue());
+        String configTarget = targetLevelConfig.getKey();
+        if (combinedConfig.containsKey(configTarget)) {
+          combinedConfig.get(configTarget).putAll(pendingConfig);
+        } else {
+          combinedConfig.put(configTarget, pendingConfig);
+        }
+      }
     }
-    return configs;
+
+    ImmutableSortedMap.Builder<String, ImmutableMap<String, String>> configBuilder =
+        ImmutableSortedMap.naturalOrder();
+    for (Map.Entry<String, HashMap<String, String>> config : combinedConfig.entrySet()) {
+      configBuilder.put(config.getKey(), ImmutableMap.copyOf(config.getValue()));
+    }
+
+    return Optional.of(configBuilder.build());
+  }
+
+  private static ImmutableMap<String, String> getDefaultDebugBuildConfiguration() {
+    return new ImmutableMap.Builder<String, String>()
+        .put("DEAD_CODE_STRIPPING", "NO")
+        .put("ONLY_ACTIVE_ARCH", "YES")
+        .put("GCC_SYMBOLS_PRIVATE_EXTERN", "NO")
+        .build();
+  }
+
+  private ImmutableMap<String, String> getTargetCxxBuildConfigurationForTargetNode(
+      TargetNode<?> targetNode, Map<String, String> appendedConfig) {
+    if (targetNode.getDescription() instanceof CxxLibraryDescription) {
+      return CxxPlatformXcodeConfigGenerator.getCxxXcodeTargetBuildConfigurationsFromCxxPlatform(
+          defaultCxxPlatform, appendedConfig);
+    } else {
+      return CxxPlatformXcodeConfigGenerator.getAppleXcodeTargetBuildConfigurationsFromCxxPlatform(
+          defaultCxxPlatform, appendedConfig);
+    }
   }
 
   private void addEntitlementsPlistIntoTarget(
@@ -2533,6 +2580,7 @@ public class ProjectGenerator {
       PBXTarget target,
       PBXGroup targetGroup,
       ImmutableMap<String, ImmutableMap<String, String>> configurations,
+      ImmutableMap<String, String> cxxPlatformXcodeBuildSettings,
       ImmutableMap<String, String> overrideBuildSettings,
       ImmutableMap<String, String> defaultBuildSettings,
       ImmutableMap<String, String> appendBuildSettings)
@@ -2554,6 +2602,13 @@ public class ProjectGenerator {
               .getUnchecked(configurationEntry.getKey());
 
       HashMap<String, String> combinedOverrideConfigs = new HashMap<>(overrideBuildSettings);
+      for (Map.Entry<String, String> entry : cxxPlatformXcodeBuildSettings.entrySet()) {
+        String existingSetting = targetLevelInlineSettings.get(entry.getKey());
+        if (existingSetting == null) {
+          combinedOverrideConfigs.put(entry.getKey(), entry.getValue());
+        }
+      }
+
       for (Map.Entry<String, String> entry : defaultBuildSettings.entrySet()) {
         String existingSetting = targetLevelInlineSettings.get(entry.getKey());
         if (existingSetting == null) {

--- a/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
@@ -2071,7 +2071,7 @@ public class ProjectGeneratorTest {
     BuildTarget buildTarget = BuildTargetFactory.newInstance(rootPath, "//foo", "lib");
     TargetNode<?> node =
         AppleLibraryBuilder.createBuilder(buildTarget)
-            .setConfigs(ImmutableSortedMap.of("Debug", ImmutableMap.of()))
+            .setConfigs(ImmutableSortedMap.of("RandomConfig", ImmutableMap.of()))
             .setSrcs(
                 ImmutableSortedSet.of(
                     SourceWithFlags.of(FakeSourcePath.of("foo.m"), ImmutableList.of("-foo")),
@@ -2089,7 +2089,7 @@ public class ProjectGeneratorTest {
     assertThat(target.isa(), equalTo("PBXNativeTarget"));
     assertThat(target.getProductType(), equalTo(ProductTypes.STATIC_LIBRARY));
 
-    assertHasConfigurations(target, "Debug");
+    assertHasConfigurations(target, "RandomConfig");
     assertEquals("Should have exact number of build phases", 1, target.getBuildPhases().size());
     assertHasSingletonSourcesPhaseWithSourcesAndFlags(
         target,

--- a/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
@@ -3078,15 +3078,12 @@ public class ProjectGeneratorTest {
         ProjectGeneratorTestUtils.getBuildSettings(projectFilesystem, buildTarget, target, "Debug");
 
     assertEquals(
-        "$(inherited) "
-            + "-Wno-deprecated -Wno-conversion -ffoo -fbar",
+        "$(inherited) " + "-Wno-deprecated -Wno-conversion -ffoo -fbar",
         settings.get("OTHER_CFLAGS"));
     assertEquals(
-        "$(inherited) "
-            + "-Wundeclared-selector -Wno-objc-designated-initializers -ffoo -fbar",
+        "$(inherited) " + "-Wundeclared-selector -Wno-objc-designated-initializers -ffoo -fbar",
         settings.get("OTHER_CPLUSPLUSFLAGS"));
-    assertEquals(
-        "$(inherited) -fatal_warnings -ObjC -lbaz", settings.get("OTHER_LDFLAGS"));
+    assertEquals("$(inherited) -fatal_warnings -ObjC -lbaz", settings.get("OTHER_LDFLAGS"));
   }
 
   @Test
@@ -3173,8 +3170,7 @@ public class ProjectGeneratorTest {
     ImmutableMap<String, String> settings =
         ProjectGeneratorTestUtils.getBuildSettings(projectFilesystem, buildTarget, target, "Debug");
     assertEquals(
-        "$(inherited) -Wno-deprecated -Wno-conversion -DHELLO",
-        settings.get("OTHER_CFLAGS"));
+        "$(inherited) -Wno-deprecated -Wno-conversion -DHELLO", settings.get("OTHER_CFLAGS"));
   }
 
   @Test
@@ -3254,8 +3250,7 @@ public class ProjectGeneratorTest {
         "$(inherited) -Wno-deprecated -Wno-conversion -fbar-iphone",
         settings.get("OTHER_CFLAGS[sdk=iphonesimulator*][arch=x86_64]"));
     assertEquals(
-        "$(inherited) "
-            + "-Wundeclared-selector -Wno-objc-designated-initializers -fbar-iphone",
+        "$(inherited) " + "-Wundeclared-selector -Wno-objc-designated-initializers -fbar-iphone",
         settings.get("OTHER_CPLUSPLUSFLAGS[sdk=iphonesimulator*][arch=x86_64]"));
     assertEquals(null, settings.get("OTHER_LDFLAGS[sdk=iphonesimulator*][arch=x86_64]"));
 
@@ -3267,8 +3262,7 @@ public class ProjectGeneratorTest {
             projectFilesystem, dependentBuildTarget, dependentTarget, "Debug");
 
     assertEquals(
-        "$(inherited) "
-            + "-Wno-deprecated -Wno-conversion -ffoo-iphone -fbar-iphone",
+        "$(inherited) " + "-Wno-deprecated -Wno-conversion -ffoo-iphone -fbar-iphone",
         dependentSettings.get("OTHER_CFLAGS[sdk=iphonesimulator*][arch=x86_64]"));
     assertEquals(
         "$(inherited) "

--- a/test/com/facebook/buck/features/apple/project/ProjectIntegrationTest.java
+++ b/test/com/facebook/buck/features/apple/project/ProjectIntegrationTest.java
@@ -485,13 +485,14 @@ public class ProjectIntegrationTest {
 
   @Test
   public void testBuckProjectWithAppleBundleTests() throws IOException, InterruptedException {
+    assumeTrue(Platform.detect() == Platform.MACOS);
+    assumeTrue(AppleNativeIntegrationTestUtils.isApplePlatformAvailable(ApplePlatform.MACOSX));
     ProjectWorkspace workspace =
         TestDataHelper.createProjectWorkspaceForScenario(
             this, "project_with_apple_bundle_test", temporaryFolder);
     workspace.setUp();
 
-    ProcessResult result =
-        workspace.runBuckCommand("project", "//app:bundle");
+    ProcessResult result = workspace.runBuckCommand("project", "//app:bundle");
     result.assertSuccess();
 
     ProcessExecutor.Result xcodeTestResult =

--- a/test/com/facebook/buck/features/apple/project/ProjectIntegrationTest.java
+++ b/test/com/facebook/buck/features/apple/project/ProjectIntegrationTest.java
@@ -494,18 +494,18 @@ public class ProjectIntegrationTest {
         workspace.runBuckCommand("project", "//app:bundle");
     result.assertSuccess();
 
-    ProcessResult xcodeTestResult =
-        workspace.runBuckCommand(
+    ProcessExecutor.Result xcodeTestResult =
+        workspace.runCommand(
             "xcodebuild",
             "-workspace",
             "app/bundle.xcworkspace",
             "-scheme",
             "bundle",
-            "-destination",
-            "'platform=OS X,arch=x86_64'",
+            "-destination 'platform=OS X,arch=x86_64'",
             "clean",
             "test");
-    result.assertSuccess();
+    xcodeTestResult.getStderr().ifPresent(System.err::print);
+    assertEquals("xcodebuild should succeed", 0, xcodeTestResult.getExitCode());
   }
 
   @Test

--- a/test/com/facebook/buck/features/apple/project/ProjectIntegrationTest.java
+++ b/test/com/facebook/buck/features/apple/project/ProjectIntegrationTest.java
@@ -484,6 +484,31 @@ public class ProjectIntegrationTest {
   }
 
   @Test
+  public void testBuckProjectWithAppleBundleTests() throws IOException, InterruptedException {
+    ProjectWorkspace workspace =
+        TestDataHelper.createProjectWorkspaceForScenario(
+            this, "project_with_apple_bundle_test", temporaryFolder);
+    workspace.setUp();
+
+    ProcessResult result =
+        workspace.runBuckCommand("project", "//app:bundle");
+    result.assertSuccess();
+
+    ProcessResult xcodeTestResult =
+        workspace.runBuckCommand(
+            "xcodebuild",
+            "-workspace",
+            "app/bundle.xcworkspace",
+            "-scheme",
+            "bundle",
+            "-destination",
+            "'platform=OS X,arch=x86_64'",
+            "clean",
+            "test");
+    result.assertSuccess();
+  }
+
+  @Test
   public void testBuckProjectWithEmbeddedCellBuckoutAndMergedHeaderMap()
       throws IOException, InterruptedException {
     assumeTrue(Platform.detect() == Platform.MACOS);

--- a/test/com/facebook/buck/features/apple/project/testdata/project_focus/Apps/Apps.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_focus/Apps/Apps.xcodeproj/project.pbxproj.expected
@@ -24,6 +24,19 @@
 			<key>explicitFileType</key>
 			<string>text.xcconfig</string>
 		</dict>
+		<key>1DD70E29EC32D25600000000</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>TestApp#iphonesimulator-x86_64-Profile.xcconfig</string>
+			<key>path</key>
+			<string>../buck-out/gen/Apps/TestApp#iphonesimulator-x86_64-Profile.xcconfig</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>explicitFileType</key>
+			<string>text.xcconfig</string>
+		</dict>
 		<key>1DD70E295FC97DB800000000</key>
 		<dict>
 			<key>isa</key>
@@ -48,6 +61,7 @@
 			<key>children</key>
 			<array>
 				<string>1DD70E297D7A05EC00000000</string>
+				<string>1DD70E29EC32D25600000000</string>
 				<string>1DD70E295FC97DB800000000</string>
 			</array>
 		</dict>
@@ -170,6 +184,18 @@
 			<key>baseConfigurationReference</key>
 			<string>1DD70E297D7A05EC00000000</string>
 		</dict>
+		<key>4952437350C7218900000000</key>
+		<dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Profile</string>
+			<key>buildSettings</key>
+			<dict>
+			</dict>
+			<key>baseConfigurationReference</key>
+			<string>1DD70E29EC32D25600000000</string>
+		</dict>
 		<key>49524373A439BFE700000000</key>
 		<dict>
 			<key>isa</key>
@@ -189,6 +215,7 @@
 			<key>buildConfigurations</key>
 			<array>
 				<string>4952437303EDA63300000000</string>
+				<string>4952437350C7218900000000</string>
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
@@ -225,6 +252,16 @@
 			<dict>
 			</dict>
 		</dict>
+		<key>4952437350C7218900000001</key>
+		<dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Profile</string>
+			<key>buildSettings</key>
+			<dict>
+			</dict>
+		</dict>
 		<key>49524373A439BFE700000001</key>
 		<dict>
 			<key>isa</key>
@@ -242,6 +279,7 @@
 			<key>buildConfigurations</key>
 			<array>
 				<string>4952437303EDA63300000001</string>
+				<string>4952437350C7218900000001</string>
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_focus/Libraries/Dep1/Dep1.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_focus/Libraries/Dep1/Dep1.xcodeproj/project.pbxproj.expected
@@ -24,6 +24,19 @@
 			<key>explicitFileType</key>
 			<string>text.xcconfig</string>
 		</dict>
+		<key>1DD70E290CF44C0B00000000</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>Dep1_1-Profile.xcconfig</string>
+			<key>path</key>
+			<string>../../buck-out/gen/Libraries/Dep1/Dep1_1-Profile.xcconfig</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>explicitFileType</key>
+			<string>text.xcconfig</string>
+		</dict>
 		<key>1DD70E29808AF76D00000000</key>
 		<dict>
 			<key>isa</key>
@@ -48,6 +61,7 @@
 			<key>children</key>
 			<array>
 				<string>1DD70E29184868E100000000</string>
+				<string>1DD70E290CF44C0B00000000</string>
 				<string>1DD70E29808AF76D00000000</string>
 			</array>
 		</dict>
@@ -170,6 +184,18 @@
 			<key>baseConfigurationReference</key>
 			<string>1DD70E29184868E100000000</string>
 		</dict>
+		<key>4952437350C7218900000000</key>
+		<dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Profile</string>
+			<key>buildSettings</key>
+			<dict>
+			</dict>
+			<key>baseConfigurationReference</key>
+			<string>1DD70E290CF44C0B00000000</string>
+		</dict>
 		<key>49524373A439BFE700000000</key>
 		<dict>
 			<key>isa</key>
@@ -189,6 +215,7 @@
 			<key>buildConfigurations</key>
 			<array>
 				<string>4952437303EDA63300000000</string>
+				<string>4952437350C7218900000000</string>
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
@@ -256,6 +283,16 @@
 			<dict>
 			</dict>
 		</dict>
+		<key>4952437350C7218900000001</key>
+		<dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Profile</string>
+			<key>buildSettings</key>
+			<dict>
+			</dict>
+		</dict>
 		<key>49524373A439BFE700000001</key>
 		<dict>
 			<key>isa</key>
@@ -273,6 +310,7 @@
 			<key>buildConfigurations</key>
 			<array>
 				<string>4952437303EDA63300000001</string>
+				<string>4952437350C7218900000001</string>
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_focus/Libraries/Dep2/Dep2.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_focus/Libraries/Dep2/Dep2.xcodeproj/project.pbxproj.expected
@@ -24,6 +24,19 @@
 			<key>explicitFileType</key>
 			<string>text.xcconfig</string>
 		</dict>
+		<key>1DD70E29947CAF1C00000000</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>Dep2-Profile.xcconfig</string>
+			<key>path</key>
+			<string>../../buck-out/gen/Libraries/Dep2/Dep2-Profile.xcconfig</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>explicitFileType</key>
+			<string>text.xcconfig</string>
+		</dict>
 		<key>1DD70E2908135A7E00000000</key>
 		<dict>
 			<key>isa</key>
@@ -48,6 +61,7 @@
 			<key>children</key>
 			<array>
 				<string>1DD70E292E005C3200000000</string>
+				<string>1DD70E29947CAF1C00000000</string>
 				<string>1DD70E2908135A7E00000000</string>
 			</array>
 		</dict>
@@ -156,6 +170,18 @@
 			<key>baseConfigurationReference</key>
 			<string>1DD70E292E005C3200000000</string>
 		</dict>
+		<key>4952437350C7218900000000</key>
+		<dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Profile</string>
+			<key>buildSettings</key>
+			<dict>
+			</dict>
+			<key>baseConfigurationReference</key>
+			<string>1DD70E29947CAF1C00000000</string>
+		</dict>
 		<key>49524373A439BFE700000000</key>
 		<dict>
 			<key>isa</key>
@@ -175,6 +201,7 @@
 			<key>buildConfigurations</key>
 			<array>
 				<string>4952437303EDA63300000000</string>
+				<string>4952437350C7218900000000</string>
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
@@ -211,6 +238,16 @@
 			<dict>
 			</dict>
 		</dict>
+		<key>4952437350C7218900000001</key>
+		<dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Profile</string>
+			<key>buildSettings</key>
+			<dict>
+			</dict>
+		</dict>
 		<key>49524373A439BFE700000001</key>
 		<dict>
 			<key>isa</key>
@@ -228,6 +265,7 @@
 			<key>buildConfigurations</key>
 			<array>
 				<string>4952437303EDA63300000001</string>
+				<string>4952437350C7218900000001</string>
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_focus_pattern/Apps/Apps.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_focus_pattern/Apps/Apps.xcodeproj/project.pbxproj.expected
@@ -24,6 +24,19 @@
 			<key>explicitFileType</key>
 			<string>text.xcconfig</string>
 		</dict>
+		<key>1DD70E295DE482B000000000</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>TestApp-Profile.xcconfig</string>
+			<key>path</key>
+			<string>../buck-out/gen/Apps/TestApp-Profile.xcconfig</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>explicitFileType</key>
+			<string>text.xcconfig</string>
+		</dict>
 		<key>1DD70E29D17B2E1200000000</key>
 		<dict>
 			<key>isa</key>
@@ -48,6 +61,7 @@
 			<key>children</key>
 			<array>
 				<string>1DD70E29E4B004C600000000</string>
+				<string>1DD70E295DE482B000000000</string>
 				<string>1DD70E29D17B2E1200000000</string>
 			</array>
 		</dict>
@@ -170,6 +184,18 @@
 			<key>baseConfigurationReference</key>
 			<string>1DD70E29E4B004C600000000</string>
 		</dict>
+		<key>4952437350C7218900000000</key>
+		<dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Profile</string>
+			<key>buildSettings</key>
+			<dict>
+			</dict>
+			<key>baseConfigurationReference</key>
+			<string>1DD70E295DE482B000000000</string>
+		</dict>
 		<key>49524373A439BFE700000000</key>
 		<dict>
 			<key>isa</key>
@@ -189,6 +215,7 @@
 			<key>buildConfigurations</key>
 			<array>
 				<string>4952437303EDA63300000000</string>
+				<string>4952437350C7218900000000</string>
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
@@ -225,6 +252,16 @@
 			<dict>
 			</dict>
 		</dict>
+		<key>4952437350C7218900000001</key>
+		<dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Profile</string>
+			<key>buildSettings</key>
+			<dict>
+			</dict>
+		</dict>
 		<key>49524373A439BFE700000001</key>
 		<dict>
 			<key>isa</key>
@@ -242,6 +279,7 @@
 			<key>buildConfigurations</key>
 			<array>
 				<string>4952437303EDA63300000001</string>
+				<string>4952437350C7218900000001</string>
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_focus_pattern/Libraries/Dep1/Dep1.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_focus_pattern/Libraries/Dep1/Dep1.xcodeproj/project.pbxproj.expected
@@ -24,6 +24,19 @@
 			<key>explicitFileType</key>
 			<string>text.xcconfig</string>
 		</dict>
+		<key>1DD70E290CF44C0B00000000</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>Dep1_1-Profile.xcconfig</string>
+			<key>path</key>
+			<string>../../buck-out/gen/Libraries/Dep1/Dep1_1-Profile.xcconfig</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>explicitFileType</key>
+			<string>text.xcconfig</string>
+		</dict>
 		<key>1DD70E29808AF76D00000000</key>
 		<dict>
 			<key>isa</key>
@@ -45,6 +58,19 @@
 			<string>Dep1_2-Debug.xcconfig</string>
 			<key>path</key>
 			<string>../../buck-out/gen/Libraries/Dep1/Dep1_2-Debug.xcconfig</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>explicitFileType</key>
+			<string>text.xcconfig</string>
+		</dict>
+		<key>1DD70E29D1862E2A00000000</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>Dep1_2-Profile.xcconfig</string>
+			<key>path</key>
+			<string>../../buck-out/gen/Libraries/Dep1/Dep1_2-Profile.xcconfig</string>
 			<key>sourceTree</key>
 			<string>SOURCE_ROOT</string>
 			<key>explicitFileType</key>
@@ -74,8 +100,10 @@
 			<key>children</key>
 			<array>
 				<string>1DD70E29184868E100000000</string>
+				<string>1DD70E290CF44C0B00000000</string>
 				<string>1DD70E29808AF76D00000000</string>
 				<string>1DD70E29F9DA46C000000000</string>
+				<string>1DD70E29D1862E2A00000000</string>
 				<string>1DD70E29451CD98C00000000</string>
 			</array>
 		</dict>
@@ -238,6 +266,18 @@
 			<key>baseConfigurationReference</key>
 			<string>1DD70E29184868E100000000</string>
 		</dict>
+		<key>4952437350C7218900000000</key>
+		<dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Profile</string>
+			<key>buildSettings</key>
+			<dict>
+			</dict>
+			<key>baseConfigurationReference</key>
+			<string>1DD70E290CF44C0B00000000</string>
+		</dict>
 		<key>49524373A439BFE700000000</key>
 		<dict>
 			<key>isa</key>
@@ -257,6 +297,7 @@
 			<key>buildConfigurations</key>
 			<array>
 				<string>4952437303EDA63300000000</string>
+				<string>4952437350C7218900000000</string>
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
@@ -295,6 +336,18 @@
 			<key>baseConfigurationReference</key>
 			<string>1DD70E29F9DA46C000000000</string>
 		</dict>
+		<key>4952437350C7218900000001</key>
+		<dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Profile</string>
+			<key>buildSettings</key>
+			<dict>
+			</dict>
+			<key>baseConfigurationReference</key>
+			<string>1DD70E29D1862E2A00000000</string>
+		</dict>
 		<key>49524373A439BFE700000001</key>
 		<dict>
 			<key>isa</key>
@@ -314,6 +367,7 @@
 			<key>buildConfigurations</key>
 			<array>
 				<string>4952437303EDA63300000001</string>
+				<string>4952437350C7218900000001</string>
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
@@ -350,6 +404,16 @@
 			<dict>
 			</dict>
 		</dict>
+		<key>4952437350C7218900000002</key>
+		<dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Profile</string>
+			<key>buildSettings</key>
+			<dict>
+			</dict>
+		</dict>
 		<key>49524373A439BFE700000002</key>
 		<dict>
 			<key>isa</key>
@@ -367,6 +431,7 @@
 			<key>buildConfigurations</key>
 			<array>
 				<string>4952437303EDA63300000002</string>
+				<string>4952437350C7218900000002</string>
 				<string>49524373A439BFE700000002</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_focus_pattern_cell/Apps/Apps.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_focus_pattern_cell/Apps/Apps.xcodeproj/project.pbxproj.expected
@@ -24,6 +24,19 @@
 			<key>explicitFileType</key>
 			<string>text.xcconfig</string>
 		</dict>
+		<key>1DD70E295DE482B000000000</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>TestApp-Profile.xcconfig</string>
+			<key>path</key>
+			<string>../buck-out/gen/Apps/TestApp-Profile.xcconfig</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>explicitFileType</key>
+			<string>text.xcconfig</string>
+		</dict>
 		<key>1DD70E29D17B2E1200000000</key>
 		<dict>
 			<key>isa</key>
@@ -48,6 +61,7 @@
 			<key>children</key>
 			<array>
 				<string>1DD70E29E4B004C600000000</string>
+				<string>1DD70E295DE482B000000000</string>
 				<string>1DD70E29D17B2E1200000000</string>
 			</array>
 		</dict>
@@ -170,6 +184,18 @@
 			<key>baseConfigurationReference</key>
 			<string>1DD70E29E4B004C600000000</string>
 		</dict>
+		<key>4952437350C7218900000000</key>
+		<dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Profile</string>
+			<key>buildSettings</key>
+			<dict>
+			</dict>
+			<key>baseConfigurationReference</key>
+			<string>1DD70E295DE482B000000000</string>
+		</dict>
 		<key>49524373A439BFE700000000</key>
 		<dict>
 			<key>isa</key>
@@ -189,6 +215,7 @@
 			<key>buildConfigurations</key>
 			<array>
 				<string>4952437303EDA63300000000</string>
+				<string>4952437350C7218900000000</string>
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
@@ -225,6 +252,16 @@
 			<dict>
 			</dict>
 		</dict>
+		<key>4952437350C7218900000001</key>
+		<dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Profile</string>
+			<key>buildSettings</key>
+			<dict>
+			</dict>
+		</dict>
 		<key>49524373A439BFE700000001</key>
 		<dict>
 			<key>isa</key>
@@ -242,6 +279,7 @@
 			<key>buildConfigurations</key>
 			<array>
 				<string>4952437303EDA63300000001</string>
+				<string>4952437350C7218900000001</string>
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_focus_pattern_cell/Apps/TestApp.xcworkspace/buck-project.meta.json.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_focus_pattern_cell/Apps/TestApp.xcworkspace/buck-project.meta.json.expected
@@ -1,1 +1,1 @@
-{"required-targets":[],"xcconfig-paths":["bar/buck-out/gen/Dep2/Dep2-Debug.xcconfig","bar/buck-out/gen/Dep2/Dep2-Release.xcconfig","buck-out/gen/Apps/TestApp-Debug.xcconfig","buck-out/gen/Apps/TestApp-Release.xcconfig"],"copy-in-xcode":[]}
+{"required-targets":[],"xcconfig-paths":["bar/buck-out/gen/Dep2/Dep2-Debug.xcconfig","bar/buck-out/gen/Dep2/Dep2-Profile.xcconfig","bar/buck-out/gen/Dep2/Dep2-Release.xcconfig","buck-out/gen/Apps/TestApp-Debug.xcconfig","buck-out/gen/Apps/TestApp-Profile.xcconfig","buck-out/gen/Apps/TestApp-Release.xcconfig"],"copy-in-xcode":[]}

--- a/test/com/facebook/buck/features/apple/project/testdata/project_focus_pattern_cell/bar/Dep2/Dep2.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_focus_pattern_cell/bar/Dep2/Dep2.xcodeproj/project.pbxproj.expected
@@ -24,6 +24,19 @@
 			<key>explicitFileType</key>
 			<string>text.xcconfig</string>
 		</dict>
+		<key>1DD70E29947CAF1C00000000</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>Dep2-Profile.xcconfig</string>
+			<key>path</key>
+			<string>../buck-out/gen/Dep2/Dep2-Profile.xcconfig</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>explicitFileType</key>
+			<string>text.xcconfig</string>
+		</dict>
 		<key>1DD70E2908135A7E00000000</key>
 		<dict>
 			<key>isa</key>
@@ -48,6 +61,7 @@
 			<key>children</key>
 			<array>
 				<string>1DD70E292E005C3200000000</string>
+				<string>1DD70E29947CAF1C00000000</string>
 				<string>1DD70E2908135A7E00000000</string>
 			</array>
 		</dict>
@@ -156,6 +170,18 @@
 			<key>baseConfigurationReference</key>
 			<string>1DD70E292E005C3200000000</string>
 		</dict>
+		<key>4952437350C7218900000000</key>
+		<dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Profile</string>
+			<key>buildSettings</key>
+			<dict>
+			</dict>
+			<key>baseConfigurationReference</key>
+			<string>1DD70E29947CAF1C00000000</string>
+		</dict>
 		<key>49524373A439BFE700000000</key>
 		<dict>
 			<key>isa</key>
@@ -175,6 +201,7 @@
 			<key>buildConfigurations</key>
 			<array>
 				<string>4952437303EDA63300000000</string>
+				<string>4952437350C7218900000000</string>
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
@@ -211,6 +238,16 @@
 			<dict>
 			</dict>
 		</dict>
+		<key>4952437350C7218900000001</key>
+		<dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Profile</string>
+			<key>buildSettings</key>
+			<dict>
+			</dict>
+		</dict>
 		<key>49524373A439BFE700000001</key>
 		<dict>
 			<key>isa</key>
@@ -228,6 +265,7 @@
 			<key>buildConfigurations</key>
 			<array>
 				<string>4952437303EDA63300000001</string>
+				<string>4952437350C7218900000001</string>
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_with_apple_bundle_test/.buckconfig
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_with_apple_bundle_test/.buckconfig
@@ -1,0 +1,15 @@
+[cxx]
+  default_platform = macosx-x86_64
+  cflags = -g -std=c11
+  cxxflags = -g -std=c++14
+
+[alias]
+  app = //:binary
+
+[project]
+  ide = xcode
+  ignore = .buckd, \
+           .hg, \
+           .git, \
+           buck-out, \
+

--- a/test/com/facebook/buck/features/apple/project/testdata/project_with_apple_bundle_test/app/AppDelegate.h
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_with_apple_bundle_test/app/AppDelegate.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
+ *
+ * The examples provided by Facebook are for non-commercial testing and evaluation
+ * purposes only. Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import <Cocoa/Cocoa.h>
+
+@interface AppDelegate : NSObject <NSApplicationDelegate>
+
+@end

--- a/test/com/facebook/buck/features/apple/project/testdata/project_with_apple_bundle_test/app/AppDelegate.m
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_with_apple_bundle_test/app/AppDelegate.m
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
+ *
+ * The examples provided by Facebook are for non-commercial testing and evaluation
+ * purposes only. Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import "AppDelegate.h"
+
+@interface AppDelegate () <NSMenuDelegate>
+
+@property (nonatomic) NSWindow *window;
+
+@end
+
+
+@implementation AppDelegate
+
+- (void)applicationDidFinishLaunching:(NSNotification *)aNotification
+{
+    self.window = [[[NSApplication sharedApplication] windows] firstObject];
+    self.window.title = NSBundle.mainBundle.infoDictionary[(NSString *)kCFBundleNameKey];
+}
+
+@end

--- a/test/com/facebook/buck/features/apple/project/testdata/project_with_apple_bundle_test/app/BUCK.fixture
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_with_apple_bundle_test/app/BUCK.fixture
@@ -1,0 +1,42 @@
+apple_bundle(
+    name = "bundle",
+    binary = ":binary",
+    extension = "app",
+    info_plist = "Info.plist",
+    tests = [
+        ':barTests'
+    ]
+)
+
+apple_binary(
+    name = "binary",
+    srcs = glob([
+        "*.m",
+    ]),
+    compiler_flags = ["-Wno-objc-designated-initializers"],
+    frameworks = [
+        "$SDKROOT/System/Library/Frameworks/Foundation.framework",
+        "$SDKROOT/System/Library/Frameworks/Cocoa.framework",
+    ],
+    headers = glob([
+        "*.h",
+    ]),
+    preprocessor_flags = ["-fobjc-arc"],
+)
+
+apple_test(
+    name = 'barTests',
+    info_plist = 'tests/Info.plist',
+    test_host_app = ':bundle',
+    headers = glob([
+        'tests/*.h',
+    ]),
+    srcs = glob([
+        'tests/*.m',
+    ]),
+    frameworks = [
+        '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+        '$SDKROOT/System/Library/Frameworks/Cocoa.framework',
+        '$PLATFORM_DIR/Developer/Library/Frameworks/XCTest.framework',
+    ],
+)

--- a/test/com/facebook/buck/features/apple/project/testdata/project_with_apple_bundle_test/app/Info.plist
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_with_apple_bundle_test/app/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.foo.bar</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.10</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_with_apple_bundle_test/app/Utility.h
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_with_apple_bundle_test/app/Utility.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
+ *
+ * The examples provided by Facebook are for non-commercial testing and evaluation
+ * purposes only. Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface Utility: NSObject
+
+-(NSString*) barString;
+
+@end

--- a/test/com/facebook/buck/features/apple/project/testdata/project_with_apple_bundle_test/app/Utility.m
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_with_apple_bundle_test/app/Utility.m
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
+ *
+ * The examples provided by Facebook are for non-commercial testing and evaluation
+ * purposes only. Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import "Utility.h"
+
+@implementation Utility
+
+-(NSString*) barString {
+    return @"bar";
+}
+
+@end

--- a/test/com/facebook/buck/features/apple/project/testdata/project_with_apple_bundle_test/app/main.m
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_with_apple_bundle_test/app/main.m
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
+ *
+ * The examples provided by Facebook are for non-commercial testing and evaluation
+ * purposes only. Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import <Cocoa/Cocoa.h>
+#import <AppDelegate.h>
+
+int main(int argc, const char *argv[])
+{
+    AppDelegate *appDelegate = [AppDelegate new];
+    NSApplication.sharedApplication.delegate = appDelegate;
+    
+    return NSApplicationMain(argc, argv);
+}

--- a/test/com/facebook/buck/features/apple/project/testdata/project_with_apple_bundle_test/app/tests/BarTests.m
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_with_apple_bundle_test/app/tests/BarTests.m
@@ -1,0 +1,22 @@
+//
+//  Copyright (c) 2016-2018 Uber Technologies, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import <Utility.h>
+
+@interface BarTests : XCTestCase
+
+@end
+
+
+@implementation BarTests
+
+- (void)testBarString
+{
+    Utility *utility = [[Utility alloc] init];
+    XCTAssertTrue([[utility barString] isEqualToString:@"bar"], @"Test should have access to binary sources");
+}
+
+@end

--- a/test/com/facebook/buck/features/apple/project/testdata/project_with_apple_bundle_test/app/tests/Info.plist
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_with_apple_bundle_test/app/tests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.facebook.demoAppTest</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_with_unique_library_names/Apps/Apps.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_with_unique_library_names/Apps/Apps.xcodeproj/project.pbxproj.expected
@@ -24,6 +24,19 @@
 			<key>explicitFileType</key>
 			<string>text.xcconfig</string>
 		</dict>
+		<key>1DD70E295DE482B000000000</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>TestApp-Profile.xcconfig</string>
+			<key>path</key>
+			<string>../buck-out/gen/Apps/TestApp-Profile.xcconfig</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>explicitFileType</key>
+			<string>text.xcconfig</string>
+		</dict>
 		<key>1DD70E29D17B2E1200000000</key>
 		<dict>
 			<key>isa</key>
@@ -48,6 +61,7 @@
 			<key>children</key>
 			<array>
 				<string>1DD70E29E4B004C600000000</string>
+				<string>1DD70E295DE482B000000000</string>
 				<string>1DD70E29D17B2E1200000000</string>
 			</array>
 		</dict>
@@ -265,6 +279,18 @@
 			<key>baseConfigurationReference</key>
 			<string>1DD70E29E4B004C600000000</string>
 		</dict>
+		<key>4952437350C7218900000000</key>
+		<dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Profile</string>
+			<key>buildSettings</key>
+			<dict>
+			</dict>
+			<key>baseConfigurationReference</key>
+			<string>1DD70E295DE482B000000000</string>
+		</dict>
 		<key>49524373A439BFE700000000</key>
 		<dict>
 			<key>isa</key>
@@ -284,6 +310,7 @@
 			<key>buildConfigurations</key>
 			<array>
 				<string>4952437303EDA63300000000</string>
+				<string>4952437350C7218900000000</string>
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
@@ -322,6 +349,16 @@
 			<dict>
 			</dict>
 		</dict>
+		<key>4952437350C7218900000001</key>
+		<dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Profile</string>
+			<key>buildSettings</key>
+			<dict>
+			</dict>
+		</dict>
 		<key>49524373A439BFE700000001</key>
 		<dict>
 			<key>isa</key>
@@ -339,6 +376,7 @@
 			<key>buildConfigurations</key>
 			<array>
 				<string>4952437303EDA63300000001</string>
+				<string>4952437350C7218900000001</string>
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_with_unique_library_names/Libraries/Libraries.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_with_unique_library_names/Libraries/Libraries.xcodeproj/project.pbxproj.expected
@@ -24,6 +24,19 @@
 			<key>explicitFileType</key>
 			<string>text.xcconfig</string>
 		</dict>
+		<key>1DD70E29CFEACCFD00000000</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>Dep1-Profile.xcconfig</string>
+			<key>path</key>
+			<string>../buck-out/gen/Libraries/Dep1-Profile.xcconfig</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>explicitFileType</key>
+			<string>text.xcconfig</string>
+		</dict>
 		<key>1DD70E294381785F00000000</key>
 		<dict>
 			<key>isa</key>
@@ -45,6 +58,19 @@
 			<string>Dep2-Debug.xcconfig</string>
 			<key>path</key>
 			<string>../buck-out/gen/Libraries/Dep2-Debug.xcconfig</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>explicitFileType</key>
+			<string>text.xcconfig</string>
+		</dict>
+		<key>1DD70E29947CAF1C00000000</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>Dep2-Profile.xcconfig</string>
+			<key>path</key>
+			<string>../buck-out/gen/Libraries/Dep2-Profile.xcconfig</string>
 			<key>sourceTree</key>
 			<string>SOURCE_ROOT</string>
 			<key>explicitFileType</key>
@@ -74,8 +100,10 @@
 			<key>children</key>
 			<array>
 				<string>1DD70E294C6E7E5300000000</string>
+				<string>1DD70E29CFEACCFD00000000</string>
 				<string>1DD70E294381785F00000000</string>
 				<string>1DD70E292E005C3200000000</string>
+				<string>1DD70E29947CAF1C00000000</string>
 				<string>1DD70E2908135A7E00000000</string>
 			</array>
 		</dict>
@@ -282,6 +310,18 @@
 			<key>baseConfigurationReference</key>
 			<string>1DD70E294C6E7E5300000000</string>
 		</dict>
+		<key>4952437350C7218900000000</key>
+		<dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Profile</string>
+			<key>buildSettings</key>
+			<dict>
+			</dict>
+			<key>baseConfigurationReference</key>
+			<string>1DD70E29CFEACCFD00000000</string>
+		</dict>
 		<key>49524373A439BFE700000000</key>
 		<dict>
 			<key>isa</key>
@@ -301,6 +341,7 @@
 			<key>buildConfigurations</key>
 			<array>
 				<string>4952437303EDA63300000000</string>
+				<string>4952437350C7218900000000</string>
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
@@ -356,6 +397,18 @@
 			<key>baseConfigurationReference</key>
 			<string>1DD70E292E005C3200000000</string>
 		</dict>
+		<key>4952437350C7218900000001</key>
+		<dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Profile</string>
+			<key>buildSettings</key>
+			<dict>
+			</dict>
+			<key>baseConfigurationReference</key>
+			<string>1DD70E29947CAF1C00000000</string>
+		</dict>
 		<key>49524373A439BFE700000001</key>
 		<dict>
 			<key>isa</key>
@@ -375,6 +428,7 @@
 			<key>buildConfigurations</key>
 			<array>
 				<string>4952437303EDA63300000001</string>
+				<string>4952437350C7218900000001</string>
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
@@ -412,6 +466,16 @@
 			<dict>
 			</dict>
 		</dict>
+		<key>4952437350C7218900000002</key>
+		<dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Profile</string>
+			<key>buildSettings</key>
+			<dict>
+			</dict>
+		</dict>
 		<key>49524373A439BFE700000002</key>
 		<dict>
 			<key>isa</key>
@@ -429,6 +493,7 @@
 			<key>buildConfigurations</key>
 			<array>
 				<string>4952437303EDA63300000002</string>
+				<string>4952437350C7218900000002</string>
 				<string>49524373A439BFE700000002</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>

--- a/test/com/facebook/buck/features/apple/project/testdata/target_using_genrule_source/lib/lib.xcworkspace/buck-project.meta.json.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/target_using_genrule_source/lib/lib.xcworkspace/buck-project.meta.json.expected
@@ -1,1 +1,1 @@
-{"required-targets":["other_cell//:gen","//lib:gen"],"xcconfig-paths":["buck-out/gen/lib/lib#default,static-Debug.xcconfig","buck-out/gen/lib/lib#default,static-Release.xcconfig"],"copy-in-xcode":[]}
+{"required-targets":["other_cell//:gen","//lib:gen"],"xcconfig-paths":["buck-out/gen/lib/lib#default,static-Debug.xcconfig","buck-out/gen/lib/lib#default,static-Profile.xcconfig","buck-out/gen/lib/lib#default,static-Release.xcconfig"],"copy-in-xcode":[]}


### PR DESCRIPTION
Adds some common settings that makes sense for Debug config, including:
- 'DEAD_CODE_STRIPPING': 'NO'
- 'ONLY_ACTIVE_ARCH': 'YES'
- 'GCC_SYMBOLS_PRIVATE_EXTERN': 'NO'

Also fix the issue where default flags are wiped out if user defined custom project configs in the target level.

With the old approach (user defined config override the default configs), Buck have no context which config is the debug version, so now default configs are merged with the user-defined ones, with debug having the extra flags above.