### PR TITLE
Fix RES_FOLDERS_RELATIVE_PATH to be actually relative

### DIFF
--- a/src/com/facebook/buck/features/project/intellij/IjProjectPaths.java
+++ b/src/com/facebook/buck/features/project/intellij/IjProjectPaths.java
@@ -71,6 +71,21 @@ public class IjProjectPaths {
     return getModuleDir(module).relativize(path);
   }
 
+  /**
+   * @param path path to folder.
+   * @param moduleLocationBasePath path to the location of the .iml file.
+   * @return a path, relative to the module .iml file location describing a folder without the
+   *     IntelliJ format.
+   */
+  static String toRelativeString(Path path, Path moduleLocationBasePath) {
+    String moduleRelativePath = moduleLocationBasePath.relativize(path).toString();
+    if (moduleRelativePath.isEmpty()) {
+      return "";
+    } else {
+      return "/" + MorePaths.pathWithUnixSeparators(moduleRelativePath);
+    }
+  }
+
   /** @return path relative to project root, prefixed with $PROJECT_DIR$ */
   public String getProjectQualifiedPath(Path path) {
     String projectRelativePath = MorePaths.pathWithUnixSeparators(getProjectRelativePath(path));

--- a/src/com/facebook/buck/features/project/intellij/IjProjectTemplateDataPreparer.java
+++ b/src/com/facebook/buck/features/project/intellij/IjProjectTemplateDataPreparer.java
@@ -496,7 +496,7 @@ public class IjProjectTemplateDataPreparer {
       Set<String> relativeResourcePaths = new HashSet<>(resourcePaths.size());
       for (Path resourcePath : resourcePaths) {
         relativeResourcePaths.add(
-            getUrl(projectPaths.getModuleQualifiedPath(resourcePath, module)));
+            IjProjectPaths.toRelativeString(resourcePath, module.getModuleBasePath()));
       }
 
       androidProperties.put(

--- a/test/com/facebook/buck/features/project/intellij/testdata/aggregation_with_custom_packages/java/default/dep1/android_res/java_default_dep1_android_res.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/aggregation_with_custom_packages/java/default/dep1/android_res/java_default_dep1_android_res.iml.expected
@@ -5,7 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../../../buck-out/android/java/default/dep1/android_res/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../../../buck-out/android/java/default/dep1/android_res/gen" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/../../../../buck-out/gen/java/default/dep1/android_res/android_res#resources-symlink-tree/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/../../../../buck-out/gen/java/default/dep1/android_res/android_res#resources-symlink-tree/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/android_resource_aggregation/modules/android_res_custom_package/modules_android_res_custom_package.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/android_resource_aggregation/modules/android_res_custom_package/modules_android_res_custom_package.iml.expected
@@ -6,7 +6,7 @@
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/android_res_custom_package/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/android_res_custom_package/gen" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/android_resource_aggregation/modules/modules.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/android_resource_aggregation/modules/modules.iml.expected
@@ -6,7 +6,7 @@
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../buck-out/android/modules/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../buck-out/android/modules/gen" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/android_res2/res;file://$MODULE_DIR$/android_res1/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/android_res1/res;/android_res2/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/android_resource_aggregation_with_limit/modules/android_res_custom_package/modules_android_res_custom_package.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/android_resource_aggregation_with_limit/modules/android_res_custom_package/modules_android_res_custom_package.iml.expected
@@ -6,7 +6,7 @@
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/android_res_custom_package/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/android_res_custom_package/gen" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/android_resource_aggregation_with_limit/modules/modules.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/android_resource_aggregation_with_limit/modules/modules.iml.expected
@@ -6,7 +6,7 @@
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../buck-out/android/modules/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../buck-out/android/modules/gen" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/android_res2/res;file://$MODULE_DIR$/android_res3/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/android_res3/res;/android_res2/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/android_resources_in_the_same_folder/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/android_resources_in_the_same_folder/modules/dep1/modules_dep1.iml.expected
@@ -5,7 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/proj-res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/proj-res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/create_new_workspace/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/create_new_workspace/modules/dep1/modules_dep1.iml.expected
@@ -5,7 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/generate_android_manifest/modules/android_res1/modules_android_res1.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/generate_android_manifest/modules/android_res1/modules_android_res1.iml.expected
@@ -7,7 +7,7 @@
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/android_res1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/android_res1/gen" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/../../buck-out/android/modules/android_res1/gen/com/test/AndroidManifest.xml" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/generate_android_manifest/modules/android_res2/modules_android_res2.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/generate_android_manifest/modules/android_res2/modules_android_res2.iml.expected
@@ -7,7 +7,7 @@
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/android_res2/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/android_res2/gen" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/../../buck-out/android/modules/android_res2/gen/com/test/AndroidManifest.xml" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/generate_android_manifest/modules/android_res_custom_package/modules_android_res_custom_package.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/generate_android_manifest/modules/android_res_custom_package/modules_android_res_custom_package.iml.expected
@@ -7,7 +7,7 @@
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/android_res_custom_package/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/android_res_custom_package/gen" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/../../buck-out/android/modules/android_res_custom_package/gen/com/test/custom/AndroidManifest.xml" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/ignored_excluded/android_res/android_res.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/ignored_excluded/android_res/android_res.iml.expected
@@ -5,7 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../buck-out/android/android_res/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../buck-out/android/android_res/gen" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/../buck-out/gen/android_res/android_res#resources-symlink-tree/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/../buck-out/gen/android_res/android_res#resources-symlink-tree/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/imls_in_idea/.idea/modules/android_app_lib.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/imls_in_idea/.idea/modules/android_app_lib.iml.expected
@@ -6,7 +6,7 @@
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/android/app/lib/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/android/app/lib/gen" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/../../android/app/lib/AndroidManifest.xml" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/../../buck-out/gen/android/app/lib/res#resources-symlink-tree/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/../../../buck-out/gen/android/app/lib/res#resources-symlink-tree/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/project_with_android_resources/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/project_with_android_resources/modules/dep1/modules_dep1.iml.expected
@@ -5,7 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/proj-res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/proj-res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/project_with_excluded_resources/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/project_with_excluded_resources/modules/dep1/modules_dep1.iml.expected
@@ -5,7 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/project_with_extra_output_modules/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/project_with_extra_output_modules/modules/dep1/modules_dep1.iml.expected
@@ -5,7 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/../../buck-out/gen/modules/dep1/dep1#resources-symlink-tree/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/../../buck-out/gen/modules/dep1/dep1#resources-symlink-tree/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/project_with_multiple_resources_with_package_names/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/project_with_multiple_resources_with_package_names/modules/dep1/modules_dep1.iml.expected
@@ -5,7 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/proj-res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/proj-res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/project_with_subdir_glob_resources/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/project_with_subdir_glob_resources/modules/dep1/modules_dep1.iml.expected
@@ -5,7 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/proj-res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/proj-res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/project_with_subdir_glob_resources/modules/dep2/modules_dep2.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/project_with_subdir_glob_resources/modules/dep2/modules_dep2.iml.expected
@@ -5,7 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep2/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep2/gen" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/../../buck-out/gen/modules/dep2/dep2#resources-symlink-tree/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/../../buck-out/gen/modules/dep2/dep2#resources-symlink-tree/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/save_generated_files_list/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/save_generated_files_list/modules/dep1/modules_dep1.iml.expected
@@ -5,7 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/update_existing_workspace/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/update_existing_workspace/modules/dep1/modules_dep1.iml.expected
@@ -5,7 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/update_malformed_workspace/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/update_malformed_workspace/modules/dep1/modules_dep1.iml.expected
@@ -5,7 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/update_workspace_without_ignored_nodes/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/update_workspace_without_ignored_nodes/modules/dep1/modules_dep1.iml.expected
@@ -5,7 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/update_workspace_without_manager_node/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/update_workspace_without_manager_node/modules/dep1/modules_dep1.iml.expected
@@ -5,7 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />

--- a/test/com/facebook/buck/features/project/intellij/testdata/update_workspace_without_project_node/modules/dep1/modules_dep1.iml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/update_workspace_without_project_node/modules/dep1/modules_dep1.iml.expected
@@ -5,7 +5,7 @@
       <configuration>
         <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/../../buck-out/android/modules/dep1/gen" />
         <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/../../buck-out/android/modules/dep1/gen" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="/res" />
         <option name="LIBRARY_PROJECT" value="true" />
         <option name="PROJECT_TYPE" value="1" />
         <option name="UPDATE_PROPERTY_FILES" value="false" />


### PR DESCRIPTION
This changes the behavior of buck project to correctly set the `RES_FOLDERS_RELATIVE_PATH` value to be relative to the module. The android intellij plugin expects a proper relative path and does not work when macros like `$MODULE_DIR` etc. are prepended to the path.

This change is required to support Android Layout Preview in buck project and intellij.