### PR TITLE
[iOS][Umbrella] Do not include Target-Swift.h in umbrella header

### DIFF
--- a/src/com/facebook/buck/apple/clang/UmbrellaHeader.java
+++ b/src/com/facebook/buck/apple/clang/UmbrellaHeader.java
@@ -29,8 +29,7 @@ public class UmbrellaHeader {
 
   public String render() {
     String swiftGeneratedHeader = String.format("%s-Swift.h", targetName);
-    return headerNames
-        .stream()
+    return headerNames.stream()
         // Remove the Target-Swift.h header file from the list of header names.
         // The umbrella header should not import the generated Objective-C header.
         // It is the job of the module map to make sure that Swift code is accessible

--- a/src/com/facebook/buck/apple/clang/UmbrellaHeader.java
+++ b/src/com/facebook/buck/apple/clang/UmbrellaHeader.java
@@ -28,7 +28,14 @@ public class UmbrellaHeader {
   }
 
   public String render() {
-    return headerNames.stream()
+    String swiftGeneratedHeader = String.format("%s-Swift.h", targetName);
+    return headerNames
+        .stream()
+        // Remove the Target-Swift.h header file from the list of header names.
+        // The umbrella header should not import the generated Objective-C header.
+        // It is the job of the module map to make sure that Swift code is accessible
+        // to Objective-C via the Target-Swift.h header file.
+        .filter(x -> !x.equals(swiftGeneratedHeader))
         .map(x -> String.format("#import <%s/%s>\n", targetName, x))
         .reduce("", String::concat);
   }

--- a/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
@@ -903,7 +903,11 @@ public class ProjectGeneratorTest {
     List<Path> headerSymlinkTrees = projectGenerator.getGeneratedHeaderSymlinkTrees();
     assertThat(headerSymlinkTrees, hasSize(2));
     assertEquals("buck-out/gen/_p/CwkbTNOBmb-pub", headerSymlinkTrees.get(0).toString());
-    assertTrue(projectFilesystem.isFile(headerSymlinkTrees.get(0).resolve("lib/lib.h")));
+
+    Path umbrellaHeaderPath = headerSymlinkTrees.get(0).resolve("lib/lib.h");
+    Optional<String> umbrellaContents = projectFilesystem.readFileIfItExists(umbrellaHeaderPath);
+    assertTrue(umbrellaContents.isPresent());
+    assertFalse(umbrellaContents.get().contains("lib-Swift.h"));
   }
 
   @Test


### PR DESCRIPTION
This PR removes `#import <Target/Target-Swift.h>` from the `Target.h` umbrella file for each module named "Target".

Umbrella files should not have the generated `-Swift.h` file included in them. The generated `-Swift.h` should be used by the module map, not by the umbrella header.