### PR TITLE
Allow 'Apple Development' code sign identities for iOS signing

### DIFF
--- a/src/com/facebook/buck/apple/toolchain/impl/CodeSignIdentityStoreFactory.java
+++ b/src/com/facebook/buck/apple/toolchain/impl/CodeSignIdentityStoreFactory.java
@@ -43,7 +43,7 @@ public class CodeSignIdentityStoreFactory implements ToolchainFactory<CodeSignId
 
   // Parse the fingerprint and name, but don't match invalid certificates (revoked, expired, etc).
   private static final Pattern CODE_SIGN_IDENTITY_PATTERN =
-      Pattern.compile("([A-F0-9]{40}) \"(iPhone.*)\"(?!.*\\(CSSMERR_.*\\))");
+      Pattern.compile("([A-F0-9]{40}) \"(iPhone.*|Apple Development.*)\"(?!.*\\(CSSMERR_.*\\))");
 
   /**
    * Construct a store by asking the system keychain for all stored code sign identities.

--- a/test/com/facebook/buck/apple/toolchain/impl/CodeSignIdentityStoreFactoryTest.java
+++ b/test/com/facebook/buck/apple/toolchain/impl/CodeSignIdentityStoreFactoryTest.java
@@ -50,19 +50,33 @@ public class CodeSignIdentityStoreFactoryTest {
                 + "\"iPhone Developer: Foo Bar (12345ABCDE)\" (CSSMERR_TP_CERT_EXPIRED)\n"
                 + "  3) BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB "
                 + "\"iPhone Developer: Foo Bar (54321EDCBA)\"\n"
-                + "     3 valid identities found\n",
+                + "  4) CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC "
+                + "\"Apple Development: Fizz Buzz (12345AAAAA)\"\n"
+                + "  5) DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD "
+                + "\"Apple Development: Fizz Buzz (AAAAA12345)\" (CSSMERR_TP_CERT_REVOKED)\n"
+                + "  6) FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF "
+                + "\"Apple Development: Fizz Buzz (54321BBBBB)\" (CSSMERR_TP_CERT_EXPIRED)\n"
+                + "     6 valid identities found\n",
             "");
+
     FakeProcessExecutor processExecutor =
         new FakeProcessExecutor(ImmutableMap.of(processExecutorParams, process));
     CodeSignIdentityStore store =
         CodeSignIdentityStoreFactory.fromSystem(processExecutor, ImmutableList.of("unused"));
+
     ImmutableList<CodeSignIdentity> expected =
         ImmutableList.of(
             CodeSignIdentity.builder()
                 .setFingerprint(
                     CodeSignIdentity.toFingerprint("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"))
                 .setSubjectCommonName("iPhone Developer: Foo Bar (54321EDCBA)")
+                .build(),
+            CodeSignIdentity.builder()
+                .setFingerprint(
+                    CodeSignIdentity.toFingerprint("CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"))
+                .setSubjectCommonName("Apple Development: Fizz Buzz (12345AAAAA)")
                 .build());
+
     assertThat(store.getIdentitiesSupplier().get(), equalTo(expected));
   }
 


### PR DESCRIPTION
Summary:
When buck searches for code signing identities it fails to process
Apple Development certificates new to Xcode 11, which can sign
both iOS and Mac binaries.