### PR TITLE
Don't cache fat binaries when cache_links = false

### DIFF
--- a/src/com/facebook/buck/apple/AppleBinaryDescription.java
+++ b/src/com/facebook/buck/apple/AppleBinaryDescription.java
@@ -54,6 +54,7 @@ import com.facebook.buck.cxx.CxxBinaryMetadataFactory;
 import com.facebook.buck.cxx.CxxCompilationDatabase;
 import com.facebook.buck.cxx.FrameworkDependencies;
 import com.facebook.buck.cxx.HasAppleDebugSymbolDeps;
+import com.facebook.buck.cxx.toolchain.CxxBuckConfig;
 import com.facebook.buck.cxx.toolchain.CxxPlatform;
 import com.facebook.buck.cxx.toolchain.CxxPlatforms;
 import com.facebook.buck.cxx.toolchain.CxxPlatformsProvider;
@@ -110,6 +111,7 @@ public class AppleBinaryDescription
   private final XCodeDescriptions xcodeDescriptions;
   private final Optional<SwiftLibraryDescription> swiftDelegate;
   private final AppleConfig appleConfig;
+  private final CxxBuckConfig cxxBuckConfig;
   private final SwiftBuckConfig swiftBuckConfig;
   private final CxxBinaryImplicitFlavors cxxBinaryImplicitFlavors;
   private final CxxBinaryFactory cxxBinaryFactory;
@@ -121,6 +123,7 @@ public class AppleBinaryDescription
       XCodeDescriptions xcodeDescriptions,
       SwiftLibraryDescription swiftDelegate,
       AppleConfig appleConfig,
+      CxxBuckConfig cxxBuckConfig,
       SwiftBuckConfig swiftBuckConfig,
       CxxBinaryImplicitFlavors cxxBinaryImplicitFlavors,
       CxxBinaryFactory cxxBinaryFactory,
@@ -131,6 +134,7 @@ public class AppleBinaryDescription
     // TODO(T22135033): Make apple_binary not use a Swift delegate
     this.swiftDelegate = Optional.of(swiftDelegate);
     this.appleConfig = appleConfig;
+    this.cxxBuckConfig = cxxBuckConfig;
     this.swiftBuckConfig = swiftBuckConfig;
     this.cxxBinaryImplicitFlavors = cxxBinaryImplicitFlavors;
     this.cxxBinaryFactory = cxxBinaryFactory;
@@ -445,7 +449,8 @@ public class AppleBinaryDescription
           params,
           graphBuilder,
           fatBinaryInfo.get(),
-          thinRules.build());
+          thinRules.build(),
+          cxxBuckConfig);
     } else {
       return requireThinBinary(
           context,

--- a/src/com/facebook/buck/apple/AppleDescriptionProvider.java
+++ b/src/com/facebook/buck/apple/AppleDescriptionProvider.java
@@ -91,6 +91,7 @@ public class AppleDescriptionProvider implements DescriptionProvider {
             xcodeDescriptions,
             swiftLibraryDescription,
             appleConfig,
+            cxxBuckConfig,
             swiftBuckConfig,
             cxxBinaryImplicitFlavors,
             cxxBinaryFactory,

--- a/src/com/facebook/buck/apple/AppleLibraryDescription.java
+++ b/src/com/facebook/buck/apple/AppleLibraryDescription.java
@@ -566,7 +566,8 @@ public class AppleLibraryDescription
           params,
           graphBuilder,
           multiarchFileInfo.get(),
-          thinRules.build());
+          thinRules.build(),
+          cxxBuckConfig);
     } else {
       return requireSingleArchUnstrippedBuildRule(
           context,

--- a/src/com/facebook/buck/apple/MultiarchFile.java
+++ b/src/com/facebook/buck/apple/MultiarchFile.java
@@ -55,6 +55,8 @@ public class MultiarchFile extends AbstractBuildRuleWithDeclaredAndExtraDeps
 
   @AddToRuleKey private final ImmutableSortedSet<SourcePath> thinBinaries;
 
+  private final boolean isCacheable;
+
   @AddToRuleKey(stringify = true)
   private final Path output;
 
@@ -65,11 +67,13 @@ public class MultiarchFile extends AbstractBuildRuleWithDeclaredAndExtraDeps
       SourcePathRuleFinder ruleFinder,
       Tool lipo,
       ImmutableSortedSet<SourcePath> thinBinaries,
+      boolean isCacheable,
       Path output) {
     super(buildTarget, projectFilesystem, buildRuleParams);
     this.ruleFinder = ruleFinder;
     this.lipo = lipo;
     this.thinBinaries = ImmutableSortedSet.copyOf(thinBinaries);
+    this.isCacheable = isCacheable;
     this.output = output;
   }
 
@@ -151,5 +155,10 @@ public class MultiarchFile extends AbstractBuildRuleWithDeclaredAndExtraDeps
         // These rules may generate supplemental object files that are linked into the binary, and
         // must be materialized in order for dsymutil to find them.
         .concat(getBuildDeps().stream());
+  }
+
+  @Override
+  public boolean isCacheable() {
+    return isCacheable;
   }
 }

