### PR TITLE
Fix typo in fetch command docs

### DIFF
--- a/docs/command/fetch.soy
+++ b/docs/command/fetch.soy
@@ -31,7 +31,7 @@
 {param overview}
 <p>
   A command that fetches one or more resources defined by {call buck.remote_file /} rules. This
-  should generally by run before {call buck.cmd_build /} if {call buck.remote_file /} rules are used
+  should generally be run before {call buck.cmd_build /} if {call buck.remote_file /} rules are used
   in the repository. You must specify one or more {call buck.build_target /}s on the command line.
 </p>
 <p>


### PR DESCRIPTION
This PR fixes a small typo in the docs for the `buck fetch` command.