### PR TITLE
Escape paths in the query_paths macro expander

### DIFF
--- a/src/com/facebook/buck/rules/macros/QueryPathsMacroExpander.java
+++ b/src/com/facebook/buck/rules/macros/QueryPathsMacroExpander.java
@@ -29,6 +29,7 @@ import com.facebook.buck.query.QueryBuildTarget;
 import com.facebook.buck.query.QueryFileTarget;
 import com.facebook.buck.rules.args.Arg;
 import com.facebook.buck.rules.query.Query;
+import com.facebook.buck.util.Escaper;
 import com.google.common.collect.ImmutableList;
 import java.util.Objects;
 import java.util.Optional;
@@ -100,6 +101,7 @@ public class QueryPathsMacroExpander extends QueryMacroExpander<QueryPathsMacro>
               .stream()
               .map(pathResolver::getAbsolutePath)
               .map(Object::toString)
+              .map(Escaper::escapeAsShellString)
               .sorted()
               .collect(Collectors.joining(" ")));
     }

--- a/test/com/facebook/buck/rules/macros/QueryPathsMacroExpanderIntegrationTest.java
+++ b/test/com/facebook/buck/rules/macros/QueryPathsMacroExpanderIntegrationTest.java
@@ -26,6 +26,7 @@ import com.facebook.buck.testutil.integration.TestDataHelper;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -60,9 +61,14 @@ public class QueryPathsMacroExpanderIntegrationTest {
     // Remove the newline added by echo from the result
     String seen = new String(Files.readAllBytes(result), UTF_8).trim();
 
+    // Read in the file list
+    Path filelistPath = Paths.get(seen.substring(1));
+    String filelist = new String(Files.readAllBytes(filelistPath), UTF_8);
+
     Path beta = workspace.getPath("beta.txt");
     Path spaces = workspace.getPath("file with spaces.txt");
     assertTrue(beta.isAbsolute());
-    assertEquals(beta.toString() + "\n" + spaces.toString(), seen);
+    assertTrue(filelist.contains(beta.toString()));
+    assertTrue(filelist.contains("'" + spaces + "'"));
   }
 }

--- a/test/com/facebook/buck/rules/macros/QueryPathsMacroExpanderIntegrationTest.java
+++ b/test/com/facebook/buck/rules/macros/QueryPathsMacroExpanderIntegrationTest.java
@@ -60,8 +60,9 @@ public class QueryPathsMacroExpanderIntegrationTest {
     // Remove the newline added by echo from the result
     String seen = new String(Files.readAllBytes(result), UTF_8).trim();
 
-    Path expected = workspace.getPath("beta.txt");
-    assertTrue(expected.isAbsolute());
-    assertEquals(expected.toString(), seen);
+    Path beta = workspace.getPath("beta.txt");
+    Path spaces = workspace.getPath("file with spaces.txt");
+    assertTrue(beta.isAbsolute());
+    assertEquals(beta.toString() + "\n" + spaces.toString(), seen);
   }
 }

--- a/test/com/facebook/buck/rules/macros/testdata/query-paths/BUCK.fixture
+++ b/test/com/facebook/buck/rules/macros/testdata/query-paths/BUCK.fixture
@@ -7,7 +7,7 @@ export_file(
 # Has no deps
 java_library(
     name = "example",
-    resources = ["beta.txt"],
+    resources = ["beta.txt", "file with spaces.txt"],
     deps = [],
 )
 
@@ -20,5 +20,5 @@ genrule(
 genrule(
     name = "files",
     out = "files.txt",
-    cmd = "echo $(query_paths 'inputs(deps(:example))') >$OUT",
+    cmd = 'PATHS=($(query_paths "inputs(deps(:example))")); for p in "${PATHS[@]}"; do echo "$p"; done | sort > $OUT',
 )

--- a/test/com/facebook/buck/rules/macros/testdata/query-paths/BUCK.fixture
+++ b/test/com/facebook/buck/rules/macros/testdata/query-paths/BUCK.fixture
@@ -20,5 +20,5 @@ genrule(
 genrule(
     name = "files",
     out = "files.txt",
-    cmd = 'PATHS=($(query_paths "inputs(deps(:example))")); for p in "${PATHS[@]}"; do echo "$p"; done | sort > $OUT',
+    cmd = "echo $(@query_paths 'inputs(deps(:example))') >$OUT",
 )

--- a/test/com/facebook/buck/rules/macros/testdata/query-paths/file with spaces.txt
+++ b/test/com/facebook/buck/rules/macros/testdata/query-paths/file with spaces.txt
@@ -1,0 +1,1 @@
+HI THERE


### PR DESCRIPTION
Escape paths output by the `$(query_paths )` macro, otherwise the space separated list of paths is not parseable for paths with spaces in them.