### PR TITLE
Add support for exported_deps in android_resource

### DIFF
--- a/src/com/facebook/buck/android/AndroidAarDescription.java
+++ b/src/com/facebook/buck/android/AndroidAarDescription.java
@@ -177,6 +177,7 @@ public class AndroidAarDescription
                 .add(assembleResourceDirectories)
                 .addAll(originalBuildRuleParams.getDeclaredDeps().get())
                 .build(),
+            /* exportedDeps */ ImmutableSortedSet.of(),
             assembleResourceDirectories.getSourcePathToOutput(),
             /* resSrcs */ ImmutableSortedMap.of(),
             /* rDotJavaPackage */ null,

--- a/src/com/facebook/buck/android/AndroidLibraryGraphEnhancer.java
+++ b/src/com/facebook/buck/android/AndroidLibraryGraphEnhancer.java
@@ -29,7 +29,6 @@ import com.facebook.buck.jvm.java.JavacOptions;
 import com.facebook.buck.jvm.java.JavacPluginParams;
 import com.facebook.buck.jvm.java.JavacToJarStepFactory;
 import com.facebook.buck.util.DependencyMode;
-import com.facebook.buck.util.stream.RichStream;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
@@ -101,10 +100,7 @@ public class AndroidLibraryGraphEnhancer {
     switch (resourceDependencyMode) {
       case FIRST_ORDER:
         androidResourceDeps =
-            RichStream.from(originalDeps)
-                .filter(HasAndroidResourceDeps.class)
-                .filter(input -> input.getRes() != null)
-                .toImmutableSet();
+            HasAndroidResourceDeps.getTransitiveExportedResourceDeps(originalDeps);
         break;
       case TRANSITIVE:
         androidResourceDeps =

--- a/src/com/facebook/buck/android/AndroidPrebuiltAarDescription.java
+++ b/src/com/facebook/buck/android/AndroidPrebuiltAarDescription.java
@@ -145,6 +145,9 @@ public class AndroidPrebuiltAarDescription
                     graphBuilder.getAllRules(args.getDeps()), AndroidPrebuiltAar.class),
                 AndroidPrebuiltAar::getPrebuiltJar));
 
+    Iterable<AndroidPrebuiltAar> androidPrebuiltAarDeps =
+        Iterables.filter(graphBuilder.getAllRules(args.getDeps()), AndroidPrebuiltAar.class);
+
     if (flavors.contains(AAR_PREBUILT_JAR_FLAVOR)) {
       Preconditions.checkState(
           flavors.size() == 1,
@@ -231,6 +234,7 @@ public class AndroidPrebuiltAarDescription
                 .getJavacOptions(),
             ExtraClasspathProvider.EMPTY),
         /* exportedDeps */ javaDeps,
+        androidPrebuiltAarDeps,
         args.getRequiredForSourceOnlyAbi(),
         args.getMavenCoords(),
         args.isUseSystemLibraryLoader());

--- a/src/com/facebook/buck/android/AndroidResourceDescription.java
+++ b/src/com/facebook/buck/android/AndroidResourceDescription.java
@@ -199,6 +199,7 @@ public class AndroidResourceDescription
             AndroidResourceHelper.androidResOnly(params.getDeclaredDeps().get())),
         graphBuilder,
         graphBuilder.getAllRules(args.getDeps()),
+        graphBuilder.getAllRules(args.getExportedDeps()),
         resInputs.getSecond().orElse(null),
         resInputs.getFirst().map(MappedSymlinkTree::getLinks).orElse(ImmutableSortedMap.of()),
         args.getPackage().orElse(null),
@@ -381,6 +382,9 @@ public class AndroidResourceDescription
     Optional<String> getPackage();
 
     Optional<SourcePath> getManifest();
