### PR TITLE
SwiftCompile: utilize relative instead of absolute path for shorter swiftc argument character count

### DIFF
--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -208,7 +208,7 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
             getBuildDeps().stream()
                 .filter(SwiftCompile.class::isInstance)
                 .map(BuildRule::getSourcePathToOutput)
-                .map(input -> resolver.getAbsolutePath(input).toString())
+                .map(input -> resolver.getRelativePath(input).toString())
                 .collect(ImmutableSet.toImmutableSet())));
 
     boolean hasMainEntry =


### PR DESCRIPTION
This PR shortens the paths used in Swift build commands, which is more helpful than it sounds.

Late last week, Airbnb found that some of our `swiftc` build commands were failing with the following exception:

> java.io.IOException: Cannot run program "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc" (in directory "/usr/local/var/buildkite-agent/builds/apps"): error=7, Argument list too long

This was happening because our `swiftc` commands were longer than [ARG_MAX](https://www.in-ulm.de/~mascheck/various/argmax/). The primary cause of our `swiftc` commands being so long is that we had more than 440 modules in our application target.

The argument list included many full paths to our modules, over and over again. This PR resulted in the generated `swiftc` command using approximately nineteen thousand fewer characters, which enables us to write ~20 more modules before we end up with a compiler command that is too long again. For context, the total character limit is 262144 on the machines we use.

We're working on a longer-term fix, but it seemed reasonable to push this fix back up to Facebook's repo as well.

A quick note to the reviewer: [other code](https://github.com/airbnb/buck/blob/4bd4842e77818b331be29ae7235db83d299f428b/src/com/facebook/buck/swift/SwiftCompile.java#L393) in this file is already using relative paths, so this PR helps standardize on using relative paths – we aren't introducing a new concept.