### PR TITLE
Add snapshot_images_diff_path to apple_test

### DIFF
--- a/src/com/facebook/buck/apple/AppleTestDescription.java
+++ b/src/com/facebook/buck/apple/AppleTestDescription.java
@@ -378,6 +378,7 @@ public class AppleTestDescription
                     .getDefaultTestRuleTimeoutMs()),
         args.getIsUiTest(),
         args.getSnapshotReferenceImagesPath(),
+        args.getSnapshotImagesDiffPath(),
         args.getEnv());
   }
 
@@ -704,6 +705,9 @@ public class AppleTestDescription
 
     // for use with FBSnapshotTestcase, injects the path as FB_REFERENCE_IMAGE_DIR
     Optional<Either<SourcePath, String>> getSnapshotReferenceImagesPath();
+
+    // for use with FBSnapshotTestcase, injects the path as IMAGE_DIFF_DIR
+    Optional<Either<SourcePath, String>> getSnapshotImagesDiffPath();
 
     // Bundle related fields.
     ImmutableMap<String, String> getDestinationSpecifier();

--- a/src/com/facebook/buck/apple/XctoolRunTestsStep.java
+++ b/src/com/facebook/buck/apple/XctoolRunTestsStep.java
@@ -74,6 +74,7 @@ class XctoolRunTestsStep implements Step {
       Executors.newSingleThreadScheduledExecutor();
   private static final String XCTOOL_ENV_VARIABLE_PREFIX = "XCTOOL_TEST_ENV_";
   private static final String FB_REFERENCE_IMAGE_DIR = "FB_REFERENCE_IMAGE_DIR";
+  private static final String IMAGE_DIFF_DIR = "IMAGE_DIFF_DIR";
 
   private final ProjectFilesystem filesystem;
 
@@ -96,6 +97,7 @@ class XctoolRunTestsStep implements Step {
   private final Optional<String> logLevel;
   private final Optional<Long> timeoutInMs;
   private final Optional<String> snapshotReferenceImagesPath;
+  private final Optional<String> snapshotImagesDiffPath;
 
   // Helper class to parse the output of `xctool -listTestsOnly` then
   // store it in a multimap of {target: [testDesc1, testDesc2, ...], ... } pairs.
@@ -170,7 +172,8 @@ class XctoolRunTestsStep implements Step {
       Optional<String> logLevelEnvironmentVariable,
       Optional<String> logLevel,
       Optional<Long> timeoutInMs,
-      Optional<String> snapshotReferenceImagesPath) {
+      Optional<String> snapshotReferenceImagesPath,
+      Optional<String> snapshotImagesDiffPath) {
     Preconditions.checkArgument(
         !(logicTestBundlePaths.isEmpty()
             && appTestBundleToHostAppPaths.isEmpty()
@@ -203,6 +206,7 @@ class XctoolRunTestsStep implements Step {
     this.logLevel = logLevel;
     this.timeoutInMs = timeoutInMs;
     this.snapshotReferenceImagesPath = snapshotReferenceImagesPath;
+    this.snapshotImagesDiffPath = snapshotImagesDiffPath;
   }
 
   @Override
@@ -230,6 +234,9 @@ class XctoolRunTestsStep implements Step {
     if (snapshotReferenceImagesPath.isPresent()) {
       environment.put(
           XCTOOL_ENV_VARIABLE_PREFIX + FB_REFERENCE_IMAGE_DIR, snapshotReferenceImagesPath.get());
+    }
+    if (snapshotImagesDiffPath.isPresent()) {
+      environment.put(XCTOOL_ENV_VARIABLE_PREFIX + IMAGE_DIFF_DIR, snapshotImagesDiffPath.get());
     }
 
     environment.putAll(this.environmentOverrides);

--- a/test/com/facebook/buck/apple/XctoolRunTestsStepTest.java
+++ b/test/com/facebook/buck/apple/XctoolRunTestsStepTest.java
@@ -76,6 +76,7 @@ public class XctoolRunTestsStepTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
     ProcessExecutorParams xctoolParams =
         ProcessExecutorParams.builder()
@@ -123,6 +124,7 @@ public class XctoolRunTestsStepTest {
             AppleDeveloperDirectoryForTestsProvider.of(Paths.get("/path/to/developer/dir")),
             TestSelectorList.EMPTY,
             false,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
@@ -185,6 +187,7 @@ public class XctoolRunTestsStepTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     ProcessExecutorParams xctoolParams =
@@ -242,6 +245,7 @@ public class XctoolRunTestsStepTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     ProcessExecutorParams xctoolParams =
@@ -292,6 +296,7 @@ public class XctoolRunTestsStepTest {
             AppleDeveloperDirectoryForTestsProvider.of(Paths.get("/path/to/developer/dir")),
             TestSelectorList.EMPTY,
             false,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
@@ -354,6 +359,7 @@ public class XctoolRunTestsStepTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     ProcessExecutorParams xctoolParams =
@@ -409,6 +415,7 @@ public class XctoolRunTestsStepTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     ProcessExecutorParams xctoolParams =
@@ -458,6 +465,7 @@ public class XctoolRunTestsStepTest {
             AppleDeveloperDirectoryForTestsProvider.of(Paths.get("/path/to/developer/dir")),
             TestSelectorList.builder().addRawSelectors("#.*Magic.*").build(),
             false,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
@@ -554,6 +562,7 @@ public class XctoolRunTestsStepTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     ProcessExecutorParams xctoolListOnlyParams =
@@ -615,6 +624,7 @@ public class XctoolRunTestsStepTest {
             AppleDeveloperDirectoryForTestsProvider.of(Paths.get("/path/to/developer/dir")),
             TestSelectorList.builder().addRawSelectors("Blargh#Xyzzy").build(),
             false,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
@@ -682,7 +692,8 @@ public class XctoolRunTestsStepTest {
             Optional.of("TEST_LOG_LEVEL"),
             Optional.of("verbose"),
             Optional.empty(),
-            Optional.of("/path/to/snapshotimages"));
+            Optional.of("/path/to/snapshotimages"),
+            Optional.of("/path/to/snapshotfailurediffs"));
     ProcessExecutorParams xctoolParams =
         ProcessExecutorParams.builder()
             .setCommand(
@@ -698,12 +709,14 @@ public class XctoolRunTestsStepTest {
             // This is the important part of this test: only if the process is executed
             // with a matching environment will the test pass.
             .setEnvironment(
-                ImmutableMap.of(
-                    "DEVELOPER_DIR", "/path/to/developer/dir",
-                    "XCTOOL_TEST_ENV_TEST_LOG_PATH", "/path/to/test-logs",
-                    "XCTOOL_TEST_ENV_TEST_LOG_LEVEL", "verbose",
-                    "XCTOOL_TEST_ENV_FB_REFERENCE_IMAGE_DIR", "/path/to/snapshotimages",
-                    "LLVM_PROFILE_FILE", "/tmp/some.profraw"))
+                ImmutableMap.<String, String>builder()
+                    .put("DEVELOPER_DIR", "/path/to/developer/dir")
+                    .put("XCTOOL_TEST_ENV_TEST_LOG_PATH", "/path/to/test-logs")
+                    .put("XCTOOL_TEST_ENV_TEST_LOG_LEVEL", "verbose")
+                    .put("XCTOOL_TEST_ENV_FB_REFERENCE_IMAGE_DIR", "/path/to/snapshotimages")
+                    .put("XCTOOL_TEST_ENV_IMAGE_DIFF_DIR", "/path/to/snapshotfailurediffs")
+                    .put("LLVM_PROFILE_FILE", "/tmp/some.profraw")
+                    .build())
             .setDirectory(projectFilesystem.getRootPath().toAbsolutePath())
             .setRedirectOutput(ProcessBuilder.Redirect.PIPE)
             .build();


### PR DESCRIPTION
This adds `snapshot_images_diff_path` as an argument to `apple_test`. It is meant to be a complement of `snapshot_reference_images_path` so we can get snapshot failure diffs by sending `IMAGE_DIFF_DIR` to xctool.