### PR TITLE
Fix default swift version fallback

### DIFF
--- a/src/com/facebook/buck/apple/AppleLibraryDescriptionSwiftEnhancer.java
+++ b/src/com/facebook/buck/apple/AppleLibraryDescriptionSwiftEnhancer.java
@@ -67,7 +67,11 @@ public class AppleLibraryDescriptionSwiftEnhancer {
     SourcePathRuleFinder rulePathFinder = new SourcePathRuleFinder(graphBuilder);
     SwiftLibraryDescriptionArg.Builder delegateArgsBuilder = SwiftLibraryDescriptionArg.builder();
     SwiftDescriptions.populateSwiftLibraryDescriptionArg(
-        DefaultSourcePathResolver.from(rulePathFinder), delegateArgsBuilder, args, target);
+        swiftBuckConfig,
+        DefaultSourcePathResolver.from(rulePathFinder),
+        delegateArgsBuilder,
+        args,
+        target);
     SwiftLibraryDescriptionArg swiftArgs = delegateArgsBuilder.build();
 
     Preprocessor preprocessor = platform.getCpp().resolve(graphBuilder);

--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -1032,7 +1032,15 @@ public class ProjectGenerator {
   private Optional<String> getSwiftVersionForTargetNode(TargetNode<?> targetNode) {
     Optional<TargetNode<SwiftCommonArg>> targetNodeWithSwiftArgs =
         TargetNodes.castArg(targetNode, SwiftCommonArg.class);
-    return targetNodeWithSwiftArgs.flatMap(t -> t.getConstructorArg().getSwiftVersion());
+    Optional<String> targetExplicitSwiftVersion =
+        targetNodeWithSwiftArgs.flatMap(t -> t.getConstructorArg().getSwiftVersion());
+    if (!targetExplicitSwiftVersion.isPresent()
+        && (targetNode.getDescription() instanceof AppleLibraryDescription
+            || targetNode.getDescription() instanceof AppleBinaryDescription
+            || targetNode.getDescription() instanceof AppleTestDescription)) {
+      return swiftBuckConfig.getVersion();
+    }
+    return targetExplicitSwiftVersion;
   }
 
   private static String sourceNameRelativeToOutput(

--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -1032,15 +1032,7 @@ public class ProjectGenerator {
   private Optional<String> getSwiftVersionForTargetNode(TargetNode<?> targetNode) {
     Optional<TargetNode<SwiftCommonArg>> targetNodeWithSwiftArgs =
         TargetNodes.castArg(targetNode, SwiftCommonArg.class);
-    Optional<String> targetExplicitSwiftVersion =
-        targetNodeWithSwiftArgs.flatMap(t -> t.getConstructorArg().getSwiftVersion());
-    if (!targetExplicitSwiftVersion.isPresent()
-        && (targetNode.getDescription() instanceof AppleLibraryDescription
-            || targetNode.getDescription() instanceof AppleBinaryDescription
-            || targetNode.getDescription() instanceof AppleTestDescription)) {
-      return swiftBuckConfig.getVersion();
-    }
-    return targetExplicitSwiftVersion;
+    return targetNodeWithSwiftArgs.flatMap(t -> t.getConstructorArg().getSwiftVersion());
   }
 
   private static String sourceNameRelativeToOutput(

--- a/src/com/facebook/buck/swift/SwiftDescriptions.java
+++ b/src/com/facebook/buck/swift/SwiftDescriptions.java
@@ -56,6 +56,7 @@ public class SwiftDescriptions {
   }
 
   public static void populateSwiftLibraryDescriptionArg(
+      SwiftBuckConfig swiftBuckConfig,
       SourcePathResolver sourcePathResolver,
       SwiftLibraryDescriptionArg.Builder output,
       CxxLibraryDescription.CommonArg args,
@@ -64,8 +65,12 @@ public class SwiftDescriptions {
     output.setName(args.getName());
     output.setSrcs(filterSwiftSources(sourcePathResolver, args.getSrcs()));
     if (args instanceof SwiftCommonArg) {
+      Optional<String> swiftVersion = ((SwiftCommonArg) args).getSwiftVersion();
+      if (!swiftVersion.isPresent()) {
+        swiftVersion = swiftBuckConfig.getVersion();
+      }
       output.setCompilerFlags(((SwiftCommonArg) args).getSwiftCompilerFlags());
-      output.setVersion(((SwiftCommonArg) args).getSwiftVersion());
+      output.setVersion(swiftVersion);
     } else {
       output.setCompilerFlags(args.getCompilerFlags());
     }

--- a/src/com/facebook/buck/swift/SwiftLibraryDescription.java
+++ b/src/com/facebook/buck/swift/SwiftLibraryDescription.java
@@ -408,6 +408,7 @@ public class SwiftLibraryDescription
 
     SwiftLibraryDescriptionArg.Builder delegateArgsBuilder = SwiftLibraryDescriptionArg.builder();
     SwiftDescriptions.populateSwiftLibraryDescriptionArg(
+        swiftBuckConfig,
         DefaultSourcePathResolver.from(new SourcePathRuleFinder(graphBuilder)),
         delegateArgsBuilder,
         args,

--- a/test/com/facebook/buck/swift/SwiftDescriptionsTest.java
+++ b/test/com/facebook/buck/swift/SwiftDescriptionsTest.java
@@ -19,6 +19,8 @@ package com.facebook.buck.swift;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
+import com.facebook.buck.apple.AppleLibraryDescription;
+import com.facebook.buck.apple.AppleLibraryDescriptionArg;
 import com.facebook.buck.core.config.FakeBuckConfig;
 import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.model.BuildTargetFactory;
@@ -46,9 +48,9 @@ public class SwiftDescriptionsTest {
     BuildTarget buildTarget = BuildTargetFactory.newInstance("//foo:bar");
 
     SwiftLibraryDescriptionArg.Builder outputBuilder =
-        SwiftLibraryDescriptionArg.builder().setName("bar").setVersion("3");
+        SwiftLibraryDescriptionArg.builder();
 
-    CxxLibraryDescriptionArg.Builder args = CxxLibraryDescriptionArg.builder().setName("bar");
+    AppleLibraryDescriptionArg.Builder args = AppleLibraryDescriptionArg.builder().setName("bar");
 
     PathSourcePath swiftSrc = FakeSourcePath.of("foo/bar.swift");
 
@@ -59,7 +61,9 @@ public class SwiftDescriptionsTest {
     SwiftBuckConfig swiftBuckConfig =
         new SwiftBuckConfig(
             FakeBuckConfig.builder()
-                .setSections(ImmutableMap.of("swift", ImmutableMap.of("compiler_flags", "-g")))
+                .setSections(
+                    ImmutableMap.of(
+                        "swift", ImmutableMap.of("compiler_flags", "-g", "version", "3")))
                 .build());
 
     SwiftDescriptions.populateSwiftLibraryDescriptionArg(
@@ -67,13 +71,14 @@ public class SwiftDescriptionsTest {
     SwiftLibraryDescriptionArg output = outputBuilder.build();
     assertThat(output.getModuleName().get(), equalTo("bar"));
     assertThat(output.getSrcs(), equalTo(ImmutableSortedSet.<SourcePath>of(swiftSrc)));
+    assertThat(output.getVersion().get(), equalTo("3"));
 
-    args.setModuleName("baz");
+    args.setModuleName("baz").setSwiftVersion("4");
 
     SwiftDescriptions.populateSwiftLibraryDescriptionArg(
         swiftBuckConfig, pathResolver, outputBuilder, args.build(), buildTarget);
     output = outputBuilder.build();
     assertThat(output.getModuleName().get(), equalTo("baz"));
-    assertThat(output.getVersion().get(), equalTo("3"));
+    assertThat(output.getVersion().get(), equalTo("4"));
   }
 }

--- a/test/com/facebook/buck/swift/SwiftDescriptionsTest.java
+++ b/test/com/facebook/buck/swift/SwiftDescriptionsTest.java
@@ -19,7 +19,6 @@ package com.facebook.buck.swift;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import com.facebook.buck.apple.AppleLibraryDescription;
 import com.facebook.buck.apple.AppleLibraryDescriptionArg;
 import com.facebook.buck.core.config.FakeBuckConfig;
 import com.facebook.buck.core.model.BuildTarget;
@@ -33,7 +32,6 @@ import com.facebook.buck.core.sourcepath.SourcePath;
 import com.facebook.buck.core.sourcepath.SourceWithFlags;
 import com.facebook.buck.core.sourcepath.resolver.SourcePathResolver;
 import com.facebook.buck.core.sourcepath.resolver.impl.DefaultSourcePathResolver;
-import com.facebook.buck.cxx.CxxLibraryDescriptionArg;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
 import org.junit.Test;
@@ -47,8 +45,7 @@ public class SwiftDescriptionsTest {
         DefaultSourcePathResolver.from(new SourcePathRuleFinder(resolver));
     BuildTarget buildTarget = BuildTargetFactory.newInstance("//foo:bar");
 
-    SwiftLibraryDescriptionArg.Builder outputBuilder =
-        SwiftLibraryDescriptionArg.builder();
+    SwiftLibraryDescriptionArg.Builder outputBuilder = SwiftLibraryDescriptionArg.builder();
 
     AppleLibraryDescriptionArg.Builder args = AppleLibraryDescriptionArg.builder().setName("bar");
 

--- a/test/com/facebook/buck/swift/SwiftDescriptionsTest.java
+++ b/test/com/facebook/buck/swift/SwiftDescriptionsTest.java
@@ -19,6 +19,7 @@ package com.facebook.buck.swift;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
+import com.facebook.buck.core.config.FakeBuckConfig;
 import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.model.BuildTargetFactory;
 import com.facebook.buck.core.rules.BuildRuleResolver;
@@ -31,6 +32,7 @@ import com.facebook.buck.core.sourcepath.SourceWithFlags;
 import com.facebook.buck.core.sourcepath.resolver.SourcePathResolver;
 import com.facebook.buck.core.sourcepath.resolver.impl.DefaultSourcePathResolver;
 import com.facebook.buck.cxx.CxxLibraryDescriptionArg;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
 import org.junit.Test;
 
@@ -54,8 +56,14 @@ public class SwiftDescriptionsTest {
         ImmutableSortedSet.of(
             SourceWithFlags.of(FakeSourcePath.of("foo/foo.cpp")), SourceWithFlags.of(swiftSrc)));
 
+    SwiftBuckConfig swiftBuckConfig =
+        new SwiftBuckConfig(
+            FakeBuckConfig.builder()
+                .setSections(ImmutableMap.of("swift", ImmutableMap.of("compiler_flags", "-g")))
+                .build());
+
     SwiftDescriptions.populateSwiftLibraryDescriptionArg(
-        pathResolver, outputBuilder, args.build(), buildTarget);
+        swiftBuckConfig, pathResolver, outputBuilder, args.build(), buildTarget);
     SwiftLibraryDescriptionArg output = outputBuilder.build();
     assertThat(output.getModuleName().get(), equalTo("bar"));
     assertThat(output.getSrcs(), equalTo(ImmutableSortedSet.<SourcePath>of(swiftSrc)));
@@ -63,7 +71,7 @@ public class SwiftDescriptionsTest {
     args.setModuleName("baz");
 
     SwiftDescriptions.populateSwiftLibraryDescriptionArg(
-        pathResolver, outputBuilder, args.build(), buildTarget);
+        swiftBuckConfig, pathResolver, outputBuilder, args.build(), buildTarget);
     output = outputBuilder.build();
     assertThat(output.getModuleName().get(), equalTo("baz"));
     assertThat(output.getVersion().get(), equalTo("3"));

--- a/test/com/facebook/buck/swift/SwiftOSXBinaryIntegrationTest.java
+++ b/test/com/facebook/buck/swift/SwiftOSXBinaryIntegrationTest.java
@@ -72,7 +72,7 @@ public class SwiftOSXBinaryIntegrationTest {
     ProjectWorkspace workspace =
         TestDataHelper.createProjectWorkspaceForScenario(this, "objc_mix_swift", tmp);
     workspace.setUp();
-    workspace.addBuckConfigLocalOption("swift", "version", "2.3");
+    workspace.addBuckConfigLocalOption("swift", "version", "3");
 
     ProcessResult runResult = workspace.runBuckCommand("run", ":DemoMix#macosx-x86_64");
     runResult.assertSuccess();


### PR DESCRIPTION
Allow swift targets read and fallback to global Swift version setting, when the version is not specified on the target level.

Originally it will fallback to the compiler default version.

Also fix test with expired swift version