### PR TITLE
Replace deprecated path to Android resource directory with subdir_glob()

### DIFF
--- a/docs/learning/tutorial.soy
+++ b/docs/learning/tutorial.soy
@@ -146,7 +146,7 @@ echo "&lt;?xml version='1.0' encoding='utf-8' ?>
 {literal}<pre>
 echo "android_resource(
   name = 'res',
-  res = 'res',
+  res = subdir_glob([('res', '**')]),
   package = 'com.example',
   visibility = [
     '//apps/myapp:',


### PR DESCRIPTION
According to the android_resource [docs](https://buck.build/rule/android_resource.html#res), having a path to a directory containing Android resources is deprecated and should be replaced with `subdir_glob()`.

> **res (defaults to None)**
A dictionary mapping relative resource paths to either the resource files or the build targets that generate them. The **subdir_glob()** function can be used to generate dictionaries based on a directory structure of files checked into the repository. Alternatively, this can be a path to a directory containing Android resources, although this option is **deprecated** and might be removed in the future.

See the examples provided:

```
android_resource(
  name = 'res',
  res = subdir_glob([('res', '**')]),
  package = 'com.example',
)
```