--- a/src/com/facebook/buck/apple/MultiarchFileInfos.java
+++ b/src/com/facebook/buck/apple/MultiarchFileInfos.java
@@ -33,6 +33,7 @@ import com.facebook.buck.core.sourcepath.resolver.SourcePathResolver;
 import com.facebook.buck.core.sourcepath.resolver.impl.DefaultSourcePathResolver;
 import com.facebook.buck.cxx.CxxCompilationDatabase;
 import com.facebook.buck.cxx.CxxInferEnhancer;
+import com.facebook.buck.cxx.toolchain.CxxBuckConfig;
 import com.facebook.buck.io.filesystem.ProjectFilesystem;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.FluentIterable;
@@ -147,7 +148,8 @@ public class MultiarchFileInfos {
       BuildRuleParams params,
       ActionGraphBuilder graphBuilder,
       MultiarchFileInfo info,
-      ImmutableSortedSet<BuildRule> thinRules) {
+      ImmutableSortedSet<BuildRule> thinRules,
+      CxxBuckConfig cxxBuckConfig) {
     Optional<BuildRule> existingRule = graphBuilder.getRuleOptional(info.getFatTarget());
     if (existingRule.isPresent()) {
       return existingRule.get();
@@ -175,6 +177,7 @@ public class MultiarchFileInfos {
               ruleFinder,
               info.getRepresentativePlatform().getLipo(),
               inputs,
+              cxxBuckConfig.shouldCacheLinks(),
               BuildTargetPaths.getGenPath(
                   projectFilesystem, buildTarget, multiarchOutputPathFormat));
       graphBuilder.addToIndex(multiarchFile);

--- a/test/com/facebook/buck/apple/AppleBundleIntegrationTest.java
+++ b/test/com/facebook/buck/apple/AppleBundleIntegrationTest.java
@@ -125,6 +125,23 @@ public class AppleBundleIntegrationTest {
   }
 
   @Test
+  public void testDisablingFatBinaryCaching() throws IOException {
+    ProjectWorkspace workspace =
+        TestDataHelper.createProjectWorkspaceForScenario(
+            this, "simple_application_bundle_no_debug", tmp);
+    workspace.setUp();
+
+    String bundleTarget = "//:DemoApp#iphonesimulator-x86_64,iphonesimulator-i386,no-debug,no-include-frameworks";
+    String binaryTarget = "//:DemoAppBinary#iphonesimulator-x86_64,iphonesimulator-i386,strip-non-global";
+
+    workspace.enableDirCache();
+    workspace.runBuckBuild("-c", "cxx.cache_links=false", bundleTarget).assertSuccess();
+    workspace.runBuckCommand("clean", "--keep-cache");
+    workspace.runBuckBuild("-c", "cxx.cache_links=false", bundleTarget).assertSuccess();
+    workspace.getBuildLog().assertTargetBuiltLocally(binaryTarget);
+  }
+
+  @Test
   public void testDisablingBundleCaching() throws IOException {
     ProjectWorkspace workspace =
         TestDataHelper.createProjectWorkspaceForScenario(

--- a/test/com/facebook/buck/apple/AppleBundleIntegrationTest.java
+++ b/test/com/facebook/buck/apple/AppleBundleIntegrationTest.java
@@ -131,8 +131,10 @@ public class AppleBundleIntegrationTest {
             this, "simple_application_bundle_no_debug", tmp);
     workspace.setUp();
 
-    String bundleTarget = "//:DemoApp#iphonesimulator-x86_64,iphonesimulator-i386,no-debug,no-include-frameworks";
-    String binaryTarget = "//:DemoAppBinary#iphonesimulator-x86_64,iphonesimulator-i386,strip-non-global";
+    String bundleTarget =
+        "//:DemoApp#iphonesimulator-x86_64,iphonesimulator-i386,no-debug,no-include-frameworks";
+    String binaryTarget =
+        "//:DemoAppBinary#iphonesimulator-x86_64,iphonesimulator-i386,strip-non-global";
 
     workspace.enableDirCache();
     workspace.runBuckBuild("-c", "cxx.cache_links=false", bundleTarget).assertSuccess();

--- a/test/com/facebook/buck/apple/FakeAppleRuleDescriptions.java
+++ b/test/com/facebook/buck/apple/FakeAppleRuleDescriptions.java
@@ -327,6 +327,7 @@ public class FakeAppleRuleDescriptions {
         xcodeDescriptions,
         SWIFT_LIBRARY_DESCRIPTION,
         DEFAULT_BUCK_CONFIG.getView(AppleConfig.class),
+        CxxPlatformUtils.DEFAULT_CONFIG,
         DEFAULT_BUCK_CONFIG.getView(SwiftBuckConfig.class),
         cxxBinaryImplicitFlavors,
         cxxBinaryFactory,

--- a/test/com/facebook/buck/apple/MultiarchFileInfosTest.java
+++ b/test/com/facebook/buck/apple/MultiarchFileInfosTest.java
@@ -44,6 +44,7 @@ import com.facebook.buck.core.sourcepath.resolver.SourcePathResolver;
 import com.facebook.buck.core.sourcepath.resolver.impl.DefaultSourcePathResolver;
 import com.facebook.buck.core.toolchain.ToolchainProvider;
 import com.facebook.buck.core.toolchain.impl.ToolchainProviderBuilder;
+import com.facebook.buck.cxx.toolchain.CxxPlatformUtils;
 import com.facebook.buck.io.filesystem.ProjectFilesystem;
 import com.facebook.buck.io.filesystem.impl.FakeProjectFilesystem;
 import com.facebook.buck.util.environment.Platform;
@@ -152,7 +153,8 @@ public class MultiarchFileInfosTest {
             TestBuildRuleParams.create(),
             buildActionGraphBuilder(filesystem, fatBuildTarget, inputs),
             multiarchFileInfo,
-            inputs);
+            inputs,
+            CxxPlatformUtils.DEFAULT_CONFIG);
 
     assertThat(outputRule, instanceOf(MultiarchFile.class));
   }
@@ -185,7 +187,8 @@ public class MultiarchFileInfosTest {
             TestBuildRuleParams.create(),
             buildActionGraphBuilder(filesystem, fatBuildTarget, inputs),
             multiarchFileInfo,
-            inputs);
+            inputs,
+            CxxPlatformUtils.DEFAULT_CONFIG);
 
     assertThat(outputRule, instanceOf(NoopBuildRule.class));
   }
@@ -218,7 +221,8 @@ public class MultiarchFileInfosTest {
             TestBuildRuleParams.create(),
             buildActionGraphBuilder(filesystem, fatBuildTarget, inputs),
             multiarchFileInfo,
-            inputs);
+            inputs,
+            CxxPlatformUtils.DEFAULT_CONFIG);
 
     assertThat(outputRule, instanceOf(MultiarchFile.class));
   }


### PR DESCRIPTION
Its currently possible to disable caching for cxx links using `cache_links = false`, but this does not prevent the resulting fat binaries from being cached. This PR propagates the `cache_links` setting to fat binaries too.