### PR TITLE
Apple project generator respects default cxx platform

### DIFF
--- a/src/com/facebook/buck/apple/AppleDescriptions.java
+++ b/src/com/facebook/buck/apple/AppleDescriptions.java
@@ -137,18 +137,6 @@ public class AppleDescriptions {
         buildTarget, pathResolver, headerPathPrefix, arg.getExportedHeaders());
   }
 
-  /** @returns Apple headers converted to public cxx headers */
-  public static ImmutableSortedMap<String, SourcePath> convertHeadersToPublicCxxHeaders(
-      BuildTarget buildTarget,
-      Function<SourcePath, Path> pathResolver,
-      Path headerPathPrefix,
-      SourceSortedSet sourceSet) {
-    // The exported headers in the populated cxx constructor arg will contain exported headers from
-    // the apple constructor arg with the public include style.
-    return AppleDescriptions.parseAppleHeadersForUseFromOtherTargets(
-        buildTarget, pathResolver, headerPathPrefix, sourceSet);
-  }
-
   public static ImmutableSortedMap<String, SourcePath> convertAppleHeadersToPrivateCxxHeaders(
       BuildTarget buildTarget,
       Function<SourcePath, Path> pathResolver,
@@ -170,42 +158,6 @@ public class AppleDescriptions {
                             .stream(),
                         AppleDescriptions.parseAppleHeadersForUseFromOtherTargets(
                                 buildTarget, pathResolver, headerPathPrefix, arg.getHeaders())
-                            .entrySet()
-                            .stream())
-                    .reduce(Stream::concat)
-                    .orElse(Stream.empty())
-                    .distinct() // allow duplicate entries as long as they map to the same path
-                    .collect(
-                        ImmutableSortedMap.toImmutableSortedMap(
-                            Ordering.natural(), Map.Entry::getKey, Map.Entry::getValue)));
-
-    return headersMapBuilder.build();
-  }
-
-  /** @returns Apple headers converted to private cxx headers */
-  public static ImmutableSortedMap<String, SourcePath> convertHeadersToPrivateCxxHeaders(
-      BuildTarget buildTarget,
-      Function<SourcePath, Path> pathResolver,
-      Path headerPathPrefix,
-      SourceSortedSet privateSourceSet,
-      SourceSortedSet publicSourceSet) {
-    // The private headers should contain exported headers with the private include style and
-    // private
-    // headers with both styles.
-    ImmutableSortedMap.Builder<String, SourcePath> headersMapBuilder =
-        ImmutableSortedMap.<String, SourcePath>naturalOrder()
-            .putAll(
-                Stream.of(
-                        AppleDescriptions.parseAppleHeadersForUseFromTheSameTarget(
-                                buildTarget, pathResolver, privateSourceSet)
-                            .entrySet()
-                            .stream(),
-                        AppleDescriptions.parseAppleHeadersForUseFromTheSameTarget(
-                                buildTarget, pathResolver, publicSourceSet)
-                            .entrySet()
-                            .stream(),
-                        AppleDescriptions.parseAppleHeadersForUseFromOtherTargets(
-                                buildTarget, pathResolver, headerPathPrefix, privateSourceSet)
                             .entrySet()
                             .stream())
                     .reduce(Stream::concat)

--- a/src/com/facebook/buck/apple/AppleDescriptions.java
+++ b/src/com/facebook/buck/apple/AppleDescriptions.java
@@ -429,7 +429,8 @@ public class AppleDescriptions {
             Optional.empty(),
             AppleBuildRules.CORE_DATA_MODEL_DESCRIPTION_CLASSES,
             ImmutableList.of(targetNode),
-            RecursiveDependenciesMode.COPYING);
+            RecursiveDependenciesMode.COPYING,
+            Optional.of(appleCxxPlatform.getCxxPlatform()));
 
     BuildTarget coreDataModelBuildTarget = buildTarget.withAppendedFlavors(CoreDataModel.FLAVOR);
 
@@ -466,7 +467,8 @@ public class AppleDescriptions {
             Optional.empty(),
             AppleBuildRules.SCENEKIT_ASSETS_DESCRIPTION_CLASSES,
             ImmutableList.of(targetNode),
-            RecursiveDependenciesMode.COPYING);
+            RecursiveDependenciesMode.COPYING,
+            Optional.of(appleCxxPlatform.getCxxPlatform()));
 
     BuildTarget sceneKitAssetsBuildTarget = buildTarget.withAppendedFlavors(SceneKitAssets.FLAVOR);
 

--- a/src/com/facebook/buck/apple/AppleResources.java
+++ b/src/com/facebook/buck/apple/AppleResources.java
@@ -57,7 +57,8 @@ public class AppleResources {
                 cache,
                 mode,
                 targetNode,
-                ImmutableSet.of(AppleResourceDescription.class)))
+                ImmutableSet.of(AppleResourceDescription.class),
+                Optional.empty()))
         .transform(input -> (AppleResourceDescriptionArg) input.getConstructorArg())
         .toSet();
   }
@@ -80,7 +81,7 @@ public class AppleResources {
             mode,
             targetNode,
             IS_APPLE_BUNDLE_RESOURCE_NODE,
-            Optional.of(appleCxxPlatform));
+            Optional.of(appleCxxPlatform.getCxxPlatform()));
     ProjectFilesystem filesystem = targetNode.getFilesystem();
 
     for (TargetNode<?> resourceNode : resourceNodes) {

--- a/src/com/facebook/buck/cxx/CxxLibraryDescription.java
+++ b/src/com/facebook/buck/cxx/CxxLibraryDescription.java
@@ -195,6 +195,15 @@ public class CxxLibraryDescription
         args.getRawHeaders());
   }
 
