### PR TITLE
Fix incorrect regex match check in AbstractLocationMacro

### DIFF
--- a/src/com/facebook/buck/rules/macros/AbstractLocationMacro.java
+++ b/src/com/facebook/buck/rules/macros/AbstractLocationMacro.java
@@ -16,6 +16,7 @@
 
 package com.facebook.buck.rules.macros;
 
+import com.facebook.buck.core.exceptions.HumanReadableException;
 import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.util.immutables.BuckStyleTuple;
 import com.google.common.annotations.VisibleForTesting;
@@ -77,8 +78,10 @@ abstract class AbstractLocationMacro extends BuildTargetMacro {
    */
   public static SplitResult splitSupplementaryOutputPart(String targetish) {
     Matcher matcher = BUILD_TARGET_WITH_SUPPLEMENTARY_OUTPUT_PATTERN.matcher(targetish);
-    String outputNamePart = matcher.matches() ? matcher.group("output") : null;
-    return new SplitResult(matcher.group("target"), Optional.ofNullable(outputNamePart));
+    if (!matcher.matches()) {
+      throw new HumanReadableException(String.format("Cannot parse build target: %s", targetish));
+    }
+    return new SplitResult(matcher.group("target"), Optional.ofNullable(matcher.group("output")));
   }
 
   /** Result object of {@link #splitSupplementaryOutputPart}. */

--- a/test/com/facebook/buck/rules/macros/AbstractLocationMacroTest.java
+++ b/test/com/facebook/buck/rules/macros/AbstractLocationMacroTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.rules.macros;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+import com.facebook.buck.core.exceptions.HumanReadableException;
+import java.util.Optional;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+public class AbstractLocationMacroTest {
+  @Test
+  public void testSplitParsableBuildTarget() {
+    assertThat(
+        AbstractLocationMacro.splitSupplementaryOutputPart("target[sup]").target,
+        Matchers.equalTo("target"));
+    assertThat(
+        AbstractLocationMacro.splitSupplementaryOutputPart("target[sup]").supplementaryOutput,
+        Matchers.equalTo(Optional.of("sup")));
+    assertThat(
+        AbstractLocationMacro.splitSupplementaryOutputPart("target").target,
+        Matchers.equalTo("target"));
+    assertThat(
+        AbstractLocationMacro.splitSupplementaryOutputPart("target").supplementaryOutput,
+        Matchers.equalTo(Optional.empty()));
+  }
+
+  @Test
+  public void testSplitUnparsableBuildTarget() {
+    try {
+      AbstractLocationMacro.splitSupplementaryOutputPart("");
+      fail("Expected a HumanReadableException");
+    } catch (HumanReadableException e) {
+      assertThat(
+          e.getMessage(),
+          Matchers.startsWith("Cannot parse build target"));
+    }
+  }
+}


### PR DESCRIPTION
The existing code will throw IllegalStateException if the match was unsuccessful: https://docs.oracle.com/javase/7/docs/api/java/util/regex/Matcher.html#group(java.lang.String) The check matcher.matches() in line 80 does nothing: if the match succeeded but the supplementary part is absent, matcher.group("output") will return null anyway.
