### PR TITLE
Do not turn off framework detection by default

### DIFF
--- a/src/com/facebook/buck/features/project/intellij/templates/ij-misc.st
+++ b/src/com/facebook/buck/features/project/intellij/templates/ij-misc.st
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="FrameworkDetectionExcludesConfiguration" detection-enabled="false" />
   <component name="ProjectRootManager" version="2" languageLevel="%languageLevel%" assert-keyword="true" jdk-15="%jdk15%" project-jdk-name="%jdkName%" project-jdk-type="%jdkType%">
 %if(outputUrl)%    <output url="file://$PROJECT_DIR$/%outputUrl%" />
 %endif%  </component>

--- a/test/com/facebook/buck/features/project/intellij/testdata/project_with_language_level/.idea/misc.xml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/project_with_language_level/.idea/misc.xml.expected
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="FrameworkDetectionExcludesConfiguration" detection-enabled="false" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" assert-keyword="true" jdk-15="true" project-jdk-name="Android SDK Version 23" project-jdk-type="Android SDK">
   </component>
 </project>

--- a/test/com/facebook/buck/features/project/intellij/testdata/project_with_output_url/.idea/misc.xml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/project_with_output_url/.idea/misc.xml.expected
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="FrameworkDetectionExcludesConfiguration" detection-enabled="false" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="Android SDK Version 23" project-jdk-type="Android SDK">
     <output url="file://$PROJECT_DIR$/intellij-out/classes" />
   </component>

--- a/test/com/facebook/buck/features/project/intellij/testdata/project_with_project_settings/.idea/misc.xml.expected
+++ b/test/com/facebook/buck/features/project/intellij/testdata/project_with_project_settings/.idea/misc.xml.expected
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="FrameworkDetectionExcludesConfiguration" detection-enabled="false" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="Android SDK Version 23" project-jdk-type="Android SDK">
   </component>
 </project>


### PR DESCRIPTION
Buck projects should have the ability to let the IDE decide when certain frameworks (eg. spring) are applied. This changes the default project generation behavior to not disable framework detection anymore.