### PR TITLE
update documentation link to integration tests

### DIFF
--- a/docs/__go_common.soy
+++ b/docs/__go_common.soy
@@ -133,7 +133,7 @@ Note: Buck is currently tested with (and therefore supports) version 1.10 of Go.
 {template .more_examples}
 <p>
   For more examples, check out our <a
-  href="https://github.com/facebook/buck/tree/master/test/com/facebook/buck/go/testdata/">
+  href="https://github.com/facebook/buck/tree/master/test/com/facebook/buck/features/go/testdata">
   integration tests</a>.
 </p>
 {/template}


### PR DESCRIPTION
I noticed when I clicked on "more examples" on the website I was linked to an outdated directory. 