### PR TITLE
throw exception when no source file

### DIFF
--- a/src/com/facebook/buck/features/go/GoCompile.java
+++ b/src/com/facebook/buck/features/go/GoCompile.java
@@ -18,6 +18,7 @@ package com.facebook.buck.features.go;
 
 import com.facebook.buck.core.build.buildable.context.BuildableContext;
 import com.facebook.buck.core.build.context.BuildContext;
+import com.facebook.buck.core.exceptions.HumanReadableException;
 import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.model.impl.BuildTargetPaths;
 import com.facebook.buck.core.rulekey.AddToRuleKey;
@@ -112,7 +113,9 @@ public class GoCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
   @Override
   public ImmutableList<Step> getBuildSteps(
       BuildContext context, BuildableContext buildableContext) {
-
+    if (srcs.size() == 0) {
+      throw new HumanReadableException("No source files provided for " + packageName);
+    }
     buildableContext.recordArtifact(output);
 
     ImmutableList.Builder<Path> compileSrcListBuilder = ImmutableList.builder();

--- a/src/com/facebook/buck/features/go/GoCompileStep.java
+++ b/src/com/facebook/buck/features/go/GoCompileStep.java
@@ -17,7 +17,7 @@
 package com.facebook.buck.features.go;
 
 import com.facebook.buck.core.build.execution.context.ExecutionContext;
-import com.facebook.buck.core.util.log.Logger;
+import com.facebook.buck.core.exceptions.HumanReadableException;
 import com.facebook.buck.shell.ShellStep;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -39,7 +39,6 @@ public class GoCompileStep extends ShellStep {
   private final boolean allowExternalReferences;
   private final GoPlatform platform;
   private final Path output;
-  private static final Logger LOG = Logger.get(GoCompileStep.class);
 
   public GoCompileStep(
       Path workingDirectory,
@@ -107,8 +106,7 @@ public class GoCompileStep extends ShellStep {
 
       return commandBuilder.build();
     } else {
-      LOG.warn("No source files found in " + workingDirectory);
-      return ImmutableList.of();
+      throw new HumanReadableException("No valid source files found in " + packageName);
     }
   }
 


### PR DESCRIPTION
Stop the build when there is no source file in a package. This provides better error message to help debugging. If we let the build continue, the final .a file will be empty, and the build only fails when compiling another package that imports the empty package, making the error message misleading.

@styurin @mkaczanowski Could you take a look?