+  public static boolean isPlatformSupported(
+      CxxLibraryDescriptionArg args, CxxPlatform cxxPlatform) {
+    return !args.getSupportedPlatformsRegex().isPresent()
+        || args.getSupportedPlatformsRegex()
+            .get()
+            .matcher(cxxPlatform.getFlavor().toString())
+            .find();
+  }
+
   @Override
   public Class<CxxLibraryDescriptionArg> getConstructorArgType() {
     return CxxLibraryDescriptionArg.class;

--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -1209,18 +1209,8 @@ public class ProjectGenerator {
     CxxLibraryDescription.CommonArg arg = targetNode.getConstructorArg();
     NewNativeTargetProjectMutator mutator =
         new NewNativeTargetProjectMutator(pathRelativizer, this::resolveSourcePath);
-
-    // Both exported headers and exported platform headers will be put into the symlink tree
-    // exported platform headers will be excluded and then included by platform
-    ImmutableSet.Builder<SourcePath> exportedHeadersBuilder = ImmutableSet.builder();
-    exportedHeadersBuilder.addAll(getHeaderSourcePaths(arg.getExportedHeaders()));
-    PatternMatchedCollection<SourceSortedSet> exportedPlatformHeaders =
-        arg.getExportedPlatformHeaders();
-    for (SourceSortedSet headersSet : exportedPlatformHeaders.getValues()) {
-      exportedHeadersBuilder.addAll(getHeaderSourcePaths(headersSet));
-    }
-
-    ImmutableSet<SourcePath> exportedHeaders = exportedHeadersBuilder.build();
+    ImmutableSet<SourcePath> exportedHeaders =
+        ImmutableSet.copyOf(getHeaderSourcePaths(arg.getExportedHeaders()));
     ImmutableSet.Builder<SourcePath> headersBuilder = ImmutableSet.builder();
     headersBuilder.addAll(getHeaderSourcePaths(arg.getHeaders()));
     for (SourceSortedSet headersSet : arg.getPlatformHeaders().getValues()) {
@@ -1261,17 +1251,6 @@ public class ProjectGenerator {
       platformHeadersIterableBuilder.add(
           new Pair<>(platformHeader.getFirst(), getHeaderSourcePaths(platformHeader.getSecond())));
     }
-
-    ImmutableList<Pair<Pattern, SourceSortedSet>> exportedPlatformHeadersPatternsAndValues =
-        exportedPlatformHeaders.getPatternsAndValues();
-    for (Pair<Pattern, SourceSortedSet> exportedPlatformHeader :
-        exportedPlatformHeadersPatternsAndValues) {
-      platformHeadersIterableBuilder.add(
-          new Pair<>(
-              exportedPlatformHeader.getFirst(),
-              getHeaderSourcePaths(exportedPlatformHeader.getSecond())));
-    }
-
     ImmutableList<Pair<Pattern, Iterable<SourcePath>>> platformHeadersIterable =
         platformHeadersIterableBuilder.build();
 
@@ -2368,28 +2347,10 @@ public class ProjectGenerator {
       Path headerPathPrefix =
           AppleDescriptions.getHeaderPathPrefix(
               (AppleNativeTargetDescriptionArg) arg, targetNode.getBuildTarget());
-
-      ImmutableSortedMap.Builder<String, SourcePath> exportedHeadersBuilder =
-          ImmutableSortedMap.naturalOrder();
-      exportedHeadersBuilder.putAll(
-          AppleDescriptions.convertHeadersToPublicCxxHeaders(
-              targetNode.getBuildTarget(),
-              this::resolveSourcePath,
-              headerPathPrefix,
-              arg.getExportedHeaders()));
-
-      for (Pair<Pattern, SourceSortedSet> patternMatchedHeader :
-          arg.getExportedPlatformHeaders().getPatternsAndValues()) {
-        exportedHeadersBuilder.putAll(
-            AppleDescriptions.convertHeadersToPublicCxxHeaders(
-                targetNode.getBuildTarget(),
-                this::resolveSourcePath,
-                headerPathPrefix,
-                patternMatchedHeader.getSecond()));
-      }
-
-      ImmutableSortedMap<String, SourcePath> fullExportedHeaders = exportedHeadersBuilder.build();
-      return convertMapKeysToPaths(fullExportedHeaders);
+      ImmutableSortedMap<String, SourcePath> cxxHeaders =
+          AppleDescriptions.convertAppleHeadersToPublicCxxHeaders(
+              targetNode.getBuildTarget(), this::resolveSourcePath, headerPathPrefix, arg);
+      return convertMapKeysToPaths(cxxHeaders);
     } else {
       ActionGraphBuilder graphBuilder = actionGraphBuilderForNode.apply(targetNode);
       SourcePathRuleFinder ruleFinder = new SourcePathRuleFinder(graphBuilder);
@@ -2423,41 +2384,10 @@ public class ProjectGenerator {
       Path headerPathPrefix =
           AppleDescriptions.getHeaderPathPrefix(
               (AppleNativeTargetDescriptionArg) arg, targetNode.getBuildTarget());
-
-      ImmutableSortedMap.Builder<String, SourcePath> fullHeadersBuilder =
-          ImmutableSortedMap.naturalOrder();
-      fullHeadersBuilder.putAll(
-          AppleDescriptions.convertHeadersToPrivateCxxHeaders(
-              targetNode.getBuildTarget(),
-              this::resolveSourcePath,
-              headerPathPrefix,
-              arg.getHeaders(),
-              arg.getExportedHeaders()));
-
-      for (Pair<Pattern, SourceSortedSet> patternMatchedHeader :
-          arg.getExportedPlatformHeaders().getPatternsAndValues()) {
-        fullHeadersBuilder.putAll(
-            AppleDescriptions.convertHeadersToPrivateCxxHeaders(
-                targetNode.getBuildTarget(),
-                this::resolveSourcePath,
-                headerPathPrefix,
-                SourceSortedSet.ofNamedSources(ImmutableSortedMap.of()),
-                patternMatchedHeader.getSecond()));
-      }
-
-      for (Pair<Pattern, SourceSortedSet> patternMatchedHeader :
-          arg.getPlatformHeaders().getPatternsAndValues()) {
-        fullHeadersBuilder.putAll(
-            AppleDescriptions.convertHeadersToPrivateCxxHeaders(
-                targetNode.getBuildTarget(),
-                this::resolveSourcePath,
-                headerPathPrefix,
-                patternMatchedHeader.getSecond(),
-                SourceSortedSet.ofNamedSources(ImmutableSortedMap.of())));
-      }
-
-      ImmutableSortedMap<String, SourcePath> fullHeaders = fullHeadersBuilder.build();
-      return convertMapKeysToPaths(fullHeaders);
+      ImmutableSortedMap<String, SourcePath> cxxHeaders =
+          AppleDescriptions.convertAppleHeadersToPrivateCxxHeaders(
+              targetNode.getBuildTarget(), this::resolveSourcePath, headerPathPrefix, arg);
+      return convertMapKeysToPaths(cxxHeaders);
     } else {
       ActionGraphBuilder graphBuilder = actionGraphBuilderForNode.apply(targetNode);
       SourcePathRuleFinder ruleFinder = new SourcePathRuleFinder(graphBuilder);

--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -3564,8 +3564,7 @@ public class ProjectGenerator {
                 targetNode,
                 xcodeDescriptions.getXCodeDescriptions(),
                 Optional.of(defaultCxxPlatform)));
-    return allDeps
-        .filter(this::isLibraryWithSourcesToCompile);
+    return allDeps.filter(this::isLibraryWithSourcesToCompile);
   }
 
   private ImmutableSet<PBXFileReference> collectRecursiveLibraryDependencies(

--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -111,7 +111,6 @@ import com.facebook.buck.cxx.CxxDescriptionEnhancer;
 import com.facebook.buck.cxx.CxxLibraryDescription;
 import com.facebook.buck.cxx.CxxLibraryDescription.CommonArg;
 import com.facebook.buck.cxx.CxxPrecompiledHeaderTemplate;
-import com.facebook.buck.cxx.CxxPreprocessables;
 import com.facebook.buck.cxx.CxxSource;
 import com.facebook.buck.cxx.toolchain.CxxBuckConfig;
 import com.facebook.buck.cxx.toolchain.CxxPlatform;
@@ -1158,28 +1157,6 @@ public class ProjectGenerator {
     String sdkWithoutVersion = sdk.split("\\d+")[0];
     String arch = platformName.substring(index + 1);
     return new Pair<>(sdkWithoutVersion, arch);
-  }
-
-  /** @return a map of all exported platform headers without matching a specific platform. */
-  public static ImmutableMap<Path, SourcePath> parseAllPlatformHeaders(
-      BuildTarget buildTarget,
-      SourcePathResolver sourcePathResolver,
-      PatternMatchedCollection<SourceSortedSet> platformHeaders,
-      boolean export,
-      CxxLibraryDescription.CommonArg args) {
-    ImmutableMap.Builder<String, SourcePath> parsed = ImmutableMap.builder();
-
-    String parameterName = (export) ? "exported_platform_headers" : "platform_headers";
-
-    // Include all platform specific headers.
-    for (SourceSortedSet sourceList : platformHeaders.getValues()) {
-      parsed.putAll(
-          sourceList.toNameMap(
-              buildTarget, sourcePathResolver, parameterName, path -> true, path -> path));
-    }
-    return CxxPreprocessables.resolveHeaderMap(
-        args.getHeaderNamespace().map(Paths::get).orElse(buildTarget.getBasePath()),
-        parsed.build());
   }
 
   private PBXNativeTarget generateBinaryTarget(
@@ -2355,25 +2332,14 @@ public class ProjectGenerator {
       ActionGraphBuilder graphBuilder = actionGraphBuilderForNode.apply(targetNode);
       SourcePathRuleFinder ruleFinder = new SourcePathRuleFinder(graphBuilder);
       SourcePathResolver pathResolver = DefaultSourcePathResolver.from(ruleFinder);
-      ImmutableSortedMap.Builder<Path, SourcePath> allHeadersBuilder =
-          ImmutableSortedMap.naturalOrder();
-      return allHeadersBuilder
-          .putAll(
-              CxxDescriptionEnhancer.parseExportedHeaders(
-                  targetNode.getBuildTarget(),
-                  graphBuilder,
-                  ruleFinder,
-                  pathResolver,
-                  Optional.empty(),
-                  arg))
-          .putAll(
-              ProjectGenerator.parseAllPlatformHeaders(
-                  targetNode.getBuildTarget(),
-                  pathResolver,
-                  arg.getExportedPlatformHeaders(),
-                  true,
-                  arg))
-          .build();
+      return ImmutableSortedMap.copyOf(
+          CxxDescriptionEnhancer.parseExportedHeaders(
+              targetNode.getBuildTarget(),
+              graphBuilder,
+              ruleFinder,
+              pathResolver,
+              Optional.empty(),
+              arg));
     }
   }
 
@@ -2392,21 +2358,14 @@ public class ProjectGenerator {
       ActionGraphBuilder graphBuilder = actionGraphBuilderForNode.apply(targetNode);
       SourcePathRuleFinder ruleFinder = new SourcePathRuleFinder(graphBuilder);
       SourcePathResolver pathResolver = DefaultSourcePathResolver.from(ruleFinder);
-      ImmutableSortedMap.Builder<Path, SourcePath> allHeadersBuilder =
-          ImmutableSortedMap.naturalOrder();
-      return allHeadersBuilder
-          .putAll(
-              CxxDescriptionEnhancer.parseHeaders(
-                  targetNode.getBuildTarget(),
-                  graphBuilder,
-                  ruleFinder,
-                  pathResolver,
-                  Optional.empty(),
-                  arg))
-          .putAll(
-              ProjectGenerator.parseAllPlatformHeaders(
-                  targetNode.getBuildTarget(), pathResolver, arg.getPlatformHeaders(), false, arg))
-          .build();
+      return ImmutableSortedMap.copyOf(
+          CxxDescriptionEnhancer.parseHeaders(
+              targetNode.getBuildTarget(),
+              graphBuilder,
+              ruleFinder,
+              pathResolver,
+              Optional.empty(),
+              arg));
     }
   }
 

--- a/test/com/facebook/buck/apple/AppleBuildRulesTest.java
+++ b/test/com/facebook/buck/apple/AppleBuildRulesTest.java
@@ -156,6 +156,7 @@ public class AppleBuildRulesTest {
               cache,
               AppleBuildRules.RecursiveDependenciesMode.BUILDING,
               rootNode,
+              Optional.empty(),
               Optional.empty());
 
       assertTrue(Iterables.elementsEqual(ImmutableSortedSet.of(libraryNode, bundleNode), rules));
@@ -212,6 +213,7 @@ public class AppleBuildRulesTest {
               cache,
               AppleBuildRules.RecursiveDependenciesMode.LINKING,
               rootNode,
+              Optional.empty(),
               Optional.empty());
 
       assertEquals(
@@ -368,6 +370,7 @@ public class AppleBuildRulesTest {
               cache,
               AppleBuildRules.RecursiveDependenciesMode.LINKING,
               barFrameworkNode,
+              Optional.empty(),
               Optional.empty());
 
       assertEquals(ImmutableSortedSet.of(fooGenruleNode), ImmutableSortedSet.copyOf(rules));
@@ -420,6 +423,7 @@ public class AppleBuildRulesTest {
               cache,
               AppleBuildRules.RecursiveDependenciesMode.COPYING,
               barFrameworkNode,
+              Optional.empty(),
               Optional.empty());
 
       assertEquals(ImmutableSortedSet.of(fooGenruleNode), ImmutableSortedSet.copyOf(rules));
@@ -492,6 +496,7 @@ public class AppleBuildRulesTest {
               cache,
               AppleBuildRules.RecursiveDependenciesMode.BUILDING,
               bazFrameworkNode,
+              Optional.empty(),
               Optional.empty());
 
       assertEquals(

--- a/test/com/facebook/buck/apple/AppleLibraryBuilder.java
+++ b/test/com/facebook/buck/apple/AppleLibraryBuilder.java
@@ -24,7 +24,6 @@ import com.facebook.buck.core.sourcepath.SourceWithFlags;
 import com.facebook.buck.cxx.AbstractCxxSource;
 import com.facebook.buck.cxx.toolchain.nativelink.NativeLinkable;
 import com.facebook.buck.rules.coercer.FrameworkPath;
-import com.facebook.buck.rules.coercer.PatternMatchedCollection;
 import com.facebook.buck.rules.coercer.SourceSortedSet;
 import com.facebook.buck.rules.macros.StringWithMacros;
 import com.facebook.buck.rules.macros.StringWithMacrosUtils;
@@ -112,12 +111,6 @@ public class AppleLibraryBuilder
     return this;
   }
 
-  public AppleLibraryBuilder setPlatformSrcs(
-      PatternMatchedCollection<ImmutableSortedSet<SourceWithFlags>> platformSrcs) {
-    getArgForPopulating().setPlatformSrcs(platformSrcs);
-    return this;
-  }
-
   public AppleLibraryBuilder setExtraXcodeSources(ImmutableList<SourcePath> extraXcodeSources) {
     getArgForPopulating().setExtraXcodeSources(extraXcodeSources);
     return this;
@@ -139,18 +132,6 @@ public class AppleLibraryBuilder
 
   public AppleLibraryBuilder setHeaders(ImmutableSortedMap<String, SourcePath> headers) {
     return setHeaders(SourceSortedSet.ofNamedSources(headers));
-  }
-
-  public AppleLibraryBuilder setPlatformHeaders(
-      PatternMatchedCollection<SourceSortedSet> platformHeaders) {
-    getArgForPopulating().setPlatformHeaders(platformHeaders);
-    return this;
-  }
-
-  public AppleLibraryBuilder setExportedPlatformHeaders(
-      PatternMatchedCollection<SourceSortedSet> exportedPlatformHeaders) {
-    getArgForPopulating().setExportedPlatformHeaders(exportedPlatformHeaders);
-    return this;
   }
 
   public AppleLibraryBuilder setExportedHeaders(SourceSortedSet exportedHeaders) {

--- a/test/com/facebook/buck/cxx/CxxLibraryBuilder.java
+++ b/test/com/facebook/buck/cxx/CxxLibraryBuilder.java
@@ -209,18 +209,6 @@ public class CxxLibraryBuilder
     return this;
   }
 
-  public CxxLibraryBuilder setPlatformHeaders(
-      PatternMatchedCollection<SourceSortedSet> platformHeaders) {
-    getArgForPopulating().setPlatformHeaders(platformHeaders);
-    return this;
-  }
-
-  public CxxLibraryBuilder setExportedPlatformHeaders(
-      PatternMatchedCollection<SourceSortedSet> exportedPlatformHeaders) {
-    getArgForPopulating().setExportedPlatformHeaders(exportedPlatformHeaders);
-    return this;
-  }
-
   public CxxLibraryBuilder setCompilerFlags(ImmutableList<String> compilerFlags) {
     getArgForPopulating()
         .setCompilerFlags(

--- a/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
@@ -1249,23 +1249,9 @@ public class ProjectGeneratorTest {
     TargetNode<?> node =
         new CxxLibraryBuilder(buildTarget)
             .setExportedHeaders(ImmutableSortedSet.of(FakeSourcePath.of("foo/dir1/bar.h")))
-            .setExportedPlatformHeaders(
-                PatternMatchedCollection.<SourceSortedSet>builder()
-                    .add(
-                        Pattern.compile("iphone.*"),
-                        SourceSortedSet.ofUnnamedSources(
-                            ImmutableSortedSet.of(FakeSourcePath.of("foo/HeaderGroup2/foo3.h"))))
-                    .build())
             .setHeaders(
                 ImmutableSortedSet.of(
                     FakeSourcePath.of("foo/dir1/foo.h"), FakeSourcePath.of("foo/dir2/baz.h")))
-            .setPlatformHeaders(
-                PatternMatchedCollection.<SourceSortedSet>builder()
-                    .add(
-                        Pattern.compile("iphone.*"),
-                        SourceSortedSet.ofUnnamedSources(
-                            ImmutableSortedSet.of(FakeSourcePath.of("foo/HeaderGroup1/foo1.h"))))
-                    .build())
             .setSrcs(ImmutableSortedSet.of())
             .build();
 
@@ -1279,10 +1265,7 @@ public class ProjectGeneratorTest {
     assertThat(headerSymlinkTrees.get(0).toString(), is(equalTo("buck-out/gen/_p/CwkbTNOBmb-pub")));
     assertThatHeaderSymlinkTreeContains(
         Paths.get("buck-out/gen/_p/CwkbTNOBmb-pub"),
-        ImmutableMap.<String, String>builder()
-            .put("foo/dir1/bar.h", "foo/dir1/bar.h")
-            .put("foo/HeaderGroup2/foo3.h", "foo/HeaderGroup2/foo3.h")
-            .build());
+        ImmutableMap.of("foo/dir1/bar.h", "foo/dir1/bar.h"));
 
     assertThat(
         headerSymlinkTrees.get(1).toString(), is(equalTo("buck-out/gen/_p/CwkbTNOBmb-priv")));
@@ -1291,7 +1274,6 @@ public class ProjectGeneratorTest {
         ImmutableMap.<String, String>builder()
             .put("foo/dir1/foo.h", "foo/dir1/foo.h")
             .put("foo/dir2/baz.h", "foo/dir2/baz.h")
-            .put("foo/HeaderGroup1/foo1.h", "foo/HeaderGroup1/foo1.h")
             .build());
   }
 
@@ -1301,23 +1283,9 @@ public class ProjectGeneratorTest {
     TargetNode<?> node =
         new CxxLibraryBuilder(buildTarget)
             .setExportedHeaders(ImmutableSortedSet.of(FakeSourcePath.of("foo/dir1/bar.h")))
-            .setExportedPlatformHeaders(
-                PatternMatchedCollection.<SourceSortedSet>builder()
-                    .add(
-                        Pattern.compile("iphone.*"),
-                        SourceSortedSet.ofUnnamedSources(
-                            ImmutableSortedSet.of(FakeSourcePath.of("foo/HeaderGroup2/foo3.h"))))
-                    .build())
             .setHeaders(
                 ImmutableSortedSet.of(
                     FakeSourcePath.of("foo/dir1/foo.h"), FakeSourcePath.of("foo/dir2/baz.h")))
-            .setPlatformHeaders(
-                PatternMatchedCollection.<SourceSortedSet>builder()
-                    .add(
-                        Pattern.compile("iphone.*"),
-                        SourceSortedSet.ofUnnamedSources(
-                            ImmutableSortedSet.of(FakeSourcePath.of("foo/HeaderGroup1/foo1.h"))))
-                    .build())
             .setSrcs(ImmutableSortedSet.of())
             .setXcodePublicHeadersSymlinks(false)
             .setXcodePrivateHeadersSymlinks(false)
@@ -1333,10 +1301,7 @@ public class ProjectGeneratorTest {
     assertThat(headerSymlinkTrees.get(0).toString(), is(equalTo("buck-out/gen/_p/CwkbTNOBmb-pub")));
     assertThatHeaderMapWithoutSymLinksContains(
         Paths.get("buck-out/gen/_p/CwkbTNOBmb-pub"),
-        ImmutableMap.<String, String>builder()
-            .put("foo/dir1/bar.h", "foo/dir1/bar.h")
-            .put("foo/HeaderGroup2/foo3.h", "foo/HeaderGroup2/foo3.h")
-            .build());
+        ImmutableMap.of("foo/dir1/bar.h", "foo/dir1/bar.h"));
 
     assertThat(
         headerSymlinkTrees.get(1).toString(), is(equalTo("buck-out/gen/_p/CwkbTNOBmb-priv")));
@@ -1345,7 +1310,6 @@ public class ProjectGeneratorTest {
         ImmutableMap.<String, String>builder()
             .put("foo/dir1/foo.h", "foo/dir1/foo.h")
             .put("foo/dir2/baz.h", "foo/dir2/baz.h")
-            .put("foo/HeaderGroup1/foo1.h", "foo/HeaderGroup1/foo1.h")
             .build());
   }
 
@@ -1355,23 +1319,9 @@ public class ProjectGeneratorTest {
     TargetNode<?> node =
         new CxxLibraryBuilder(buildTarget)
             .setExportedHeaders(ImmutableSortedSet.of(FakeSourcePath.of("foo/dir1/bar.h")))
-            .setExportedPlatformHeaders(
-                PatternMatchedCollection.<SourceSortedSet>builder()
-                    .add(
-                        Pattern.compile("iphone.*"),
-                        SourceSortedSet.ofUnnamedSources(
-                            ImmutableSortedSet.of(FakeSourcePath.of("foo/HeaderGroup2/foo3.h"))))
-                    .build())
             .setHeaders(
                 ImmutableSortedSet.of(
                     FakeSourcePath.of("foo/dir1/foo.h"), FakeSourcePath.of("foo/dir2/baz.h")))
-            .setPlatformHeaders(
-                PatternMatchedCollection.<SourceSortedSet>builder()
-                    .add(
-                        Pattern.compile("iphone.*"),
-                        SourceSortedSet.ofUnnamedSources(
-                            ImmutableSortedSet.of(FakeSourcePath.of("foo/HeaderGroup1/foo1.h"))))
-                    .build())
             .setSrcs(ImmutableSortedSet.of())
             .setHeaderNamespace("name/space")
             .build();
@@ -1386,10 +1336,7 @@ public class ProjectGeneratorTest {
     assertThat(headerSymlinkTrees.get(0).toString(), is(equalTo("buck-out/gen/_p/CwkbTNOBmb-pub")));
     assertThatHeaderSymlinkTreeContains(
         Paths.get("buck-out/gen/_p/CwkbTNOBmb-pub"),
-        ImmutableMap.<String, String>builder()
-            .put("name/space/dir1/bar.h", "foo/dir1/bar.h")
-            .put("name/space/HeaderGroup2/foo3.h", "foo/HeaderGroup2/foo3.h")
-            .build());
+        ImmutableMap.of("name/space/dir1/bar.h", "foo/dir1/bar.h"));
 
     assertThat(
         headerSymlinkTrees.get(1).toString(), is(equalTo("buck-out/gen/_p/CwkbTNOBmb-priv")));
@@ -1398,7 +1345,6 @@ public class ProjectGeneratorTest {
         ImmutableMap.<String, String>builder()
             .put("name/space/dir1/foo.h", "foo/dir1/foo.h")
             .put("name/space/dir2/baz.h", "foo/dir2/baz.h")
-            .put("name/space/HeaderGroup1/foo1.h", "foo/HeaderGroup1/foo1.h")
             .build());
   }
 
@@ -1421,27 +1367,11 @@ public class ProjectGeneratorTest {
                     FakeSourcePath.of("foo/dir1/bar.h"),
                     "and/one/more.h",
                     DefaultBuildTargetSourcePath.of(publicGeneratedTarget)))
-            .setExportedPlatformHeaders(
-                PatternMatchedCollection.<SourceSortedSet>builder()
-                    .add(
-                        Pattern.compile("iphone.*"),
-                        SourceSortedSet.ofNamedSources(
-                            ImmutableSortedMap.of(
-                                "any/name2.h", FakeSourcePath.of("HeaderGroup2/foo2.h"))))
-                    .build())
             .setHeaders(
                 ImmutableSortedMap.of(
                     "any/name.h", FakeSourcePath.of("foo/dir1/foo.h"),
                     "different/name.h", FakeSourcePath.of("foo/dir2/baz.h"),
                     "one/more/name.h", DefaultBuildTargetSourcePath.of(privateGeneratedTarget)))
-            .setPlatformHeaders(
-                PatternMatchedCollection.<SourceSortedSet>builder()
-                    .add(
-                        Pattern.compile("iphone.*"),
-                        SourceSortedSet.ofNamedSources(
-                            ImmutableSortedMap.of(
-                                "any/name1.h", FakeSourcePath.of("HeaderGroup1/foo1.h"))))
-                    .build())
             .setSrcs(ImmutableSortedSet.of())
             .build();
 
@@ -1458,8 +1388,7 @@ public class ProjectGeneratorTest {
         Paths.get("buck-out/gen/_p/CwkbTNOBmb-pub"),
         ImmutableMap.of(
             "foo/yet/another/name.h", "foo/dir1/bar.h",
-            "foo/and/one/more.h", "foo/generated2.h",
-            "foo/any/name2.h", "HeaderGroup2/foo2.h"));
+            "foo/and/one/more.h", "foo/generated2.h"));
 
     assertThat(
         headerSymlinkTrees.get(1).toString(), is(equalTo("buck-out/gen/_p/CwkbTNOBmb-priv")));
@@ -1468,8 +1397,7 @@ public class ProjectGeneratorTest {
         ImmutableMap.of(
             "foo/any/name.h", "foo/dir1/foo.h",
             "foo/different/name.h", "foo/dir2/baz.h",
-            "foo/one/more/name.h", "foo/generated1.h",
-            "foo/any/name1.h", "HeaderGroup1/foo1.h"));
+            "foo/one/more/name.h", "foo/generated1.h"));
   }
 
   @Test
@@ -1491,27 +1419,11 @@ public class ProjectGeneratorTest {
                     FakeSourcePath.of("foo/dir1/bar.h"),
                     "and/one/more.h",
                     DefaultBuildTargetSourcePath.of(publicGeneratedTarget)))
