### PR TITLE
Fix instrumentation apk desugaring

### DIFF
--- a/src/com/facebook/buck/android/AndroidBinaryGraphEnhancer.java
+++ b/src/com/facebook/buck/android/AndroidBinaryGraphEnhancer.java
@@ -808,7 +808,7 @@ public class AndroidBinaryGraphEnhancer {
         apkModuleGraph.toOutgoingEdgesMap();
     APKModule rootAPKModule = apkModuleGraph.getRootAPKModule();
 
-    ImmutableSortedSet<SourcePath> additionalJarsForProguard =
+    ImmutableSortedSet<SourcePath> additionalJarsForProguardandDesugar =
         rulesToExcludeFromDex
             .stream()
             .flatMap((javaLibrary) -> javaLibrary.getImmediateClasspaths().stream())
@@ -828,7 +828,7 @@ public class AndroidBinaryGraphEnhancer {
         new NonPreDexedDexBuildable(
             androidPlatformTarget,
             ruleFinder,
-            additionalJarsForProguard,
+            additionalJarsForProguardandDesugar,
             apkModuleMap,
             classpathEntriesToDexSourcePaths,
             dexSplitMode,

--- a/src/com/facebook/buck/android/PreDexMerge.java
+++ b/src/com/facebook/buck/android/PreDexMerge.java
@@ -373,7 +373,8 @@ public class PreDexMerge extends AbstractBuildRuleWithDeclaredAndExtraDeps {
             dxMaxHeapSize,
             dexTool,
             false,
-            false));
+            false,
+            Optional.empty()));
 
     for (PreDexedFilesSorter.Result result : sortResults.values()) {
       if (!result.apkModule.equals(apkModuleGraph.getRootAPKModule())) {

--- a/src/com/facebook/buck/android/SmartDexingStep.java
+++ b/src/com/facebook/buck/android/SmartDexingStep.java
@@ -100,6 +100,7 @@ public class SmartDexingStep implements Step {
   private final Optional<String> dxMaxHeapSize;
   private final String dexTool;
   private final boolean useDexBuckedId;
+  private final Optional<Set<Path>> additonalDesugarDeps;
 
   /**
    * @param primaryOutputPath Path for the primary dex artifact.
@@ -129,7 +130,8 @@ public class SmartDexingStep implements Step {
       Optional<String> dxMaxHeapSize,
       String dexTool,
       boolean desugarInterfaceMethods,
-      boolean useDexBuckedId) {
+      boolean useDexBuckedId,
+      Optional<Set<Path>> additonalDesugarDeps) {
     this.androidPlatformTarget = androidPlatformTarget;
     this.buildContext = buildContext;
     this.filesystem = filesystem;
@@ -153,6 +155,7 @@ public class SmartDexingStep implements Step {
     this.dxMaxHeapSize = dxMaxHeapSize;
     this.dexTool = dexTool;
     this.useDexBuckedId = useDexBuckedId;
+    this.additonalDesugarDeps = additonalDesugarDeps;
   }
 
   /**
@@ -329,10 +332,11 @@ public class SmartDexingStep implements Step {
                     dxMaxHeapSize,
                     dexTool,
                     desugarInterfaceMethods
-                        ? Sets.difference(
-                            allDexInputPaths, ImmutableSet.copyOf(outputInputsPair.getValue()))
-                        : null,
-                    useDexBuckedId))
+                        ? Sets.union(
+                            Sets.difference(
+                                allDexInputPaths, ImmutableSet.copyOf(outputInputsPair.getValue())),
+                            additonalDesugarDeps.orElse(ImmutableSet.of()))
+                        : null, useDexBuckedId))
         .filter(dxPseudoRule -> !dxPseudoRule.checkIsCached())
         .map(
             dxPseudoRule -> {


### PR DESCRIPTION
Instrumentation apks were not being passed the full classpath for interface method desugaring due to the apkUnderTest's classpath being removed ahead of time from the dexing call. This change makes the full classpath available and ensures that instumentation apks are also correctly desugared by d8 when enabled.