### PR TITLE
Recognize NDK version 19

### DIFF
--- a/src/com/facebook/buck/android/toolchain/ndk/impl/NdkCxxPlatforms.java
+++ b/src/com/facebook/buck/android/toolchain/ndk/impl/NdkCxxPlatforms.java
@@ -168,7 +168,11 @@ public class NdkCxxPlatforms {
                                     ? 16
                                     : ndkVersion.startsWith("17.")
                                         ? 17
-                                        : ndkVersion.startsWith("18.") ? 18 : -1;
+                                        : ndkVersion.startsWith("18.")
+                                            ? 18
+                                            : ndkVersion.startsWith("19.")
+                                                ? 19
+                                                : -1;
   }
 
   public static String getDefaultGccVersionForNdk(String ndkVersion) {


### PR DESCRIPTION

#### Changes
Each new NDK version will break under this scheme.
This fixes the error `Unknown ndk version: 19.0.5232133`.
Please develop a long-term solution.
Reviewer @ttsugriy