### PR TITLE
Fix secondary Xcode schemes ignoring action_config_names settings

### DIFF
--- a/src/com/facebook/buck/features/apple/project/WorkspaceAndProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/WorkspaceAndProjectGenerator.java
@@ -1269,7 +1269,7 @@ public class WorkspaceAndProjectGenerator {
         wasCreatedForAppExtension,
         runnablePath,
         remoteRunnablePath,
-        XcodeWorkspaceConfigDescription.getActionConfigNamesFromArg(workspaceArguments),
+        XcodeWorkspaceConfigDescription.getActionConfigNamesFromArg(schemeConfigArg),
         targetToProjectPathMap,
         environmentVariables,
         additionalSchemeActions,

--- a/src/com/facebook/buck/features/apple/project/XcodeWorkspaceConfigDescription.java
+++ b/src/com/facebook/buck/features/apple/project/XcodeWorkspaceConfigDescription.java
@@ -65,12 +65,14 @@ public class XcodeWorkspaceConfigDescription
   }
 
   public static ImmutableMap<SchemeActionType, String> getActionConfigNamesFromArg(
-      XcodeWorkspaceConfigDescriptionArg arg) {
+      Optional<XcodeWorkspaceConfigDescriptionArg> arg) {
     // Start out with the default action config names..
     Map<SchemeActionType, String> newActionConfigNames =
         new HashMap<>(SchemeActionType.DEFAULT_CONFIG_NAMES);
     // And override them with any provided in the "action_config_names" map.
-    newActionConfigNames.putAll(arg.getActionConfigNames());
+    if (arg.isPresent()) {
+      newActionConfigNames.putAll(arg.get().getActionConfigNames());
+    }
 
     return ImmutableMap.copyOf(newActionConfigNames);
   }


### PR DESCRIPTION
Fixes https://github.com/facebook/buck/issues/2265

We use the following setup to create a secondary scheme that sends Enterprise builds:

```
xcode_workspace_config(
    name = "workspace",
    workspace_name = "MyApp",
    src_target = ":MyApp",
    environment_variables = ENV_VAR,
    extra_schemes = {
      'MyApp-Enterprise': ':myapp_enterprise_workspace',
    }
)

xcode_workspace_config(
    name = "myapp_enterprise_workspace",
    workspace_name = "MyApp-Enterprise",
    src_target = ":MyApp",
    environment_variables = ENV_VAR,
    action_config_names = {"archive": "Release-Enterprise"},
)
```

However, setting `action_config_names` on the secondary scheme currently has no effect because the schemes were always pointing to the main scheme's configs.

This PR fixes this to make secondary schemes pull their configs from their own definition.

Note that this will affect projects that were relying on this to have all schemes having the same configs and has the side effect that project scheme's actions won't be equal to `workspaceArguments` anymore - should we keep the old interaction if custom configs weren't provided?