### PR TITLE
Make Dummy R class compilation faster

### DIFF
--- a/src/com/facebook/buck/android/AndroidLibraryGraphEnhancer.java
+++ b/src/com/facebook/buck/android/AndroidLibraryGraphEnhancer.java
@@ -34,6 +34,7 @@ import com.facebook.buck.util.RichStream;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.SortedSet;
 
@@ -125,9 +126,11 @@ public class AndroidLibraryGraphEnhancer {
             dummyRDotJavaBuildTarget,
             ignored -> {
               SourcePathRuleFinder ruleFinder = new SourcePathRuleFinder(graphBuilder);
+              JavacOptions filteredOptions =
+                  javacOptions.withExtraArguments(Collections.emptyList());
 
               JavacToJarStepFactory compileToJarStepFactory =
-                  new JavacToJarStepFactory(javac, javacOptions, ExtraClasspathProvider.EMPTY);
+                  new JavacToJarStepFactory(javac, filteredOptions, ExtraClasspathProvider.EMPTY);
 
               return new DummyRDotJava(
                   dummyRDotJavaBuildTarget,

--- a/src/com/facebook/buck/android/DummyRDotJava.java
+++ b/src/com/facebook/buck/android/DummyRDotJava.java
@@ -283,7 +283,7 @@ public class DummyRDotJava extends AbstractBuildRule
         JarParameters.builder()
             .setJarPath(outputJar)
             .setEntriesToJar(ImmutableSortedSet.of(rDotJavaClassesFolder))
-            .setMergeManifests(true)
+            .setMergeManifests(false)
             .setHashEntries(true)
             .build();
     steps.add(new JarDirectoryStep(getProjectFilesystem(), jarParameters));


### PR DESCRIPTION
Dummy R java files have no dependencies/annotation processors run on them. Using empty options makes sense to avoid any overhead from javac plugins/errorprone etc. as these files do not need to be analyzed by such tools