### PR TITLE
.deb depends on openjdk-8-jre-headless

### DIFF
--- a/tools/release/platforms/debian/buck.equivs
+++ b/tools/release/platforms/debian/buck.equivs
@@ -7,7 +7,7 @@ Package: buck
 Version: v<VERSION>
 Maintainer: team@buckaroo.pm
 Recommends: watchman, nailgun
-Depends: openjdk-8-jre, python2.7
+Depends: openjdk-8-jre-headless, python2.7
 Architecture: all
 Copyright: LICENSE
 Readme: README.md


### PR DESCRIPTION
I found that openjdk headless is just enough to build and use buck.

And installing **openjdk-8-jre** on top of **openjdk-8-jre-headless** will install 129 new packages, download 68.4MB of data and requires 357MB of storage.