### PR TITLE
Add swift build target version to rulekey

### DIFF
--- a/src/com/facebook/buck/apple/toolchain/impl/AppleCxxPlatforms.java
+++ b/src/com/facebook/buck/apple/toolchain/impl/AppleCxxPlatforms.java
@@ -493,9 +493,7 @@ public class AppleCxxPlatforms {
         ImmutableList.of(
             "-frontend",
             "-sdk",
-            sdkPaths.getSdkPath().toString(),
-            "-target",
-            targetArchitectureName);
+            sdkPaths.getSdkPath().toString());
 
     ImmutableList.Builder<String> swiftStdlibToolParamsBuilder = ImmutableList.builder();
     swiftStdlibToolParamsBuilder
@@ -523,7 +521,11 @@ public class AppleCxxPlatforms {
     if (swiftc.isPresent()) {
       return Optional.of(
           SwiftPlatformFactory.build(
-              platformName, sdkPaths.getToolchainPaths(), swiftc.get(), swiftStdLibTool));
+              platformName,
+              sdkPaths.getToolchainPaths(),
+              swiftc.get(),
+              swiftStdLibTool,
+              targetArchitectureName));
     } else {
       return Optional.empty();
     }

--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -84,6 +84,7 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
   private final Optional<Path> swiftFileListPath;
 
   @AddToRuleKey private final ImmutableSortedSet<SourcePath> srcs;
+  @AddToRuleKey private final String swiftTarget;
   @AddToRuleKey private final Optional<String> version;
   @AddToRuleKey private final ImmutableList<? extends Arg> compilerFlags;
 
@@ -106,6 +107,7 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
       CxxPlatform cxxPlatform,
       SwiftBuckConfig swiftBuckConfig,
       BuildTarget buildTarget,
+      String swiftTarget,
       ProjectFilesystem projectFilesystem,
       BuildRuleParams params,
       Tool swiftCompiler,
@@ -149,6 +151,7 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
             : Optional.empty();
 
     this.srcs = ImmutableSortedSet.copyOf(srcs);
+    this.swiftTarget = swiftTarget;
     this.version = version;
     this.compilerFlags =
         new ImmutableList.Builder<Arg>()
