### PR TITLE
Add full kotlin configurations to kotlin rule

### DIFF
--- a/docs/rule/kotlin_library.soy
+++ b/docs/rule/kotlin_library.soy
@@ -69,10 +69,109 @@ the <code>resources</code> argument.
 {/call}
 
 {call buck.arg}
-  {param name: 'extra_arguments' /}
+  {param name: 'free_compiler_args' /}
   {param default: '[]' /}
   {param desc}
-  List of additional arguments to pass into the Kotlin compiler.
+    A list of additional compiler arguments.
+  {/param}
+{/call}
+
+{call buck.arg}
+  {param name: 'all_warnings_as_errors' /}
+  {param default: 'false' /}
+  {param desc}
+    Report an error if there are any warnings.
+  {/param}
+{/call}
+
+{call buck.arg}
+  {param name: 'suppress_warnings' /}
+  {param default: 'false' /}
+  {param desc}
+    Generate no warnings.
+  {/param}
+{/call}
+
+{call buck.arg}
+  {param name: 'verbose' /}
+  {param default: 'false' /}
+  {param desc}
+    Enable verbose logging output.
+  {/param}
+{/call}
+
+{call buck.arg}
+  {param name: 'include_runtime' /}
+  {param default: 'false' /}
+  {param desc}
+    Include Kotlin runtime in to resulting .jar
+  {/param}
+{/call}
+
+{call buck.arg}
+  {param name: 'jvm_target' /}
+  {param default: '1.6' /}
+  {param desc}
+    Target version of the generated JVM bytecode (1.6 or 1.8), default is 1.6
+    Possible values: "1.6", "1.8"
+  {/param}
+{/call}
+
+{call buck.arg}
+  {param name: 'jdk_home' /}
+  {param default: 'None' /}
+  {param desc}
+    Path to JDK home directory to include into classpath, if differs from default JAVA_HOME
+  {/param}
+{/call}
+
+{call buck.arg}
+  {param name: 'no_jdk' /}
+  {param default: 'false' /}
+  {param desc}
+    Don't include Java runtime into classpath.
+  {/param}
+{/call}
+
+{call buck.arg}
+  {param name: 'no_stdlib' /}
+  {param default: 'true' /}
+  {param desc}
+    Don't include kotlin-stdlib.jar or kotlin-reflect.jar into classpath.
+  {/param}
+{/call}
+
+{call buck.arg}
+  {param name: 'no_reflect' /}
+  {param default: 'true' /}
+  {param desc}
+    Don't include kotlin-reflect.jar into classpath.
+  {/param}
+{/call}
+
+{call buck.arg}
+  {param name: 'java_parameters' /}
+  {param default: 'false' /}
+  {param desc}
+    Generate metadata for Java 1.8 reflection on method parameters.
+  {/param}
+{/call}
+
+{call buck.arg}
+  {param name: 'api_version' /}
+  {param default: 'None' /}
+  {param desc}
+    Allow to use declarations only from the specified version of bundled libraries.
+    Possible values: "1.0", "1.1", "1.2", "1.3", "1.4 (EXPERIMENTAL)".
+  {/param}
+{/call}
+
+{call buck.arg}
+  {param name: 'language_version' /}
+  {param default: 'None' /}
+  {param desc}
+    Provide source compatibility with specified language version.
+    Possible values: "1.0", "1.1", "1.2", "1.3", "1.4 (EXPERIMENTAL)".
   {/param}
 {/call}
 

