### PR TITLE
Add target chrome trace step event

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,6 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="GoogleStyle" />
   </state>
 </component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="GoogleStyle" />
   </state>
 </component>

--- a/src/com/facebook/buck/android/IntraDexReorderStep.java
+++ b/src/com/facebook/buck/android/IntraDexReorderStep.java
@@ -88,7 +88,7 @@ public class IntraDexReorderStep implements Step {
     try {
       List<Step> dxSteps = generateReorderCommands();
       for (Step step : dxSteps) {
-        StepRunner.runStep(context, step);
+        StepRunner.runStep(context, step, Optional.of(buildTarget));
       }
     } catch (StepFailedException e) {
       context.logError(e, "There was an error in intra dex reorder step.");

--- a/src/com/facebook/buck/android/SmartDexingStep.java
+++ b/src/com/facebook/buck/android/SmartDexingStep.java
@@ -216,8 +216,8 @@ public class SmartDexingStep implements Step {
                     secondaryBlobOutput,
                     secondaryCompressedBlobOutput,
                     xzCompressionLevel.orElse(XzStep.DEFAULT_COMPRESSION_LEVEL));
-            StepRunner.runStep(context, concatStep);
-            StepRunner.runStep(context, xzStep);
+            StepRunner.runStep(context, concatStep, Optional.empty());
+            StepRunner.runStep(context, xzStep, Optional.empty());
           }
         }
       }
@@ -242,7 +242,7 @@ public class SmartDexingStep implements Step {
                     (Callable<Void>)
                         () -> {
                           for (Step step : steps) {
-                            StepRunner.runStep(context, step);
+                            StepRunner.runStep(context, step, Optional.empty());
                           }
                           return null;
                         })

--- a/src/com/facebook/buck/cli/TestRunning.java
+++ b/src/com/facebook/buck/cli/TestRunning.java
@@ -151,7 +151,7 @@ public class TestRunning {
                       buildContext.getBuildCellRootPath(),
                       library.getProjectFilesystem(),
                       JacocoConstants.getJacocoOutputDir(library.getProjectFilesystem())))) {
-            StepRunner.runStep(executionContext, step);
+            StepRunner.runStep(executionContext, step, Optional.empty());
           }
         } catch (StepFailedException e) {
           params
@@ -433,7 +433,8 @@ public class TestRunning {
                         .getSpoolMode()
                     == JavacOptions.SpoolMode.INTERMEDIATE_TO_DISK,
                 options.getCoverageIncludes(),
-                options.getCoverageExcludes()));
+                options.getCoverageExcludes()),
+            Optional.empty());
       } catch (StepFailedException e) {
         params
             .getBuckEventBus()
@@ -839,7 +840,7 @@ public class TestRunning {
           LOG.debug("Test steps will run for %s", buildTarget);
           eventBus.post(TestRuleEvent.started(buildTarget));
           for (Step step : steps) {
-            StepRunner.runStep(context, step);
+            StepRunner.runStep(context, step, Optional.of(buildTarget));
           }
           LOG.debug("Test steps did run for %s", buildTarget);
           eventBus.post(TestRuleEvent.finished(buildTarget));

--- a/src/com/facebook/buck/core/build/engine/impl/CachingBuildRuleBuilder.java
+++ b/src/com/facebook/buck/core/build/engine/impl/CachingBuildRuleBuilder.java
@@ -58,7 +58,6 @@ import com.facebook.buck.core.build.stats.BuildRuleDurationTracker;
 import com.facebook.buck.core.exceptions.BuckUncheckedExecutionException;
 import com.facebook.buck.core.exceptions.HumanReadableException;
 import com.facebook.buck.core.model.BuildId;
-import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.model.TargetConfigurationSerializer;
 import com.facebook.buck.core.rulekey.RuleKey;
 import com.facebook.buck.core.rules.BuildRule;

--- a/src/com/facebook/buck/core/build/engine/impl/CachingBuildRuleBuilder.java
+++ b/src/com/facebook/buck/core/build/engine/impl/CachingBuildRuleBuilder.java
@@ -58,6 +58,7 @@ import com.facebook.buck.core.build.stats.BuildRuleDurationTracker;
 import com.facebook.buck.core.exceptions.BuckUncheckedExecutionException;
 import com.facebook.buck.core.exceptions.HumanReadableException;
 import com.facebook.buck.core.model.BuildId;
+import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.model.TargetConfigurationSerializer;
 import com.facebook.buck.core.rulekey.RuleKey;
 import com.facebook.buck.core.rules.BuildRule;
@@ -1284,7 +1285,8 @@ class CachingBuildRuleBuilder {
                       rule.getType(),
                       CachingBuildEngine.STEP_TYPE_CONTEXT_KEY,
                       CachingBuildEngine.StepType.POST_BUILD_STEP.toString()))),