@@ -175,6 +178,8 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
   private SwiftCompileStep makeCompileStep(SourcePathResolver resolver) {
     ImmutableList.Builder<String> compilerCommand = ImmutableList.builder();
     compilerCommand.addAll(swiftCompiler.getCommandPrefix(resolver));
+
+    compilerCommand.add("-target", swiftTarget);
 
     if (bridgingHeader.isPresent()) {
       compilerCommand.add(
@@ -277,20 +282,8 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
 
     // The swift compiler path will be the first element of the command prefix
     compilerCommand.add(commandPrefix.get(0));
-
-    String target = "";
-    for (int i = 0; i < commandPrefix.size() - 1; ++i) {
-      if (commandPrefix.get(i).equals("-target")) {
-        target = commandPrefix.get(i + 1);
-        break;
-      }
-    }
-
     compilerCommand.add("-modulewrap", modulePath.toString(), "-o", moduleObjectPath.toString());
-
-    if (!target.isEmpty()) {
-      compilerCommand.add("-target", target);
-    }
+    compilerCommand.add("-target", swiftTarget);
 
     ProjectFilesystem projectFilesystem = getProjectFilesystem();
     return new SwiftCompileStep(

--- a/src/com/facebook/buck/swift/SwiftLibraryDescription.java
+++ b/src/com/facebook/buck/swift/SwiftLibraryDescription.java
@@ -278,6 +278,7 @@ public class SwiftLibraryDescription
           cxxPlatform,
           swiftBuckConfig,
           buildTarget,
+          swiftPlatform.get().getSwiftTarget(),
           projectFilesystem,
           params.copyAppendingExtraDeps(
               () ->
@@ -445,6 +446,7 @@ public class SwiftLibraryDescription
         cxxPlatform,
         swiftBuckConfig,
         buildTarget,
+        swiftPlatform.getSwiftTarget(),
         projectFilesystem,
         paramsWithSrcDeps,
         swiftPlatform.getSwiftc(),

--- a/src/com/facebook/buck/swift/toolchain/AbstractSwiftPlatform.java
+++ b/src/com/facebook/buck/swift/toolchain/AbstractSwiftPlatform.java
@@ -51,4 +51,10 @@ interface AbstractSwiftPlatform {
    *     "@executable_path/Frameworks" is a common rpath.
    */
   ImmutableList<Path> getSwiftSharedLibraryRunPaths();
+
+  /**
+   * @return String that represents the architecture target the swift module is built for
+   * e.g. x86_64-apple-ios9.0
+   */
+  String getSwiftTarget();
 }

--- a/src/com/facebook/buck/swift/toolchain/impl/SwiftPlatformFactory.java
+++ b/src/com/facebook/buck/swift/toolchain/impl/SwiftPlatformFactory.java
@@ -32,12 +32,17 @@ public class SwiftPlatformFactory {
   private SwiftPlatformFactory() {}
 
   public static SwiftPlatform build(
-      String platformName, Set<Path> toolchainPaths, Tool swiftc, Optional<Tool> swiftStdLibTool) {
+      String platformName,
+      Set<Path> toolchainPaths,
+      Tool swiftc,
+      Optional<Tool> swiftStdLibTool,
+      String swiftTarget) {
     SwiftPlatform.Builder builder =
         SwiftPlatform.builder()
             .setSwiftc(swiftc)
             .setSwiftStdlibTool(swiftStdLibTool)
-            .setSwiftSharedLibraryRunPaths(buildSharedRunPaths(platformName));
+            .setSwiftSharedLibraryRunPaths(buildSharedRunPaths(platformName))
+            .setSwiftTarget(swiftTarget);
 
     for (Path toolchainPath : toolchainPaths) {
       Path swiftRuntimePath = toolchainPath.resolve("usr/lib/swift").resolve(platformName);

--- a/test/com/facebook/buck/apple/toolchain/impl/AppleCxxPlatformsTest.java
+++ b/test/com/facebook/buck/apple/toolchain/impl/AppleCxxPlatformsTest.java
@@ -1095,11 +1095,11 @@ public class AppleCxxPlatformsTest {
   @Test
   public void checkSwiftPlatformUsesCorrectMinTargetSdk() {
     AppleCxxPlatform platformWithConfiguredSwift = buildAppleCxxPlatformWithSwiftToolchain();
-    Tool swiftc = platformWithConfiguredSwift.getSwiftPlatform().get().getSwiftc();
+    SwiftPlatform swiftPlatform = platformWithConfiguredSwift.getSwiftPlatform().get();
+    Tool swiftc = swiftPlatform.getSwiftc();
     assertThat(swiftc, notNullValue());
     assertThat(swiftc, instanceOf(VersionedTool.class));
-    VersionedTool versionedSwiftc = (VersionedTool) swiftc;
-    assertThat(versionedSwiftc.getExtraArgs(), hasItem("i386-apple-ios7.0"));
+    assertThat(swiftPlatform.getSwiftTarget(), equalTo("i386-apple-ios7.0"));
   }
 
   @Test

--- a/test/com/facebook/buck/swift/SwiftNativeLinkableTest.java
+++ b/test/com/facebook/buck/swift/SwiftNativeLinkableTest.java
@@ -56,7 +56,11 @@ public class SwiftNativeLinkableTest {
   public void testStaticLinkerFlagsOnMobile() {
     SwiftPlatform swiftPlatform =
         SwiftPlatformFactory.build(
-            "iphoneos", ImmutableSet.of(), swiftcTool, Optional.of(swiftStdTool));
+            "iphoneos",
+            ImmutableSet.of(),
+            swiftcTool,
+            Optional.of(swiftStdTool),
+            "x86_64-apple-ios9.3");
 
     ImmutableList.Builder<Arg> staticArgsBuilder = ImmutableList.builder();
     SwiftRuntimeNativeLinkable.populateLinkerArguments(
@@ -88,7 +92,11 @@ public class SwiftNativeLinkableTest {
   public void testStaticLinkerFlagsOnMac() {
     SwiftPlatform swiftPlatform =
         SwiftPlatformFactory.build(
-            "macosx", ImmutableSet.of(), swiftcTool, Optional.of(swiftStdTool));
+            "macosx",
+            ImmutableSet.of(),
+            swiftcTool,
+            Optional.of(swiftStdTool),
+            "x86_64-apple-ios9.3");
 
     ImmutableList.Builder<Arg> sharedArgsBuilder = ImmutableList.builder();
     SwiftRuntimeNativeLinkable.populateLinkerArguments(

--- a/test/com/facebook/buck/swift/toolchain/impl/SwiftPlatformFactoryIntegrationTest.java
+++ b/test/com/facebook/buck/swift/toolchain/impl/SwiftPlatformFactoryIntegrationTest.java
@@ -51,11 +51,16 @@ public class SwiftPlatformFactoryIntegrationTest {
   public void testBuildSwiftPlatformWithEmptyToolchainPaths() {
     SwiftPlatform swiftPlatform =
         SwiftPlatformFactory.build(
-            "iphoneos", ImmutableSet.of(), swiftcTool, Optional.of(swiftStdTool));
+            "iphoneos",
+            ImmutableSet.of(),
+            swiftcTool,
+            Optional.of(swiftStdTool),
+            "x86_64-apple-ios9.3");
     assertThat(swiftPlatform.getSwiftStdlibTool().get(), equalTo(swiftStdTool));
     assertThat(swiftPlatform.getSwiftc(), equalTo(swiftcTool));
     assertThat(swiftPlatform.getSwiftRuntimePaths(), empty());
     assertThat(swiftPlatform.getSwiftStaticRuntimePaths(), empty());
+    assertThat(swiftPlatform.getSwiftTarget(), equalTo("x86_64-apple-ios9.3"));
   }
 
   @Test
@@ -63,7 +68,11 @@ public class SwiftPlatformFactoryIntegrationTest {
     Path dir = tmp.newFolder("foo");
     SwiftPlatform swiftPlatform =
         SwiftPlatformFactory.build(
-            "iphoneos", ImmutableSet.of(dir), swiftcTool, Optional.of(swiftStdTool));
+            "iphoneos",
+            ImmutableSet.of(dir),
+            swiftcTool,
+            Optional.of(swiftStdTool),
+            "x86_64-apple-ios9.3");
     assertThat(swiftPlatform.getSwiftRuntimePaths(), empty());
     assertThat(swiftPlatform.getSwiftStaticRuntimePaths(), empty());
   }
@@ -81,7 +90,8 @@ public class SwiftPlatformFactoryIntegrationTest {
                 tmp.getRoot().resolve("foo2"),
                 tmp.getRoot().resolve("foo3")),
             swiftcTool,
-            Optional.of(swiftStdTool));
+            Optional.of(swiftStdTool),
+            "x86_64-apple-ios9.3");
     assertThat(swiftPlatform.getSwiftRuntimePaths(), hasSize(1));
     assertThat(swiftPlatform.getSwiftStaticRuntimePaths(), hasSize(2));
   }


### PR DESCRIPTION
Add swift archicture version into rule key.

This allow swift module to be rebuilt when buckconfig architecture version change (e.g. iphoneos_target_sdk_version = 9.3). 

Originally this would potentially cause issue since module is not rebuilt, and linking modules with different target architecture versions is not allowed -> build failure 