### PR TITLE
java plugin arguments

### DIFF
--- a/docs/__jvm_common.soy
+++ b/docs/__jvm_common.soy
@@ -219,3 +219,28 @@
   {/param}
 {/call}
 {/template}
+
+/***/
+{template .plugins}
+{call buck.arg}
+  {param name: 'plugins' /}
+  {param default: '[]' /}
+  {param desc}
+     <p><code>java_plugin</code> or <code>java_annotation_processor</code> rules
+     to run together with compilation.</p>
+  {/param}
+{/call}
+{/template}
+
+/***/
+{template .plugins_arguments}
+{call buck.arg}
+  {param name: 'plugins_arguments' /}
+  {param default: '{}' /}
+  {param desc}
+     <p><code>java_plugin</code> rules arguments to be passed to corresponding
+     rules on <code>plugins</plugins>. It maps the plugin name passed as `plugin_name`
+     on the respective rule to a list of arguments.</p>
+  {/param}
+{/call}
+{/template}

--- a/docs/__jvm_common.soy
+++ b/docs/__jvm_common.soy
@@ -236,11 +236,11 @@
 {template .plugins_arguments}
 {call buck.arg}
   {param name: 'plugins_arguments' /}
-  {param default: '{}' /}
+  {{param default : '{}' /}}
   {param desc}
      <p><code>java_plugin</code> rules arguments to be passed to corresponding
-     rules on <code>plugins</plugins>. It maps the plugin name passed as `plugin_name`
-     on the respective rule to a list of arguments.</p>
+     rules on <code>plugins</code>. Each key is represented as the name passed as `plugin_name`
+     on the respective rule to a list of arguments (value).</p>
   {/param}
 {/call}
 {/template}

--- a/docs/rule/android_library.soy
+++ b/docs/rule/android_library.soy
@@ -219,6 +219,10 @@ compiled class files and resources.
 
 {call jvm_common.required_for_source_only_abi /}
 
+{call jvm_common.plugins /}
+
+{call jvm_common.plugins_arguments /}
+
 {call buck.tests_arg /}
 
 {/param} // args

--- a/docs/rule/java_library.soy
+++ b/docs/rule/java_library.soy
@@ -162,6 +162,10 @@ the <code>resources</code> argument.
 
 {call jvm_common.on_unused_dependencies /}
 
+{call jvm_common.plugins /}
+
+{call jvm_common.plugins_arguments /}
+
 {call buck.tests_arg /}
 
 {/param} // close args

--- a/docs/rule/java_test.soy
+++ b/docs/rule/java_test.soy
@@ -159,6 +159,10 @@ A <code>java_test()</code> rule is used to define a set of
   {/param}
 {/call}
 
+{call jvm_common.plugins /}
+
+{call jvm_common.plugins_arguments /}
+
 {call jvm_common.test_env /}
 
 {/param} // close args

