### PR TITLE
Modify binary jar for prebuilt aars to come from unzip aar directory

### DIFF
--- a/src/com/facebook/buck/features/project/intellij/DefaultIjLibraryFactory.java
+++ b/src/com/facebook/buck/features/project/intellij/DefaultIjLibraryFactory.java
@@ -24,7 +24,6 @@ import com.facebook.buck.core.model.targetgraph.DescriptionWithTargetGraph;
 import com.facebook.buck.core.model.targetgraph.TargetNode;
 import com.facebook.buck.core.sourcepath.DefaultBuildTargetSourcePath;
 import com.facebook.buck.core.sourcepath.PathSourcePath;
-import com.facebook.buck.core.sourcepath.SourcePath;
 import com.facebook.buck.features.project.intellij.model.IjLibrary;
 import com.facebook.buck.features.project.intellij.model.IjLibraryFactory;
 import com.facebook.buck.features.project.intellij.model.IjLibraryFactoryResolver;
@@ -152,9 +151,6 @@ class DefaultIjLibraryFactory extends IjLibraryFactory {
     @Override
     public void apply(
         TargetNode<AndroidPrebuiltAarDescriptionArg> targetNode, IjLibrary.Builder library) {
-      Optional<SourcePath> libraryPath = libraryFactoryResolver.getPathIfJavaLibrary(targetNode);
-      libraryPath.ifPresent(path -> library.addBinaryJars(libraryFactoryResolver.getPath(path)));
-
       AndroidPrebuiltAarDescriptionArg arg = targetNode.getConstructorArg();
       arg.getSourceJar()
           .ifPresent(
@@ -172,6 +168,7 @@ class DefaultIjLibraryFactory extends IjLibraryFactory {
       // Based on https://developer.android.com/studio/projects/android-library.html#aar-contents,
       // the AAR library is required to have a resources folder.
       library.addClassPaths(Paths.get(aarUnpackPath.toString(), "res"));
+      library.addBinaryJars(Paths.get(aarUnpackPath.toString(), "classes.jar"));
     }
   }
 

--- a/test/com/facebook/buck/features/project/intellij/DefaultIjLibraryFactoryTest.java
+++ b/test/com/facebook/buck/features/project/intellij/DefaultIjLibraryFactoryTest.java
@@ -81,7 +81,7 @@ public class DefaultIjLibraryFactoryTest {
             .addDep(guava.getBuildTarget())
             .build();
 
-    androidSupportBinaryJarPath = FakeSourcePath.of("buck_out/support.aar/classes.jar");
+    androidSupportBinaryJarPath = FakeSourcePath.of("buck-out/bin/third_party/java/support/__unpack_support#aar_unzip__/classes.jar");
     androidSupportResClassPath =
         FakeSourcePath.of("buck-out/bin/third_party/java/support/__unpack_support#aar_unzip__/res");
     baseOutputPath = FakeSourcePath.of("buck-out/base.jar");

--- a/test/com/facebook/buck/features/project/intellij/DefaultIjModuleFactoryTest.java
+++ b/test/com/facebook/buck/features/project/intellij/DefaultIjModuleFactoryTest.java
@@ -625,7 +625,7 @@ public class DefaultIjModuleFactoryTest {
 
   @Test
   public void testAndroidPrebuiltAar() {
-    SourcePath androidSupportBinaryPath = FakeSourcePath.of("third_party/java/support/support.aar");
+    SourcePath androidSupportBinaryPath = FakeSourcePath.of("buck-out/bin/third_party/java/support/__unpack_support#aar_unzip__/classes.jar");
     Path androidSupportSourcesPath = Paths.get("third_party/java/support/support-sources.jar");
     String androidSupportJavadocUrl = "file:///support/docs";
     TargetNode<?> androidPrebuiltAar =


### PR DESCRIPTION
When running buck project, `res` folder is available from the unzipped aar directory already. This modifies the path to `classes.jar` to also come from the same location and avoid having to build a separate flavor of android_prebuilt_aar

This change is required to support Android Layout Preview in buck project and intellij