### PR TITLE
Change dummy r dot java extra classpath to point to jars

### DIFF
--- a/src/com/facebook/buck/android/DummyRDotJava.java
+++ b/src/com/facebook/buck/android/DummyRDotJava.java
@@ -370,7 +370,7 @@ public class DummyRDotJava extends AbstractBuildRule
     return BuildTargetPaths.getGenPath(filesystem, buildTarget, "__%s_dummyrdotjava_output__");
   }
 
-  private static Path getOutputJarPath(BuildTarget buildTarget, ProjectFilesystem filesystem) {
+  public static Path getOutputJarPath(BuildTarget buildTarget, ProjectFilesystem filesystem) {
     return getPathToOutputDir(buildTarget, filesystem)
         .resolve(String.format("%s.jar", buildTarget.getShortNameAndFlavorPostfix()));
   }

--- a/src/com/facebook/buck/features/project/intellij/DefaultIjModuleFactoryResolver.java
+++ b/src/com/facebook/buck/features/project/intellij/DefaultIjModuleFactoryResolver.java
@@ -71,7 +71,7 @@ class DefaultIjModuleFactoryResolver implements IjModuleFactoryResolver {
     if (dummyRDotJavaRule.isPresent()) {
       requiredBuildTargets.add(dummyRDotJavaTarget);
       return Optional.of(
-          DummyRDotJava.getRDotJavaBinFolder(dummyRDotJavaTarget, projectFilesystem));
+          DummyRDotJava.getOutputJarPath(dummyRDotJavaTarget, projectFilesystem));
     }
     return Optional.empty();
   }

--- a/src/com/facebook/buck/features/project/intellij/IjModuleGraphFactory.java
+++ b/src/com/facebook/buck/features/project/intellij/IjModuleGraphFactory.java
@@ -293,7 +293,7 @@ public final class IjModuleGraphFactory {
       if (!module.getExtraClassPathDependencies().isEmpty()) {
         IjLibrary extraClassPathLibrary =
             IjLibrary.builder()
-                .setClassPaths(module.getExtraClassPathDependencies())
+                .setBinaryJars(module.getExtraClassPathDependencies())
                 .setTargets(ImmutableSet.of())
                 .setName("library_" + module.getName() + "_extra_classpath")
                 .build();

--- a/test/com/facebook/buck/features/project/intellij/IjModuleGraphTest.java
+++ b/test/com/facebook/buck/features/project/intellij/IjModuleGraphTest.java
@@ -485,7 +485,7 @@ public class IjModuleGraphTest {
         FluentIterable.from(moduleGraph.getNodes()).filter(IjLibrary.class).first().get();
 
     assertEquals(ImmutableSet.of(rDotJavaClassPath), productModule.getExtraClassPathDependencies());
-    assertEquals(ImmutableSet.of(rDotJavaClassPath), rDotJavaLibrary.getClassPaths());
+    assertEquals(ImmutableSet.of(rDotJavaClassPath), rDotJavaLibrary.getBinaryJars());
     assertEquals(
         moduleGraph.getDependentLibrariesFor(productModule),
         ImmutableMap.of(rDotJavaLibrary, DependencyType.PROD));

--- a/test/com/facebook/buck/features/project/intellij/ProjectIntegrationTest.java
+++ b/test/com/facebook/buck/features/project/intellij/ProjectIntegrationTest.java
@@ -150,6 +150,7 @@ public class ProjectIntegrationTest {
     runBuckProjectAndVerify("project_with_java_resources");
   }
 
+  @Test
   public void testVersion2BuckProjectWithExtraOutputModules()
       throws InterruptedException, IOException {
     runBuckProjectAndVerify("project_with_extra_output_modules");

--- a/test/com/facebook/buck/features/project/intellij/testdata/android_resources_in_the_same_folder/.idea/libraries/library_modules_dep1_extra_classpath.xml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/android_resources_in_the_same_folder/.idea/libraries/library_modules_dep1_extra_classpath.xml.expected
@@ -1,7 +1,7 @@
 <component name="libraryTable">
   <library name="library_modules_dep1_extra_classpath">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/buck-out/bin/modules/dep1/lib__dep2#dummy_r_dot_java__scratch/classes" />
+      <root url="jar://$PROJECT_DIR$/buck-out/gen/modules/dep1/__dep2#dummy_r_dot_java_dummyrdotjava_output__/dep2#dummy_r_dot_java.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES />

--- a/test/com/facebook/buck/features/project/intellij/testdata/project_with_android_resources/.idea/libraries/library_modules_dep2_extra_classpath.xml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/project_with_android_resources/.idea/libraries/library_modules_dep2_extra_classpath.xml.expected
@@ -1,8 +1,8 @@
 <component name="libraryTable">
   <library name="library_modules_dep2_extra_classpath">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/buck-out/bin/modules/dep2/lib__dep2#dummy_r_dot_java__scratch/classes" />
-      <root url="file://$PROJECT_DIR$/buck-out/bin/modules/dep2/lib__dep3#dummy_r_dot_java__scratch/classes" />
+      <root url="jar://$PROJECT_DIR$/buck-out/gen/modules/dep2/__dep2#dummy_r_dot_java_dummyrdotjava_output__/dep2#dummy_r_dot_java.jar!/" />
+      <root url="jar://$PROJECT_DIR$/buck-out/gen/modules/dep2/__dep3#dummy_r_dot_java_dummyrdotjava_output__/dep3#dummy_r_dot_java.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES />

--- a/test/com/facebook/buck/features/project/intellij/testdata/project_with_extra_output_modules/.idea/libraries/library_modules_dep1_extra_classpath.xml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/project_with_extra_output_modules/.idea/libraries/library_modules_dep1_extra_classpath.xml.expected
@@ -1,7 +1,7 @@
 <component name="libraryTable">
   <library name="library_modules_dep1_extra_classpath">
     <CLASSES>
-      <root url="file://$PROJECT_DIR$/buck-out/bin/modules/dep1/__dep2#dummy_r_dot_java_rdotjava_bin__" />
+      <root url="jar://$PROJECT_DIR$/buck-out/gen/modules/dep1/__dep2#dummy_r_dot_java_dummyrdotjava_output__/dep2#dummy_r_dot_java.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES />

--- a/test/com/facebook/buck/features/project/intellij/testdata/project_with_extra_output_modules/project_root.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/project_with_extra_output_modules/project_root.iml.expected
@@ -3,6 +3,7 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/buck-out/.trash" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/buck-out/bin" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/buck-out/log" isTestSource="false" />
     </content>


### PR DESCRIPTION
Currently, buck project points the dummy r dot java output in the iml to the scratch directory. This is not always available especially when the outputs are materialized from the network cache. This changes the behavior to point to the final jar instead which will make sure the R classes can be found in all cases (from network, local build with both variations of `jar_spool_mode`).

This change is required to support Android Layout Preview in buck project and intellij.