### PR TITLE
Disable the OSO scrubber when not caching links

### DIFF
--- a/src/com/facebook/buck/android/toolchain/ndk/impl/NdkCxxPlatforms.java
+++ b/src/com/facebook/buck/android/toolchain/ndk/impl/NdkCxxPlatforms.java
@@ -526,7 +526,8 @@ public class NdkCxxPlatforms {
                         compilerType.cxx,
                         version,
                         cxxRuntime,
-                        executableFinder))))
+                        executableFinder)),
+                config.shouldCacheLinks()))
         .addAllLdflags(getLdFlags(targetConfiguration, androidConfig))
         .setStrip(getGccTool(toolchainPaths, "strip", version, executableFinder))
         .setSymbolNameTool(

--- a/src/com/facebook/buck/apple/toolchain/impl/AppleCxxPlatforms.java
+++ b/src/com/facebook/buck/apple/toolchain/impl/AppleCxxPlatforms.java
@@ -421,7 +421,9 @@ public class AppleCxxPlatforms {
             cpp,
             cxxpp,
             new DefaultLinkerProvider(
-                LinkerProvider.Type.DARWIN, new ConstantToolProvider(clangXxPath)),
+                LinkerProvider.Type.DARWIN,
+                new ConstantToolProvider(clangXxPath),
+                config.shouldCacheLinks()),
             ImmutableList.<String>builder().addAll(cflags).addAll(ldflagsBuilder.build()).build(),
             strip,
             ArchiverProvider.from(new BsdArchiver(ar)),

--- a/src/com/facebook/buck/cxx/toolchain/CxxBuckConfig.java
+++ b/src/com/facebook/buck/cxx/toolchain/CxxBuckConfig.java
@@ -407,7 +407,9 @@ public class CxxBuckConfig {
     }
     Optional<LinkerProvider.Type> type =
         delegate.getEnum(cxxSection, LINKER_PLATFORM, LinkerProvider.Type.class);
-    return Optional.of(new DefaultLinkerProvider(type.orElse(defaultType), toolProvider.get()));
+    return Optional.of(
+        new DefaultLinkerProvider(
+            type.orElse(defaultType), toolProvider.get(), shouldCacheLinks()));
   }
 
   public HeaderVerification getHeaderVerificationOrIgnore() {

--- a/src/com/facebook/buck/cxx/toolchain/DefaultCxxPlatforms.java
+++ b/src/com/facebook/buck/cxx/toolchain/DefaultCxxPlatforms.java
@@ -204,7 +204,8 @@ public class DefaultCxxPlatforms {
         new DefaultLinkerProvider(
             linkerType,
             new ConstantToolProvider(
-                new HashedFileTool(() -> config.getSourcePath(defaultLinker)))),
+                new HashedFileTool(() -> config.getSourcePath(defaultLinker))),
+            config.shouldCacheLinks()),
         ImmutableList.of(),
         getHashedFileTool(config, "strip", DEFAULT_STRIP, env),
         ArchiverProvider.from(archiver),

