### PR TITLE
[CI] Add haddock to linux builds in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,7 @@ matrix:
           # base ghc package does not include dynamic libraries
           # https://stackoverflow.com/a/11711501/1548477
           - ghc-dynamic
+          - ghc-haddock
     env: CI_ACTION=integration GROOVY_HOME=/usr/share/groovy/
     # ANDROID_SDK is required for build.
     android:
@@ -118,6 +119,7 @@ matrix:
           # base ghc package does not include dynamic libraries
           # https://stackoverflow.com/a/11711501/1548477
           - ghc-dynamic
+          - ghc-haddock
     # https://docs.travis-ci.com/user/caching#Things-not-to-cache
     # https://docs.travis-ci.com/user/caching#Explicitly-disabling-caching
     cache:


### PR DESCRIPTION
In f8ef6ce29f62e1fec5a949ce5030099cd66a8f0f it looks like things were
refactored such that we're more eagerly instantiating the whole
toolchain (build 10842 failed when this landed).
Make sure that we have haddock installed and that haskell integration
tests pass again

Test Plan: Tested installing ghc-haddock in trusty locally, will wait
for travis builds to confirm passing