### PR TITLE
Fix android bundle output

### DIFF
--- a/src/com/facebook/buck/android/AndroidBinaryBuildable.java
+++ b/src/com/facebook/buck/android/AndroidBinaryBuildable.java
@@ -780,26 +780,38 @@ class AndroidBinaryBuildable implements AddsToRuleKey {
 
   /** The APK at this path will be jar signed, but not zipaligned. */
   private Path getSignedApkPath() {
-    return Paths.get(getUnsignedApkPath().replaceAll("\\.unsigned\\.apk$", ".signed.apk"));
+    return Paths.get(getUnsignedApkPath()
+        .replaceAll("\\.unsigned\\.apk$", ".signed.apk")
+        .replaceAll("\\.unsigned\\.aab$", ".signed.aab"));
   }
 
   /** The APK at this path will be zipaligned and jar signed. */
   private Path getZipalignedApkPath() {
-    return Paths.get(getUnsignedApkPath().replaceAll("\\.unsigned\\.apk$", ".zipaligned.apk"));
+    return Paths.get(getUnsignedApkPath()
+        .replaceAll("\\.unsigned\\.apk$", ".zipaligned.apk")
+        .replaceAll("\\.unsigned\\.aab$", ".signed.aab"));
   }
 
   /** The APK at this path will be zipaligned and v2 signed. */
   Path getFinalApkPath() {
-    return Paths.get(getUnsignedApkPath().replaceAll("\\.unsigned\\.apk$", ".apk"));
+    return Paths.get(getUnsignedApkPath()
+        .replaceAll("\\.unsigned\\.apk$", ".apk")
+        .replaceAll("\\.unsigned\\.aab$", ".aab"));
   }
 
   /** The APK at this path will have compressed resources, but will not be zipaligned. */
   private Path getCompressedResourcesApkPath() {
-    return Paths.get(getUnsignedApkPath().replaceAll("\\.unsigned\\.apk$", ".compressed.apk"));
+    return Paths.get(getUnsignedApkPath()
+        .replaceAll("\\.unsigned\\.apk$", ".compressed.apk")
+        .replaceAll("\\.unsigned\\.aab$", ".compressed.aab"));
   }
 
   private String getUnsignedApkPath() {
-    return getPath("%s.unsigned.apk").toString();
+    return getPath("%s.unsigned." + getExtension()).toString();
+  }
+
+  private String getExtension() {
+    return isApk ? "apk" : "aab";
   }
 
   private Path getPath(String format) {
@@ -808,7 +820,7 @@ class AndroidBinaryBuildable implements AddsToRuleKey {
 
   private Path getRedexedApkPath() {
     Path path = BuildTargetPaths.getGenPath(getProjectFilesystem(), getBuildTarget(), "%s__redex");
-    return path.resolve(getBuildTarget().getShortName() + ".redex.apk");
+    return path.resolve(getBuildTarget().getShortName() + ".redex." + getExtension());
   }
 
   /**

--- a/src/com/facebook/buck/android/AndroidBinaryBuildable.java
+++ b/src/com/facebook/buck/android/AndroidBinaryBuildable.java
@@ -780,30 +780,34 @@ class AndroidBinaryBuildable implements AddsToRuleKey {
 
   /** The APK at this path will be jar signed, but not zipaligned. */
   private Path getSignedApkPath() {
-    return Paths.get(getUnsignedApkPath()
-        .replaceAll("\\.unsigned\\.apk$", ".signed.apk")
-        .replaceAll("\\.unsigned\\.aab$", ".signed.aab"));
+    return Paths.get(
+        getUnsignedApkPath()
+            .replaceAll("\\.unsigned\\.apk$", ".signed.apk")
+            .replaceAll("\\.unsigned\\.aab$", ".signed.aab"));
   }
 
   /** The APK at this path will be zipaligned and jar signed. */
   private Path getZipalignedApkPath() {
-    return Paths.get(getUnsignedApkPath()
-        .replaceAll("\\.unsigned\\.apk$", ".zipaligned.apk")
-        .replaceAll("\\.unsigned\\.aab$", ".signed.aab"));
+    return Paths.get(
+        getUnsignedApkPath()
+            .replaceAll("\\.unsigned\\.apk$", ".zipaligned.apk")
+            .replaceAll("\\.unsigned\\.aab$", ".signed.aab"));
   }
 
   /** The APK at this path will be zipaligned and v2 signed. */
   Path getFinalApkPath() {
-    return Paths.get(getUnsignedApkPath()
-        .replaceAll("\\.unsigned\\.apk$", ".apk")
-        .replaceAll("\\.unsigned\\.aab$", ".aab"));
+    return Paths.get(
+        getUnsignedApkPath()
+            .replaceAll("\\.unsigned\\.apk$", ".apk")
+            .replaceAll("\\.unsigned\\.aab$", ".aab"));
   }
 
   /** The APK at this path will have compressed resources, but will not be zipaligned. */
   private Path getCompressedResourcesApkPath() {
-    return Paths.get(getUnsignedApkPath()
-        .replaceAll("\\.unsigned\\.apk$", ".compressed.apk")
-        .replaceAll("\\.unsigned\\.aab$", ".compressed.aab"));
+    return Paths.get(
+        getUnsignedApkPath()
+            .replaceAll("\\.unsigned\\.apk$", ".compressed.apk")
+            .replaceAll("\\.unsigned\\.aab$", ".compressed.aab"));
   }
 
   private String getUnsignedApkPath() {

--- a/test/com/facebook/buck/android/AndroidAppBundleIntegrationTest.java
+++ b/test/com/facebook/buck/android/AndroidAppBundleIntegrationTest.java
@@ -84,7 +84,7 @@ public class AndroidAppBundleIntegrationTest extends AbiCompilationModeTest {
     Path aab =
         workspace.getPath(
             BuildTargetPaths.getGenPath(
-                filesystem, BuildTargetFactory.newInstance(target), "%s.signed.apk"));
+                filesystem, BuildTargetFactory.newInstance(target), "%s.signed.aab"));
     Date dosEpoch = new Date(ZipUtil.dosToJavaTime(ZipConstants.DOS_FAKE_TIME));
     try (ZipInputStream is = new ZipInputStream(Files.newInputStream(aab))) {
       for (ZipEntry entry = is.getNextEntry(); entry != null; entry = is.getNextEntry()) {
@@ -175,7 +175,7 @@ public class AndroidAppBundleIntegrationTest extends AbiCompilationModeTest {
     Path aab =
         workspace.getPath(
             BuildTargetPaths.getGenPath(
-                filesystem, BuildTargetFactory.newInstance(target), "%s.signed.apk"));
+                filesystem, BuildTargetFactory.newInstance(target), "%s.signed.aab"));
 
     ZipInspector zipInspector = new ZipInspector(aab);
     zipInspector.assertFileExists("small_with_no_resource_deps/assets.pb");


### PR DESCRIPTION
Currently output of android bundle rules had `apk` format. 
This PR introduces the correct `aab` format