### PR TITLE
Remove dominated clause in conditional

### DIFF
--- a/src/com/facebook/buck/features/haskell/HaskellLibraryDescription.java
+++ b/src/com/facebook/buck/features/haskell/HaskellLibraryDescription.java
@@ -500,7 +500,7 @@ public class HaskellLibraryDescription
       @Override
       public Iterable<BuildRule> visit(BuildRule rule) {
         ImmutableSet.Builder<BuildRule> traverse = ImmutableSet.builder();
-        if (rule instanceof HaskellCompileDep || rule instanceof PrebuiltHaskellLibrary) {
+        if (rule instanceof HaskellCompileDep) {
           HaskellCompileDep haskellCompileDep = (HaskellCompileDep) rule;
 
           // Get haddock-interfaces


### PR DESCRIPTION
As PrebuiltHaskellLibrary inherits from HaskellCompileDep, this part
of the conditional isn't necessary.

Split out of https://github.com/facebook/buck/pull/2168