### PR TITLE
Fix error message when Android build-tools directory is empty

### DIFF
--- a/src/com/facebook/buck/android/toolchain/impl/AndroidBuildToolsResolver.java
+++ b/src/com/facebook/buck/android/toolchain/impl/AndroidBuildToolsResolver.java
@@ -63,9 +63,9 @@ public class AndroidBuildToolsResolver {
   }
 
   private Optional<Path> findBuildTools(Path sdkPath) {
-    Path toolsDir = sdkPath.resolve("build-tools");
+    Path buildToolsDir = sdkPath.resolve("build-tools");
 
-    if (toolsDir.toFile().isDirectory()) {
+    if (buildToolsDir.toFile().isDirectory()) {
       // In older versions of the ADT that have been upgraded via the SDK manager, the build-tools
       // directory appears to contain subfolders of the form "17.0.0". However, newer versions of
       // the ADT that are downloaded directly from http://developer.android.com/ appear to have
@@ -74,7 +74,7 @@ public class AndroidBuildToolsResolver {
       File[] directories;
       try {
         directories =
-            toolsDir
+            buildToolsDir
                 .toFile()
                 .listFiles(
                     pathname -> {
@@ -125,11 +125,11 @@ public class AndroidBuildToolsResolver {
       if (newestBuildDir == null) {
         buildToolsErrorMessage =
             Optional.of(
-                buildTools
+                buildToolsDir
                     + " was empty, but should have "
                     + "contained a subdirectory with build tools. Install them using the Android "
                     + "SDK Manager ("
-                    + toolsDir.getParent().resolve("tools").resolve("android")
+                    + buildToolsDir.getParent().resolve("tools").resolve("android")
                     + ").");
         return Optional.empty();
       }

--- a/test/com/facebook/buck/android/toolchain/impl/AndroidBuildToolsResolverTest.java
+++ b/test/com/facebook/buck/android/toolchain/impl/AndroidBuildToolsResolverTest.java
@@ -96,12 +96,14 @@ public class AndroidBuildToolsResolverTest {
     sdkDir.resolve("build-tools").toFile().mkdir();
     sdkDir.resolve("tools").toFile().mkdir();
     Path toolsDir = sdkDir.resolve("tools").toAbsolutePath();
+    Path buildToolsDir = sdkDir.resolve("build-tools").toAbsolutePath();
     AndroidBuildToolsResolver resolver =
         new AndroidBuildToolsResolver(androidBuckConfig, AndroidSdkLocation.of(sdkDir));
 
     expectedException.expect(HumanReadableException.class);
     expectedException.expectMessage(
-        "null was empty, but should have contained a subdirectory "
+        buildToolsDir
+            + " was empty, but should have contained a subdirectory "
             + "with build tools. Install them using the Android SDK Manager ("
             + toolsDir
             + File.separator


### PR DESCRIPTION
Before this fix, when a user didn't have any Android build tools installed and tried to build an Android Buck project, he would have got the following error message: `null was empty, but should have contained a subdirectory with build tools. Install them using the Android SDK Manager (/Users/username/Library/Android/sdk/tools/android).` This PR provides the absolute path to the 'build-tools' directory instead of 'null': `/Users/username/Library/Android/sdk/build-tools was empty, but should have contained a subdirectory with build tools. Install them using the Android SDK Manager (/Users/username/Library/Android/sdk/tools/android).` It also fixes the corresponding unit test, which had the error message hardcoded.