+
+    @Value.NaturalOrder
+    ImmutableSortedSet<BuildTarget> getExportedDeps();
 
     @Value.Default
     default boolean getResourceUnion() {

--- a/src/com/facebook/buck/features/js/JsBundleDescription.java
+++ b/src/com/facebook/buck/features/js/JsBundleDescription.java
@@ -310,6 +310,7 @@ public class JsBundleDescription
         params,
         graphBuilder,
         ImmutableSortedSet.of(), // deps
+        ImmutableSortedSet.of(), // exported_deps
         jsBundle.getSourcePathToResources(),
         ImmutableSortedMap.of(), // resSrcs
         rDotJavaPackage,

--- a/src/com/facebook/buck/features/project/intellij/ExportedDepsClosureResolver.java
+++ b/src/com/facebook/buck/features/project/intellij/ExportedDepsClosureResolver.java
@@ -16,6 +16,7 @@
 
 package com.facebook.buck.features.project.intellij;
 
+import com.facebook.buck.android.AndroidPrebuiltAarDescriptionArg;
 import com.facebook.buck.core.description.arg.BuildRuleArg;
 import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.model.targetgraph.TargetGraph;
@@ -63,6 +64,9 @@ public class ExportedDepsClosureResolver {
               .build();
     } else if (targetNode.getConstructorArg() instanceof PrebuiltJarDescriptionArg) {
       PrebuiltJarDescriptionArg arg = (PrebuiltJarDescriptionArg) targetNode.getConstructorArg();
+      exportedDeps = arg.getDeps();
+    } else if (targetNode.getConstructorArg() instanceof AndroidPrebuiltAarDescriptionArg) {
+      AndroidPrebuiltAarDescriptionArg arg = (AndroidPrebuiltAarDescriptionArg) targetNode.getConstructorArg();
       exportedDeps = arg.getDeps();
     }
 

--- a/test/com/facebook/buck/android/AndroidBinaryGraphEnhancerTest.java
+++ b/test/com/facebook/buck/android/AndroidBinaryGraphEnhancerTest.java
@@ -778,6 +778,7 @@ public class AndroidBinaryGraphEnhancerTest {
                     .copyAppendingExtraDeps(ImmutableSortedSet.of(resourcesDep)),
                 graphBuilder,
                 ImmutableSortedSet.of(),
+                ImmutableSortedSet.of(),
                 resourcesDep.getSourcePathToOutput(),
                 ImmutableSortedMap.of(),
                 null,

--- a/test/com/facebook/buck/android/AndroidResourceRuleBuilder.java
+++ b/test/com/facebook/buck/android/AndroidResourceRuleBuilder.java
@@ -43,6 +43,7 @@ public class AndroidResourceRuleBuilder {
     private ProjectFilesystem projectFilesystem = new FakeProjectFilesystem();
     private BuildTarget buildTarget;
     private ImmutableSortedSet<BuildRule> deps = ImmutableSortedSet.of();
+    private ImmutableSortedSet<BuildRule> exportedDeps = ImmutableSortedSet.of();
     private SourcePath res;
     private ImmutableSortedMap<Path, SourcePath> resSrcs = ImmutableSortedMap.of();
     private String rDotJavaPackage;
@@ -58,6 +59,7 @@ public class AndroidResourceRuleBuilder {
           TestBuildRuleParams.create(),
           ruleFinder,
           deps,
+          exportedDeps,
           res,
           resSrcs,
           rDotJavaPackage,
@@ -79,6 +81,11 @@ public class AndroidResourceRuleBuilder {
 
     public Builder setDeps(ImmutableSortedSet<BuildRule> deps) {
       this.deps = deps;
+      return this;
+    }
+
+    public Builder setExportedDeps(ImmutableSortedSet<BuildRule> exportedDeps) {
+      this.exportedDeps = exportedDeps;
       return this;
     }
 

--- a/test/com/facebook/buck/android/AndroidResourceTest.java
+++ b/test/com/facebook/buck/android/AndroidResourceTest.java
@@ -117,6 +117,7 @@ public class AndroidResourceTest {
             params,
             ruleFinder,
             /* deps */ ImmutableSortedSet.of(),
+            /* exported_deps */ ImmutableSortedSet.of(),
             FakeSourcePath.of("foo/res"),
             ImmutableSortedMap.of(
                 Paths.get("values/strings.xml"), FakeSourcePath.of("foo/res/values/strings.xml")),
@@ -146,6 +147,7 @@ public class AndroidResourceTest {
             params,
             ruleFinder,
             /* deps */ ImmutableSortedSet.of(),
+            /* exported_deps */ ImmutableSortedSet.of(),
             FakeSourcePath.of("foo/res"),
             ImmutableSortedMap.of(
                 Paths.get("values/strings.xml"), FakeSourcePath.of("foo/res/values/strings.xml")),

--- a/test/com/facebook/buck/android/RobolectricTestRuleTest.java
+++ b/test/com/facebook/buck/android/RobolectricTestRuleTest.java
@@ -90,6 +90,16 @@ public class RobolectricTestRuleTest {
     }
 
     @Override
+    public ImmutableSet<BuildRule> getResourceDeps() {
+      return ImmutableSet.of();
+    }
+
+    @Override
+    public ImmutableSet<BuildRule> getExportedResourceDeps() {
+      return ImmutableSet.of();
+    }
+
+    @Override
     public BuildTarget getBuildTarget() {
       return null;
     }


### PR DESCRIPTION
Similar to how `java_library` & `android_library` can have `exported_deps`, this adds support for the same to `android_res`. Since `android_library` can't have resource deps in its `exported_deps`, this achieve that by having exported deps in `android_res` instead.

