### PR TITLE
Reordering extraClasspath dependencies ahead of module dependencies 

### DIFF
--- a/test/com/facebook/buck/features/project/intellij/testdata/project_with_android_resources/modules/dep2/modules_dep2.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/project_with_android_resources/modules/dep2/modules_dep2.iml.expected
@@ -25,7 +25,7 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="module" module-name="modules_dep1" scope="COMPILE" />
     <orderEntry type="library" name="library_modules_dep2_extra_classpath" scope="COMPILE" level="project" />
+    <orderEntry type="module" module-name="modules_dep1" scope="COMPILE" />
   </component>
 </module>


### PR DESCRIPTION
In order to prevent Intellij from picking the first incorrect `R.class` file from the module dependencies, we need to move its own `extraClasspath` dependencies higher than external modules such that the first lookup of `R.class` will come from the module's generated directory.

This is required for support layout-preview with BUCK in Intellij.