--- a/docs/rule/kotlin_library.soy
+++ b/docs/rule/kotlin_library.soy
@@ -176,6 +176,10 @@ remote_file(
 
 {call buck.tests_arg /}
 
+{call jvm_common.plugins /}
+
+{call jvm_common.plugins_arguments /}
+
 {/param} // close args
 
 {param examples}

--- a/docs/rule/kotlin_test.soy
+++ b/docs/rule/kotlin_test.soy
@@ -122,6 +122,10 @@ A <code>kotlin_test()</code> rule is used to define a set of
   {/param}
 {/call}
 
+{call jvm_common.plugins /}
+
+{call jvm_common.plugins_arguments /}
+
 {call jvm_common.test_env /}
 
 {/param} // close args

--- a/docs/rule/robolectric_test.soy
+++ b/docs/rule/robolectric_test.soy
@@ -78,6 +78,10 @@ with Robolectric test runner. It extends from <code>java_test()</code> rule.
   {/param}
 {/call}
 
+{call jvm_common.plugins /}
+
+{call jvm_common.plugins_arguments /}
+
 {/param} // close args
 
 {/call} // close buck.rule

--- a/src/com/facebook/buck/android/AndroidLibraryGraphEnhancer.java
+++ b/src/com/facebook/buck/android/AndroidLibraryGraphEnhancer.java
@@ -124,8 +124,13 @@ public class AndroidLibraryGraphEnhancer {
         graphBuilder.computeIfAbsent(
             dummyRDotJavaBuildTarget,
             ignored -> {
-              JavacOptions filteredOptions =
-                  javacOptions.withExtraArguments(Collections.emptyList());
+              // No need to run annotation processor or javac plugins
+              JavacOptions filteredOptions = JavacOptions.builder()
+                  .from(javacOptions)
+                  .setExtraArguments(Collections.emptyList())
+                  .setJavaAnnotationProcessorParams(JavacPluginParams.EMPTY)
+                  .setStandardJavacPluginParams(JavacPluginParams.EMPTY)
+                  .build();
 
               JavacToJarStepFactory compileToJarStepFactory =
                   new JavacToJarStepFactory(javac, filteredOptions, ExtraClasspathProvider.EMPTY);

--- a/src/com/facebook/buck/android/AndroidLibraryGraphEnhancer.java
+++ b/src/com/facebook/buck/android/AndroidLibraryGraphEnhancer.java
@@ -125,12 +125,13 @@ public class AndroidLibraryGraphEnhancer {
             dummyRDotJavaBuildTarget,
             ignored -> {
               // No need to run annotation processor or javac plugins
-              JavacOptions filteredOptions = JavacOptions.builder()
-                  .from(javacOptions)
-                  .setExtraArguments(Collections.emptyList())
-                  .setJavaAnnotationProcessorParams(JavacPluginParams.EMPTY)
-                  .setStandardJavacPluginParams(JavacPluginParams.EMPTY)
-                  .build();
+              JavacOptions filteredOptions =
+                  JavacOptions.builder()
+                      .from(javacOptions)
+                      .setExtraArguments(Collections.emptyList())
+                      .setJavaAnnotationProcessorParams(JavacPluginParams.EMPTY)
+                      .setStandardJavacPluginParams(JavacPluginParams.EMPTY)
+                      .build();
 
               JavacToJarStepFactory compileToJarStepFactory =
                   new JavacToJarStepFactory(javac, filteredOptions, ExtraClasspathProvider.EMPTY);

--- a/src/com/facebook/buck/jvm/java/AbstractJavacOptions.java
+++ b/src/com/facebook/buck/jvm/java/AbstractJavacOptions.java
@@ -236,10 +236,9 @@ abstract class AbstractJavacOptions implements AddsToRuleKey {
         // Javac plugins should be declared as:
         // '-Xplugin:<pluginName> <arg1> <arg2> <arg3> ...'
         String pluginName = properties.getProcessorNames().first();
-        String pluginArguments = getJavacPluginArguments()
-            .getOrDefault(pluginName, ImmutableList.of())
-            .stream()
-            .reduce("", (s, s2) -> s + " " + s2);
+        String pluginArguments =
+            getJavacPluginArguments().getOrDefault(pluginName, ImmutableList.of()).stream()
+                .reduce("", (s, s2) -> s + " " + s2);
         optionsConsumer.addFlag("Xplugin:" + pluginName + pluginArguments);
       }
 

--- a/src/com/facebook/buck/jvm/java/AbstractJavacOptions.java
+++ b/src/com/facebook/buck/jvm/java/AbstractJavacOptions.java
@@ -239,7 +239,7 @@ abstract class AbstractJavacOptions implements AddsToRuleKey {
         String pluginArguments = getJavacPluginArguments()
             .getOrDefault(pluginName, ImmutableList.of())
             .stream()
-            .reduce(" ", (s, s2) -> s + " " + s2);
+            .reduce("", (s, s2) -> s + " " + s2);
         optionsConsumer.addFlag("Xplugin:" + pluginName + pluginArguments);
       }
 

--- a/src/com/facebook/buck/jvm/java/JavacOptionsFactory.java
+++ b/src/com/facebook/buck/jvm/java/JavacOptionsFactory.java
@@ -64,6 +64,8 @@ public final class JavacOptionsFactory {
         jvmLibraryArg.buildStandardJavacParams(buildTarget, resolver);
     builder.setStandardJavacPluginParams(standardJavacPluginsParams);
 
+    builder.setJavacPluginArguments(jvmLibraryArg.getPluginsArguments());
+
     return builder.build();
   }
 

--- a/src/com/facebook/buck/jvm/java/JvmLibraryArg.java
+++ b/src/com/facebook/buck/jvm/java/JvmLibraryArg.java
@@ -35,6 +35,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -74,6 +75,8 @@ public interface JvmLibraryArg extends CommonDescriptionArg, MaybeRequiredForSou
   Optional<Boolean> getAnnotationProcessorOnly();
 
   ImmutableList<BuildTarget> getPlugins();
+
+  Map<String, ImmutableList<String>> getPluginsArguments();
 
   Optional<AbiGenerationMode> getAbiGenerationMode();
 

--- a/test/com/facebook/buck/jvm/java/JavacOptionsTest.java
+++ b/test/com/facebook/buck/jvm/java/JavacOptionsTest.java
@@ -132,11 +132,13 @@ public class JavacOptionsTest {
     JavacPluginParams params =
         JavacPluginParams.builder().addPluginProperties(resolvedProps).build();
 
-    JavacOptions options = createStandardBuilder()
-        .setStandardJavacPluginParams(params)
-        .putJavacPluginArguments("ThePlugin", ImmutableList.of("param1", "param2", "param3"))
-        .putJavacPluginArguments("ThePluginOther", ImmutableList.of("param4", "param5", "param6"))
-        .build();
+    JavacOptions options =
+        createStandardBuilder()
+            .setStandardJavacPluginParams(params)
+            .putJavacPluginArguments("ThePlugin", ImmutableList.of("param1", "param2", "param3"))
+            .putJavacPluginArguments(
+                "ThePluginOther", ImmutableList.of("param4", "param5", "param6"))
+            .build();
 
     assertOptionsHasFlag(options, "Xplugin:ThePlugin param1 param2 param3");
     // Testing there is no duplicated info


### PR DESCRIPTION
Added support for `pluings_paramenters` for all targets that relies on `JvmLibraryArgs` as they base description.

This is used to add parameters for plugins defined on `plugins` parameter. 