-          step);
+          step,
+          Optional.of(rule.getBuildTarget()));
 
       // Check for interruptions that may have been ignored by step.
       if (Thread.interrupted()) {
@@ -1451,7 +1453,7 @@ class CachingBuildRuleBuilder {
       try (Scope ignored = BuildRuleExecutionEvent.scope(eventBus, rule)) {
         // Get and run all of the commands.
         for (Step step : getSteps(buildRuleBuildContext, buildableContext)) {
-          StepRunner.runStep(executionContext, step);
+          StepRunner.runStep(executionContext, step, Optional.of(rule.getBuildTarget()));
           rethrowIgnoredInterruptedException(step);
         }
       }

--- a/src/com/facebook/buck/core/rules/impl/AbstractBuildRule.java
+++ b/src/com/facebook/buck/core/rules/impl/AbstractBuildRule.java
@@ -35,6 +35,7 @@ import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableSet;
 import java.lang.reflect.Field;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
@@ -159,7 +160,7 @@ public abstract class AbstractBuildRule implements BuildRule {
       BuildableContext buildableContext)
       throws StepFailedException, InterruptedException {
     for (Step step : getBuildSteps(buildContext, buildableContext)) {
-      StepRunner.runStep(executionContext, step);
+      StepRunner.runStep(executionContext, step, Optional.of(getBuildTarget()));
     }
   }
 }

--- a/src/com/facebook/buck/event/listener/ChromeTraceBuildListener.java
+++ b/src/com/facebook/buck/event/listener/ChromeTraceBuildListener.java
@@ -366,7 +366,9 @@ public class ChromeTraceBuildListener implements BuckEventListener {
         "buck",
         started.getShortStepName(),
         ChromeTraceEvent.Phase.BEGIN,
-        ImmutableMap.of(),
+        ImmutableMap.of(
+            "description", started.getDescription(),
+            "target", started.getParentTarget()),
         started);
   }
 
@@ -378,6 +380,7 @@ public class ChromeTraceBuildListener implements BuckEventListener {
         ChromeTraceEvent.Phase.END,
         ImmutableMap.of(
             "description", finished.getDescription(),
+            "target", finished.getParentTarget(),
             "exit_code", Integer.toString(finished.getExitCode())),
         finished);
   }

--- a/src/com/facebook/buck/rules/modern/builders/IsolatedBuildableBuilder.java
+++ b/src/com/facebook/buck/rules/modern/builders/IsolatedBuildableBuilder.java
@@ -334,7 +334,7 @@ public abstract class IsolatedBuildableBuilder {
       for (Step step :
           ModernBuildRule.stepsForBuildable(
               buildContext, reconstructed.buildable, filesystem, reconstructed.target)) {
-        StepRunner.runStep(executionContext, step);
+        StepRunner.runStep(executionContext, step, Optional.of(reconstructed.target));
       }
 
       LOG.info(

--- a/src/com/facebook/buck/rules/modern/builders/ReconstructingStrategy.java
+++ b/src/com/facebook/buck/rules/modern/builders/ReconstructingStrategy.java
@@ -127,7 +127,10 @@ class ReconstructingStrategy extends AbstractModernBuildRuleStrategy {
                             reconstructed,
                             rule.getProjectFilesystem(),
                             rule.getBuildTarget())) {
-                      StepRunner.runStep(strategyContext.getExecutionContext(), step);
+                      StepRunner.runStep(
+                          strategyContext.getExecutionContext(),
+                          step,
+                          Optional.of(rule.getBuildTarget()));
                     }
                     converted.recordOutputs(strategyContext.getBuildableContext());
                   } catch (IOException | StepFailedException | InterruptedException e) {

--- a/src/com/facebook/buck/step/StepEvent.java
+++ b/src/com/facebook/buck/step/StepEvent.java
@@ -70,7 +70,8 @@ public abstract class StepEvent extends AbstractBuckEvent
     return getShortStepName();
   }
 
