### PR TITLE
Added friend_paths to kotlin_library rule API

### DIFF
--- a/docs/rule/kotlin_library.soy
+++ b/docs/rule/kotlin_library.soy
@@ -77,6 +77,15 @@ the <code>resources</code> argument.
 {/call}
 
 {call buck.arg}
+  {param name: 'friend_paths' /}
+  {param default: '[]' /}
+  {param desc}
+  List of source paths to pass into the Kotlin compiler as friend-paths, that is, modules
+  you can have access to internal methods.
+  {/param}
+{/call}
+
+{call buck.arg}
   {param name: 'annotation_processing_tool' /}
   {param default : 'kapt' /}
   {param desc}

--- a/src/com/facebook/buck/jvm/kotlin/KotlinConfiguredCompilerFactory.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinConfiguredCompilerFactory.java
@@ -64,6 +64,7 @@ public class KotlinConfiguredCompilerFactory extends ConfiguredCompilerFactory {
         kotlinBuckConfig.getKotlinc(),
         kotlinBuckConfig.getKotlinHomeLibraries(),
         kotlinArgs.getExtraKotlincArguments(),
+        kotlinArgs.getFriendPaths(),
         kotlinArgs.getAnnotationProcessingTool().orElse(AnnotationProcessingTool.KAPT),
         extraClasspathProviderSupplier.apply(toolchainProvider),
         getJavac(buildRuleResolver, args),

--- a/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
@@ -26,6 +26,7 @@ import com.facebook.buck.core.model.targetgraph.DescriptionWithTargetGraph;
 import com.facebook.buck.core.rules.ActionGraphBuilder;
 import com.facebook.buck.core.rules.BuildRule;
 import com.facebook.buck.core.rules.BuildRuleParams;
+import com.facebook.buck.core.sourcepath.SourcePath;
 import com.facebook.buck.core.toolchain.ToolchainProvider;
 import com.facebook.buck.core.util.immutables.BuckStyleImmutable;
 import com.facebook.buck.io.filesystem.ProjectFilesystem;
@@ -196,6 +197,8 @@ public class KotlinLibraryDescription
     ImmutableList<String> getExtraKotlincArguments();
 
     Optional<AnnotationProcessingTool> getAnnotationProcessingTool();
+
+    ImmutableList<SourcePath> getFriendPaths();
   }
 
   @BuckStyleImmutable

--- a/src/com/facebook/buck/jvm/kotlin/KotlincStep.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlincStep.java
@@ -161,7 +161,11 @@ public class KotlincStep implements Step {
     builder.add(VERBOSE);
 
     if (!extraArguments.isEmpty()) {
-      builder.addAll(extraArguments);
+      for (String extraArgument : extraArguments) {
+        if (!extraArgument.isEmpty()) {
+          builder.add(extraArgument);
+        }
+      }
     }
 
     return builder.build();

--- a/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
@@ -399,6 +399,7 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
             kotlinc,
             ImmutableList.<String>builder()
                 .addAll(extraKotlincArguments)
+                .add(friendPathsArg)
                 .add(MODULE_NAME)
                 .add(invokingRule.getShortNameAndFlavorPostfix())
                 .add(COMPILER_BUILTINS)
@@ -446,6 +447,9 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
 
   private String getFriendsPath(
       SourcePathResolver sourcePathResolver, ImmutableList<SourcePath> friendPathsSourcePaths) {
+    if (friendPathsSourcePaths.isEmpty()) {
+      return "";
+    }
 
     // https://youtrack.jetbrains.com/issue/KT-29933
     ImmutableSortedSet<String> absoluteFriendPaths =

--- a/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
@@ -445,19 +445,18 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
   }
 
   private String getFriendsPath(
-      SourcePathResolver sourcePathResolver,
-      ImmutableList<SourcePath> friendPathsSourcePaths) {
+      SourcePathResolver sourcePathResolver, ImmutableList<SourcePath> friendPathsSourcePaths) {
 
     // https://youtrack.jetbrains.com/issue/KT-29933
-    ImmutableSortedSet<String> absoluteFriendPaths = ImmutableSortedSet.copyOf(
-        friendPathsSourcePaths
-            .stream()
-            .map(path -> sourcePathResolver.getAbsolutePath(path).toString())
-            .collect(Collectors.toSet()));
+    ImmutableSortedSet<String> absoluteFriendPaths =
+        ImmutableSortedSet.copyOf(
+            friendPathsSourcePaths
+                .stream()
+                .map(path -> sourcePathResolver.getAbsolutePath(path).toString())
+                .collect(Collectors.toSet()));
 
-    return "-Xfriend-paths=" + absoluteFriendPaths
-        .stream()
-        .reduce("", (path1, path2) -> path1 + "," + path2);
+    return "-Xfriend-paths="
+        + absoluteFriendPaths.stream().reduce("", (path1, path2) -> path1 + "," + path2);
   }
 
   @Override

--- a/test/com/facebook/buck/jvm/kotlin/KotlinTestIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/kotlin/KotlinTestIntegrationTest.java
@@ -69,4 +69,10 @@ public class KotlinTestIntegrationTest {
     ProcessResult result = workspace.runBuckCommand("test", "//com/example/basic:failing");
     result.assertTestFailure("Test should've failed.");
   }
+
+  @Test
+  public void weCanAccessAnotherModuleInternalModuleByAddingItToFriendPaths() throws Exception {
+    ProcessResult result = workspace.runBuckCommand("test", "//com/example/friend_paths:passing");
+    result.assertSuccess("Build should've succeeded.");
+  }
 }

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_test_description/com/example/friend_paths/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_test_description/com/example/friend_paths/BUCK.fixture
@@ -1,0 +1,23 @@
+kotlin_library(
+    name = "main",
+    srcs = [
+        "Main.kt",
+    ],
+    visibility = [
+        "PUBLIC",
+    ],
+)
+
+kotlin_test(
+    name = "passing",
+    srcs = [
+        "PassingUnitTest.kt",
+    ],
+    friend_paths = [
+        ":main",
+    ],
+    deps = [
+        "buck//third-party/java/junit:junit",
+        ":main",
+    ],
+)

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_test_description/com/example/friend_paths/Main.kt
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_test_description/com/example/friend_paths/Main.kt
@@ -1,0 +1,5 @@
+package com.example.friend_paths
+
+class Main {
+    internal fun main() {}
+}

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_test_description/com/example/friend_paths/PassingUnitTest.kt
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_test_description/com/example/friend_paths/PassingUnitTest.kt
@@ -1,0 +1,14 @@
+package com.example.friend_paths
+
+import org.junit.runners.JUnit4
+import org.junit.runner.RunWith
+import org.junit.Test
+
+@RunWith(JUnit4::class)
+class PassingUnitTests {
+
+    @Test
+    fun testAbleToAccessInternalMethod() {
+        Main().main()
+    }
+}


### PR DESCRIPTION
This is a feature of kotlin compiler to allow other modules to access chosen module's internal methods/variables.
This is keen to have a good test coverage on kotlin without exposing your libraries internals