### PR TITLE
Support All Future NDKs

### DIFF
--- a/src/com/facebook/buck/android/toolchain/ndk/impl/NdkCxxPlatforms.java
+++ b/src/com/facebook/buck/android/toolchain/ndk/impl/NdkCxxPlatforms.java
@@ -159,7 +159,7 @@ public class NdkCxxPlatforms {
     }
     try {
       return Integer.parseInt(ndkVersion.substring(0, ndkVersion.indexOf(".")));
-    } catch (NumberFormatException e) {
+    } catch (IndexOutOfBoundsException | NumberFormatException e) {
       return -1;
     }
   }

--- a/src/com/facebook/buck/android/toolchain/ndk/impl/NdkCxxPlatforms.java
+++ b/src/com/facebook/buck/android/toolchain/ndk/impl/NdkCxxPlatforms.java
@@ -150,25 +150,18 @@ public class NdkCxxPlatforms {
   private NdkCxxPlatforms() {}
 
   static int getNdkMajorVersion(String ndkVersion) {
-    return ndkVersion.startsWith("r9")
-        ? 9
-        : ndkVersion.startsWith("r10")
-            ? 10
-            : ndkVersion.startsWith("11.")
-                ? 11
-                : ndkVersion.startsWith("12.")
-                    ? 12
-                    : ndkVersion.startsWith("13.")
-                        ? 13
-                        : ndkVersion.startsWith("14.")
-                            ? 14
-                            : ndkVersion.startsWith("15.")
-                                ? 15
-                                : ndkVersion.startsWith("16.")
-                                    ? 16
-                                    : ndkVersion.startsWith("17.")
-                                        ? 17
-                                        : ndkVersion.startsWith("18.") ? 18 : -1;
+    if (ndkVersion.startsWith("r")) {
+      return ndkVersion.startsWith("r9")
+          ? 9
+          : ndkVersion.startsWith("r10")
+              ? 10
+              : -1;
+    }
+    try {
+      return Integer.parseInt(ndkVersion.substring(0, ndkVersion.indexOf(".")));
+    } catch (NumberFormatException e) {
+      return -1;
+    }
   }
 
   public static String getDefaultGccVersionForNdk(String ndkVersion) {


### PR DESCRIPTION

#### Changes
This approach is superior to https://github.com/facebook/buck/pull/2189 because it will not break when google releases another NDK.
Reviewers @ttsugriy