### PR TITLE
Switch the default for `should_remap_host_platform` from false to true

### DIFF
--- a/src/com/facebook/buck/cxx/toolchain/CxxBuckConfig.java
+++ b/src/com/facebook/buck/cxx/toolchain/CxxBuckConfig.java
@@ -438,7 +438,7 @@ public class CxxBuckConfig {
 
   /** @return whether to remap to the underlying host platform or to use #default */
   public boolean getShouldRemapHostPlatform() {
-    return delegate.getBooleanValue(cxxSection, SHOULD_REMAP_HOST_PLATFORM, false);
+    return delegate.getBooleanValue(cxxSection, SHOULD_REMAP_HOST_PLATFORM, true);
   }
 
   private Optional<ToolProvider> getToolProvider(String name) {


### PR DESCRIPTION
https://github.com/facebook/buck/issues/2073 announces the deprecation and switch of should_remap_host_platform.

Given the lack of opposition, the current timeline is as follows:
1. Switch the default from false to true next week (10/29)
2. Remove the false codepath in two more weeks unless there is any opposition

Thoughts?