### PR TITLE
fix swift version query in project gen

### DIFF
--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -1051,8 +1051,8 @@ public class ProjectGenerator {
         targetNodeWithSwiftArgs.flatMap(t -> t.getConstructorArg().getSwiftVersion());
     if (!targetExplicitSwiftVersion.isPresent()
         && (targetNode.getDescription() instanceof AppleLibraryDescription
-        || targetNode.getDescription() instanceof AppleBinaryDescription
-        || targetNode.getDescription() instanceof AppleTestDescription)) {
+            || targetNode.getDescription() instanceof AppleBinaryDescription
+            || targetNode.getDescription() instanceof AppleTestDescription)) {
       return swiftBuckConfig.getVersion();
     }
     return targetExplicitSwiftVersion;

--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -1047,7 +1047,15 @@ public class ProjectGenerator {
   private Optional<String> getSwiftVersionForTargetNode(TargetNode<?> targetNode) {
     Optional<TargetNode<SwiftCommonArg>> targetNodeWithSwiftArgs =
         TargetNodes.castArg(targetNode, SwiftCommonArg.class);
-    return targetNodeWithSwiftArgs.flatMap(t -> t.getConstructorArg().getSwiftVersion());
+    Optional<String> targetExplicitSwiftVersion =
+        targetNodeWithSwiftArgs.flatMap(t -> t.getConstructorArg().getSwiftVersion());
+    if (!targetExplicitSwiftVersion.isPresent()
+        && (targetNode.getDescription() instanceof AppleLibraryDescription
+        || targetNode.getDescription() instanceof AppleBinaryDescription
+        || targetNode.getDescription() instanceof AppleTestDescription)) {
+      return swiftBuckConfig.getVersion();
+    }
+    return targetExplicitSwiftVersion;
   }
 
   private static String sourceNameRelativeToOutput(


### PR DESCRIPTION
This fix a problem where project gen ignores the swift version when it's default