### PR TITLE
Applies #2118 for android app bundles

### DIFF
--- a/src/com/facebook/buck/android/AndroidBundleDescription.java
+++ b/src/com/facebook/buck/android/AndroidBundleDescription.java
@@ -47,6 +47,7 @@ import com.facebook.buck.jvm.java.JavaOptions;
 import com.facebook.buck.jvm.java.JavacFactory;
 import com.facebook.buck.jvm.java.toolchain.JavaOptionsProvider;
 import com.facebook.buck.rules.macros.StringWithMacros;
+import com.facebook.buck.util.Optionals;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -74,6 +75,8 @@ public class AndroidBundleDescription
 
   private final JavaBuckConfig javaBuckConfig;
   private final AndroidBuckConfig androidBuckConfig;
+  private final JavacFactory javacFactory;
+  private final Supplier<JavaOptions> javaOptions;
   private final ProGuardConfig proGuardConfig;
   private final CxxBuckConfig cxxBuckConfig;
   private final DxConfig dxConfig;
@@ -81,13 +84,11 @@ public class AndroidBundleDescription
   private final ToolchainProvider toolchainProvider;
   private final AndroidBinaryGraphEnhancerFactory androidBinaryGraphEnhancerFactory;
   private final AndroidBundleFactory androidBundleFactory;
-  private final JavacFactory javacFactory;
-  private final Supplier<JavaOptions> javaOptions;
 
   public AndroidBundleDescription(
       JavaBuckConfig javaBuckConfig,
-      AndroidBuckConfig androidBuckConfig,
       ProGuardConfig proGuardConfig,
+      AndroidBuckConfig androidBuckConfig,
       BuckConfig buckConfig,
       CxxBuckConfig cxxBuckConfig,
       DxConfig dxConfig,
@@ -95,6 +96,8 @@ public class AndroidBundleDescription
       AndroidBinaryGraphEnhancerFactory androidBinaryGraphEnhancerFactory,
       AndroidBundleFactory androidBundleFactory) {
     this.javaBuckConfig = javaBuckConfig;
+    this.javacFactory = JavacFactory.getDefault(toolchainProvider);
+    this.javaOptions = JavaOptionsProvider.getDefaultJavaOptions(toolchainProvider);
     this.androidBuckConfig = androidBuckConfig;
     this.proGuardConfig = proGuardConfig;
     this.cxxBuckConfig = cxxBuckConfig;
@@ -103,8 +106,6 @@ public class AndroidBundleDescription
     this.toolchainProvider = toolchainProvider;
     this.androidBinaryGraphEnhancerFactory = androidBinaryGraphEnhancerFactory;
     this.androidBundleFactory = androidBundleFactory;
-    this.javacFactory = JavacFactory.getDefault(toolchainProvider);
-    this.javaOptions = JavaOptionsProvider.getDefaultJavaOptions(toolchainProvider);
   }
 
   @Override
@@ -243,12 +244,13 @@ public class AndroidBundleDescription
       ImmutableCollection.Builder<BuildTarget> targetGraphOnlyDepsBuilder) {
     javacFactory.addParseTimeDeps(targetGraphOnlyDepsBuilder, null);
     javaOptions.get().addParseTimeDeps(targetGraphOnlyDepsBuilder);
+
+    Optionals.addIfPresent(proGuardConfig.getProguardTarget(), extraDepsBuilder);
+
     if (constructorArg.getRedex()) {
       // If specified, this option may point to either a BuildTarget or a file.
       Optional<BuildTarget> redexTarget = androidBuckConfig.getRedexTarget();
-      if (redexTarget.isPresent()) {
-        extraDepsBuilder.add(redexTarget.get());
-      }
+      redexTarget.ifPresent(extraDepsBuilder::add);
     }
   }
 

--- a/src/com/facebook/buck/android/AndroidDescriptionsProvider.java
+++ b/src/com/facebook/buck/android/AndroidDescriptionsProvider.java
@@ -70,8 +70,8 @@ public class AndroidDescriptionsProvider implements DescriptionProvider {
         new AndroidBuildConfigDescription(toolchainProvider),
         new AndroidBundleDescription(
             javaConfig,
-            androidBuckConfig,
             proGuardConfig,
+            androidBuckConfig,
             config,
             cxxBuckConfig,
             dxConfig,

--- a/test/com/facebook/buck/android/AndroidBundleBuilder.java
+++ b/test/com/facebook/buck/android/AndroidBundleBuilder.java
@@ -64,8 +64,8 @@ public class AndroidBundleBuilder
     super(
         new AndroidBundleDescription(
             DEFAULT_JAVA_CONFIG,
-            new AndroidBuckConfig(buckConfig, Platform.detect()),
             new ProGuardConfig(buckConfig),
+            new AndroidBuckConfig(buckConfig, Platform.detect()),
             buckConfig,
             CxxPlatformUtils.DEFAULT_CONFIG,
             new DxConfig(buckConfig),


### PR DESCRIPTION
* Keep consistency between `AndroidBundleDescription` and `AndroidBinaryDescription` (if they are supposed to be equal, they should be equal on the API as well)
* Resolves https://github.com/facebook/buck/issues/2182
