### PR TITLE
Add support for downloading maven dependencies from local gradle cache

### DIFF
--- a/docs/files-and-dirs/buckconfig.soy
+++ b/docs/files-and-dirs/buckconfig.soy
@@ -3588,12 +3588,18 @@ int run_starter(
   {param description}
     This section defines the set of maven repositories that Buck can use when attempting to resolve
     maven artifacts.  It takes the form of key value pairs of a short name for the repo and the URL.
-    The URL may either be an HTTP(S) URL, or point to a directory on your local disk.
+    The URL may either be an:
+    - HTTP(S) URL
+    - point to a directory on your local disk
+    - gradle cache directory. should be prefixed with 'gradle:' and can have an optional 'GRADLE_USER_HOME', which will be picked up from the system env.
+
+    These repos are tried based on the natural ordering of their names.
 
 {literal}<pre class="prettyprint lang-ini">
 [maven_repositories]
   central = https://repo1.maven.org/maven2
   m2 = ~/.m2/repository
+  gradle = gradle:GRADLE_USER_HOME/caches/modules-2/files-2.1/
 </pre>{/literal}
 <p>
 Note that if you are using Buck to talk to Maven and you are using IPv6, you

--- a/src/com/facebook/buck/file/downloader/impl/AbstractOnDiskDownloader.java
+++ b/src/com/facebook/buck/file/downloader/impl/AbstractOnDiskDownloader.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.file.downloader.impl;
+
+import com.facebook.buck.event.BuckEventBus;
+import com.facebook.buck.file.downloader.Downloader;
+import com.facebook.buck.file.downloader.impl.DownloadEvent.Started;
+import java.io.BufferedInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/** A {@link Downloader} that pulls content from the local file system. */
+public abstract class AbstractOnDiskDownloader implements Downloader {
+  private final Path root;
+
+  public AbstractOnDiskDownloader(Path root) throws FileNotFoundException {
+    if (!Files.exists(root)) {
+      throw new FileNotFoundException(
+          String.format("Maven root %s doesn't exist", root.toString()));
+    }
+
+    this.root = root;
+  }
+
+  @Override
+  public boolean fetch(BuckEventBus eventBus, URI uri, Path output) throws IOException {
+    if (!"mvn".equals(uri.getScheme())) {
+      return false;
+    }
+
+    Path target = getTargetPath(uri);
+
+    if (!Files.exists(target)) {
+      throw new IOException(String.format("Unable to download %s (derived from %s)", target, uri));
+    }
+
+    Started started = DownloadEvent.started(target.toUri());
+    eventBus.post(started);
+
+    try (InputStream is = new BufferedInputStream(Files.newInputStream(target))) {
+      Files.copy(is, output);
+    } finally {
+      eventBus.post(DownloadEvent.finished(started));
+    }
+    return true;
+  }
+
+  public Path getRoot() {
+    return root;
+  }
+
+  public abstract Path getTargetPath(URI uri);
+}

--- a/src/com/facebook/buck/file/downloader/impl/OnDiskGradleDownloader.java
+++ b/src/com/facebook/buck/file/downloader/impl/OnDiskGradleDownloader.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.file.downloader.impl;
+
+import com.facebook.buck.core.config.BuckConfig;
+import com.facebook.buck.core.exceptions.HumanReadableException;
+import com.facebook.buck.file.downloader.Downloader;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+/** A {@link Downloader} that pulls content in gradle format from the local file system. */
+public class OnDiskGradleDownloader extends AbstractOnDiskDownloader {
+  private static final String GRADLE_HOME = "GRADLE_USER_HOME";
+
+  public OnDiskGradleDownloader(Path root) throws FileNotFoundException {
+    super(root);
+  }
+
+  @Override
+  public Path getTargetPath(URI uri) {
+    // Get the relative path that the maven item is located at.
+    String relativePath = MavenUrlDecoder.toLocalGradlePath(uri);
+
+    Path fullPath = getRoot().resolve(relativePath);
+
+    try {
+      // Gradle keeps artifacts in the below format
+      // <group>/<artifactId>/<version>/some-hash/<filename>
+      // List all the folders in the parent directory, iterate and
+      // append hash & filename and return if the file is present.
+
+      if (Files.exists(fullPath.getParent())) {
+        try (Stream<Path> files = Files.list(fullPath.getParent())) {
+          List<Path> actualPaths =
+              files
+                  .filter(dir -> Files.isDirectory(dir))
+                  .map(dir -> dir.resolve(fullPath.getFileName()))
+                  .filter(path -> Files.exists(path))
+                  .collect(ImmutableList.toImmutableList());
+
+          // Only return found path if only one artifact matches.
+          if (actualPaths.size() == 1) {
+            return actualPaths.get(0);
+          }
+        }
+      }
+      return fullPath;
+
+    } catch (IOException e) {
+      throw new HumanReadableException("Failed to list folders in the directory", e);
+    }
+  }
+
+  static URL getUrl(String repo, BuckConfig config) throws MalformedURLException {
+    String filePath = repo.substring("gradle:".length());
+
+    if (filePath.startsWith(GRADLE_HOME)) {
+      String gradleHome = config.getEnvironment().get(GRADLE_HOME);
+
+      if (Strings.isNullOrEmpty(gradleHome)) {
+        throw new HumanReadableException(
+            "GRADLE_USER_HOME needs to be set for using local gradle cache '%s' See "
+                + "https://buckbuild.com/concept/buckconfig.html#maven_repositories "
+                + "for how to configure this setting",
+            repo);
+      }
+      filePath = filePath.replace(GRADLE_HOME, gradleHome);
+    }
+
+    return new URL("file:" + filePath);
+  }
+}

--- a/src/com/facebook/buck/file/downloader/impl/StackedDownloader.java
+++ b/src/com/facebook/buck/file/downloader/impl/StackedDownloader.java
@@ -93,6 +93,26 @@ public class StackedDownloader implements Downloader {
         } catch (MalformedURLException e) {
           throw new HumanReadableException("Unable to determine path from %s", repo);
         }
+      } else if (repo.startsWith("gradle:")) {
+        try {
+          URL url = OnDiskGradleDownloader.getUrl(repo, config);
+          Objects.requireNonNull(url.getPath());
+
+          downloaders.add(
+              new OnDiskGradleDownloader(
+                  config.resolvePathThatMayBeOutsideTheProjectFilesystem(
+                      Paths.get(url.getPath()))));
+        } catch (FileNotFoundException e) {
+          throw new HumanReadableException(
+              e,
+              "Error occurred when attempting to use %s "
+                  + "as a local Gradle repository as configured in .buckconfig.  See "
+                  + "https://buckbuild.com/concept/buckconfig.html#maven_repositories for how to "
+                  + "configure this setting",
+              repo);
+        } catch (MalformedURLException e) {
+          throw new HumanReadableException("Unable to determine path from %s", repo);
+        }
       } else {
         try {
           downloaders.add(

--- a/test/com/facebook/buck/file/downloader/impl/OnDiskGradleDownloaderTest.java
+++ b/test/com/facebook/buck/file/downloader/impl/OnDiskGradleDownloaderTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.buck.file.downloader.impl;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import com.facebook.buck.core.config.BuckConfig;
+import com.facebook.buck.core.config.FakeBuckConfig;
+import com.facebook.buck.core.exceptions.HumanReadableException;
+import com.facebook.buck.event.BuckEventBusForTests;
+import com.facebook.buck.file.downloader.Downloader;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class OnDiskGradleDownloaderTest {
+
+  private FileSystem filesystem;
+  private Path root;
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Before
+  public void setupFilesystem() throws IOException {
+    filesystem = Jimfs.newFileSystem(Configuration.unix());
+    root = filesystem.getPath("/home/bob/.gradle/caches/files");
+    Files.createDirectories(root);
+  }
+
+  @Test
+  public void shouldOnlyAcceptMvnUris() throws IOException {
+    Path relativePath = filesystem.getPath("some/file.txt");
+    Path output = filesystem.getPath("output.txt");
+
+    Downloader downloader = new OnDiskGradleDownloader(root);
+    boolean result =
+        downloader.fetch(BuckEventBusForTests.newInstance(), relativePath.toUri(), output);
+
+    assertFalse(result);
+  }
+
+  @Test
+  public void shouldDownloadFileFromLocalGradleCache() throws URISyntaxException, IOException {
+    URI uri = new URI("mvn:com.group:project:jar:0.1");
+    Path output = filesystem.getPath("output.txt");
+
+    Path source = root.resolve("com.group/project/0.1/hash/project-0.1.jar");
+    Files.createDirectories(source.getParent());
+    Files.write(source, "cake".getBytes(UTF_8));
+
+    Downloader downloader = new OnDiskGradleDownloader(root);
+    downloader.fetch(BuckEventBusForTests.newInstance(), uri, output);
+
+    String result = new String(Files.readAllBytes(output), UTF_8);
+
+    assertThat("cake", Matchers.equalTo(result));
+  }
+
+  @Test
+  public void shouldDownloadFileFromLocalGradleCacheWindows()
+      throws URISyntaxException, IOException {
+    FileSystem filesystem = Jimfs.newFileSystem(Configuration.windows());
+    Path root = filesystem.getPath("C:\\Users\\bob\\.m2");
+    Files.createDirectories(root);
+
+    URI uri = new URI("mvn:com.group:project:jar:0.1");
+    Path output = filesystem.getPath("output.txt");
+
+    Path source = root.resolve("com.group/project/0.1/hash/project-0.1.jar");
+    Files.createDirectories(source.getParent());
+    Files.write(source, "cake".getBytes(UTF_8));
+
+    Downloader downloader = new OnDiskGradleDownloader(root);
+    downloader.fetch(BuckEventBusForTests.newInstance(), uri, output);
+
+    String result = new String(Files.readAllBytes(output), UTF_8);
+
+    assertThat("cake", Matchers.equalTo(result));
+  }
+
+  @Test
+  public void shouldDownloadFileFromLocalGradleCacheWithMultipleEntries()
+      throws URISyntaxException, IOException {
+    URI uri = new URI("mvn:com.group:project:jar:0.1");
+    Path output = filesystem.getPath("output.txt");
+
+    Path prebuiltJar = root.resolve("com.group/project/0.1/hash1/project-0.1.jar");
+    Path sourcesJar = root.resolve("com.group/project/0.1/hash2/project-0.1-sources.jar");
+    Files.createDirectories(prebuiltJar.getParent());
+    Files.createDirectories(sourcesJar.getParent());
+    Files.write(prebuiltJar, "cake".getBytes(UTF_8));
+    Files.write(sourcesJar, "pastry".getBytes(UTF_8));
+
+    Downloader downloader = new OnDiskGradleDownloader(root);
+    downloader.fetch(BuckEventBusForTests.newInstance(), uri, output);
+
+    String result = new String(Files.readAllBytes(output), UTF_8);
+
+    assertThat("cake", Matchers.equalTo(result));
+  }
+
+  @Test
+  public void shouldNotDownloadFileFromLocalGradleCacheWithMultipleSameEntries()
+      throws URISyntaxException, IOException {
+    URI uri = new URI("mvn:com.group:project:jar:0.1");
+    Path output = filesystem.getPath("output.txt");
+
+    Path prebuiltJar = root.resolve("com.group/project/0.1/hash1/project-0.1.jar");
+    Path sourcesJar = root.resolve("com.group/project/0.1/hash2/project-0.1.jar");
+    Files.createDirectories(prebuiltJar.getParent());
+    Files.createDirectories(sourcesJar.getParent());
+    Files.write(prebuiltJar, "cake".getBytes(UTF_8));
+    Files.write(sourcesJar, "pastry".getBytes(UTF_8));
+
+    Downloader downloader = new OnDiskGradleDownloader(root);
+
+    thrown.expect(IOException.class);
+    thrown.expectMessage(
+        "Unable to download /home/bob/.gradle/caches/files/com.group/project/0.1/project-0.1.jar");
+
+    downloader.fetch(BuckEventBusForTests.newInstance(), uri, output);
+  }
+
+  @Test
+  public void shouldThrowFileNotFoundExceptionWhenPathDoesntExist() throws FileNotFoundException {
+    Path rootNotExist = filesystem.getPath("not/a/valid/path");
+
+    thrown.expect(FileNotFoundException.class);
+    thrown.expectMessage(String.format("Maven root %s doesn't exist", rootNotExist.toString()));
+
+    new OnDiskGradleDownloader(rootNotExist);
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenGradleHomeIsNotSet() throws MalformedURLException {
+    BuckConfig buckConfig = FakeBuckConfig.builder().build();
+
+    try {
+      OnDiskGradleDownloader.getUrl("gradle:GRADLE_USER_HOME/caches/files", buckConfig);
+      Assert.fail("should have thrown an exception");
+    } catch (HumanReadableException e) {
+      assertTrue(e.getHumanReadableErrorMessage().contains("GRADLE_USER_HOME"));
+    }
+  }
+
+  @Test
+  public void shouldDetectGradleHomeWhenGradleHomeIsSet() throws MalformedURLException {
+    BuckConfig buckConfig =
+        FakeBuckConfig.builder()
+            .setEnvironment(ImmutableMap.of("GRADLE_USER_HOME", "/usr/dev"))
+            .build();
+
+    URL url = OnDiskGradleDownloader.getUrl("gradle:GRADLE_USER_HOME/caches/files", buckConfig);
+
+    assertEquals("file:/usr/dev/caches/files", url.toString());
+  }
+
+  @Test
+  public void shouldReturnUrlWhenNoGradleHome() throws MalformedURLException {
+    BuckConfig buckConfig = FakeBuckConfig.builder().build();
+
+    URL url = OnDiskGradleDownloader.getUrl("gradle:/usr/eng/caches/files", buckConfig);
+
+    assertEquals("file:/usr/eng/caches/files", url.toString());
+  }
+}

--- a/test/com/facebook/buck/file/downloader/impl/StackedDownloaderTest.java
+++ b/test/com/facebook/buck/file/downloader/impl/StackedDownloaderTest.java
@@ -122,6 +122,9 @@ public class StackedDownloaderTest {
     Path m2Root = vfs.getPath(jimfAbsolutePath("/home/user/.m2/repository"));
     Files.createDirectories(m2Root);
 
+    Path gradleRoot = vfs.getPath(jimfAbsolutePath("/home/user/.gradle/cache"));
+    Files.createDirectories(gradleRoot);
+
     // Set up a config so we expect to see both a local and a remote maven repo.
     Path projectRoot = vfs.getPath(jimfAbsolutePath("/opt/local/src"));
     Files.createDirectories(projectRoot);
@@ -131,7 +134,8 @@ public class StackedDownloaderTest {
             .setSections(
                 "[maven_repositories]",
                 "local = " + m2Root,
-                "central = https://repo1.maven.org/maven2")
+                "central = https://repo1.maven.org/maven2",
+                "gradle = gradle:/home/user/.gradle/cache")
             .build();
 
     Downloader downloader =
@@ -143,17 +147,21 @@ public class StackedDownloaderTest {
     List<Downloader> downloaders = unpackDownloaders(downloader);
     boolean seenRemote = false;
     boolean seenLocal = false;
+    boolean seenGradle = false;
 
     for (Downloader seen : downloaders) {
       if (seen instanceof RemoteMavenDownloader) {
         seenRemote = true;
       } else if (seen instanceof OnDiskMavenDownloader) {
         seenLocal = true;
+      } else if (seen instanceof OnDiskGradleDownloader) {
+        seenGradle = true;
       }
     }
 
     assertTrue(seenLocal);
     assertTrue(seenRemote);
+    assertTrue(seenGradle);
   }
 
   private static String jimfAbsolutePath(String path) {

--- a/test/com/facebook/buck/file/downloader/impl/StackedDownloaderTest.java
+++ b/test/com/facebook/buck/file/downloader/impl/StackedDownloaderTest.java
@@ -122,7 +122,7 @@ public class StackedDownloaderTest {
     Path m2Root = vfs.getPath(jimfAbsolutePath("/home/user/.m2/repository"));
     Files.createDirectories(m2Root);
 
-    Path gradleRoot = vfs.getPath(jimfAbsolutePath("/home/user/.gradle/cache"));
+    Path gradleRoot = vfs.getPath(jimfAbsolutePath("/home/user/gradle/cache"));
     Files.createDirectories(gradleRoot);
 
     // Set up a config so we expect to see both a local and a remote maven repo.
@@ -135,7 +135,7 @@ public class StackedDownloaderTest {
                 "[maven_repositories]",
                 "local = " + m2Root,
                 "central = https://repo1.maven.org/maven2",
-                "gradle = gradle:/home/user/.gradle/cache")
+                "gradle = gradle:/home/user/gradle/cache")
             .build();
 
     Downloader downloader =


### PR DESCRIPTION
When running with okBuck gradle cache already has all the artifacts downloaded. 
This allows us to reuse existing gradle cache for downloading external dependencies in buck.

This change doesn't modify any previous behavior.
```
maven_repositories
    gradle = gradle:GRADLE_USER_HOME/caches/modules-2/files-2.1/
```