-  public static Started started(String shortName, String description, UUID uuid, String parentTarget) {
+  public static Started started(
+      String shortName, String description, UUID uuid, String parentTarget) {
     return new Started(shortName, description, uuid, parentTarget);
   }
 
@@ -93,7 +94,11 @@ public abstract class StepEvent extends AbstractBuckEvent
     private final int exitCode;
 
     protected Finished(Started started, int exitCode) {
-      super(started.getShortStepName(), started.getDescription(), started.getUuid(), started.getParentTarget());
+      super(
+          started.getShortStepName(),
+          started.getDescription(),
+          started.getUuid(),
+          started.getParentTarget());
       this.exitCode = exitCode;
     }
 

--- a/src/com/facebook/buck/step/StepEvent.java
+++ b/src/com/facebook/buck/step/StepEvent.java
@@ -31,14 +31,15 @@ public abstract class StepEvent extends AbstractBuckEvent
 
   private final String shortName;
   private final String description;
-
   @JsonIgnore private final UUID uuid;
+  private final String parentTarget;
 
-  protected StepEvent(String shortName, String description, UUID uuid) {
+  protected StepEvent(String shortName, String description, UUID uuid, String parentTarget) {
     super(EventKey.slowValueKey("StepEvent", uuid));
     this.shortName = shortName;
     this.description = description;
     this.uuid = uuid;
+    this.parentTarget = parentTarget;
   }
 
   @Override
@@ -55,6 +56,10 @@ public abstract class StepEvent extends AbstractBuckEvent
     return uuid;
   }
 
+  public String getParentTarget() {
+    return parentTarget;
+  }
+
   @Override
   public String getCategory() {
     return getShortStepName();
@@ -65,8 +70,8 @@ public abstract class StepEvent extends AbstractBuckEvent
     return getShortStepName();
   }
 
-  public static Started started(String shortName, String description, UUID uuid) {
-    return new Started(shortName, description, uuid);
+  public static Started started(String shortName, String description, UUID uuid, String parentTarget) {
+    return new Started(shortName, description, uuid, parentTarget);
   }
 
   public static Finished finished(Started started, int exitCode) {
@@ -74,8 +79,8 @@ public abstract class StepEvent extends AbstractBuckEvent
   }
 
   public static class Started extends StepEvent {
-    protected Started(String shortName, String description, UUID uuid) {
-      super(shortName, description, uuid);
+    protected Started(String shortName, String description, UUID uuid, String parentTarget) {
+      super(shortName, description, uuid, parentTarget);
     }
 
     @Override
@@ -88,7 +93,7 @@ public abstract class StepEvent extends AbstractBuckEvent
     private final int exitCode;
 
     protected Finished(Started started, int exitCode) {
-      super(started.getShortStepName(), started.getDescription(), started.getUuid());
+      super(started.getShortStepName(), started.getDescription(), started.getUuid(), started.getParentTarget());
       this.exitCode = exitCode;
     }
 

--- a/src/com/facebook/buck/step/StepRunner.java
+++ b/src/com/facebook/buck/step/StepRunner.java
@@ -44,11 +44,15 @@ public final class StepRunner {
     if (context.getVerbosity().shouldPrintCommand()) {
       context.getStdErr().println(step.getDescription(context));
     }
+    String parentTarget = "";
+    if (buildTarget.isPresent()) {
+      parentTarget = buildTarget.get().getFullyQualifiedName();
+    }
 
     String stepShortName = step.getShortName();
     String stepDescription = step.getDescription(context);
     UUID stepUuid = UUID.randomUUID();
-    StepEvent.Started started = StepEvent.started(stepShortName, stepDescription, stepUuid);
+    StepEvent.Started started = StepEvent.started(stepShortName, stepDescription, stepUuid, parentTarget);
     LOG.verbose(started.toString());
     context.getBuckEventBus().post(started);
     StepExecutionResult executionResult = StepExecutionResults.ERROR;

--- a/src/com/facebook/buck/step/StepRunner.java
+++ b/src/com/facebook/buck/step/StepRunner.java
@@ -17,8 +17,10 @@
 package com.facebook.buck.step;
 
 import com.facebook.buck.core.build.execution.context.ExecutionContext;
+import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.util.log.Logger;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.UUID;
 
 /** Utility class for running {@link Step}s */
@@ -37,7 +39,7 @@ public final class StepRunner {
    * @throws StepFailedException if the step failed
    * @throws InterruptedException if an interrupt occurred while executing the {@link Step}
    */
-  public static void runStep(ExecutionContext context, Step step)
+  public static void runStep(ExecutionContext context, Step step, Optional<BuildTarget> buildTarget)
       throws StepFailedException, InterruptedException {
     if (context.getVerbosity().shouldPrintCommand()) {
       context.getStdErr().println(step.getDescription(context));

--- a/src/com/facebook/buck/step/StepRunner.java
+++ b/src/com/facebook/buck/step/StepRunner.java
@@ -52,7 +52,8 @@ public final class StepRunner {
     String stepShortName = step.getShortName();
     String stepDescription = step.getDescription(context);
     UUID stepUuid = UUID.randomUUID();
-    StepEvent.Started started = StepEvent.started(stepShortName, stepDescription, stepUuid, parentTarget);
+    StepEvent.Started started =
+        StepEvent.started(stepShortName, stepDescription, stepUuid, parentTarget);
     LOG.verbose(started.toString());
     context.getBuckEventBus().post(started);
     StepExecutionResult executionResult = StepExecutionResults.ERROR;

--- a/test/com/facebook/buck/event/listener/BuildThreadStateRendererTest.java
+++ b/test/com/facebook/buck/event/listener/BuildThreadStateRendererTest.java
@@ -58,6 +58,7 @@ public class BuildThreadStateRendererTest {
   private static final BuildRule RULE2 = createFakeRule(TARGET2);
   private static final BuildRule RULE3 = createFakeRule(TARGET3);
   private static final BuildRule RULE4 = createFakeRule(TARGET4);
+  private static final String BUILD_TARGET_NAME = "//test:target";
 
   @Test
   public void emptyInput() {
@@ -202,7 +203,7 @@ public class BuildThreadStateRendererTest {
       long threadId, long timeMs, String name) {
     return Optional.of(
         TestEventConfigurator.configureTestEventAtTime(
-            StepEvent.started(name, name + " description", UUID.randomUUID()),
+            StepEvent.started(name, name + " description", UUID.randomUUID(), BUILD_TARGET_NAME),
             timeMs,
             TimeUnit.MILLISECONDS,
             threadId));

--- a/test/com/facebook/buck/event/listener/ChromeTraceBuildListenerTest.java
+++ b/test/com/facebook/buck/event/listener/ChromeTraceBuildListenerTest.java
@@ -478,7 +478,7 @@ public class ChromeTraceBuildListenerTest {
 
     BuildRuleEvent.Started started = BuildRuleEvent.started(rule, durationTracker);
     eventBus.post(started);
-    eventBus.post(StepEvent.started(stepShortName, stepDescription, stepUuid));
+    eventBus.post(StepEvent.started(stepShortName, stepDescription, stepUuid, rule.getFullyQualifiedName()));
 
     JavacPhaseEvent.Started runProcessorsStartedEvent =
         JavacPhaseEvent.started(
@@ -516,7 +516,7 @@ public class ChromeTraceBuildListenerTest {
     eventBus.post(JavacPhaseEvent.finished(runProcessorsStartedEvent, ImmutableMap.of()));
 
     eventBus.post(
-        StepEvent.finished(StepEvent.started(stepShortName, stepDescription, stepUuid), 0));
+        StepEvent.finished(StepEvent.started(stepShortName, stepDescription, stepUuid, rule.getFullyQualifiedName()), 0));
     eventBus.post(
         BuildRuleEvent.finished(
             started,

--- a/test/com/facebook/buck/event/listener/ChromeTraceBuildListenerTest.java
+++ b/test/com/facebook/buck/event/listener/ChromeTraceBuildListenerTest.java
@@ -478,7 +478,8 @@ public class ChromeTraceBuildListenerTest {
 
     BuildRuleEvent.Started started = BuildRuleEvent.started(rule, durationTracker);
     eventBus.post(started);
-    eventBus.post(StepEvent.started(stepShortName, stepDescription, stepUuid, rule.getFullyQualifiedName()));
+    eventBus.post(
+        StepEvent.started(stepShortName, stepDescription, stepUuid, rule.getFullyQualifiedName()));
 
     JavacPhaseEvent.Started runProcessorsStartedEvent =
         JavacPhaseEvent.started(
@@ -516,7 +517,10 @@ public class ChromeTraceBuildListenerTest {
     eventBus.post(JavacPhaseEvent.finished(runProcessorsStartedEvent, ImmutableMap.of()));
 
     eventBus.post(
-        StepEvent.finished(StepEvent.started(stepShortName, stepDescription, stepUuid, rule.getFullyQualifiedName()), 0));
+        StepEvent.finished(
+            StepEvent.started(
+                stepShortName, stepDescription, stepUuid, rule.getFullyQualifiedName()),
+            0));
     eventBus.post(
         BuildRuleEvent.finished(
             started,
@@ -646,7 +650,13 @@ public class ChromeTraceBuildListenerTest {
     assertNextResult(
         resultListCopy, "//fake:rule", ChromeTraceEvent.Phase.BEGIN, ImmutableMap.of());
 
-    assertNextResult(resultListCopy, "fakeStep", ChromeTraceEvent.Phase.BEGIN, emptyArgs);
+    assertNextResult(
+        resultListCopy,
+        "fakeStep",
+        ChromeTraceEvent.Phase.BEGIN,
+        ImmutableMap.of(
+            "description", "I'm a Fake Step!",
+            "target", "//fake:rule"));
 
     assertNextResult(
         resultListCopy, "run annotation processors", ChromeTraceEvent.Phase.BEGIN, emptyArgs);
@@ -693,6 +703,7 @@ public class ChromeTraceBuildListenerTest {
         ChromeTraceEvent.Phase.END,
         ImmutableMap.of(
             "description", "I'm a Fake Step!",
+            "target", "//fake:rule",
             "exit_code", "0"));
 
     assertNextResult(

--- a/test/com/facebook/buck/event/listener/SuperConsoleEventBusListenerTest.java
+++ b/test/com/facebook/buck/event/listener/SuperConsoleEventBusListenerTest.java
@@ -462,9 +462,10 @@ public class SuperConsoleEventBusListenerTest {
 
     String stepShortName = "doing_something";
     String stepDescription = "working hard";
+    String buildTargetName = "//some:target";
     UUID stepUuid = UUID.randomUUID();
     StepEvent.Started stepEventStarted =
-        StepEvent.started(stepShortName, stepDescription, stepUuid);
+        StepEvent.started(stepShortName, stepDescription, stepUuid, buildTargetName);
     eventBus.postWithoutConfiguring(
         configureTestEventAtTime(stepEventStarted, 800L, TimeUnit.MILLISECONDS, /* threadId */ 0L));
 
@@ -481,9 +482,10 @@ public class SuperConsoleEventBusListenerTest {
 
     String innerStepShortName = "doing_something_inner";
     String innerStepDescription = "working hard (for real)";
+    String innerBuildTargetName = "//other:target";
     UUID innerStepUuid = UUID.randomUUID();
     StepEvent.Started innerStepEventStarted =
-        StepEvent.started(innerStepShortName, innerStepDescription, innerStepUuid);
+        StepEvent.started(innerStepShortName, innerStepDescription, innerStepUuid, innerBuildTargetName);
     eventBus.postWithoutConfiguring(
         configureTestEventAtTime(
             innerStepEventStarted, 800L, TimeUnit.MILLISECONDS, /* threadId */ 0L));
@@ -874,9 +876,10 @@ public class SuperConsoleEventBusListenerTest {
 
     String stepShortName = "doing_something";
     String stepDescription = "working hard";
+    String buildTargetName = "//some:target";
     UUID stepUuid = UUID.randomUUID();
     StepEvent.Started stepEventStarted =
-        StepEvent.started(stepShortName, stepDescription, stepUuid);
+        StepEvent.started(stepShortName, stepDescription, stepUuid, buildTargetName);
     eventBus.postWithoutConfiguring(
         configureTestEventAtTime(stepEventStarted, 800L, TimeUnit.MILLISECONDS, /* threadId */ 0L));
 
@@ -1858,7 +1861,7 @@ public class SuperConsoleEventBusListenerTest {
             " - //:test... 0.1 sec"));
 
     UUID stepUuid = new UUID(0, 1);
-    StepEvent.Started stepEventStarted = StepEvent.started("step_name", "step_desc", stepUuid);
+    StepEvent.Started stepEventStarted = StepEvent.started("step_name", "step_desc", stepUuid, "//target:name");
     eventBus.postWithoutConfiguring(
         configureTestEventAtTime(
             stepEventStarted, 3300L, TimeUnit.MILLISECONDS, /* threadId */ 0L));
@@ -2165,7 +2168,7 @@ public class SuperConsoleEventBusListenerTest {
             " - //:test... 0.1 sec"));
 
     UUID stepUuid = new UUID(0, 1);
-    StepEvent.Started stepEventStarted = StepEvent.started("step_name", "step_desc", stepUuid);
+    StepEvent.Started stepEventStarted = StepEvent.started("step_name", "step_desc", stepUuid, "//target:name");
     eventBus.postWithoutConfiguring(
         configureTestEventAtTime(
             stepEventStarted, 3300L, TimeUnit.MILLISECONDS, /* threadId */ 0L));
@@ -2493,7 +2496,7 @@ public class SuperConsoleEventBusListenerTest {
             " - //:test... 0.1 sec"));
 
     UUID stepUuid = new UUID(0, 1);
-    StepEvent.Started stepEventStarted = StepEvent.started("step_name", "step_desc", stepUuid);
+    StepEvent.Started stepEventStarted = StepEvent.started("step_name", "step_desc", stepUuid, "//target:name");
     eventBus.postWithoutConfiguring(
         configureTestEventAtTime(
             stepEventStarted, 3300L, TimeUnit.MILLISECONDS, /* threadId */ 0L));
@@ -2646,6 +2649,7 @@ public class SuperConsoleEventBusListenerTest {
     String stepShortName = "doing_something";
     String stepDescription = "working hard";
     UUID stepUuid = UUID.randomUUID();
+    String buildTargetName = "//build:target";
 
     FakeRuleKeyFactory ruleKeyFactory =
         new FakeRuleKeyFactory(ImmutableMap.of(fakeTarget, new RuleKey("aaaa")));
@@ -2684,7 +2688,7 @@ public class SuperConsoleEventBusListenerTest {
 
     // Post events that run a step for 100ms.
     StepEvent.Started stepEventStarted =
-        StepEvent.started(stepShortName, stepDescription, stepUuid);
+        StepEvent.started(stepShortName, stepDescription, stepUuid, buildTargetName);
     eventBus.postWithoutConfiguring(
         configureTestEventAtTime(stepEventStarted, 0L, TimeUnit.MILLISECONDS, /* threadId */ 0L));
     eventBus.postWithoutConfiguring(
@@ -2732,7 +2736,7 @@ public class SuperConsoleEventBusListenerTest {
 
     // Post events that run another step.
     StepEvent.Started step2EventStarted =
-        StepEvent.started(stepShortName, stepDescription, stepUuid);
+        StepEvent.started(stepShortName, stepDescription, stepUuid, buildTargetName);
     eventBus.postWithoutConfiguring(
         configureTestEventAtTime(
             step2EventStarted, 400L, TimeUnit.MILLISECONDS, /* threadId */ 0L));

--- a/test/com/facebook/buck/event/listener/SuperConsoleEventBusListenerTest.java
+++ b/test/com/facebook/buck/event/listener/SuperConsoleEventBusListenerTest.java
@@ -485,7 +485,8 @@ public class SuperConsoleEventBusListenerTest {
     String innerBuildTargetName = "//other:target";
     UUID innerStepUuid = UUID.randomUUID();
     StepEvent.Started innerStepEventStarted =
-        StepEvent.started(innerStepShortName, innerStepDescription, innerStepUuid, innerBuildTargetName);
+        StepEvent.started(
+            innerStepShortName, innerStepDescription, innerStepUuid, innerBuildTargetName);
     eventBus.postWithoutConfiguring(
         configureTestEventAtTime(
             innerStepEventStarted, 800L, TimeUnit.MILLISECONDS, /* threadId */ 0L));
@@ -1861,7 +1862,8 @@ public class SuperConsoleEventBusListenerTest {
             " - //:test... 0.1 sec"));
 
     UUID stepUuid = new UUID(0, 1);
-    StepEvent.Started stepEventStarted = StepEvent.started("step_name", "step_desc", stepUuid, "//target:name");
+    StepEvent.Started stepEventStarted =
+        StepEvent.started("step_name", "step_desc", stepUuid, "//target:name");
     eventBus.postWithoutConfiguring(
         configureTestEventAtTime(
             stepEventStarted, 3300L, TimeUnit.MILLISECONDS, /* threadId */ 0L));
@@ -2168,7 +2170,8 @@ public class SuperConsoleEventBusListenerTest {
             " - //:test... 0.1 sec"));
 
     UUID stepUuid = new UUID(0, 1);
-    StepEvent.Started stepEventStarted = StepEvent.started("step_name", "step_desc", stepUuid, "//target:name");
+    StepEvent.Started stepEventStarted =
+        StepEvent.started("step_name", "step_desc", stepUuid, "//target:name");
     eventBus.postWithoutConfiguring(
         configureTestEventAtTime(
             stepEventStarted, 3300L, TimeUnit.MILLISECONDS, /* threadId */ 0L));
@@ -2496,7 +2499,8 @@ public class SuperConsoleEventBusListenerTest {
             " - //:test... 0.1 sec"));
 
     UUID stepUuid = new UUID(0, 1);
-    StepEvent.Started stepEventStarted = StepEvent.started("step_name", "step_desc", stepUuid, "//target:name");
+    StepEvent.Started stepEventStarted =
+        StepEvent.started("step_name", "step_desc", stepUuid, "//target:name");
     eventBus.postWithoutConfiguring(
         configureTestEventAtTime(
             stepEventStarted, 3300L, TimeUnit.MILLISECONDS, /* threadId */ 0L));

--- a/test/com/facebook/buck/event/listener/TestThreadStateRendererTest.java
+++ b/test/com/facebook/buck/event/listener/TestThreadStateRendererTest.java
@@ -226,7 +226,7 @@ public class TestThreadStateRendererTest {
       long threadId, long timeMs, String name) {
     return Optional.of(
         TestEventConfigurator.configureTestEventAtTime(
-            StepEvent.started(name, name + " description", UUID.randomUUID()),
+            StepEvent.started(name, name + " description", UUID.randomUUID(), "//test:target"),
             timeMs,
             TimeUnit.MILLISECONDS,
             threadId));

--- a/test/com/facebook/buck/step/StepRunnerTest.java
+++ b/test/com/facebook/buck/step/StepRunnerTest.java
@@ -27,6 +27,7 @@ import com.facebook.buck.event.BuckEventBusForTests;
 import com.facebook.buck.event.FakeBuckEventListener;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
+import java.util.Optional;
 import org.junit.Test;
 
 public class StepRunnerTest {
@@ -42,9 +43,9 @@ public class StepRunnerTest {
     eventBus.register(listener);
 
     ExecutionContext context = TestExecutionContext.newBuilder().setBuckEventBus(eventBus).build();
-    StepRunner.runStep(context, passingStep);
+    StepRunner.runStep(context, passingStep, Optional.empty());
     try {
-      StepRunner.runStep(context, failingStep);
+      StepRunner.runStep(context, failingStep, Optional.empty());
       fail("Failing step should have thrown an exception");
     } catch (StepFailedException e) {
       assertEquals(e.getStep(), failingStep);
@@ -84,7 +85,7 @@ public class StepRunnerTest {
     ExecutionContext context = TestExecutionContext.newInstance();
 
     try {
-      StepRunner.runStep(context, new ExplosionStep());
+      StepRunner.runStep(context, new ExplosionStep(), Optional.empty());
       fail("Should have thrown a StepFailedException!");
     } catch (StepFailedException e) {
       assertTrue(


### PR DESCRIPTION
Reverts https://github.com/facebook/buck/commit/22d997120c5424e026aca1aaca889db9f264a345#diff-bd53cf424d15a06cf508a1341b4c93d1
Add target information to step event on chrome trace file.

This is generally useful when parsing the chrome trace file in order to get information about about steps events and associate them with the given target being run.