### PR TITLE
Use absolute paths for DERIVED_FILE_DIR

### DIFF
--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -1665,19 +1665,17 @@ public class ProjectGenerator {
       }
       extraSettingsBuilder.put("USE_HEADERMAP", shouldSetUseHeadermap ? "YES" : "NO");
 
+      Path repoRoot = projectFilesystem.getRootPath().toAbsolutePath().normalize();
       defaultSettingsBuilder.put(
-          "REPO_ROOT", projectFilesystem.getRootPath().toAbsolutePath().normalize().toString());
+          "REPO_ROOT", repoRoot.toString());
       if (hasSwiftVersionArg && containsSwiftCode && isFocusedOnTarget) {
         // We need to be able to control the directory where Xcode places the derived sources, so
         // that the Obj-C Generated Header can be included in the header map and imported through
         // a framework-style import like <Module/Module-Swift.h>
         Path derivedSourcesDir =
             getDerivedSourcesDirectoryForBuildTarget(buildTarget, projectFilesystem);
-        Path derivedSourceDirRelativeToProjectRoot =
-            pathRelativizer.outputDirToRootRelative(derivedSourcesDir);
-
         defaultSettingsBuilder.put(
-            "DERIVED_FILE_DIR", derivedSourceDirRelativeToProjectRoot.toString());
+            "DERIVED_FILE_DIR", repoRoot.resolve(derivedSourcesDir).toString());
       }
 
       defaultSettingsBuilder.put(PRODUCT_NAME, getProductName(buildTargetNode));

--- a/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertEquals;
@@ -5975,7 +5976,8 @@ public class ProjectGeneratorTest {
     PBXTarget pbxTarget = assertTargetExistsAndReturnTarget(pbxProject, "//foo:lib");
     ImmutableMap<String, String> buildSettings = getBuildSettings(buildTarget, pbxTarget, "Debug");
 
-    assertThat(buildSettings.get("DERIVED_FILE_DIR"), equalTo("../" + derivedSourcesUserDir));
+    assertThat(buildSettings.get("DERIVED_FILE_DIR"), startsWith("/"));
+    assertTrue(buildSettings.get("DERIVED_FILE_DIR").endsWith(derivedSourcesUserDir));
     assertThat(
         buildSettings.get("SWIFT_OBJC_INTERFACE_HEADER_NAME"), equalTo(objCGeneratedHeaderName));
   }


### PR DESCRIPTION
If a `.mlmodel` is added to an Xcode target where that module's `DERIVED_FILE_DIR` is set to a relative path, Xcode will crash.

This PR sets `DERIVED_FILE_DIR` to be an absolute path, which allows `.mlmodel`s to be included in generated Xcode projects without Xcode crashing.