### PR TITLE
Xcode project set LD_RUNPATH_SEARCH_PATHS for binaries with Swift

### DIFF
--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -2249,7 +2249,7 @@ public class ProjectGenerator {
   }
 
   private ImmutableMap<String, String> getFrameworkAndLibrarySearchPathConfigs(
-      TargetNode<?> node, boolean includeFrameworks) {
+      TargetNode<? extends CxxLibraryDescription.CommonArg> node, boolean includeFrameworks) {
     HashSet<String> frameworkSearchPaths = new HashSet<>();
     frameworkSearchPaths.add("$BUILT_PRODUCTS_DIR");
     HashSet<String> librarySearchPaths = new HashSet<>();
@@ -2345,7 +2345,7 @@ public class ProjectGenerator {
       librarySearchPaths.add("$DT_TOOLCHAIN_DIR/usr/lib/swift/$PLATFORM_NAME");
     }
 
-    if (swiftDeps.size() > 0) {
+    if (swiftDeps.size() > 0 || projGenerationStateCache.targetContainsSwiftSourceCode(node)) {
       iOSLdRunpathSearchPaths.add("@executable_path/Frameworks");
       iOSLdRunpathSearchPaths.add("@loader_path/Frameworks");
       macOSLdRunpathSearchPaths.add("@executable_path/../Frameworks");

--- a/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
@@ -5916,9 +5916,6 @@ public class ProjectGeneratorTest {
     PBXTarget target = assertTargetExistsAndReturnTarget(project, "//foo:bin");
     ImmutableMap<String, String> buildSettings = getBuildSettings(binBuildTarget, target, "Debug");
     assertThat(
-        buildSettings.get("LIBRARY_SEARCH_PATHS"),
-        containsString("$DT_TOOLCHAIN_DIR/usr/lib/swift/$PLATFORM_NAME"));
-    assertThat(
         buildSettings.get("LD_RUNPATH_SEARCH_PATHS[sdk=iphoneos*]"),
         equalTo("$(inherited) @executable_path/Frameworks @loader_path/Frameworks"));
     assertThat(

--- a/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
@@ -5900,8 +5900,7 @@ public class ProjectGeneratorTest {
   }
 
   @Test
-  public void testGeneratedProjectForAppleBinaryWithSwiftSources()
-      throws IOException {
+  public void testGeneratedProjectForAppleBinaryWithSwiftSources() throws IOException {
     BuildTarget binBuildTarget = BuildTargetFactory.newInstance(rootPath, "//foo", "bin");
     TargetNode<?> appBinaryNode =
         AppleBinaryBuilder.createBuilder(binBuildTarget)


### PR DESCRIPTION
With #1543, the project generator sets the `LD_RUNPATH_SEARCH_PATHS` for the targets with Swift dependencies. This expands on that for the case when the binary itself has Swift sources but no Swift dependencies.