### PR TITLE
use SDK 26 and build tools 26.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,7 @@ matrix:
         - build-tools-26.0.2
         - android-26
         - addon-google_apis-google-23
+        - addon-google_apis-google-21
         - extra-android-support
     dist: trusty
     addons:
@@ -131,6 +132,7 @@ matrix:
         - build-tools-26.0.2
         - android-26
         - addon-google_apis-google-23
+        - addon-google_apis-google-21
         - extra-android-support
     dist: trusty
     addons:
@@ -161,6 +163,7 @@ matrix:
         - build-tools-26.0.2
         - android-26
         - addon-google_apis-google-23
+        - addon-google_apis-google-21
         - extra-android-support
     dist: trusty
     addons:
@@ -191,6 +194,7 @@ matrix:
         - build-tools-26.0.2
         - android-26
         - addon-google_apis-google-23
+        - addon-google_apis-google-21
         - extra-android-support
     dist: trusty
     addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ matrix:
       components:
         - tools
         - platform-tools
-        - build-tools-23.0.2
-        - android-23
+        - build-tools-26.0.2
+        - android-26
   - os: linux
     jdk: openjdk8
     dist: trusty
@@ -30,8 +30,8 @@ matrix:
       components:
         - tools
         - platform-tools
-        - build-tools-23.0.2
-        - android-23
+        - build-tools-26.0.2
+        - android-26
   - os: linux
     jdk: openjdk8
     dist: trusty
@@ -46,8 +46,8 @@ matrix:
       components:
         - tools
         - platform-tools
-        - build-tools-23.0.2
-        - android-23
+        - build-tools-26.0.2
+        - android-26
   - os: linux
     jdk: openjdk8
     dist: trusty
@@ -61,8 +61,8 @@ matrix:
       components:
         - tools
         - platform-tools
-        - build-tools-23.0.2
-        - android-23
+        - build-tools-26.0.2
+        - android-26
   - os: linux
     jdk: openjdk8
     dist: trusty
@@ -85,19 +85,17 @@ matrix:
       components:
         - tools
         - platform-tools
-        - build-tools-23.0.2
-        - android-23
+        - build-tools-26.0.2
+        - android-26
   - os: linux
     jdk: openjdk8
     android:
       components:
         - tools
         - platform-tools
-        - build-tools-23.0.2
-        - android-23
+        - build-tools-26.0.2
+        - android-26
         - addon-google_apis-google-23
-        - android-21
-        - addon-google_apis-google-21
         - extra-android-support
     dist: trusty
     addons:
@@ -130,11 +128,9 @@ matrix:
       components:
         - tools
         - platform-tools
-        - build-tools-23.0.2
-        - android-23
+        - build-tools-26.0.2
+        - android-26
         - addon-google_apis-google-23
-        - android-21
-        - addon-google_apis-google-21
         - extra-android-support
     dist: trusty
     addons:
@@ -162,11 +158,9 @@ matrix:
       components:
         - tools
         - platform-tools
-        - build-tools-23.0.2
-        - android-23
+        - build-tools-26.0.2
+        - android-26
         - addon-google_apis-google-23
-        - android-21
-        - addon-google_apis-google-21
         - extra-android-support
     dist: trusty
     addons:
@@ -194,11 +188,9 @@ matrix:
       components:
         - tools
         - platform-tools
-        - build-tools-23.0.2
-        - android-23
+        - build-tools-26.0.2
+        - android-26
         - addon-google_apis-google-23
-        - android-21
-        - addon-google_apis-google-21
         - extra-android-support
     dist: trusty
     addons:

--- a/scripts/exopackage_test_single.sh
+++ b/scripts/exopackage_test_single.sh
@@ -62,8 +62,8 @@ for BUCKFILE in `find . -name BUCK.fixture` ; do
 done
 cat >.buckconfig <<EOF
 [java]
-  source_level = 7
-  target_level = 7
+  source_level = 8
+  target_level = 8
 [ndk]
   cxx_runtime = system
   cpu_abis = armv7, x86

