### PR TITLE
don't bundle apps except in watch apps

### DIFF
--- a/src/com/facebook/buck/apple/AppleDescriptions.java
+++ b/src/com/facebook/buck/apple/AppleDescriptions.java
@@ -1039,23 +1039,16 @@ public class AppleDescriptions {
                 "Path cannot be null for AppleBundle [%s].",
                 appleBundle);
 
-        if (AppleBundleExtension.APPEX.toFileExtension().equals(appleBundle.getExtension())
-            || AppleBundleExtension.APP.toFileExtension().equals(appleBundle.getExtension())) {
-          Path destinationPath;
-
+        if (AppleBundleExtension.APP.toFileExtension().equals(appleBundle.getExtension())) {
           String platformName = appleBundle.getPlatformName();
-
-          if ((platformName.equals(ApplePlatform.WATCHOS.getName())
-                  || platformName.equals(ApplePlatform.WATCHSIMULATOR.getName()))
-              && appleBundle.getExtension().equals(AppleBundleExtension.APP.toFileExtension())) {
-            destinationPath = destinations.getWatchAppPath();
+          if (platformName.equals(ApplePlatform.WATCHOS.getName()) ||
+              platformName.equals(ApplePlatform.WATCHSIMULATOR.getName())) {
+            extensionBundlePaths.put(sourcePath, destinations.getWatchAppPath().toString());
           } else if (appleBundle.isLegacyWatchApp()) {
-            destinationPath = destinations.getResourcesPath();
-          } else {
-            destinationPath = destinations.getPlugInsPath();
+            extensionBundlePaths.put(sourcePath, destinations.getResourcesPath().toString());
           }
-
-          extensionBundlePaths.put(sourcePath, destinationPath.toString());
+        } else if (AppleBundleExtension.APPEX.toFileExtension().equals(appleBundle.getExtension())) {
+          extensionBundlePaths.put(sourcePath, destinations.getPlugInsPath().toString());
         } else if (AppleBundleExtension.FRAMEWORK
             .toFileExtension()
             .equals(appleBundle.getExtension())) {

--- a/src/com/facebook/buck/apple/AppleDescriptions.java
+++ b/src/com/facebook/buck/apple/AppleDescriptions.java
@@ -1041,13 +1041,15 @@ public class AppleDescriptions {
 
         if (AppleBundleExtension.APP.toFileExtension().equals(appleBundle.getExtension())) {
           String platformName = appleBundle.getPlatformName();
-          if (platformName.equals(ApplePlatform.WATCHOS.getName()) ||
-              platformName.equals(ApplePlatform.WATCHSIMULATOR.getName())) {
+          if (platformName.equals(ApplePlatform.WATCHOS.getName())
+              || platformName.equals(ApplePlatform.WATCHSIMULATOR.getName())) {
             extensionBundlePaths.put(sourcePath, destinations.getWatchAppPath().toString());
           } else if (appleBundle.isLegacyWatchApp()) {
             extensionBundlePaths.put(sourcePath, destinations.getResourcesPath().toString());
           }
-        } else if (AppleBundleExtension.APPEX.toFileExtension().equals(appleBundle.getExtension())) {
+        } else if (AppleBundleExtension.APPEX
+            .toFileExtension()
+            .equals(appleBundle.getExtension())) {
           extensionBundlePaths.put(sourcePath, destinations.getPlugInsPath().toString());
         } else if (AppleBundleExtension.FRAMEWORK
             .toFileExtension()


### PR DESCRIPTION
Fix for apple bundle dependency bundling. It is only valid to bundle apps when they are watch apps. This prevents the bundling of apps inside test bundles that have test hosts.