### PR TITLE
Fixes 2108

### DIFF
--- a/src/com/facebook/buck/core/cell/impl/LocalCellProviderFactory.java
+++ b/src/com/facebook/buck/core/cell/impl/LocalCellProviderFactory.java
@@ -68,6 +68,7 @@ public class LocalCellProviderFactory {
     }
 
     ImmutableSet<Path> allRoots = ImmutableSet.copyOf(cellPathMapping.values());
+
     return new CellProvider(
         cellProvider ->
             new CacheLoader<Path, Cell>() {


### PR DESCRIPTION
 * Transitive targets are now discovered from the root manifest
 * Added tests

See: https://github.com/facebook/buck/issues/2108