--- a/src/com/facebook/buck/android/toolchain/AbstractAndroidPlatformTarget.java
+++ b/src/com/facebook/buck/android/toolchain/AbstractAndroidPlatformTarget.java
@@ -34,7 +34,7 @@ import org.immutables.value.Value;
 public abstract class AbstractAndroidPlatformTarget implements Toolchain, AddsToRuleKey {
   public static final String DEFAULT_NAME = "android-platform-target";
 
-  public static final String DEFAULT_ANDROID_PLATFORM_TARGET = "android-23";
+  public static final String DEFAULT_ANDROID_PLATFORM_TARGET = "android-26";
 
   @Override
   public String getName() {

--- a/test/com/facebook/buck/android/toolchain/impl/AndroidPlatformTargetProducerTest.java
+++ b/test/com/facebook/buck/android/toolchain/impl/AndroidPlatformTargetProducerTest.java
@@ -147,7 +147,7 @@ public class AndroidPlatformTargetProducerTest {
   public void testLooksForOptionalLibraries() throws IOException {
     File androidSdkDir = tempDir.newFolder();
     Path pathToAndroidSdkDir = androidSdkDir.toPath();
-    File buildToolsDir = new File(new File(androidSdkDir, "build-tools"), "23.0.1");
+    File buildToolsDir = new File(new File(androidSdkDir, "build-tools"), "26.0.2");
     buildToolsDir.mkdirs();
     File optionalLibsDir = new File(androidSdkDir, "platforms/android-26/optional");
     optionalLibsDir.mkdirs();

--- a/test/com/facebook/buck/android/toolchain/impl/AndroidPlatformTargetProducerTest.java
+++ b/test/com/facebook/buck/android/toolchain/impl/AndroidPlatformTargetProducerTest.java
@@ -149,7 +149,7 @@ public class AndroidPlatformTargetProducerTest {
     Path pathToAndroidSdkDir = androidSdkDir.toPath();
     File buildToolsDir = new File(new File(androidSdkDir, "build-tools"), "23.0.1");
     buildToolsDir.mkdirs();
-    File optionalLibsDir = new File(androidSdkDir, "platforms/android-23/optional");
+    File optionalLibsDir = new File(androidSdkDir, "platforms/android-26/optional");
     optionalLibsDir.mkdirs();
     Files.touch(new File(optionalLibsDir, "httpclient.jar"));
     Files.touch(new File(optionalLibsDir, "telemetry.jar"));
@@ -173,15 +173,15 @@ public class AndroidPlatformTargetProducerTest {
     assertEquals(platformId, androidPlatformTarget.getPlatformName());
     assertEquals(
         ImmutableList.of(
-            pathToAndroidSdkDir.resolve("platforms/android-23/android.jar"),
-            pathToAndroidSdkDir.resolve("platforms/android-23/optional/httpclient.jar"),
-            pathToAndroidSdkDir.resolve("platforms/android-23/optional/telemetry.jar"),
+            pathToAndroidSdkDir.resolve("platforms/android-26/android.jar"),
+            pathToAndroidSdkDir.resolve("platforms/android-26/optional/httpclient.jar"),
+            pathToAndroidSdkDir.resolve("platforms/android-26/optional/telemetry.jar"),
             pathToAndroidSdkDir.resolve("add-ons/addon-google_apis-google-23/libs/effects.jar"),
             pathToAndroidSdkDir.resolve("add-ons/addon-google_apis-google-23/libs/maps.jar"),
             pathToAndroidSdkDir.resolve("add-ons/addon-google_apis-google-23/libs/usb.jar")),
         androidPlatformTarget.getBootclasspathEntries());
     assertEquals(
-        pathToAndroidSdkDir.resolve("platforms/android-23/android.jar"),
+        pathToAndroidSdkDir.resolve("platforms/android-26/android.jar"),
         androidPlatformTarget.getAndroidJar());
   }
 

--- a/test/com/facebook/buck/testutil/endtoend/testdata/mobile/.buckconfig
+++ b/test/com/facebook/buck/testutil/endtoend/testdata/mobile/.buckconfig
@@ -20,8 +20,6 @@
 
 [java]
   src_roots = /android/java/
-  source_level = 6
-  target_level = 6
 
 [project]
     default_android_manifest = //android/AndroidManifest.xml


### PR DESCRIPTION
Starting November 2018, Google requires apps to target at least API 26 for Play Store. And it might be best to drop older APIs from test and use API 26 as a base. So everyone must have upgraded to SDK 26 by now.

See https://support.google.com/googleplay/android-developer/answer/113469#targetsdk