### PR TITLE
Update linter

### DIFF
--- a/scripts/travisci_test_java_file_format
+++ b/scripts/travisci_test_java_file_format
@@ -11,7 +11,7 @@ trap finish EXIT
 
 REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 
-FORMAT_JAR_VERSION="1.6"
+FORMAT_JAR_VERSION="1.7"
 FORMAT_JAR_NAME="google-java-format-${FORMAT_JAR_VERSION}-all-deps.jar"
 FORMAT_JAR_URL="https://github.com/google/google-java-format/releases/download/google-java-format-${FORMAT_JAR_VERSION}/${FORMAT_JAR_NAME}"
 FORMAT_JAR_LOCATION="${HOME}/${FORMAT_JAR_NAME}"


### PR DESCRIPTION
We recently updated our linter internally to google-java-format 1.7, and missed this script. Update here so that travis passes properly on new PRs