### PR TITLE
Don't cache AppleDsym when cache_strip = false

### DIFF
--- a/src/com/facebook/buck/apple/AppleBinaryDescription.java
+++ b/src/com/facebook/buck/apple/AppleBinaryDescription.java
@@ -54,6 +54,7 @@ import com.facebook.buck.cxx.CxxBinaryMetadataFactory;
 import com.facebook.buck.cxx.CxxCompilationDatabase;
 import com.facebook.buck.cxx.FrameworkDependencies;
 import com.facebook.buck.cxx.HasAppleDebugSymbolDeps;
+import com.facebook.buck.cxx.toolchain.CxxBuckConfig;
 import com.facebook.buck.cxx.toolchain.CxxPlatform;
 import com.facebook.buck.cxx.toolchain.CxxPlatforms;
 import com.facebook.buck.cxx.toolchain.CxxPlatformsProvider;
@@ -110,6 +111,7 @@ public class AppleBinaryDescription
   private final XCodeDescriptions xcodeDescriptions;
   private final Optional<SwiftLibraryDescription> swiftDelegate;
   private final AppleConfig appleConfig;
+  private final CxxBuckConfig cxxBuckConfig;
   private final SwiftBuckConfig swiftBuckConfig;
   private final CxxBinaryImplicitFlavors cxxBinaryImplicitFlavors;
   private final CxxBinaryFactory cxxBinaryFactory;
@@ -121,6 +123,7 @@ public class AppleBinaryDescription
       XCodeDescriptions xcodeDescriptions,
       SwiftLibraryDescription swiftDelegate,
       AppleConfig appleConfig,
+      CxxBuckConfig cxxBuckConfig,
       SwiftBuckConfig swiftBuckConfig,
       CxxBinaryImplicitFlavors cxxBinaryImplicitFlavors,
       CxxBinaryFactory cxxBinaryFactory,
@@ -131,6 +134,7 @@ public class AppleBinaryDescription
     // TODO(T22135033): Make apple_binary not use a Swift delegate
     this.swiftDelegate = Optional.of(swiftDelegate);
     this.appleConfig = appleConfig;
+    this.cxxBuckConfig = cxxBuckConfig;
     this.swiftBuckConfig = swiftBuckConfig;
     this.cxxBinaryImplicitFlavors = cxxBinaryImplicitFlavors;
     this.cxxBinaryFactory = cxxBinaryFactory;
@@ -319,7 +323,8 @@ public class AppleBinaryDescription
         unstrippedBinaryRule,
         AppleDebugFormat.FLAVOR_DOMAIN.getRequiredValue(buildTarget),
         cxxPlatformsProvider,