--- a/src/com/facebook/buck/jvm/kotlin/KotlinConfiguredCompilerFactory.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinConfiguredCompilerFactory.java
@@ -90,8 +90,7 @@ public class KotlinConfiguredCompilerFactory extends ConfiguredCompilerFactory {
   private ImmutableList<String> condenseCompilerArguments(CoreArg kotlinArgs) {
     ImmutableMap.Builder<String, Optional<String>> optionBuilder = ImmutableMap.builder();
     LinkedHashMap<String, Optional<String>> freeArgs = Maps.newLinkedHashMap();
-    kotlinArgs.getFreeCompilerArgs()
-        .forEach(arg -> freeArgs.put(arg, Optional.empty()));
+    kotlinArgs.getFreeCompilerArgs().forEach(arg -> freeArgs.put(arg, Optional.empty()));
     optionBuilder.putAll(freeArgs);
 
     // Args from CommonToolArguments.kt and KotlinCommonToolOptions.kt
@@ -110,7 +109,9 @@ public class KotlinConfiguredCompilerFactory extends ConfiguredCompilerFactory {
     if (kotlinArgs.getIncludeRuntime()) {
       optionBuilder.put("-include-runtime", Optional.empty());
     }
-    kotlinArgs.getJdkHome().ifPresent(jdkHome -> optionBuilder.put("-jdk-home", Optional.of(jdkHome)));
+    kotlinArgs
+        .getJdkHome()
+        .ifPresent(jdkHome -> optionBuilder.put("-jdk-home", Optional.of(jdkHome)));
     if (kotlinArgs.getNoJdk()) {
       optionBuilder.put("-no-jdk", Optional.empty());
     }
@@ -123,22 +124,27 @@ public class KotlinConfiguredCompilerFactory extends ConfiguredCompilerFactory {
     if (kotlinArgs.getJavaParameters()) {
       optionBuilder.put("-java-parameters", Optional.empty());
     }
-    kotlinArgs.getApiVersion().ifPresent(apiVersion -> optionBuilder.put("-api-version", Optional.of(apiVersion)));
-    kotlinArgs.languageVersion().ifPresent(languageVersion -> optionBuilder.put("-language-version", Optional.of(languageVersion)));
+    kotlinArgs
+        .getApiVersion()
+        .ifPresent(apiVersion -> optionBuilder.put("-api-version", Optional.of(apiVersion)));
+    kotlinArgs
+        .languageVersion()
+        .ifPresent(
+            languageVersion ->
+                optionBuilder.put("-language-version", Optional.of(languageVersion)));
 
     // Return de-duping keys and sorting by them.
-    return optionBuilder.build()
-        .entrySet()
-        .stream()
+    return optionBuilder.build().entrySet().stream()
         .filter(distinctByKey(Map.Entry::getKey))
         .sorted(comparing(Map.Entry::getKey, String.CASE_INSENSITIVE_ORDER))
-        .flatMap(entry -> {
-          if (entry.getValue().isPresent()) {
-            return ImmutableList.of(entry.getKey(), entry.getValue().get()).stream();
-          } else {
-            return ImmutableList.of(entry.getKey()).stream();
-          }
-        })
+        .flatMap(
+            entry -> {
+              if (entry.getValue().isPresent()) {
+                return ImmutableList.of(entry.getKey(), entry.getValue().get()).stream();
+              } else {
+                return ImmutableList.of(entry.getKey()).stream();
+              }
+            })
         .collect(toImmutableList());
   }
 

--- a/src/com/facebook/buck/jvm/kotlin/KotlinConfiguredCompilerFactory.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinConfiguredCompilerFactory.java
@@ -16,6 +16,9 @@
 
 package com.facebook.buck.jvm.kotlin;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Comparator.comparing;
+
 import com.facebook.buck.core.rules.BuildRuleResolver;
 import com.facebook.buck.core.rules.SourcePathRuleFinder;
 import com.facebook.buck.core.toolchain.ToolchainProvider;
@@ -28,8 +31,17 @@ import com.facebook.buck.jvm.java.JavacOptions;
 import com.facebook.buck.jvm.java.JvmLibraryArg;
 import com.facebook.buck.jvm.kotlin.KotlinLibraryDescription.AnnotationProcessingTool;
 import com.facebook.buck.jvm.kotlin.KotlinLibraryDescription.CoreArg;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
 public class KotlinConfiguredCompilerFactory extends ConfiguredCompilerFactory {
@@ -63,7 +75,7 @@ public class KotlinConfiguredCompilerFactory extends ConfiguredCompilerFactory {
     return new KotlincToJarStepFactory(
         kotlinBuckConfig.getKotlinc(),
         kotlinBuckConfig.getKotlinHomeLibraries(),
-        kotlinArgs.getExtraKotlincArguments(),
+        condenseCompilerArguments(kotlinArgs),
         kotlinArgs.getFriendPaths(),
         kotlinArgs.getAnnotationProcessingTool().orElse(AnnotationProcessingTool.KAPT),
         extraClasspathProviderSupplier.apply(toolchainProvider),
@@ -73,5 +85,65 @@ public class KotlinConfiguredCompilerFactory extends ConfiguredCompilerFactory {
 
   private Javac getJavac(BuildRuleResolver resolver, @Nullable JvmLibraryArg arg) {
     return javacFactory.create(new SourcePathRuleFinder(resolver), arg);
+  }
+
+  private ImmutableList<String> condenseCompilerArguments(CoreArg kotlinArgs) {
+    ImmutableMap.Builder<String, Optional<String>> optionBuilder = ImmutableMap.builder();
+    LinkedHashMap<String, Optional<String>> freeArgs = Maps.newLinkedHashMap();
+    kotlinArgs.getFreeCompilerArgs()
+        .forEach(arg -> freeArgs.put(arg, Optional.empty()));
+    optionBuilder.putAll(freeArgs);
+
+    // Args from CommonToolArguments.kt and KotlinCommonToolOptions.kt
+    if (kotlinArgs.getAllWarningsAsErrors()) {
+      optionBuilder.put("-Werror", Optional.empty());
+    }
+    if (kotlinArgs.getSuppressWarnings()) {
+      optionBuilder.put("-nowarn", Optional.empty());
+    }
+    if (kotlinArgs.getVerbose()) {
+      optionBuilder.put("-verbose", Optional.empty());
+    }
+
+    // Args from K2JVMCompilerArguments.kt and KotlinJvmOptions.kt
+    optionBuilder.put("-jvm-target", Optional.of(kotlinArgs.getJvmTarget()));
+    if (kotlinArgs.getIncludeRuntime()) {
+      optionBuilder.put("-include-runtime", Optional.empty());
+    }
+    kotlinArgs.getJdkHome().ifPresent(jdkHome -> optionBuilder.put("-jdk-home", Optional.of(jdkHome)));
+    if (kotlinArgs.getNoJdk()) {
+      optionBuilder.put("-no-jdk", Optional.empty());
+    }
+    if (kotlinArgs.getNoStdlib()) {
+      optionBuilder.put("-no-stdlib", Optional.empty());
+    }
+    if (kotlinArgs.getNoReflect()) {
+      optionBuilder.put("-no-reflect", Optional.empty());
+    }
+    if (kotlinArgs.getJavaParameters()) {
+      optionBuilder.put("-java-parameters", Optional.empty());
+    }
+    kotlinArgs.getApiVersion().ifPresent(apiVersion -> optionBuilder.put("-api-version", Optional.of(apiVersion)));
+    kotlinArgs.languageVersion().ifPresent(languageVersion -> optionBuilder.put("-language-version", Optional.of(languageVersion)));
+
+    // Return de-duping keys and sorting by them.
+    return optionBuilder.build()
+        .entrySet()
+        .stream()
+        .filter(distinctByKey(Map.Entry::getKey))
+        .sorted(comparing(Map.Entry::getKey, String.CASE_INSENSITIVE_ORDER))
+        .flatMap(entry -> {
+          if (entry.getValue().isPresent()) {
+            return ImmutableList.of(entry.getKey(), entry.getValue().get()).stream();
+          } else {
+            return ImmutableList.of(entry.getKey()).stream();
+          }
+        })
+        .collect(toImmutableList());
+  }
+
+  private static <T> Predicate<T> distinctByKey(Function<? super T, ?> keyExtractor) {
+    Set<Object> seen = ConcurrentHashMap.newKeySet();
+    return t -> seen.add(keyExtractor.apply(t));
   }
 }

--- a/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
@@ -195,98 +195,78 @@ public class KotlinLibraryDescription
 
   public interface CoreArg extends JavaLibraryDescription.CoreArg {
 
-    /**
-     * A list of additional compiler arguments.
-     */
+    /** A list of additional compiler arguments. */
     ImmutableList<String> getFreeCompilerArgs();
 
-    /**
-     * Report an error if there are any warnings.
-     */
+    /** Report an error if there are any warnings. */
     @Value.Default
     default boolean getAllWarningsAsErrors() {
       return false;
     }
 
-    /**
-     * Generate no warnings.
-     */
+    /** Generate no warnings. */
     @Value.Default
     default boolean getSuppressWarnings() {
       return false;
     }
 
-    /**
-     * Enable verbose logging output.
-     */
+    /** Enable verbose logging output. */
     @Value.Default
     default boolean getVerbose() {
       return false;
     }
 
-    /**
-     * Include Kotlin runtime in to resulting .jar
-     */
+    /** Include Kotlin runtime in to resulting .jar */
     @Value.Default
     default boolean getIncludeRuntime() {
       return false;
     }
 
     /**
-     * Target version of the generated JVM bytecode (1.6 or 1.8), default is 1.6
-     * Possible values: "1.6", "1.8"
+     * Target version of the generated JVM bytecode (1.6 or 1.8), default is 1.6 Possible values:
+     * "1.6", "1.8"
      */
     @Value.Default
     default String getJvmTarget() {
       return "1.6";
     }
 
-    /**
-     * Path to JDK home directory to include into classpath, if differs from default JAVA_HOME
-     */
+    /** Path to JDK home directory to include into classpath, if differs from default JAVA_HOME */
     Optional<String> getJdkHome();
 
-    /**
-     * Don't include Java runtime into classpath.
-     */
+    /** Don't include Java runtime into classpath. */
     @Value.Default
     default boolean getNoJdk() {
       return false;
     }
 
-    /**
-     * Don't include kotlin-stdlib.jar or kotlin-reflect.jar into classpath.
-     */
+    /** Don't include kotlin-stdlib.jar or kotlin-reflect.jar into classpath. */
     @Value.Default
     default boolean getNoStdlib() {
       return true;
     }
 
-    /**
-     * Don't include kotlin-reflect.jar into classpath.
-     */
+    /** Don't include kotlin-reflect.jar into classpath. */
     @Value.Default
     default boolean getNoReflect() {
       return true;
     }
 
-    /**
-     * Generate metadata for Java 1.8 reflection on method parameters.
-     */
+    /** Generate metadata for Java 1.8 reflection on method parameters. */
     @Value.Default
     default boolean getJavaParameters() {
       return false;
     }
 
     /**
-     * Allow to use declarations only from the specified version of bundled libraries.
-     * Possible values: "1.0", "1.1", "1.2", "1.3", "1.4 (EXPERIMENTAL)".
+     * Allow to use declarations only from the specified version of bundled libraries. Possible
+     * values: "1.0", "1.1", "1.2", "1.3", "1.4 (EXPERIMENTAL)".
      */
     Optional<String> getApiVersion();
 
     /**
-     * Provide source compatibility with specified language version.
-     * Possible values: "1.0", "1.1", "1.2", "1.3", "1.4 (EXPERIMENTAL)".
+     * Provide source compatibility with specified language version. Possible values: "1.0", "1.1",
+     * "1.2", "1.3", "1.4 (EXPERIMENTAL)".
      */
     Optional<String> languageVersion();
 

--- a/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
@@ -194,7 +194,101 @@ public class KotlinLibraryDescription
   }
 
   public interface CoreArg extends JavaLibraryDescription.CoreArg {
-    ImmutableList<String> getExtraKotlincArguments();
+
+    /**
+     * A list of additional compiler arguments.
+     */
+    ImmutableList<String> getFreeCompilerArgs();
+
+    /**
+     * Report an error if there are any warnings.
+     */
+    @Value.Default
+    default boolean getAllWarningsAsErrors() {
+      return false;
+    }
+
+    /**
+     * Generate no warnings.
+     */
+    @Value.Default
+    default boolean getSuppressWarnings() {
+      return false;
+    }
+
+    /**
+     * Enable verbose logging output.
+     */
+    @Value.Default
+    default boolean getVerbose() {
+      return false;
+    }
+
+    /**
+     * Include Kotlin runtime in to resulting .jar
+     */
+    @Value.Default
+    default boolean getIncludeRuntime() {
+      return false;
+    }
+
+    /**
+     * Target version of the generated JVM bytecode (1.6 or 1.8), default is 1.6
+     * Possible values: "1.6", "1.8"
+     */
+    @Value.Default
+    default String getJvmTarget() {
+      return "1.6";
+    }
+
+    /**
+     * Path to JDK home directory to include into classpath, if differs from default JAVA_HOME
+     */
+    Optional<String> getJdkHome();
+
+    /**
+     * Don't include Java runtime into classpath.
+     */
+    @Value.Default
+    default boolean getNoJdk() {
+      return false;
+    }
+
+    /**
+     * Don't include kotlin-stdlib.jar or kotlin-reflect.jar into classpath.
+     */
+    @Value.Default
+    default boolean getNoStdlib() {
+      return true;
+    }
+
+    /**
+     * Don't include kotlin-reflect.jar into classpath.
+     */
+    @Value.Default
+    default boolean getNoReflect() {
+      return true;
+    }
+
+    /**
+     * Generate metadata for Java 1.8 reflection on method parameters.
+     */
+    @Value.Default
+    default boolean getJavaParameters() {
+      return false;
+    }
+
+    /**
+     * Allow to use declarations only from the specified version of bundled libraries.
+     * Possible values: "1.0", "1.1", "1.2", "1.3", "1.4 (EXPERIMENTAL)".
+     */
+    Optional<String> getApiVersion();
+
+    /**
+     * Provide source compatibility with specified language version.
+     * Possible values: "1.0", "1.1", "1.2", "1.3", "1.4 (EXPERIMENTAL)".
+     */
+    Optional<String> languageVersion();
 
     Optional<AnnotationProcessingTool> getAnnotationProcessingTool();
 

--- a/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
@@ -94,9 +94,6 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
   private static final String AP_OPTIONS = KAPT3_PLUGIN + "apoptions=";
   private static final String KAPT_GENERATED = "kapt.kotlin.generated";
   private static final String MODULE_NAME = "-module-name";
-  private static final String NO_STDLIB = "-no-stdlib";
-  private static final String NO_REFLECT = "-no-reflect";
-  private static final String VERBOSE = "-verbose";
 
   private static final PathMatcher KOTLIN_PATH_MATCHER = FileExtensionMatcher.of("kt");
   private static final PathMatcher SRC_ZIP_MATCHER = GlobPatternMatcher.of("**.src.zip");
@@ -237,11 +234,8 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
               ImmutableList.<String>builder()
                   .addAll(extraKotlincArguments)
                   .add(friendPathsArg)
-                  .add(NO_STDLIB)
-                  .add(NO_REFLECT)
                   .add(COMPILER_BUILTINS)
                   .add(LOAD_BUILTINS_FROM)
-                  .add(VERBOSE)
                   .add()
                   .build(),
               projectFilesystem,

--- a/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
@@ -270,8 +270,7 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
     // Note that this filters out only .kt files, so this keeps both .java and .src.zip files.
     ImmutableSortedSet<Path> javaSourceFiles =
         ImmutableSortedSet.copyOf(
-            sources
-                .stream()
+            sources.stream()
                 .filter(input -> !KOTLIN_PATH_MATCHER.matches(input))
                 .collect(Collectors.toSet()));
 
@@ -319,10 +318,7 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
 
     ImmutableList<String> pluginFields =
         ImmutableList.copyOf(
-            javacOptions
-                .getAnnotationProcessingParams()
-                .getModernProcessors()
-                .stream()
+            javacOptions.getAnnotationProcessingParams().getModernProcessors().stream()
                 .map(
                     resolvedJavacPluginProperties ->
                         resolvedJavacPluginProperties.getJavacPluginJsr199Fields(
@@ -454,8 +450,7 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
     // https://youtrack.jetbrains.com/issue/KT-29933
     ImmutableSortedSet<String> absoluteFriendPaths =
         ImmutableSortedSet.copyOf(
-            friendPathsSourcePaths
-                .stream()
+            friendPathsSourcePaths.stream()
                 .map(path -> sourcePathResolver.getAbsolutePath(path).toString())
                 .collect(Collectors.toSet()));
 


### PR DESCRIPTION
These match the configurable JVM arguments in other build systems and better match naming conventions.

Note that much of this logic is borrowed from OkBuck, where we already extract these arguments from gradle configurations

CC @thalescm @kageiit @raviagarwal7 