### PR TITLE
Replace "incorrect" types to make project generation work with xcodeproj 

### DIFF
--- a/src/com/facebook/buck/apple/xcode/xcodeproj/PBXBuildPhase.java
+++ b/src/com/facebook/buck/apple/xcode/xcodeproj/PBXBuildPhase.java
@@ -54,6 +54,6 @@ public abstract class PBXBuildPhase extends PBXProjectItem {
     s.addField("files", files);
     name.ifPresent(phaseName -> s.addField("name", phaseName));
     runOnlyForDeploymentPostprocessing.ifPresent(
-        runOnly -> s.addField("runOnlyForDeploymentPostprocessing", runOnly ? 1 : 0));
+        runOnly -> s.addField("runOnlyForDeploymentPostprocessing", runOnly ? "1" : "0"));
   }
 }

--- a/src/com/facebook/buck/apple/xcode/xcodeproj/PBXContainerItemProxy.java
+++ b/src/com/facebook/buck/apple/xcode/xcodeproj/PBXContainerItemProxy.java
@@ -77,6 +77,6 @@ public class PBXContainerItemProxy extends PBXContainerItem {
 
     s.addField("containerPortal", containerPortal.getGlobalID());
     s.addField("remoteGlobalIDString", remoteGlobalIDString);
-    s.addField("proxyType", proxyType.getIntValue());
+    s.addField("proxyType", String.valueOf(proxyType.getIntValue()));
   }
 }

--- a/src/com/facebook/buck/apple/xcode/xcodeproj/PBXCopyFilesBuildPhase.java
+++ b/src/com/facebook/buck/apple/xcode/xcodeproj/PBXCopyFilesBuildPhase.java
@@ -67,7 +67,7 @@ public class PBXCopyFilesBuildPhase extends PBXBuildPhase {
   @Override
   public void serializeInto(XcodeprojSerializer s) {
     super.serializeInto(s);
-    s.addField("dstSubfolderSpec", dstSubfolderSpec.getDestination().getValue());
+    s.addField("dstSubfolderSpec", String.valueOf(dstSubfolderSpec.getDestination().getValue()));
     s.addField("dstPath", dstSubfolderSpec.getPath().orElse(""));
   }
 }

--- a/test/com/facebook/buck/apple/xcode/xcodeproj/PBXBuildPhasesTest.java
+++ b/test/com/facebook/buck/apple/xcode/xcodeproj/PBXBuildPhasesTest.java
@@ -73,7 +73,7 @@ public class PBXBuildPhasesTest {
     NSDictionary copyPhaseDict = getObjectForGID(copyPhase.getGlobalID(), projPlist);
 
     assertEquals(new NSString(copyPhaseName), copyPhaseDict.get("name"));
-    assertEquals(new NSNumber(1), copyPhaseDict.get("runOnlyForDeploymentPostprocessing"));
+    assertEquals(new NSString("1"), copyPhaseDict.get("runOnlyForDeploymentPostprocessing"));
   }
 
   @Test
@@ -99,7 +99,7 @@ public class PBXBuildPhasesTest {
     NSDictionary phaseDict = getObjectForGID(buildPhase.getGlobalID(), projPlist);
 
     assertEquals(new NSString(phaseName), phaseDict.get("name"));
-    assertEquals(new NSNumber(1), phaseDict.get("runOnlyForDeploymentPostprocessing"));
+    assertEquals(new NSString("1"), phaseDict.get("runOnlyForDeploymentPostprocessing"));
     assertEquals(new NSArray(new NSString(input)), phaseDict.get("inputPaths"));
     assertEquals(new NSArray(new NSString(output)), phaseDict.get("outputPaths"));
     assertEquals(new NSArray(new NSString(inputFileList)), phaseDict.get("inputFileListPaths"));


### PR DESCRIPTION
Buck currently outputs an XML for `project.pbxproj` where `runOnlyForDeploymentPostprocessing` and `dstSubfolderSpec` are treated as `integer`.

```
			<key>runOnlyForDeploymentPostprocessing</key>
			<integer>1</integer>
			<key>dstSubfolderSpec</key>
			<integer>16</integer>
```

When trying to open the `.xcodeproj` file with [xcodeproj](https://github.com/CocoaPods/Xcodeproj) we're getting:

> [Xcodeproj] Type checking error: got `Fixnum` for attribute: Attribute `dstSubfolderSpec` (type: `simple`, classes: `[String]`, owner class: `PBXCopyFilesBuildPhase`)

This [seems to be a bug](https://github.com/CocoaPods/Xcodeproj/issues/475) in xcodeproj itself.

To work around this, I'm forcing these 2 keys to have Strings as values instead of Int. After doing this, `xcodeproj` can succesfully open our project.

This was all already done in our [fork of buck here](https://github.com/airbnb/buck/pull/8)

---

I'm also including here @donholly commit in their fork that adds the same workaround for the same issue in PBXContainerItemProxy https://github.com/Clubroom/buck/commit/8fa5ae58c5df0e991d2f2e80830a73206c384bf3