-            .setExportedPlatformHeaders(
-                PatternMatchedCollection.<SourceSortedSet>builder()
-                    .add(
-                        Pattern.compile("iphone.*"),
-                        SourceSortedSet.ofNamedSources(
-                            ImmutableSortedMap.of(
-                                "any/name2.h", FakeSourcePath.of("HeaderGroup2/foo2.h"))))
-                    .build())
             .setHeaders(
                 ImmutableSortedMap.of(
                     "any/name.h", FakeSourcePath.of("foo/dir1/foo.h"),
                     "different/name.h", FakeSourcePath.of("foo/dir2/baz.h"),
                     "one/more/name.h", DefaultBuildTargetSourcePath.of(privateGeneratedTarget)))
-            .setPlatformHeaders(
-                PatternMatchedCollection.<SourceSortedSet>builder()
-                    .add(
-                        Pattern.compile("iphone.*"),
-                        SourceSortedSet.ofNamedSources(
-                            ImmutableSortedMap.of(
-                                "any/name1.h", FakeSourcePath.of("HeaderGroup1/foo1.h"))))
-                    .build())
             .setSrcs(ImmutableSortedSet.of())
             .setHeaderNamespace("name/space")
             .build();
@@ -1529,8 +1441,7 @@ public class ProjectGeneratorTest {
         Paths.get("buck-out/gen/_p/CwkbTNOBmb-pub"),
         ImmutableMap.of(
             "name/space/yet/another/name.h", "foo/dir1/bar.h",
-            "name/space/and/one/more.h", "foo/generated2.h",
-            "name/space/any/name2.h", "HeaderGroup2/foo2.h"));
+            "name/space/and/one/more.h", "foo/generated2.h"));
 
     assertThat(
         headerSymlinkTrees.get(1).toString(), is(equalTo("buck-out/gen/_p/CwkbTNOBmb-priv")));
