### PR TITLE
Make kotlin_home buck config support specifying source path.

### DIFF
--- a/docs/files-and-dirs/buckconfig.soy
+++ b/docs/files-and-dirs/buckconfig.soy
@@ -3105,33 +3105,19 @@ or the value could be a custom platform flavor:
 
 {call buckconfig.entry}
   {param section: 'kotlin' /}
-  {param name: 'kotlinc' /}
-  {param example_value: '/usr/local/bin/kotlinc' /}
-  {param description}
-    The path to the <code>kotlinc</code> compiler executable to use when external compilation is
-    forced.  This setting has no effect by itself and must be paired with the
-    {sp}{call buckconfig.kotlin_external /} setting.
-  {/param}
-{/call}
-
-{call buckconfig.entry}
-  {param section: 'kotlin' /}
   {param name: 'external' /}
   {param example_value: 'true' /}
   {param description}
     Forces external compilation via <code>kotlinc</code>.  When external compilation is forced the
     following heuristics are used to locate the <code>kotlinc</code> executable:
     <ul>
-      <li>If the <code>{call buckconfig.kotlin_kotlinc /}</code> setting is specified, the executable specified by that path
-          will be used.
-      </li>
       <li>If the {call buckconfig.kotlin_kotlin_home /} path setting is specified, Buck will look
-          for a <code>bin</code> directory under that path for an executable named
-          {sp}<code>kotlinc</code>.
+          for an executable named {sp}<code>kotlinc</code> first under <code>kotlin_home<code> directory
+          and then under <code>kotlin_home/bin</code> directory.
       </li>
-      <li>If a <code>KOTLIN_HOME</code> environment variable is present, Buck will look for a
-          {sp}<code>bin</code> directory under that path for an executable named
-          {sp}<code>kotlinc</code>.
+      <li>If a <code>KOTLIN_HOME</code> environment variable is present, Buck will look
+          for an executable named {sp}<code>kotlinc</code> first under <code>$KOTLIN_HOME<code> directory
+          and then under <code>$KOTLIN_HOME/bin</code> directory.
       </li>
       <li>Lastly, if none of the above are specified, Buck will look for the <code>kotlinc</code>
           {sp}executable in the paths listed in the <code>PATH</code> environment variable.
@@ -3150,25 +3136,29 @@ or the value could be a custom platform flavor:
     assets (executables and JAR files) can be found.  This path is used in the following ways:
     <ul>
       <li>
-        When in-memory compilation is used, the <code>kotlin-compiler.jar</code> and other related
-        Kotlin JARs required for compilation are located via this path using the following
-        heuristics:
+        When in-memory compilation is used, the <code>kotlin-compiler-embeddable.jar</code> and other
+        related Kotlin JARs required for compilation are expected to be in <code>libexec/lib</code>
+        directory under this path. A build target or a relative path to the project root can be
+        specified here. Other required jars are specified below:
         <ul>
           <li>
-            The root of the directory specified by this path is searched.
+            <code>kotlin-annotation-processing-gradle.jar</code>
           </li>
           <li>
-            If there is a <code>lib</code> directory under this path, it is searched.
+            <code>kotlin-reflect.jar</code>
           </li>
           <li>
-            If there is a <code>libexec</code> directory under this path, it is searched.
+            <code>kotlin-stdlib.jar</code>
+          </li>
+          <li>
+            <code>kotlin-script-runtime.jar</code>
           </li>
         </ul>
       </li>
       <li>
-        If external compilation is called for (see {call buckconfig.kotlin_external /}), a
-        {sp}<code>bin</code> directory under this directory will be searched to locate the
-        {sp}<code>kotlinc</code> executable.
+        If external compilation is called for (see {call buckconfig.kotlin_external /}), Buck will look
+        for an executable named {sp}<code>kotlinc</code> first under <code>kotlin_home<code> directory
+        and then under <code>kotlin_home/bin</code> directory.
       </li>
     </ul>
     If this setting is not specified, the location of the Kotlin home directory can be specified

--- a/src/com/facebook/buck/jvm/kotlin/ExternalKotlinc.java
+++ b/src/com/facebook/buck/jvm/kotlin/ExternalKotlinc.java
@@ -15,8 +15,6 @@
  */
 package com.facebook.buck.jvm.kotlin;
 
-import static com.google.common.collect.Iterables.transform;
-
 import com.facebook.buck.core.exceptions.HumanReadableException;
 import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.rulekey.AddToRuleKey;
