### PR TITLE
Updated PublishCommand to allow it to publish artifacts concurrently.

### DIFF
--- a/src/com/facebook/buck/cli/PublishCommand.java
+++ b/src/com/facebook/buck/cli/PublishCommand.java
@@ -61,43 +61,49 @@ public class PublishCommand extends BuildCommand {
   private static final String PUBLISH_GEN_PATH = "publish";
 
   @Option(
-      name = REMOTE_REPO_LONG_ARG,
-      aliases = REMOTE_REPO_SHORT_ARG,
-      usage = "A url of the remote repository to publish artifact(s) to")
+    name = REMOTE_REPO_LONG_ARG,
+    aliases = REMOTE_REPO_SHORT_ARG,
+    usage = "A url of the remote repository to publish artifact(s) to"
+  )
   @Nullable
   private URL remoteRepo = null;
 
   @Option(
-      name = TO_MAVEN_CENTRAL_LONG_ARG,
-      usage = "Same as \"" + REMOTE_REPO_LONG_ARG + " " + Publisher.MAVEN_CENTRAL_URL + "\"")
+    name = TO_MAVEN_CENTRAL_LONG_ARG,
+    usage = "Same as \"" + REMOTE_REPO_LONG_ARG + " " + Publisher.MAVEN_CENTRAL_URL + "\""
+  )
   private boolean toMavenCentral = false;
 
   @Option(
-      name = INCLUDE_SOURCE_LONG_ARG,
-      aliases = INCLUDE_SOURCE_SHORT_ARG,
-      usage = "Publish source code as well")
+    name = INCLUDE_SOURCE_LONG_ARG,
+    aliases = INCLUDE_SOURCE_SHORT_ARG,
+    usage = "Publish source code as well"
+  )
   private boolean includeSource = false;
 
   @Option(
-      name = INCLUDE_DOCS_LONG_ARG,
-      aliases = INCLUDE_DOCS_SHORT_ARG,
-      usage = "Publish docs as well")
+    name = INCLUDE_DOCS_LONG_ARG,
+    aliases = INCLUDE_DOCS_SHORT_ARG,
+    usage = "Publish docs as well"
+  )
   private boolean includeDocs = false;
 
   @Option(name = DRY_RUN_LONG_ARG, usage = "Just print the artifacts to be published")
   private boolean dryRun = false;
 
   @Option(
-      name = "--username",
-      aliases = "-u",
-      usage = "User name to use to authenticate with the server")
+    name = "--username",
+    aliases = "-u",
+    usage = "User name to use to authenticate with the server"
+  )
   @Nullable
   private String username = null;
 
   @Option(
-      name = "--password",
-      aliases = "-p",
-      usage = "Password to use to authenticate with the server")
+    name = "--password",
+    aliases = "-p",
+    usage = "Password to use to authenticate with the server"
+  )
   @Nullable
   private String password = null;
 
@@ -175,6 +181,7 @@ public class PublishCommand extends BuildCommand {
             repoUrl,
             Optional.ofNullable(username),
             Optional.ofNullable(password),
+            getConcurrencyLimit(params.getBuckConfig()).threadLimit,
             dryRun);
 
     try {

--- a/test/com/facebook/buck/maven/PublisherTest.java
+++ b/test/com/facebook/buck/maven/PublisherTest.java
@@ -60,6 +60,7 @@ public class PublisherTest {
             /* remoteRepoUrl */ Publisher.MAVEN_CENTRAL,
             /* username */ Optional.empty(),
             /* password */ Optional.empty(),
+            /* concurrencyLimit */ 4,
             /* dryRun */ true);
   }
 

--- a/test/com/facebook/buck/maven/TestPublisher.java
+++ b/test/com/facebook/buck/maven/TestPublisher.java
@@ -57,6 +57,7 @@ public class TestPublisher extends Publisher implements AutoCloseable {
         httpd.getRootUri().toURL(),
         /* username */ Optional.empty(),
         /* password */ Optional.empty(),
+        /* concurrencyLimit */ 1,
         /* dryRun */ false);
     this.httpd = httpd;
     this.putRequestsHandler = putRequestsHandler;


### PR DESCRIPTION
This makes sizeable publishes much faster.

This change uses ConcurrencyLimit as specified by num_threads option or default.

Please advice if you think there is a better way introducing parallelism into publishing yet without having to rewrite publishing from scratch.  