### PR TITLE
Include Prebuilt jar's transitiveClasspath when building the javaplugin properties 

### DIFF
--- a/src/com/facebook/buck/jvm/java/PrebuiltJar.java
+++ b/src/com/facebook/buck/jvm/java/PrebuiltJar.java
@@ -61,7 +61,6 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.function.Supplier;
 
-@BuildsAnnotationProcessor
 public class PrebuiltJar extends AbstractBuildRuleWithDeclaredAndExtraDeps
     implements AndroidPackageable,
         ExportDependencies,

--- a/src/com/facebook/buck/jvm/java/PrebuiltJarDescription.java
+++ b/src/com/facebook/buck/jvm/java/PrebuiltJarDescription.java
@@ -118,11 +118,11 @@ public class PrebuiltJarDescription
       input = arg.getBinaryJar();
     }
 
-    class ExistingOuputs extends AbstractBuildRuleWithDeclaredAndExtraDeps {
+    class ExistingOutputs extends AbstractBuildRuleWithDeclaredAndExtraDeps {
       @AddToRuleKey private final SourcePath source;
       private final Path output;
 
-      protected ExistingOuputs(
+      protected ExistingOutputs(
           BuildTarget buildTarget,
           ProjectFilesystem projectFilesystem,
           BuildRuleParams params,
@@ -162,7 +162,7 @@ public class PrebuiltJarDescription
         return ExplicitBuildTargetSourcePath.of(getBuildTarget(), output);
       }
     }
-    return new ExistingOuputs(buildTarget, projectFilesystem, params, input);
+    return new ExistingOutputs(buildTarget, projectFilesystem, params, input);
   }
 
   @Override


### PR DESCRIPTION
PrebuiltJar has `deps` which is exported by default. Include it’s transitiveClasspath when building the javaplugin properties (https://github.com/facebook/buck/blob/master/src/com/facebook/buck/jvm/java/AbstractJavacPluginProperties.java#L97).

Previously: With rules defined below `dagger` processor will only have `javaDep` and `firstLevelPrebuilt` in its classpath.

After:  With rules defined below `dagger` processor will only have `javaDep`, `firstLevelPrebuilt` and `transitivePrebuilt` as well. Same is the behaviour if the prebuilt is added as a dependency to a java library since deps of prebuilt are exported by default.
```
java_annotation_processor(
    name = 'dagger',
    deps = [
         '//:javaDep',
         '//lib/firstLevelPrebuilt'
     ]
)

prebuilt_jar(
    name = 'firstLevelPrebuilt'
    deps = [
        '//lib:transitivePrebuilt'
    ]
)

prebuilt_jar(
    name = 'transitivePrebuilt'
)
```

Added Tests.