@@ -40,6 +38,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /** kotlinc implemented as a separate binary. */
 public class ExternalKotlinc implements Kotlinc, AddsToRuleKey {
@@ -47,6 +46,7 @@ public class ExternalKotlinc implements Kotlinc, AddsToRuleKey {
   private static final KotlincVersion DEFAULT_VERSION = KotlincVersion.of("unknown version");
 
   private final Path pathToKotlinc;
+
   private final Supplier<KotlincVersion> version;
 
   public ExternalKotlinc(Path pathToKotlinc) {
@@ -100,6 +100,7 @@ public class ExternalKotlinc implements Kotlinc, AddsToRuleKey {
   public int buildWithClasspath(
       ExecutionContext context,
       BuildTarget invokingRule,
+      ImmutableList<Path> kotlinHomeLibraries,
       ImmutableList<String> options,
       ImmutableSortedSet<Path> kotlinSourceFilePaths,
       Path pathToSrcsList,
@@ -126,9 +127,10 @@ public class ExternalKotlinc implements Kotlinc, AddsToRuleKey {
             .add(pathToKotlinc.toString())
             .addAll(options)
             .addAll(
-                transform(
-                    expandedSources,
-                    path -> projectFilesystem.resolve(path).toAbsolutePath().toString()))
+                expandedSources
+                    .stream()
+                    .map(path -> projectFilesystem.resolve(path).toAbsolutePath().toString())
+                    .collect(Collectors.toList()))
             .build();
 
     // Run the command
@@ -186,6 +188,11 @@ public class ExternalKotlinc implements Kotlinc, AddsToRuleKey {
 
   @Override
   public ImmutableList<Path> getAdditionalClasspathEntries(SourcePathResolver sourcePathResolver) {
+    return ImmutableList.of();
+  }
+
+  @Override
+  public ImmutableList<Path> getHomeLibraries(SourcePathResolver sourcePathResolver) {
     return ImmutableList.of();
   }
 

--- a/src/com/facebook/buck/jvm/kotlin/JarBackedReflectedKotlinc.java
+++ b/src/com/facebook/buck/jvm/kotlin/JarBackedReflectedKotlinc.java
@@ -134,12 +134,12 @@ public class JarBackedReflectedKotlinc implements Kotlinc {
 
   @Override
   public ImmutableList<String> getCommandPrefix(SourcePathResolver resolver) {
-    throw new UnsupportedOperationException("Target kotlinc may not be used externally");
+    throw new UnsupportedOperationException("In memory kotlinc may not be used externally");
   }
 
   @Override
   public KotlincVersion getVersion() {
-    throw new UnsupportedOperationException("Target based kotlinc doesn't have a version");
+    throw new UnsupportedOperationException("In memory kotlinc doesn't have a version");
   }
 
   @Override

--- a/src/com/facebook/buck/jvm/kotlin/JarBackedReflectedKotlinc.java
+++ b/src/com/facebook/buck/jvm/kotlin/JarBackedReflectedKotlinc.java
@@ -16,12 +16,9 @@
 
 package com.facebook.buck.jvm.kotlin;
 
-import static com.google.common.collect.Iterables.transform;
-
 import com.facebook.buck.core.exceptions.HumanReadableException;
 import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.rulekey.AddToRuleKey;
-import com.facebook.buck.core.sourcepath.PathSourcePath;
 import com.facebook.buck.core.sourcepath.SourcePath;
 import com.facebook.buck.core.sourcepath.resolver.SourcePathResolver;
 import com.facebook.buck.io.filesystem.ProjectFilesystem;
@@ -31,15 +28,14 @@ import com.facebook.buck.util.ClassLoaderCache;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
-import java.io.File;
 import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -51,7 +47,20 @@ public class JarBackedReflectedKotlinc implements Kotlinc {
 
   private static final String COMPILER_CLASS = "org.jetbrains.kotlin.cli.jvm.K2JVMCompiler";
   private static final String EXIT_CODE_CLASS = "org.jetbrains.kotlin.cli.common.ExitCode";
-  private static final KotlincVersion VERSION = KotlincVersion.of("in memory");
+
+  private static final String FOLDER_PREFIX = "libexec/lib";
+
+  private static final String KOTLIN_ANNOTATION_PROCESSING =
+      "kotlin-annotation-processing-gradle.jar";
+
+  private static final String KOTLIN_COMPILER_EMBEDDABLE = "kotlin-compiler-embeddable.jar";
+  private static final String KOTLIN_REFLECT = "kotlin-reflect.jar";
+  private static final String KOTLIN_SCRIPT_RUNTIME = "kotlin-script-runtime.jar";
+  private static final String KOTLIN_STDLIB = "kotlin-stdlib.jar";
+
+  private static final ImmutableList<String> HOME_LIBRARIES_JAR =
+      ImmutableList.of(
+          KOTLIN_COMPILER_EMBEDDABLE, KOTLIN_REFLECT, KOTLIN_SCRIPT_RUNTIME, KOTLIN_STDLIB);
 
   private static final Function<Path, URL> PATH_TO_URL =
       p -> {
@@ -65,22 +74,10 @@ public class JarBackedReflectedKotlinc implements Kotlinc {
   // Used to hang onto the KotlinDaemonShim for the life of the buckd process
   private static final Map<Set<String>, Object> kotlinShims = new ConcurrentHashMap<>();
 
-  @AddToRuleKey private final ImmutableSet<SourcePath> compilerClassPath;
-  private final Path annotationProcessingClassPath;
-  private final Path standardLibraryClasspath;
+  @AddToRuleKey private final SourcePath kotlinHome;
 
-  JarBackedReflectedKotlinc(
-      ImmutableSet<SourcePath> compilerClassPath,
-      Path annotationProcessingClassPath,
-      Path standardLibraryClasspath) {
-    this.compilerClassPath = compilerClassPath;
-    this.annotationProcessingClassPath = annotationProcessingClassPath;
-    this.standardLibraryClasspath = standardLibraryClasspath;
-  }
-
-  @Override
-  public KotlincVersion getVersion() {
-    return VERSION;
+  JarBackedReflectedKotlinc(SourcePath kotlinHome) {
+    this.kotlinHome = kotlinHome;
   }
 
   @Override
@@ -103,12 +100,31 @@ public class JarBackedReflectedKotlinc implements Kotlinc {
 
   @Override
   public Path getAnnotationProcessorPath(SourcePathResolver sourcePathResolver) {
-    return annotationProcessingClassPath;
+    return sourcePathResolver
+        .getAbsolutePath(this.kotlinHome)
+        .resolve(FOLDER_PREFIX)
+        .resolve(KOTLIN_ANNOTATION_PROCESSING);
   }
 
   @Override
   public Path getStdlibPath(SourcePathResolver sourcePathResolver) {
-    return standardLibraryClasspath;
+    return sourcePathResolver
+        .getAbsolutePath(this.kotlinHome)
+        .resolve(FOLDER_PREFIX)
+        .resolve(KOTLIN_STDLIB);
+  }
+
+  @Override
+  public ImmutableList<Path> getHomeLibraries(SourcePathResolver sourcePathResolver) {
+    return HOME_LIBRARIES_JAR
+        .stream()
+        .map(
+            jar ->
+                sourcePathResolver
+                    .getAbsolutePath(this.kotlinHome)
+                    .resolve(FOLDER_PREFIX)
+                    .resolve(jar))
+        .collect(ImmutableList.toImmutableList());
   }
 
   @Override
@@ -118,13 +134,19 @@ public class JarBackedReflectedKotlinc implements Kotlinc {
 
   @Override
   public ImmutableList<String> getCommandPrefix(SourcePathResolver resolver) {
-    throw new UnsupportedOperationException("In memory kotlinc may not be used externally");
+    throw new UnsupportedOperationException("Target kotlinc may not be used externally");
+  }
+
+  @Override
+  public KotlincVersion getVersion() {
+    throw new UnsupportedOperationException("Target based kotlinc doesn't have a version");
   }
 
   @Override
   public int buildWithClasspath(
       ExecutionContext context,
       BuildTarget invokingRule,
+      ImmutableList<Path> kotlinHomeLibraries,
       ImmutableList<String> options,
       ImmutableSortedSet<Path> kotlinSourceFilePaths,
       Path pathToSrcsList,
@@ -149,23 +171,23 @@ public class JarBackedReflectedKotlinc implements Kotlinc {
         ImmutableList.<String>builder()
             .addAll(options)
             .addAll(
-                transform(
-                    expandedSources,
-                    path -> projectFilesystem.resolve(path).toAbsolutePath().toString()))
+                expandedSources
+                    .stream()
+                    .map(path -> projectFilesystem.resolve(path).toAbsolutePath().toString())
+                    .collect(Collectors.toList()))
             .build();
 
-    Set<File> compilerIdPaths =
-        compilerClassPath
+    Set<String> kotlinHomeLibrariesStringPaths =
+        kotlinHomeLibraries
             .stream()
-            .map(p -> ((PathSourcePath) p).getRelativePath())
-            .map(Path::toFile)
+            .map(Path::toAbsolutePath)
+            .map(Path::toString)
             .collect(Collectors.toSet());
 
     try {
       Object compilerShim =
           kotlinShims.computeIfAbsent(
-              compilerIdPaths.stream().map(File::getAbsolutePath).collect(Collectors.toSet()),
-              k -> loadCompilerShim(context));
+              kotlinHomeLibrariesStringPaths, k -> loadCompilerShim(context, kotlinHomeLibraries));
 
       Method compile = compilerShim.getClass().getMethod("exec", PrintStream.class, String[].class);
 
@@ -187,7 +209,7 @@ public class JarBackedReflectedKotlinc implements Kotlinc {
     }
   }
 
-  private Object loadCompilerShim(ExecutionContext context) {
+  private Object loadCompilerShim(ExecutionContext context, List<Path> kotlinHomeLibraries) {
     try {
       ClassLoaderCache classLoaderCache = context.getClassLoaderCache();
       classLoaderCache.addRef();
@@ -195,12 +217,7 @@ public class JarBackedReflectedKotlinc implements Kotlinc {
       ClassLoader classLoader =
           classLoaderCache.getClassLoaderForClassPath(
               SynchronizedToolProvider.getSystemToolClassLoader(),
-              ImmutableList.copyOf(
-                  compilerClassPath
-                      .stream()
-                      .map(p -> ((PathSourcePath) p).getRelativePath())
-                      .map(PATH_TO_URL)
-                      .iterator()));
+              ImmutableList.copyOf(kotlinHomeLibraries.stream().map(PATH_TO_URL).iterator()));
 
       return classLoader.loadClass(COMPILER_CLASS).newInstance();
     } catch (Exception ex) {

--- a/src/com/facebook/buck/jvm/kotlin/KotlinBuckConfig.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinBuckConfig.java
@@ -18,11 +18,9 @@ package com.facebook.buck.jvm.kotlin;
 
 import com.facebook.buck.core.config.BuckConfig;
 import com.facebook.buck.core.exceptions.HumanReadableException;
+import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.sourcepath.SourcePath;
-import com.facebook.buck.core.util.log.Logger;
 import com.facebook.buck.io.ExecutableFinder;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedSet;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,151 +29,51 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 
 public class KotlinBuckConfig {
-
-  private static final Logger LOG = Logger.get(KotlinBuckConfig.class);
-
   private static final String SECTION = "kotlin";
+  private static final String KOTLIN_HOME_CONFIG = "kotlin_home";
 
   private static final Path DEFAULT_KOTLIN_COMPILER = Paths.get("kotlinc");
 
   private final BuckConfig delegate;
-  private @Nullable Path kotlinHome;
+  private @Nullable Kotlinc kotlinc;
 
   public KotlinBuckConfig(BuckConfig delegate) {
     this.delegate = delegate;
   }
 
   public Kotlinc getKotlinc() {
-    if (isExternalCompilation()) {
-      return new ExternalKotlinc(getPathToCompilerBinary());
-    } else {
-      ImmutableSet<SourcePath> classpathEntries =
-          ImmutableSet.of(
-              delegate.getPathSourcePath(getPathToStdlibJar()),
-              delegate.getPathSourcePath(getPathToReflectJar()),
-              delegate.getPathSourcePath(getPathToScriptRuntimeJar()),
-              delegate.getPathSourcePath(getPathToCompilerJar()));
-
-      return new JarBackedReflectedKotlinc(
-          classpathEntries, getPathToAnnotationProcessingJar(), getPathToStdlibJar());
+    if (kotlinc == null) {
+      if (isExternalCompilation()) {
+        kotlinc = new ExternalKotlinc(getPathToCompilerBinary());
+      } else {
+        Optional<SourcePath> kotlinHomeSourcePath =
+            delegate.getSourcePath(SECTION, KOTLIN_HOME_CONFIG);
+        if (kotlinHomeSourcePath.isPresent()) {
+          kotlinc = new JarBackedReflectedKotlinc(kotlinHomeSourcePath.get());
+        } else {
+          throw new HumanReadableException(
+              "kotlin_home needs to be set when not an external compilation");
+        }
+      }
     }
+    return kotlinc;
   }
 
-  public ImmutableSortedSet<Path> getKotlinHomeLibraries() {
-    return ImmutableSortedSet.copyOf(
-        ImmutableSortedSet.of(
-            getPathToStdlibJar(),
-            getPathToReflectJar(),
-            getPathToScriptRuntimeJar(),
-            getPathToCompilerJar()));
+  public Optional<BuildTarget> getKotlinHomeTarget() {
+    return delegate.getMaybeBuildTarget(SECTION, KOTLIN_HOME_CONFIG);
   }
 
-  Path getPathToCompilerBinary() {
-    Path compilerPath = getKotlinHome().resolve("kotlinc");
+  private Path getPathToCompilerBinary() {
+    Path kotlinHome = getKotlinHome();
+    Path compilerPath = kotlinHome.resolve("kotlinc");
     if (!Files.isExecutable(compilerPath)) {
-      compilerPath = getKotlinHome().resolve(Paths.get("bin", "kotlinc"));
+      compilerPath = kotlinHome.resolve("bin").resolve("kotlinc");
       if (!Files.isExecutable(compilerPath)) {
         throw new HumanReadableException("Could not resolve kotlinc location.");
       }
     }
 
     return new ExecutableFinder().getExecutable(compilerPath, delegate.getEnvironment());
-  }
-
-  private Path getPathToJar(String jarName) {
-    Path reflect = getKotlinHome().resolve(jarName + ".jar");
-    if (Files.isRegularFile(reflect)) {
-      return reflect.normalize();
-    }
-
-    reflect = getKotlinHome().resolve(Paths.get("lib", jarName + ".jar"));
-    if (Files.isRegularFile(reflect)) {
-      return reflect.normalize();
-    }
-
-    reflect = getKotlinHome().resolve(Paths.get("libexec", "lib", jarName + ".jar"));
-    if (Files.isRegularFile(reflect)) {
-      return reflect.normalize();
-    }
-
-    throw new HumanReadableException(
-        "Could not resolve " + jarName + " JAR location (kotlin home:" + getKotlinHome() + ").");
-  }
-
-  /**
-   * Get the path to the Kotlin runtime jar.
-   *
-   * @return the Kotlin runtime jar path
-   */
-  Path getPathToStdlibJar() {
-    try {
-      return getPathToJar("kotlin-stdlib");
-    } catch (HumanReadableException e) {
-      // TODO: Check if kt version < 1.1
-      return getPathToJar("kotlin-runtime");
-    }
-  }
-
-  /**
-   * Get the path to the Kotlin reflection jar.
-   *
-   * @return the Kotlin reflection jar path
-   */
-  Path getPathToReflectJar() {
-    return getPathToJar("kotlin-reflect");
-  }
-
-  /**
-   * Get the path to the Kotlin script runtime jar.
-   *
-   * @return the Kotlin script runtime jar path
-   */
-  Path getPathToScriptRuntimeJar() {
-    return getPathToJar("kotlin-script-runtime");
-  }
-
-  /**
-   * Get the path to the Kotlin compiler jar.
-   *
-   * @return the Kotlin compiler jar path
-   */
-  Path getPathToCompilerJar() {
-    try {
-      return getPathToJar("kotlin-compiler-embeddable");
-    } catch (HumanReadableException e) {
-      LOG.warn(
-          "kotlin-compiler-embeddable.jar was not found in "
-              + kotlinHome
-              + " directory, this"
-              + " may result in kapt not working properly. Proceeding with kotlin-compiler.jar");
-      return getPathToJar("kotlin-compiler");
-    }
-  }
-
-  /**
-   * Get the path to the Kotlin annotation processing jar.
-   *
-   * @return the Kotlin annotation processing jar path
-   */
-  Path getPathToAnnotationProcessingJar() {
-    try {
-      return getPathToJar("kotlin-annotation-processing-gradle");
-    } catch (HumanReadableException e) {
-      LOG.warn(
-          "kotlin-annotation-processing-gradle.jar was not found in "
-              + kotlinHome
-              + " directory, searching for kotlin-annotation-processing-maven.jar");
-      try {
-        return getPathToJar("kotlin-annotation-processing-maven");
-      } catch (HumanReadableException er) {
-        LOG.warn(
-            "kotlin-annotation-processing-maven.jar was not found in "
-                + kotlinHome
-                + " directory, this"
-                + " may result in kapt not working properly. Proceeding with kotlin-annotation-processing.jar");
-        return getPathToJar("kotlin-annotation-processing");
-      }
-    }
   }
 
   /**
@@ -203,19 +101,22 @@ public class KotlinBuckConfig {
    * @return the Kotlin home path
    */
   private Path getKotlinHome() {
-    if (kotlinHome != null) {
-      return kotlinHome;
+    if (!isExternalCompilation()) {
+      throw new HumanReadableException(
+          "kotlinHome path can only be queried when it's an external compilation");
     }
 
-    try {
-      // Check the buck configuration for a specified kotlin home
-      Optional<String> value = delegate.getValue(SECTION, "kotlin_home");
+    Path kotlinHome;
 
+    try {
+      Optional<String> value = delegate.getValue(SECTION, KOTLIN_HOME_CONFIG);
       if (value.isPresent()) {
+        // try to get kotlin home path from kotlin_home buck config
         boolean isAbsolute = Paths.get(value.get()).isAbsolute();
-        Optional<Path> homePath = delegate.getPath(SECTION, "kotlin_home", !isAbsolute);
+        Optional<Path> homePath = delegate.getPath(SECTION, KOTLIN_HOME_CONFIG, !isAbsolute);
+
         if (homePath.isPresent() && Files.isDirectory(homePath.get())) {
-          return homePath.get().toRealPath().normalize();
+          kotlinHome = homePath.get().toRealPath().normalize();
         } else {
           throw new HumanReadableException(
               "Kotlin home directory (" + homePath + ") specified in .buckconfig was not found.");
@@ -224,7 +125,7 @@ public class KotlinBuckConfig {
         // If the KOTLIN_HOME environment variable is specified we trust it
         String home = delegate.getEnvironment().get("KOTLIN_HOME");
         if (home != null) {
-          return Paths.get(home).normalize();
+          kotlinHome = Paths.get(home).normalize();
         } else {
           // Lastly, we try to resolve from the system PATH
           Optional<Path> compiler =
@@ -235,7 +136,6 @@ public class KotlinBuckConfig {
             if (kotlinHome != null && kotlinHome.endsWith(Paths.get("bin"))) {
               kotlinHome = kotlinHome.getParent().normalize();
             }
-            return kotlinHome;
           } else {
             throw new HumanReadableException(
                 "Could not resolve kotlin home directory, Consider setting KOTLIN_HOME.");
@@ -246,5 +146,7 @@ public class KotlinBuckConfig {
       throw new HumanReadableException(
           "Could not resolve kotlin home directory, Consider setting KOTLIN_HOME.", io);
     }
+
+    return kotlinHome;
   }
 }

--- a/src/com/facebook/buck/jvm/kotlin/KotlinConfiguredCompilerFactory.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinConfiguredCompilerFactory.java
@@ -16,6 +16,7 @@
 
 package com.facebook.buck.jvm.kotlin;
 
+import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.rules.BuildRuleResolver;
 import com.facebook.buck.core.rules.SourcePathRuleFinder;
 import com.facebook.buck.core.toolchain.ToolchainProvider;
@@ -28,6 +29,8 @@ import com.facebook.buck.jvm.java.JavacOptions;
 import com.facebook.buck.jvm.java.JvmLibraryArg;
 import com.facebook.buck.jvm.kotlin.KotlinLibraryDescription.AnnotationProcessingTool;
 import com.facebook.buck.jvm.kotlin.KotlinLibraryDescription.CoreArg;
+import com.facebook.buck.util.Optionals;
+import com.google.common.collect.ImmutableCollection;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -62,7 +65,6 @@ public class KotlinConfiguredCompilerFactory extends ConfiguredCompilerFactory {
     CoreArg kotlinArgs = Objects.requireNonNull((CoreArg) args);
     return new KotlincToJarStepFactory(
         kotlinBuckConfig.getKotlinc(),
-        kotlinBuckConfig.getKotlinHomeLibraries(),
         kotlinArgs.getExtraKotlincArguments(),
         kotlinArgs.getAnnotationProcessingTool().orElse(AnnotationProcessingTool.KAPT),
         extraClasspathProviderSupplier.apply(toolchainProvider),
@@ -72,5 +74,12 @@ public class KotlinConfiguredCompilerFactory extends ConfiguredCompilerFactory {
 
   private Javac getJavac(BuildRuleResolver resolver, @Nullable JvmLibraryArg arg) {
     return javacFactory.create(new SourcePathRuleFinder(resolver), arg);
+  }
+
+  @Override
+  public void addTargetDeps(
+      ImmutableCollection.Builder<BuildTarget> extraDepsBuilder,
+      ImmutableCollection.Builder<BuildTarget> targetGraphOnlyDepsBuilder) {
+    Optionals.addIfPresent(kotlinBuckConfig.getKotlinHomeTarget(), extraDepsBuilder);
   }
 }

--- a/src/com/facebook/buck/jvm/kotlin/KotlinLibraryBuilder.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinLibraryBuilder.java
@@ -24,7 +24,6 @@ import com.facebook.buck.core.toolchain.ToolchainProvider;
 import com.facebook.buck.io.filesystem.ProjectFilesystem;
 import com.facebook.buck.jvm.java.DefaultJavaLibraryRules;
 import com.facebook.buck.jvm.java.JavaBuckConfig;
-import com.facebook.buck.jvm.java.JavacFactory;
 
 final class KotlinLibraryBuilder {
   private KotlinLibraryBuilder() {}
@@ -36,10 +35,9 @@ final class KotlinLibraryBuilder {
       BuildRuleParams params,
       ActionGraphBuilder graphBuilder,
       CellPathResolver cellPathResolver,
-      KotlinBuckConfig kotlinBuckConfig,
+      KotlinConfiguredCompilerFactory compilerFactory,
       JavaBuckConfig javaBuckConfig,
-      KotlinLibraryDescription.CoreArg args,
-      JavacFactory javacFactory) {
+      KotlinLibraryDescription.CoreArg args) {
     return new DefaultJavaLibraryRules.Builder(
         buildTarget,
         projectFilesystem,
@@ -47,7 +45,7 @@ final class KotlinLibraryBuilder {
         params,
         graphBuilder,
         cellPathResolver,
-        new KotlinConfiguredCompilerFactory(kotlinBuckConfig, javacFactory),
+        compilerFactory,
         javaBuckConfig,
         args);
   }

--- a/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
@@ -58,18 +58,18 @@ public class KotlinLibraryDescription
       ImmutableSet.of(JavaLibrary.SRC_JAR, JavaLibrary.MAVEN_JAR);
 
   private final ToolchainProvider toolchainProvider;
-  private final KotlinBuckConfig kotlinBuckConfig;
   private final JavaBuckConfig javaBuckConfig;
   private final JavacFactory javacFactory;
+  private final KotlinConfiguredCompilerFactory compilerFactory;
 
   public KotlinLibraryDescription(
       ToolchainProvider toolchainProvider,
       KotlinBuckConfig kotlinBuckConfig,
       JavaBuckConfig javaBuckConfig) {
     this.toolchainProvider = toolchainProvider;
-    this.kotlinBuckConfig = kotlinBuckConfig;
     this.javaBuckConfig = javaBuckConfig;
     this.javacFactory = JavacFactory.getDefault(toolchainProvider);
+    this.compilerFactory = new KotlinConfiguredCompilerFactory(kotlinBuckConfig, javacFactory);
   }
 
   @Override
@@ -139,10 +139,9 @@ public class KotlinLibraryDescription
                 params,
                 graphBuilder,
                 context.getCellPathResolver(),
-                kotlinBuckConfig,
+                compilerFactory,
                 javaBuckConfig,
-                args,
-                javacFactory)
+                args)
             .setJavacOptions(javacOptions)
             .build();
 
@@ -176,6 +175,7 @@ public class KotlinLibraryDescription
       ImmutableCollection.Builder<BuildTarget> extraDepsBuilder,
       ImmutableCollection.Builder<BuildTarget> targetGraphOnlyDepsBuilder) {
     javacFactory.addParseTimeDeps(targetGraphOnlyDepsBuilder, constructorArg);
+    compilerFactory.addTargetDeps(extraDepsBuilder, targetGraphOnlyDepsBuilder);
   }
 
   public enum AnnotationProcessingTool {

--- a/src/com/facebook/buck/jvm/kotlin/KotlinTestDescription.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinTestDescription.java
@@ -45,10 +45,10 @@ import com.facebook.buck.util.MoreSuppliers;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.immutables.value.Value;
 
 /** Description for kotlin_test. */
@@ -61,6 +61,7 @@ public class KotlinTestDescription
   private final Supplier<JavaOptions> javaOptionsForTests;
   private final JavacFactory javacFactory;
   private final Supplier<JavacOptions> defaultJavacOptions;
+  private final KotlinConfiguredCompilerFactory compilerFactory;
 
   public KotlinTestDescription(
       ToolchainProvider toolchainProvider,
@@ -76,6 +77,8 @@ public class KotlinTestDescription
                 toolchainProvider
                     .getByName(JavacOptionsProvider.DEFAULT_NAME, JavacOptionsProvider.class)
                     .getJavacOptions());
+
+    this.compilerFactory = new KotlinConfiguredCompilerFactory(kotlinBuckConfig, javacFactory);
   }
 
   @Override
@@ -105,10 +108,9 @@ public class KotlinTestDescription
                 params,
                 graphBuilder,
                 context.getCellPathResolver(),
-                kotlinBuckConfig,
+                compilerFactory,
                 javaBuckConfig,
-                args,
-                javacFactory)
+                args)
             .setJavacOptions(javacOptions)
             .build();
 
@@ -136,7 +138,10 @@ public class KotlinTestDescription
         args.getContacts(),
         args.getTestType().orElse(TestType.JUNIT),
         javaOptionsForTests.get().getJavaRuntimeLauncher(graphBuilder),
-        Lists.transform(args.getVmArgs(), vmArg -> macrosConverter.convert(vmArg, graphBuilder)),
+        args.getVmArgs()
+            .stream()
+            .map(vmArg -> macrosConverter.convert(vmArg, graphBuilder))
+            .collect(Collectors.toList()),
         ImmutableMap.of(), /* nativeLibsEnvironment */
         args.getTestRuleTimeoutMs()
             .map(Optional::of)
@@ -160,6 +165,7 @@ public class KotlinTestDescription
       ImmutableCollection.Builder<BuildTarget> targetGraphOnlyDepsBuilder) {
     javacFactory.addParseTimeDeps(targetGraphOnlyDepsBuilder, constructorArg);
     javaOptionsForTests.get().addParseTimeDeps(targetGraphOnlyDepsBuilder);
+    compilerFactory.addTargetDeps(extraDepsBuilder, targetGraphOnlyDepsBuilder);
   }
 
   @BuckStyleImmutable

--- a/src/com/facebook/buck/jvm/kotlin/Kotlinc.java
+++ b/src/com/facebook/buck/jvm/kotlin/Kotlinc.java
@@ -42,6 +42,7 @@ public interface Kotlinc extends Tool {
   int buildWithClasspath(
       ExecutionContext context,
       BuildTarget invokingRule,
+      ImmutableList<Path> kotlinHomeLibraries,
       ImmutableList<String> options,
       ImmutableSortedSet<Path> kotlinSourceFilePaths,
       Path pathToSrcsList,
@@ -61,6 +62,8 @@ public interface Kotlinc extends Tool {
   Path getStdlibPath(SourcePathResolver sourcePathResolver);
 
   ImmutableList<Path> getAdditionalClasspathEntries(SourcePathResolver sourcePathResolver);
+
+  ImmutableList<Path> getHomeLibraries(SourcePathResolver sourcePathResolver);
 
   default ImmutableList<Path> getExpandedSourcePaths(
       ProjectFilesystem projectFilesystem,

--- a/src/com/facebook/buck/jvm/kotlin/KotlincStep.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlincStep.java
@@ -43,6 +43,7 @@ public class KotlincStep implements Step {
   private static final String VERBOSE = "-verbose";
 
   private final Kotlinc kotlinc;
+  private final ImmutableList<Path> kotlinHomeLibraries;
   private final ImmutableSortedSet<Path> combinedClassPathEntries;
   private final Path outputDirectory;
   private final ImmutableList<String> extraArguments;
@@ -59,6 +60,7 @@ public class KotlincStep implements Step {
       Path pathToSrcsList,
       ImmutableSortedSet<Path> combinedClassPathEntries,
       Kotlinc kotlinc,
+      ImmutableList<Path> kotlinHomeLibraries,
       ImmutableList<String> extraArguments,
       ProjectFilesystem filesystem,
       Optional<Path> workingDirectory) {
@@ -67,6 +69,7 @@ public class KotlincStep implements Step {
     this.sourceFilePaths = sourceFilePaths;
     this.pathToSrcsList = pathToSrcsList;
     this.kotlinc = kotlinc;
+    this.kotlinHomeLibraries = kotlinHomeLibraries;
     this.combinedClassPathEntries = combinedClassPathEntries;
     this.extraArguments = extraArguments;
     this.filesystem = filesystem;
@@ -93,6 +96,7 @@ public class KotlincStep implements Step {
           kotlinc.buildWithClasspath(
               firstOrderContext,
               invokingRule,
+              kotlinHomeLibraries,
               getOptions(context, combinedClassPathEntries),
               sourceFilePaths,
               pathToSrcsList,

--- a/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
@@ -92,18 +92,14 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
   private static final String NO_REFLECT = "-no-reflect";
   private static final String VERBOSE = "-verbose";
 
-  private final ImmutableSortedSet<Path> kotlinHomeLibraries;
-
   KotlincToJarStepFactory(
       Kotlinc kotlinc,
-      ImmutableSortedSet<Path> kotlinHomeLibraries,
       ImmutableList<String> extraKotlincArguments,
       AnnotationProcessingTool annotationProcessingTool,
       ExtraClasspathProvider extraClassPath,
       Javac javac,
       JavacOptions javacOptions) {
     this.kotlinc = kotlinc;
-    this.kotlinHomeLibraries = kotlinHomeLibraries;
     this.extraKotlincArguments = extraKotlincArguments;
     this.annotationProcessingTool = annotationProcessingTool;
     this.extraClassPath = extraClassPath;
@@ -170,7 +166,7 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
                   Optional.ofNullable(extraClassPath.getExtraClasspath())
                       .orElse(ImmutableList.of()))
               .addAll(declaredClasspathEntries)
-              .addAll(kotlinHomeLibraries)
+              .addAll(kotlinc.getHomeLibraries(buildContext.getSourcePathResolver()))
               .build();
 
       if (generatingCode && annotationProcessingTool.equals(AnnotationProcessingTool.KAPT)) {
@@ -221,6 +217,7 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
               pathToSrcsList,
               allClasspaths,
               kotlinc,
+              kotlinc.getHomeLibraries(buildContext.getSourcePathResolver()),
               ImmutableList.<String>builder()
                   .addAll(extraKotlincArguments)
                   .add(NO_STDLIB)
@@ -352,6 +349,7 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
                 .addAll(declaredClasspathEntries)
                 .build(),
             kotlinc,
+            kotlinc.getHomeLibraries(resolver),
             ImmutableList.<String>builder()
                 .addAll(extraArguments)
                 .add(MODULE_NAME)
@@ -380,6 +378,7 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
                 .addAll(declaredClasspathEntries)
                 .build(),
             kotlinc,
+            kotlinc.getHomeLibraries(resolver),
             ImmutableList.<String>builder()
                 .addAll(extraArguments)
                 .add(MODULE_NAME)

--- a/test/com/facebook/buck/jvm/kotlin/FauxKotlinLibraryBuilder.java
+++ b/test/com/facebook/buck/jvm/kotlin/FauxKotlinLibraryBuilder.java
@@ -18,6 +18,7 @@ package com.facebook.buck.jvm.kotlin;
 
 import static com.facebook.buck.jvm.java.JavaCompilationConstants.DEFAULT_JAVAC_OPTIONS;
 
+import com.facebook.buck.core.config.FakeBuckConfig;
 import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.model.targetgraph.AbstractNodeBuilder;
 import com.facebook.buck.core.rules.BuildRule;
@@ -55,7 +56,7 @@ public class FauxKotlinLibraryBuilder
                         .setJavacProvider(JavacSpec.builder().build().getJavacProvider())
                         .build())
                 .build(),
-            null,
+            new KotlinBuckConfig(FakeBuckConfig.builder().build()),
             null),
         target,
         projectFilesystem,

--- a/test/com/facebook/buck/jvm/kotlin/KotlinBuckConfigTest.java
+++ b/test/com/facebook/buck/jvm/kotlin/KotlinBuckConfigTest.java
@@ -15,24 +15,16 @@
  */
 package com.facebook.buck.jvm.kotlin;
 
-import static java.io.File.pathSeparator;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.facebook.buck.core.config.BuckConfig;
 import com.facebook.buck.core.config.FakeBuckConfig;
-import com.facebook.buck.core.exceptions.HumanReadableException;
-import com.facebook.buck.io.file.MostFiles;
-import com.facebook.buck.io.filesystem.ProjectFilesystem;
-import com.facebook.buck.io.filesystem.TestProjectFilesystems;
 import com.facebook.buck.testutil.TemporaryPaths;
-import com.facebook.buck.util.environment.EnvVariablesProvider;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.nio.file.Path;
-import org.hamcrest.Matchers;
-import org.junit.Assert;
+import java.nio.file.Paths;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,294 +33,127 @@ public class KotlinBuckConfigTest {
 
   @Rule public TemporaryPaths tmp = new TemporaryPaths();
 
-  private Path testDataDirectory;
+  Path testDataDirectory;
 
   @Before
   public void setUp() throws IOException {
     KotlinTestAssumptions.assumeUnixLike();
 
-    tmp.newFolder("faux_kotlin_home", "bin");
-    tmp.newFolder("faux_kotlin_home", "libexec", "bin");
-    tmp.newFolder("faux_kotlin_home", "libexec", "lib");
-    tmp.newExecutableFile("faux_kotlin_home/bin/kotlinc");
-    tmp.newExecutableFile("faux_kotlin_home/libexec/bin/kotlinc");
-    tmp.newExecutableFile("faux_kotlin_home/libexec/lib/kotlin-compiler.jar");
-    tmp.newExecutableFile("faux_kotlin_home/libexec/lib/kotlin-stdlib.jar");
+    tmp.newFolder("faux_kotlin_home");
+    tmp.newFolder("faux_kotlin_home/bin");
+    tmp.newFolder("faux_kotlin_home/libexec/bin");
+    tmp.newFolder("faux_kotlin_home/libexec/lib");
+    tmp.newExecutableFile("faux_kotlin_home/kotlinc");
 
     testDataDirectory = tmp.getRoot();
   }
 
   @Test
-  public void testFindsKotlinCompilerInPathLibexec() throws HumanReadableException, IOException {
-    // Get faux kotlinc binary location in project
-    Path kotlinHome = testDataDirectory.resolve("faux_kotlin_home/libexec/bin").normalize();
-    Path kotlinCompiler = kotlinHome.resolve("kotlinc");
-    MostFiles.makeExecutable(kotlinCompiler);
-
+  public void testInitializesKotlincWithSourcePathFromPathWhenNotExternal() throws IOException {
+    // GIVEN
     BuckConfig buckConfig =
         FakeBuckConfig.builder()
-            .setSections(ImmutableMap.of("kotlin", ImmutableMap.of("external", "true")))
-            .setEnvironment(
-                ImmutableMap.of(
-                    "PATH",
-                    kotlinHome + pathSeparator + EnvVariablesProvider.getSystemEnv().get("PATH")))
+            .setSections(
+                ImmutableMap.of("kotlin", ImmutableMap.of("kotlin_home", "faux_kotlin_home")))
             .build();
 
+    buckConfig
+        .getFilesystem()
+        .createNewFile(Paths.get("faux_kotlin_home/libexec/lib/kotlin-compiler-embeddable.jar"));
+
+    // WHEN
     KotlinBuckConfig kotlinBuckConfig = new KotlinBuckConfig(buckConfig);
-    String command = kotlinBuckConfig.getPathToCompilerBinary().toString();
-    assertEquals(command, kotlinCompiler.toString());
+
+    // THEN
+    assertTrue(kotlinBuckConfig.getKotlinc() instanceof JarBackedReflectedKotlinc);
+    assertFalse(kotlinBuckConfig.getKotlinHomeTarget().isPresent());
   }
 
   @Test
-  public void testFindsKotlinCompilerInPathBin() throws HumanReadableException, IOException {
-    // Get faux kotlinc binary location in project
-    Path kotlinHome = testDataDirectory.resolve("faux_kotlin_home/bin").normalize();
-    Path kotlinCompiler = kotlinHome.resolve("kotlinc");
-    MostFiles.makeExecutable(kotlinCompiler);
-
+  public void testInitializesKotlincWithSourcePathFromTargetWhenNotExternal() {
+    // GIVEN
     BuckConfig buckConfig =
         FakeBuckConfig.builder()
-            .setSections(ImmutableMap.of("kotlin", ImmutableMap.of("external", "true")))
-            .setEnvironment(
+            .setSections(
                 ImmutableMap.of(
-                    "PATH",
-                    kotlinHome + pathSeparator + EnvVariablesProvider.getSystemEnv().get("PATH")))
+                    "kotlin", ImmutableMap.of("kotlin_home", "//faux_kotlin_home:home")))
             .build();
 
+    // WHEN
     KotlinBuckConfig kotlinBuckConfig = new KotlinBuckConfig(buckConfig);
-    String command = kotlinBuckConfig.getPathToCompilerBinary().toString();
-    assertEquals(command, kotlinCompiler.toString());
+
+    // THEN
+    assertTrue(kotlinBuckConfig.getKotlinc() instanceof JarBackedReflectedKotlinc);
+    assertTrue(kotlinBuckConfig.getKotlinHomeTarget().isPresent());
   }
 
   @Test
-  public void testFindsKotlinCompilerInHomeEnvironment()
-      throws HumanReadableException, IOException {
-    // Get faux kotlinc binary location in project
-    Path kotlinHome = testDataDirectory.resolve("faux_kotlin_home").normalize();
-    Path kotlinCompiler = kotlinHome.resolve("bin").resolve("kotlinc");
-    MostFiles.makeExecutable(kotlinCompiler);
-
+  public void testInitializesKotlincWithPathWhenExternal() {
+    // GIVEN
     BuckConfig buckConfig =
         FakeBuckConfig.builder()
-            .setSections(ImmutableMap.of("kotlin", ImmutableMap.of("external", "true")))
+            .setSections(
+                ImmutableMap.of(
+                    "kotlin",
+                    ImmutableMap.of(
+                        "kotlin_home",
+                        testDataDirectory.resolve("faux_kotlin_home").toAbsolutePath().toString(),
+                        "external",
+                        "true")))
+            .build();
+
+    // WHEN
+    KotlinBuckConfig kotlinBuckConfig = new KotlinBuckConfig(buckConfig);
+
+    // THEN
+    assertTrue(kotlinBuckConfig.getKotlinc() instanceof ExternalKotlinc);
+    assertFalse(kotlinBuckConfig.getKotlinHomeTarget().isPresent());
+  }
+
+  @Test
+  public void testInitializesKotlincWithKotlinHomeEnvPathWhenExternal() {
+    // GIVEN
+    BuckConfig buckConfig =
+        FakeBuckConfig.builder()
+            .setSections(
+                ImmutableMap.of(
+                    "kotlin",
+                    ImmutableMap.of(
+                        "kotlin_home",
+                        testDataDirectory.resolve("faux_kotlin_home").toAbsolutePath().toString(),
+                        "external",
+                        "true")))
             .setEnvironment(
                 ImmutableMap.of(
                     "KOTLIN_HOME",
                     testDataDirectory.resolve("faux_kotlin_home").toAbsolutePath().toString()))
             .build();
 
+    // WHEN
     KotlinBuckConfig kotlinBuckConfig = new KotlinBuckConfig(buckConfig);
-    String command = kotlinBuckConfig.getPathToCompilerBinary().toString();
-    assertEquals(command, kotlinCompiler.toString());
+
+    // THEN
+    assertTrue(kotlinBuckConfig.getKotlinc() instanceof ExternalKotlinc);
+    assertFalse(kotlinBuckConfig.getKotlinHomeTarget().isPresent());
   }
 
   @Test
-  public void testFindsKotlinCompilerInHomeEnvironment2()
-      throws HumanReadableException, IOException {
-    // Get faux kotlinc binary location in project
-    Path kotlinHome = testDataDirectory.resolve("faux_kotlin_home/libexec").normalize();
-    Path kotlinCompiler = kotlinHome.resolve("bin").resolve("kotlinc");
-    MostFiles.makeExecutable(kotlinCompiler);
-
-    BuckConfig buckConfig =
-        FakeBuckConfig.builder()
-            .setSections(ImmutableMap.of("kotlin", ImmutableMap.of("external", "true")))
-            .setEnvironment(
-                ImmutableMap.of(
-                    "KOTLIN_HOME",
-                    testDataDirectory
-                        .resolve("faux_kotlin_home/libexec/bin")
-                        .toAbsolutePath()
-                        .toString()))
-            .build();
-
-    KotlinBuckConfig kotlinBuckConfig = new KotlinBuckConfig(buckConfig);
-    String command = kotlinBuckConfig.getPathToCompilerBinary().toString();
-    assertEquals(command, kotlinCompiler.toString());
-  }
-
-  @Test
-  public void testFindsKotlinCompilerInConfigWithRelativePath()
-      throws HumanReadableException, IOException {
-    // Get faux kotlinc binary location in project
-    Path kotlinHome = testDataDirectory.resolve("faux_kotlin_home").normalize();
-    Path kotlinCompiler = kotlinHome.resolve("bin").resolve("kotlinc");
-    MostFiles.makeExecutable(kotlinCompiler);
-
-    ProjectFilesystem filesystem =
-        TestProjectFilesystems.createProjectFilesystem(testDataDirectory.resolve("."));
-    BuckConfig buckConfig =
-        FakeBuckConfig.builder()
-            .setFilesystem(filesystem)
-            .setSections(
-                ImmutableMap.of(
-                    "kotlin",
-                    ImmutableMap.of("kotlin_home", "./faux_kotlin_home", "external", "true")))
-            .build();
-
-    KotlinBuckConfig kotlinBuckConfig = new KotlinBuckConfig(buckConfig);
-    String command = kotlinBuckConfig.getPathToCompilerBinary().toString();
-    assertEquals(command, kotlinCompiler.toString());
-  }
-
-  @Test
-  public void testFindsKotlinCompilerJarInConfigWithAbsolutePath() throws HumanReadableException {
-
-    Path kotlinRuntime =
-        testDataDirectory
-            .resolve("faux_kotlin_home")
-            .resolve("libexec")
-            .resolve("lib")
-            .resolve("kotlin-compiler.jar");
-
-    BuckConfig buckConfig =
-        FakeBuckConfig.builder()
-            .setSections(
-                ImmutableMap.of(
-                    "kotlin",
-                    ImmutableMap.of(
-                        "kotlin_home",
-                        testDataDirectory.resolve("faux_kotlin_home").toAbsolutePath().toString(),
-                        "external",
-                        "false")))
-            .build();
-
-    KotlinBuckConfig kotlinBuckConfig = new KotlinBuckConfig(buckConfig);
-    Path compilerJar = kotlinBuckConfig.getPathToCompilerJar();
-    assertEquals(kotlinRuntime, compilerJar);
-  }
-
-  @Test
-  public void testFindsKotlinCompilerJarInConfigWithAbsolutePath2() throws HumanReadableException {
-
-    Path kotlinRuntime =
-        testDataDirectory
-            .resolve("faux_kotlin_home")
-            .resolve("libexec")
-            .resolve("lib")
-            .resolve("kotlin-compiler.jar");
-
-    BuckConfig buckConfig =
-        FakeBuckConfig.builder()
-            .setSections(
-                ImmutableMap.of(
-                    "kotlin",
-                    ImmutableMap.of(
-                        "kotlin_home",
-                        testDataDirectory
-                            .resolve("faux_kotlin_home")
-                            .resolve("libexec")
-                            .toAbsolutePath()
-                            .toString(),
-                        "external",
-                        "false")))
-            .build();
-
-    KotlinBuckConfig kotlinBuckConfig = new KotlinBuckConfig(buckConfig);
-    Path compilerJar = kotlinBuckConfig.getPathToCompilerJar();
-    assertEquals(kotlinRuntime, compilerJar);
-  }
-
-  @Test
-  public void testFindsKotlinCompilerLibraryInPath() throws IOException {
-    // Get faux kotlinc binary location in project
-    Path kotlinHome = testDataDirectory.resolve("faux_kotlin_home").normalize();
-    Path kotlinCompiler = kotlinHome.resolve("libexec").resolve("bin").resolve("kotlinc");
-    MostFiles.makeExecutable(kotlinCompiler);
-
+  public void testInitializesKotlincWithPathFromEnvPathWhenExternal() {
+    // GIVEN
     BuckConfig buckConfig =
         FakeBuckConfig.builder()
             .setSections(ImmutableMap.of("kotlin", ImmutableMap.of("external", "true")))
             .setEnvironment(
                 ImmutableMap.of(
                     "PATH",
-                    kotlinCompiler.getParent()
-                        + pathSeparator
-                        + EnvVariablesProvider.getSystemEnv().get("PATH")))
+                    testDataDirectory.resolve("faux_kotlin_home").toAbsolutePath().toString()))
             .build();
 
+    // WHEN
     KotlinBuckConfig kotlinBuckConfig = new KotlinBuckConfig(buckConfig);
-    Path compilerJar = kotlinBuckConfig.getPathToCompilerJar();
-    Assert.assertThat(
-        compilerJar.toString(), Matchers.containsString(testDataDirectory.toString()));
-  }
 
-  @Test
-  public void testFindsKotlinStdlibJarInConfigWithAbsolutePath() throws HumanReadableException {
-
-    Path kotlinRuntime =
-        testDataDirectory
-            .resolve("faux_kotlin_home")
-            .resolve("libexec")
-            .resolve("lib")
-            .resolve("kotlin-stdlib.jar");
-
-    BuckConfig buckConfig =
-        FakeBuckConfig.builder()
-            .setSections(
-                ImmutableMap.of(
-                    "kotlin",
-                    ImmutableMap.of(
-                        "kotlin_home",
-                        testDataDirectory.resolve("faux_kotlin_home").toAbsolutePath().toString(),
-                        "external",
-                        "false")))
-            .build();
-
-    KotlinBuckConfig kotlinBuckConfig = new KotlinBuckConfig(buckConfig);
-    Path runtimeJar = kotlinBuckConfig.getPathToStdlibJar();
-    assertEquals(kotlinRuntime, runtimeJar);
-  }
-
-  @Test
-  public void testFindsKotlinStdlibJarInConfigWithAbsolutePath2() throws HumanReadableException {
-
-    Path kotlinRuntime =
-        testDataDirectory
-            .resolve("faux_kotlin_home")
-            .resolve("libexec")
-            .resolve("lib")
-            .resolve("kotlin-stdlib.jar");
-
-    BuckConfig buckConfig =
-        FakeBuckConfig.builder()
-            .setSections(
-                ImmutableMap.of(
-                    "kotlin",
-                    ImmutableMap.of(
-                        "kotlin_home",
-                        testDataDirectory
-                            .resolve("faux_kotlin_home")
-                            .resolve("libexec")
-                            .resolve("lib")
-                            .toAbsolutePath()
-                            .toString(),
-                        "external",
-                        "false")))
-            .build();
-
-    KotlinBuckConfig kotlinBuckConfig = new KotlinBuckConfig(buckConfig);
-    Path runtimeJar = kotlinBuckConfig.getPathToStdlibJar();
-    assertEquals(kotlinRuntime, runtimeJar);
-  }
-
-  @Test
-  public void testFindsKotlinStdlibJarInConfigWithRelativePath() throws HumanReadableException {
-
-    BuckConfig buckConfig =
-        FakeBuckConfig.builder()
-            .setFilesystem(TestProjectFilesystems.createProjectFilesystem(testDataDirectory))
-            .setSections(
-                ImmutableMap.of(
-                    "kotlin",
-                    ImmutableMap.of(
-                        "kotlin_home", "faux_kotlin_home",
-                        "external", "false")))
-            .build();
-
-    KotlinBuckConfig kotlinBuckConfig = new KotlinBuckConfig(buckConfig);
-    Path runtimeJar = kotlinBuckConfig.getPathToStdlibJar();
-    assertNotNull(runtimeJar);
-    assertTrue(runtimeJar.endsWith("faux_kotlin_home/libexec/lib/kotlin-stdlib.jar"));
+    // THEN
+    assertTrue(kotlinBuckConfig.getKotlinc() instanceof ExternalKotlinc);
+    assertFalse(kotlinBuckConfig.getKotlinHomeTarget().isPresent());
   }
 }

--- a/test/com/facebook/buck/jvm/kotlin/KotlinTestAssumptions.java
+++ b/test/com/facebook/buck/jvm/kotlin/KotlinTestAssumptions.java
@@ -33,8 +33,7 @@ public abstract class KotlinTestAssumptions {
   public static void assumeCompilerAvailable(@Nullable BuckConfig config) {
     Throwable exception = null;
     try {
-      new KotlinBuckConfig(config == null ? FakeBuckConfig.builder().build() : config)
-          .getPathToCompilerJar();
+      new KotlinBuckConfig(config == null ? FakeBuckConfig.builder().build() : config);
     } catch (HumanReadableException e) {
       exception = e;
     }


### PR DESCRIPTION
- Support specifying a source path for `kotlin_home` buck config
- Simplified and cleaned up logic to look up kotlin home.
- Updated Docs

Resolves https://github.com/facebook/buck/issues/2121

Dependent PR’s:
https://github.com/facebook/buck/pull/2131
https://github.com/facebook/buck/pull/2130