@@ -1539,8 +1450,7 @@ public class ProjectGeneratorTest {
         ImmutableMap.of(
             "name/space/any/name.h", "foo/dir1/foo.h",
             "name/space/different/name.h", "foo/dir2/baz.h",
-            "name/space/one/more/name.h", "foo/generated1.h",
-            "name/space/any/name1.h", "HeaderGroup1/foo1.h"));
+            "name/space/one/more/name.h", "foo/generated1.h"));
   }
 
   @Test
@@ -1550,13 +1460,6 @@ public class ProjectGeneratorTest {
         AppleLibraryBuilder.createBuilder(buildTarget)
             .setSrcs(ImmutableSortedSet.of())
             .setHeaders(ImmutableSortedMap.of("key.h", FakeSourcePath.of("value.h")))
-            .setPlatformHeaders(
-                PatternMatchedCollection.<SourceSortedSet>builder()
-                    .add(
-                        Pattern.compile("iphone.*"),
-                        SourceSortedSet.ofNamedSources(
-                            ImmutableSortedMap.of("key1.h", FakeSourcePath.of("value1.h"))))
-                    .build())
             .build();
 
     ProjectGenerator projectGenerator = createProjectGenerator(ImmutableSet.of(node));
@@ -1568,8 +1471,7 @@ public class ProjectGeneratorTest {
 
     assertEquals("buck-out/gen/_p/CwkbTNOBmb-priv", headerSymlinkTrees.get(1).toString());
     assertThatHeaderSymlinkTreeContains(
-        Paths.get("buck-out/gen/_p/CwkbTNOBmb-priv"),
-        ImmutableMap.of("key.h", "value.h", "key1.h", "value1.h"));
+        Paths.get("buck-out/gen/_p/CwkbTNOBmb-priv"), ImmutableMap.of("key.h", "value.h"));
 
     node =
         AppleLibraryBuilder.createBuilder(buildTarget)
@@ -1928,20 +1830,6 @@ public class ProjectGeneratorTest {
             .setHeaders(
                 ImmutableSortedSet.of(
                     FakeSourcePath.of("foo/dir1/foo.h"), FakeSourcePath.of("foo/dir2/baz.h")))
-            .setPlatformHeaders(
-                PatternMatchedCollection.<SourceSortedSet>builder()
-                    .add(
-                        Pattern.compile("iphone.*"),
-                        SourceSortedSet.ofUnnamedSources(
-                            ImmutableSortedSet.of(FakeSourcePath.of("foo/HeaderGroup1/foo1.h"))))
-                    .build())
-            .setExportedPlatformHeaders(
-                PatternMatchedCollection.<SourceSortedSet>builder()
-                    .add(
-                        Pattern.compile("iphone.*"),
-                        SourceSortedSet.ofUnnamedSources(
-                            ImmutableSortedSet.of(FakeSourcePath.of("foo/HeaderGroup2/foo3.h"))))
-                    .build())
             .setSrcs(ImmutableSortedSet.of())
             .build();
 
@@ -1964,11 +1852,7 @@ public class ProjectGeneratorTest {
     assertThat(headerSymlinkTrees.get(0).toString(), is(equalTo("buck-out/gen/_p/CwkbTNOBmb-pub")));
     assertThatHeaderSymlinkTreeContains(
         Paths.get("buck-out/gen/_p/CwkbTNOBmb-pub"),
-        ImmutableMap.of(
-            "foo/dir1/bar.h",
-            "foo/dir1/bar.h",
-            "foo/HeaderGroup2/foo3.h",
-            "foo/HeaderGroup2/foo3.h"));
+        ImmutableMap.of("foo/dir1/bar.h", "foo/dir1/bar.h"));
 
     assertThat(
         headerSymlinkTrees.get(1).toString(), is(equalTo("buck-out/gen/_p/CwkbTNOBmb-priv")));
@@ -1977,7 +1861,6 @@ public class ProjectGeneratorTest {
         ImmutableMap.<String, String>builder()
             .put("foo/dir1/foo.h", "foo/dir1/foo.h")
             .put("foo/dir2/baz.h", "foo/dir2/baz.h")
-            .put("foo/HeaderGroup1/foo1.h", "foo/HeaderGroup1/foo1.h")
             .build());
   }
 

--- a/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
@@ -82,13 +82,11 @@ import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.model.BuildTargetFactory;
 import com.facebook.buck.core.model.Flavor;
 import com.facebook.buck.core.model.InternalFlavor;
-import com.facebook.buck.core.model.UserFlavor;
 import com.facebook.buck.core.model.targetgraph.TargetGraph;
 import com.facebook.buck.core.model.targetgraph.TargetGraphFactory;
 import com.facebook.buck.core.model.targetgraph.TargetNode;
 import com.facebook.buck.core.plugin.impl.BuckPluginManagerFactory;
 import com.facebook.buck.core.rules.ActionGraphBuilder;
-import com.facebook.buck.core.rules.BuildRule;
 import com.facebook.buck.core.rules.BuildRuleResolver;
 import com.facebook.buck.core.rules.SourcePathRuleFinder;
 import com.facebook.buck.core.rules.resolver.impl.TestActionGraphBuilder;
@@ -115,8 +113,6 @@ import com.facebook.buck.io.filesystem.ProjectFilesystem;
 import com.facebook.buck.io.filesystem.impl.FakeProjectFilesystem;
 import com.facebook.buck.rules.coercer.FrameworkPath;
 import com.facebook.buck.rules.coercer.PatternMatchedCollection;
-import com.facebook.buck.rules.coercer.SourceSortedSet;
-import com.facebook.buck.rules.keys.EmptyFakeBuildRule;
 import com.facebook.buck.rules.keys.config.TestRuleKeyConfigurationFactory;
 import com.facebook.buck.rules.macros.LocationMacro;
 import com.facebook.buck.rules.macros.StringWithMacros;
@@ -129,7 +125,6 @@ import com.facebook.buck.util.environment.Platform;
 import com.facebook.buck.util.timing.IncrementingFakeClock;
 import com.facebook.buck.util.timing.SettableFakeClock;
 import com.facebook.buck.util.types.Either;
-import com.facebook.buck.util.types.Pair;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -164,9 +159,6 @@ import org.junit.rules.ExpectedException;
 
 public class ProjectGeneratorTest {
 
-  private static final BuildTarget TARGET_1 =
-      BuildTargetFactory.newInstance(Paths.get("/root"), "//example/base:one");
-  private static final BuildRule RULE_1 = new EmptyFakeBuildRule(TARGET_1);
   private static final Path OUTPUT_DIRECTORY = Paths.get("_gen");
   private static final String PROJECT_NAME = "GeneratedProject";
   private static final String PROJECT_CONTAINER = PROJECT_NAME + ".xcodeproj";
@@ -386,177 +378,6 @@ public class ProjectGeneratorTest {
       }
     }
     assertSame(count, 1);
-  }
-
-  @Test
-  public void testPlatformSourcesAndHeaders() {
-    SourceWithFlags androidSource =
-        SourceWithFlags.builder().setSourcePath(FakeSourcePath.of("androidFile.cpp")).build();
-    SourceWithFlags iOSAndSimulatorSource =
-        SourceWithFlags.builder()
-            .setSourcePath(FakeSourcePath.of("iOSAndSimulatorFile.cpp"))
-            .build();
-    SourceWithFlags macOSSource =
-        SourceWithFlags.builder().setSourcePath(FakeSourcePath.of("macOSFile.cpp")).build();
-
-    Pattern androidPattern = Pattern.compile("android");
-    Pattern simulatorPattern = Pattern.compile("^iphonesim.*");
-    Pattern iOSPattern = Pattern.compile("iphoneos");
-    Pattern macOSPattern = Pattern.compile("macos");
-
-    Pair<Pattern, ImmutableSortedSet<SourceWithFlags>> androidSources =
-        new Pair<>(androidPattern, ImmutableSortedSet.of(androidSource));
-    Pair<Pattern, ImmutableSortedSet<SourceWithFlags>> simulatorSources =
-        new Pair<>(simulatorPattern, ImmutableSortedSet.of(iOSAndSimulatorSource));
-    Pair<Pattern, ImmutableSortedSet<SourceWithFlags>> iOSSources =
-        new Pair<>(iOSPattern, ImmutableSortedSet.of(iOSAndSimulatorSource));
-    Pair<Pattern, ImmutableSortedSet<SourceWithFlags>> macOSSources =
-        new Pair<>(macOSPattern, ImmutableSortedSet.of(macOSSource));
-
-    ImmutableList.Builder<Pair<Pattern, ImmutableSortedSet<SourceWithFlags>>>
-        platformSourcesbuilder = ImmutableList.builder();
-    ImmutableList<Pair<Pattern, ImmutableSortedSet<SourceWithFlags>>> platformSources =
-        platformSourcesbuilder
-            .add(androidSources)
-            .add(simulatorSources)
-            .add(iOSSources)
-            .add(macOSSources)
-            .build();
-
-    SourcePath androidHeader = FakeSourcePath.of("androidFile.h");
-    SourcePath simulatorHeader = FakeSourcePath.of("simulatorFile.h");
-    SourcePath macOSAndIOSHeader = FakeSourcePath.of("macOSAndIOSFile.h");
-
-    Pattern androidPattern2 = Pattern.compile("android");
-    Pattern simulatorPattern2 = Pattern.compile("iphonesimulator");
-    Pattern iOSPattern2 = Pattern.compile("iphoneos");
-    Pattern macOSPattern2 = Pattern.compile("mac");
-
-    Pair<Pattern, SourceSortedSet> androidHeaders =
-        new Pair<>(
-            androidPattern2,
-            SourceSortedSet.ofUnnamedSources(ImmutableSortedSet.of(androidHeader)));
-    Pair<Pattern, SourceSortedSet> simulatorHeaders =
-        new Pair<>(
-            simulatorPattern2,
-            SourceSortedSet.ofUnnamedSources(ImmutableSortedSet.of(simulatorHeader)));
-    Pair<Pattern, SourceSortedSet> iOSHeaders =
-        new Pair<>(
-            iOSPattern2,
-            SourceSortedSet.ofUnnamedSources(ImmutableSortedSet.of(macOSAndIOSHeader)));
-    Pair<Pattern, SourceSortedSet> macOSHeaders =
-        new Pair<>(
-            macOSPattern2,
-            SourceSortedSet.ofUnnamedSources(ImmutableSortedSet.of(macOSAndIOSHeader)));
-
-    SourcePath androidAndMacHeader = FakeSourcePath.of("androidAndMacFile.h");
-    SourcePath iPhoneHeader = FakeSourcePath.of("iOSAndSimulatorFile.h");
-
-    Pattern androidPattern3 = Pattern.compile("an.*");
-    Pattern iPhonePattern = Pattern.compile("iphone");
-
-    Pair<Pattern, SourceSortedSet> androidHeaders2 =
-        new Pair<>(
-            androidPattern3,
-            SourceSortedSet.ofNamedSources(ImmutableSortedMap.of("ignored", androidAndMacHeader)));
-    Pair<Pattern, SourceSortedSet> iPhoneHeaders =
-        new Pair<>(
-            iPhonePattern,
-            SourceSortedSet.ofNamedSources(ImmutableSortedMap.of("ignored", iPhoneHeader)));
-    Pair<Pattern, SourceSortedSet> macOSHeaders2 =
-        new Pair<>(
-            macOSPattern2,
-            SourceSortedSet.ofNamedSources(ImmutableSortedMap.of("ignored", androidAndMacHeader)));
-
-    ImmutableList.Builder<Pair<Pattern, SourceSortedSet>> platformHeadersBuilder =
-        ImmutableList.builder();
-    platformHeadersBuilder.add(androidHeaders);
-    platformHeadersBuilder.add(simulatorHeaders);
-    platformHeadersBuilder.add(iOSHeaders);
-    platformHeadersBuilder.add(macOSHeaders);
-    platformHeadersBuilder.add(androidHeaders2);
-    platformHeadersBuilder.add(iPhoneHeaders);
-    platformHeadersBuilder.add(macOSHeaders2);
-    ImmutableList<Pair<Pattern, SourceSortedSet>> platformHeaders = platformHeadersBuilder.build();
-
-    ImmutableList.Builder<Pair<Pattern, Iterable<SourcePath>>> platformHeadersIterableBuilder =
-        ImmutableList.builder();
-    for (Pair<Pattern, SourceSortedSet> platformHeader : platformHeaders) {
-      platformHeadersIterableBuilder.add(
-          new Pair<>(
-              platformHeader.getFirst(),
-              ProjectGenerator.getHeaderSourcePaths(platformHeader.getSecond())));
-    }
-    ImmutableList<Pair<Pattern, Iterable<SourcePath>>> platformHeadersIterable =
-        platformHeadersIterableBuilder.build();
-
-    UserFlavor simulator =
-        UserFlavor.builder()
-            .setName("iphonesimulator11.4-i386")
-            .setDescription("buck boilerplate")
-            .build();
-    UserFlavor macOS =
-        UserFlavor.builder().setName("macosx10-x86_64").setDescription("buck boilerplate").build();
-    UserFlavor.Builder iOSBuilder =
-        UserFlavor.builder().setName("iphoneos-x86_64").setDescription("buck boilerplate");
-    UserFlavor iOS = iOSBuilder.build();
-
-    ImmutableSet<String> appleFlavors =
-        ImmutableSet.of(simulator, iOS, macOS)
-            .stream()
-            .map(f -> ProjectGenerator.applePlatformAndArchitecture(f).getFirst())
-            .collect(ImmutableSet.toImmutableSet());
-
-    ActionGraphBuilder graphBuilder = new TestActionGraphBuilder();
-    SourcePathRuleFinder ruleFinder = new SourcePathRuleFinder(graphBuilder);
-    SourcePathResolver resolver = DefaultSourcePathResolver.from(ruleFinder);
-
-    ImmutableMap<String, ImmutableSortedSet<String>> result =
-        ProjectGenerator.gatherExcludedSources(
-            appleFlavors, platformSources, platformHeadersIterable, Paths.get("."), resolver);
-
-    ImmutableSet.Builder<String> excludedResultsBuilder = ImmutableSet.builder();
-    ImmutableSet<String> excludedResults =
-        excludedResultsBuilder
-            .add("'../androidFile.cpp'")
-            .add("'../iOSAndSimulatorFile.cpp'")
-            .add("'../macOSFile.cpp'")
-            .add("'../androidFile.h'")
-            .add("'../simulatorFile.h'")
-            .add("'../macOSAndIOSFile.h'")
-            .add("'../androidAndMacFile.h'")
-            .add("'../iOSAndSimulatorFile.h'")
-            .build();
-    ImmutableSet.Builder<String> simulatorResultsBuilder = ImmutableSet.builder();
-    ImmutableSet<String> simulatorResults =
-        simulatorResultsBuilder
-            .add("'../iOSAndSimulatorFile.cpp'")
-            .add("'../simulatorFile.h'")
-            .add("'../iOSAndSimulatorFile.h'")
-            .build();
-    ImmutableSet.Builder<String> iOSResultsBuilder = ImmutableSet.builder();
-    ImmutableSet<String> iOSResults =
-        iOSResultsBuilder
-            .add("'../iOSAndSimulatorFile.cpp'")
-            .add("'../macOSAndIOSFile.h'")
-            .add("'../iOSAndSimulatorFile.h'")
-            .build();
-    ImmutableSet.Builder<String> macOSResultsBuilder = ImmutableSet.builder();
-    ImmutableSet<String> macOSResults =
-        macOSResultsBuilder
-            .add("'../macOSFile.cpp'")
-            .add("'../macOSAndIOSFile.h'")
-            .add("'../androidAndMacFile.h'")
-            .build();
-
-    ImmutableMap.Builder<String, ImmutableSet<String>> expectedBuilder = ImmutableMap.builder();
-    expectedBuilder.put("EXCLUDED_SOURCE_FILE_NAMES", excludedResults);
-    expectedBuilder.put("INCLUDED_SOURCE_FILE_NAMES[sdk=iphoneos*]", iOSResults);
-    expectedBuilder.put("INCLUDED_SOURCE_FILE_NAMES[sdk=iphonesimulator*]", simulatorResults);
-    expectedBuilder.put("INCLUDED_SOURCE_FILE_NAMES[sdk=macosx*]", macOSResults);
-    ImmutableMap<String, ImmutableSet<String>> expectedResult = expectedBuilder.build();
-
-    assertEquals(result, expectedResult);
   }
 
   @Test


### PR DESCRIPTION
Resolves https://github.com/facebook/buck/issues/2032 using a different approach.

This PR essentially solve two issues:
1. `supported_platforms_regex` now won't be included in the undesired platform, originally this could create an empty project target or unsupported source/header being included.
2.   Header collision by `glob` usage in `exported_platform_headers`, this is covered in detail in https://github.com/facebook/buck/issues/2032

@williamtwilson While i don't think this is a very elegant solution it does the job. Since this reverted couple of commits (bd07dcd6b0fe90c938985f330b2c268880b12b56, 4ab71d6a16f1bd3174657300180beed784ab5d3b and abb6939ce214492dd1fbfd5b44edfc46d47ca3f9) and uses a different approach than excluding headers based on platform, I'm up for discussion