### PR TITLE
Fixed Hybrid globber to fail on incorrectly defined glob paths.

### DIFF
--- a/src/com/facebook/buck/skylark/io/impl/HybridGlobber.java
+++ b/src/com/facebook/buck/skylark/io/impl/HybridGlobber.java
@@ -18,6 +18,7 @@ package com.facebook.buck.skylark.io.impl;
 
 import com.facebook.buck.skylark.io.Globber;
 import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.vfs.UnixGlob;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Optional;
@@ -40,11 +41,22 @@ public class HybridGlobber implements Globber {
   public Set<String> run(
       Collection<String> include, Collection<String> exclude, boolean excludeDirectories)
       throws IOException, InterruptedException {
+    checkPatternsForError(include);
+    checkPatternsForError(exclude);
     Optional<ImmutableSet<String>> watchmanResult =
         watchmanGlobber.run(include, exclude, excludeDirectories);
     if (watchmanResult.isPresent()) {
       return watchmanResult.get();
     }
     return fallbackGlobber.run(include, exclude, excludeDirectories);
+  }
+
+  private void checkPatternsForError(Collection<String> include) {
+    for (String pattern : include) {
+      String error = UnixGlob.checkPatternForError(pattern);
+      if (error != null) {
+        throw new IllegalArgumentException(error + " (in glob pattern '" + pattern + "')");
+      }
+    }
   }
 }

--- a/test/com/facebook/buck/skylark/io/impl/HybridGlobberTest.java
+++ b/test/com/facebook/buck/skylark/io/impl/HybridGlobberTest.java
@@ -19,6 +19,7 @@ package com.facebook.buck.skylark.io.impl;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
 import com.facebook.buck.cli.TestWithBuckd;
@@ -37,6 +38,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.vfs.Path;
 import java.util.Collections;
 import java.util.Optional;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -91,5 +93,22 @@ public class HybridGlobberTest {
     assertEquals(
         ImmutableSet.of("some.txt"),
         globber.run(ImmutableList.of("*.txt"), ImmutableList.of(), false));
+  }
+
+  @Test
+  public void testWatchmanGlobFailsOnBrokenPattern() throws Exception {
+    tmp.newFile("some.txt");
+    WatchmanGlobber watchmanGlobber = newGlobber(Optional.empty());
+    globber = new HybridGlobber(nativeGlobber, watchmanGlobber);
+    Exception capturedException = null;
+    try {
+      globber.run(ImmutableList.of("**folder/*.txt"), ImmutableList.of(), false);
+      fail("Globber should fail on attempt to parse incorrect path");
+    } catch (IllegalArgumentException e) {
+      capturedException = e;
+    }
+    assertThat(
+        capturedException.getMessage(),
+        Matchers.containsString("recursive wildcard must be its own segment"));
   }
 }


### PR DESCRIPTION
This fixes the https://github.com/facebook/buck/issues/2201 .

The problem was caused by watchman globbing accepting the patterns that are not correct from bazellib globbing point of view.

Luckily the path validation is exposed as public API.