### PR TITLE
Update .travis.yml to remove Travis Bot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -296,8 +296,6 @@ notifications:
   slack:
     rooms:
       secure: SYKQV9DT55kHf5Mpe6g5a3NmGXJb5E7kWiLulRp+EmKDIhf3lVmxGbx4Yr/TKZixbNILsPzhhiB56V0H+0mAgMpygVXaq4M9eSHKLljJEmEdeLKmQaRuOUikMOkpLsHw/epvmqrsvlb3yVpsJZZhhHmi9B0oQc0AnjpL/qLBaZE=
-  # Send Travis CI notifications to internal sytems like Phabricator.
-  webhooks: https://code.facebook.com/travis/webhook/
 
 script:
   - ./scripts/travisci_run.sh


### PR DESCRIPTION
Remove Travis Bot webhook. We have a replacement feature that automatically assigns Tasks to the internal commit author or oncall for every CI failure there is on Github master branch. buck: T52981441