--- a/src/com/facebook/buck/cxx/toolchain/DefaultCxxPlatforms.java
+++ b/src/com/facebook/buck/cxx/toolchain/DefaultCxxPlatforms.java
@@ -203,8 +203,7 @@ public class DefaultCxxPlatforms {
         cxxpp,
         new DefaultLinkerProvider(
             linkerType,
-            new ConstantToolProvider(
-                new HashedFileTool(() -> config.getSourcePath(defaultLinker))),
+            new ConstantToolProvider(new HashedFileTool(() -> config.getSourcePath(defaultLinker))),
             config.shouldCacheLinks()),
         ImmutableList.of(),
         getHashedFileTool(config, "strip", DEFAULT_STRIP, env),

--- a/src/com/facebook/buck/cxx/toolchain/linker/DarwinLinker.java
+++ b/src/com/facebook/buck/cxx/toolchain/linker/DarwinLinker.java
@@ -16,7 +16,6 @@
 
 package com.facebook.buck.cxx.toolchain.linker;
 
-import com.android.annotations.concurrency.Immutable;
 import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.rulekey.AddToRuleKey;
 import com.facebook.buck.core.rules.ActionGraphBuilder;

--- a/src/com/facebook/buck/cxx/toolchain/linker/DefaultLinkerProvider.java
+++ b/src/com/facebook/buck/cxx/toolchain/linker/DefaultLinkerProvider.java
@@ -29,6 +29,7 @@ public class DefaultLinkerProvider implements LinkerProvider {
 
   private final Type type;
   private final ToolProvider toolProvider;
+  private final boolean cacheLinks;
 
   private final LoadingCache<BuildRuleResolver, Linker> cache =
       CacheBuilder.newBuilder()
@@ -37,19 +38,20 @@ public class DefaultLinkerProvider implements LinkerProvider {
               new CacheLoader<BuildRuleResolver, Linker>() {
                 @Override
                 public Linker load(@Nonnull BuildRuleResolver resolver) {
-                  return build(type, toolProvider.resolve(resolver));
+                  return build(type, toolProvider.resolve(resolver), cacheLinks);
                 }
               });
 
-  public DefaultLinkerProvider(Type type, ToolProvider toolProvider) {
+  public DefaultLinkerProvider(Type type, ToolProvider toolProvider, boolean cacheLinks) {
     this.type = type;
     this.toolProvider = toolProvider;
+    this.cacheLinks = cacheLinks;
   }
 
-  private static Linker build(Type type, Tool tool) {
+  private static Linker build(Type type, Tool tool, boolean cacheLinks) {
     switch (type) {
       case DARWIN:
-        return new DarwinLinker(tool);
+        return new DarwinLinker(tool, cacheLinks);
       case GNU:
         return new GnuLinker(tool);
       case WINDOWS:

--- a/src/com/facebook/buck/features/rust/AbstractRustPlatformFactory.java
+++ b/src/com/facebook/buck/features/rust/AbstractRustPlatformFactory.java
@@ -77,7 +77,8 @@ abstract class AbstractRustPlatformFactory {
                                 rustBuckConfig
                                     .getLinkerPlatform(name)
                                     .orElse(cxxPlatform.getLd().getType()),
-                                tp))
+                                tp,
+                                true))
                 .orElseGet(cxxPlatform::getLd))
         .addAllLinkerArgs(rustBuckConfig.getLinkerFlags(name))
         .addAllLinkerArgs(!linker.isPresent() ? cxxPlatform.getLdflags() : ImmutableList.of())

--- a/test/com/facebook/buck/cxx/toolchain/CxxPlatformUtils.java
+++ b/test/com/facebook/buck/cxx/toolchain/CxxPlatformUtils.java
@@ -75,7 +75,7 @@ public class CxxPlatformUtils {
           .setAsmpp(DEFAULT_PREPROCESSOR_PROVIDER)
           .setLd(
               new DefaultLinkerProvider(
-                  LinkerProvider.Type.GNU, new ConstantToolProvider(DEFAULT_TOOL)))
+                  LinkerProvider.Type.GNU, new ConstantToolProvider(DEFAULT_TOOL), true))
           .setStrip(DEFAULT_TOOL)
           .setAr(ArchiverProvider.from(new GnuArchiver(DEFAULT_TOOL)))
           .setArchiveContents(ArchiveContents.NORMAL)

--- a/test/com/facebook/buck/cxx/toolchain/CxxPlatformsTest.java
+++ b/test/com/facebook/buck/cxx/toolchain/CxxPlatformsTest.java
@@ -77,7 +77,7 @@ public class CxxPlatformsTest {
             .setCxxpp(preprocessor)
             .setLd(
                 new DefaultLinkerProvider(
-                    LinkerProvider.Type.GNU, new ConstantToolProvider(borland)))
+                    LinkerProvider.Type.GNU, new ConstantToolProvider(borland), true))
             .setStrip(borland)
             .setSymbolNameTool(new PosixNmSymbolNameTool(borland))
             .setAr(ArchiverProvider.from(new GnuArchiver(borland)))

--- a/test/com/facebook/buck/features/rust/FakeRustConfig.java
+++ b/test/com/facebook/buck/features/rust/FakeRustConfig.java
@@ -40,7 +40,8 @@ public class FakeRustConfig extends RustBuckConfig {
               new DefaultLinkerProvider(
                   LinkerProvider.Type.GNU,
                   new ConstantToolProvider(
-                      new HashedFileTool(PathSourcePath.of(filesystem, Paths.get("/bin/rustc"))))));
+                      new HashedFileTool(PathSourcePath.of(filesystem, Paths.get("/bin/rustc")))),
+                  true));
 
   private Optional<ToolProvider> compiler = Optional.empty();
   private Optional<ImmutableList<String>> rustcFlags = Optional.empty();

--- a/test/com/facebook/buck/features/rust/RustTestUtils.java
+++ b/test/com/facebook/buck/features/rust/RustTestUtils.java
@@ -31,7 +31,7 @@ public class RustTestUtils {
           .setLinker(new ConstantToolProvider(new CommandTool.Builder().build()))
           .setLinkerProvider(
               new DefaultLinkerProvider(
-                  Type.GNU, new ConstantToolProvider(new CommandTool.Builder().build())))
+                  Type.GNU, new ConstantToolProvider(new CommandTool.Builder().build()), true))
           .setCxxPlatform(CxxPlatformUtils.DEFAULT_PLATFORM)
           .build();
 


### PR DESCRIPTION
The Darwin OSO scrubber is used to relativize the paths to object files in the generated symbol table for linked code. This is to aid with debugging when sharing artifacts across machines. If the `cache_links` config option is `false`, we know that these artifacts are not going to be shared so we can disable the scrubbing steps.

This resulted in a > 20% speedup on one of our build jobs.