-        appleCxxPlatformsFlavorDomain);
+        appleCxxPlatformsFlavorDomain,
+        cxxBuckConfig.shouldCacheStrip());
   }
 
   private BuildRule createBundleBuildRule(
@@ -393,7 +398,8 @@ public class AppleBinaryDescription
         Optional.empty(),
         Optional.empty(),
         appleConfig.getCodesignTimeout(),
-        swiftBuckConfig.getCopyStdlibToFrameworks());
+        swiftBuckConfig.getCopyStdlibToFrameworks(),
+        cxxBuckConfig.shouldCacheStrip());
   }
 
   private BuildRule createBinary(

--- a/src/com/facebook/buck/apple/AppleBundleDescription.java
+++ b/src/com/facebook/buck/apple/AppleBundleDescription.java
@@ -42,6 +42,7 @@ import com.facebook.buck.core.toolchain.ToolchainProvider;
 import com.facebook.buck.core.util.immutables.BuckStyleImmutable;
 import com.facebook.buck.cxx.CxxDescriptionEnhancer;
 import com.facebook.buck.cxx.FrameworkDependencies;
+import com.facebook.buck.cxx.toolchain.CxxBuckConfig;
 import com.facebook.buck.cxx.toolchain.CxxPlatform;
 import com.facebook.buck.cxx.toolchain.CxxPlatformsProvider;
 import com.facebook.buck.cxx.toolchain.LinkerMapMode;
@@ -77,6 +78,7 @@ public class AppleBundleDescription
   private final AppleBinaryDescription appleBinaryDescription;
   private final AppleLibraryDescription appleLibraryDescription;
   private final AppleConfig appleConfig;
+  private final CxxBuckConfig cxxBuckConfig;
   private final SwiftBuckConfig swiftBuckConfig;
 
   public AppleBundleDescription(
@@ -85,12 +87,14 @@ public class AppleBundleDescription
       AppleBinaryDescription appleBinaryDescription,
       AppleLibraryDescription appleLibraryDescription,
       AppleConfig appleConfig,
+      CxxBuckConfig cxxBuckConfig,
       SwiftBuckConfig swiftBuckConfig) {
     this.toolchainProvider = toolchainProvider;
     this.xcodeDescriptions = xcodeDescriptions;
     this.appleBinaryDescription = appleBinaryDescription;
     this.appleLibraryDescription = appleLibraryDescription;
     this.appleConfig = appleConfig;
+    this.cxxBuckConfig = cxxBuckConfig;
     this.swiftBuckConfig = swiftBuckConfig;
   }
 
@@ -185,7 +189,8 @@ public class AppleBundleDescription
         args.getCodesignIdentity(),
         args.getIbtoolModuleFlag(),
         appleConfig.getCodesignTimeout(),
-        swiftBuckConfig.getCopyStdlibToFrameworks());
+        swiftBuckConfig.getCopyStdlibToFrameworks(),
+        cxxBuckConfig.shouldCacheStrip());
   }
 
   /**

--- a/src/com/facebook/buck/apple/AppleDescriptionProvider.java
+++ b/src/com/facebook/buck/apple/AppleDescriptionProvider.java
@@ -91,6 +91,7 @@ public class AppleDescriptionProvider implements DescriptionProvider {
             xcodeDescriptions,
             swiftLibraryDescription,
             appleConfig,
+            cxxBuckConfig,
             swiftBuckConfig,
             cxxBinaryImplicitFlavors,
             cxxBinaryFactory,
@@ -114,11 +115,13 @@ public class AppleDescriptionProvider implements DescriptionProvider {
             appleBinaryDescription,
             appleLibraryDescription,
             appleConfig,
+            cxxBuckConfig,
             swiftBuckConfig),
         new AppleTestDescription(
             toolchainProvider,
             xcodeDescriptions,
             appleConfig,
+            cxxBuckConfig,
             swiftBuckConfig,
             appleLibraryDescription),
         new SceneKitAssetsDescription());

--- a/src/com/facebook/buck/apple/AppleDescriptions.java
+++ b/src/com/facebook/buck/apple/AppleDescriptions.java
@@ -55,7 +55,6 @@ import com.facebook.buck.cxx.CxxLibraryDescriptionArg;
 import com.facebook.buck.cxx.CxxStrip;
 import com.facebook.buck.cxx.FrameworkDependencies;
 import com.facebook.buck.cxx.HasAppleDebugSymbolDeps;
-import com.facebook.buck.cxx.toolchain.CxxBuckConfig;
 import com.facebook.buck.cxx.toolchain.CxxPlatformsProvider;
 import com.facebook.buck.cxx.toolchain.LinkerMapMode;
 import com.facebook.buck.cxx.toolchain.StripStyle;

--- a/src/com/facebook/buck/apple/AppleDsym.java
+++ b/src/com/facebook/buck/apple/AppleDsym.java
@@ -66,6 +66,8 @@ public class AppleDsym extends AbstractBuildRule
 
   private ImmutableSortedSet<BuildRule> buildDeps;
 
+  private final boolean isCacheable;
+
   public AppleDsym(
       BuildTarget buildTarget,
       ProjectFilesystem projectFilesystem,
@@ -74,13 +76,15 @@ public class AppleDsym extends AbstractBuildRule
       Tool lldb,
       SourcePath unstrippedBinarySourcePath,
       ImmutableSortedSet<SourcePath> additionalSymbolDeps,
-      Path dsymOutputPath) {
+      Path dsymOutputPath,
+      boolean isCacheable) {
     super(buildTarget, projectFilesystem);
     this.dsymutil = dsymutil;
     this.lldb = lldb;
     this.unstrippedBinarySourcePath = unstrippedBinarySourcePath;
     this.additionalSymbolDeps = additionalSymbolDeps;
     this.dsymOutputPath = dsymOutputPath;
+    this.isCacheable = isCacheable;
     this.buildDeps =
         Stream.concat(
                 Stream.of(this.unstrippedBinarySourcePath), this.additionalSymbolDeps.stream())
@@ -169,5 +173,10 @@ public class AppleDsym extends AbstractBuildRule
   @Override
   public SortedSet<BuildRule> getBuildDeps() {
     return buildDeps;
+  }
+
+  @Override
+  public boolean isCacheable() {
+    return isCacheable;
   }
 }

--- a/src/com/facebook/buck/apple/AppleLibraryDescription.java
+++ b/src/com/facebook/buck/apple/AppleLibraryDescription.java
@@ -441,7 +441,8 @@ public class AppleLibraryDescription
         Optional.empty(),
         Optional.empty(),
         appleConfig.getCodesignTimeout(),
-        swiftBuckConfig.getCopyStdlibToFrameworks());
+        swiftBuckConfig.getCopyStdlibToFrameworks(),
+        cxxBuckConfig.shouldCacheStrip());
   }
 
   /**
@@ -522,7 +523,8 @@ public class AppleLibraryDescription
             .getValue(buildTarget)
             .orElse(appleConfig.getDefaultDebugInfoFormatForLibraries()),
         cxxPlatformsProvider,
-        getAppleCxxPlatformDomain());
+        getAppleCxxPlatformDomain(),
+        cxxBuckConfig.shouldCacheStrip());
   }
 
   private <A extends AppleNativeTargetDescriptionArg> BuildRule requireUnstrippedBuildRule(

--- a/src/com/facebook/buck/apple/AppleTestDescription.java
+++ b/src/com/facebook/buck/apple/AppleTestDescription.java
@@ -56,6 +56,7 @@ import com.facebook.buck.cxx.CxxLibraryDescription;
 import com.facebook.buck.cxx.CxxPreprocessables;
 import com.facebook.buck.cxx.CxxPreprocessorInput;
 import com.facebook.buck.cxx.CxxStrip;
+import com.facebook.buck.cxx.toolchain.CxxBuckConfig;
 import com.facebook.buck.cxx.toolchain.CxxPlatform;
 import com.facebook.buck.cxx.toolchain.CxxPlatforms;
 import com.facebook.buck.cxx.toolchain.CxxPlatformsProvider;
@@ -124,6 +125,7 @@ public class AppleTestDescription
   private final ToolchainProvider toolchainProvider;
   private final XCodeDescriptions xcodeDescriptions;
   private final AppleConfig appleConfig;
+  private final CxxBuckConfig cxxBuckConfig;
   private final SwiftBuckConfig swiftBuckConfig;
   private final AppleLibraryDescription appleLibraryDescription;
 
@@ -131,11 +133,13 @@ public class AppleTestDescription
       ToolchainProvider toolchainProvider,
       XCodeDescriptions xcodeDescriptions,
       AppleConfig appleConfig,
+      CxxBuckConfig cxxBuckConfig,
       SwiftBuckConfig swiftBuckConfig,
       AppleLibraryDescription appleLibraryDescription) {
     this.toolchainProvider = toolchainProvider;
     this.xcodeDescriptions = xcodeDescriptions;
     this.appleConfig = appleConfig;
+    this.cxxBuckConfig = cxxBuckConfig;
     this.swiftBuckConfig = swiftBuckConfig;
     this.appleLibraryDescription = appleLibraryDescription;
   }
@@ -330,7 +334,8 @@ public class AppleTestDescription
                         args.getCodesignIdentity(),
                         Optional.empty(),
                         appleConfig.getCodesignTimeout(),
-                        swiftBuckConfig.getCopyStdlibToFrameworks())));
+                        swiftBuckConfig.getCopyStdlibToFrameworks(),
+                        cxxBuckConfig.shouldCacheStrip())));
 
     Optional<SourcePath> xctool = getXctool(projectFilesystem, params, graphBuilder);
 

--- a/test/com/facebook/buck/apple/FakeAppleRuleDescriptions.java
+++ b/test/com/facebook/buck/apple/FakeAppleRuleDescriptions.java
@@ -327,6 +327,7 @@ public class FakeAppleRuleDescriptions {
         xcodeDescriptions,
         SWIFT_LIBRARY_DESCRIPTION,
         DEFAULT_BUCK_CONFIG.getView(AppleConfig.class),
+        CxxPlatformUtils.DEFAULT_CONFIG,
         DEFAULT_BUCK_CONFIG.getView(SwiftBuckConfig.class),
         cxxBinaryImplicitFlavors,
         cxxBinaryFactory,
@@ -342,6 +343,7 @@ public class FakeAppleRuleDescriptions {
           BINARY_DESCRIPTION,
           LIBRARY_DESCRIPTION,
           DEFAULT_BUCK_CONFIG.getView(AppleConfig.class),
+          CxxPlatformUtils.DEFAULT_CONFIG,
           DEFAULT_BUCK_CONFIG.getView(SwiftBuckConfig.class));
 
   /** A fake apple_test description with an iOS platform for use in tests. */
@@ -350,6 +352,7 @@ public class FakeAppleRuleDescriptions {
           createTestToolchainProviderForApplePlatform(DEFAULT_APPLE_CXX_PLATFORM_FLAVOR_DOMAIN),
           XCodeDescriptionsFactory.create(BuckPluginManagerFactory.createPluginManager()),
           DEFAULT_BUCK_CONFIG.getView(AppleConfig.class),
+          CxxPlatformUtils.DEFAULT_CONFIG,
           DEFAULT_BUCK_CONFIG.getView(SwiftBuckConfig.class),
           LIBRARY_DESCRIPTION);
 


### PR DESCRIPTION
A recently added config option allows disabling of caching for strip rules. On Apple platforms we should also disable caching of the dSYM when this config is set, for the same reason as the original was added and to prevent the possibility of a cached dSYM incorrectly matching an uncached stripped binary with a different UUID.