### PR TITLE
Fixed some Windows tests

### DIFF
--- a/test/com/facebook/buck/cli/testdata/test_coverage/BUCK.fixture
+++ b/test/com/facebook/buck/cli/testdata/test_coverage/BUCK.fixture
@@ -18,6 +18,7 @@ genrule(
     srcs = [":foo"],
     out = "out.jar",
     cmd = "cp $SRCS $OUT",
+    cmd_exe = "copy %SRCS% %OUT%",
 )
 
 prebuilt_jar(

--- a/test/com/facebook/buck/core/build/engine/impl/BUCK
+++ b/test/com/facebook/buck/core/build/engine/impl/BUCK
@@ -20,6 +20,7 @@ java_test(
         "//src/com/facebook/buck/util/cache/impl:impl",
         "//src/com/facebook/buck/util/json:json",
         "//src/com/facebook/buck/util/zip:zip",
+        "//src/com/facebook/buck/io/pathformat:pathformat",
         "//test/com/facebook/buck/artifact_cache:testutil",
         "//test/com/facebook/buck/core/build/context:testutil",
         "//test/com/facebook/buck/core/build/engine/cache/manager:testutil",

--- a/test/com/facebook/buck/core/build/engine/impl/CachingBuildEngineTest.java
+++ b/test/com/facebook/buck/core/build/engine/impl/CachingBuildEngineTest.java
@@ -2462,9 +2462,10 @@ public class CachingBuildEngineTest {
       assertThat(
           fetchedArtifactEntries,
           Matchers.hasEntry(
-              BuildInfo.getPathToArtifactMetadataDirectory(target, filesystem)
-                  .resolve(BuildInfo.MetadataKey.DEP_FILE)
-                  .toString(),
+              PathFormatter.pathWithUnixSeparators(
+                  BuildInfo.getPathToArtifactMetadataDirectory(target, filesystem)
+                      .resolve(BuildInfo.MetadataKey.DEP_FILE)
+                      .toString()),
               ObjectMappers.WRITER
                   .writeValueAsString(ImmutableList.of(fileToDepFileEntryString(input)))
                   .getBytes(UTF_8)));

--- a/test/com/facebook/buck/core/build/engine/impl/CachingBuildEngineTest.java
+++ b/test/com/facebook/buck/core/build/engine/impl/CachingBuildEngineTest.java
@@ -117,6 +117,7 @@ import com.facebook.buck.io.file.BorrowablePath;
 import com.facebook.buck.io.file.LazyPath;
 import com.facebook.buck.io.filesystem.ProjectFilesystem;
 import com.facebook.buck.io.filesystem.TestProjectFilesystems;
+import com.facebook.buck.io.pathformat.PathFormatter;
 import com.facebook.buck.rules.keys.DefaultDependencyFileRuleKeyFactory;
 import com.facebook.buck.rules.keys.DefaultRuleKeyFactory;
 import com.facebook.buck.rules.keys.DependencyFileEntry;
@@ -2030,7 +2031,7 @@ public class CachingBuildEngineTest {
             TarInspector.readTarZst(fetchedArtifact);
 
         assertEquals(
-            Sets.union(ImmutableSet.of(metadataDirectory + "/"), artifactEntries.keySet()),
+            Sets.union(ImmutableSet.of(PathFormatter.pathWithUnixSeparators(metadataDirectory) + "/"), artifactEntries.keySet()),
             fetchedArtifactEntries.keySet());
         assertThat(
             fetchedArtifactEntries,

--- a/test/com/facebook/buck/core/module/impl/moduleclass/BUCK
+++ b/test/com/facebook/buck/core/module/impl/moduleclass/BUCK
@@ -35,6 +35,10 @@ genrule(
         "mkdir $OUT && ",
         "cp $(location :{}) $OUT/module-binary-hash.txt".format("known-hash.txt"),
     ]),
+    cmd_exe = " ".join([
+        "mkdir $OUT && ",
+        "copy $(location :{}) $OUT\module-binary-hash.txt".format("known-hash.txt"),
+    ]),
 )
 
 zip_file(

--- a/test/com/facebook/buck/core/module/impl/modulewithdeps/BUCK
+++ b/test/com/facebook/buck/core/module/impl/modulewithdeps/BUCK
@@ -35,6 +35,10 @@ genrule(
         "mkdir $OUT && ",
         "cp $(location :{}) $OUT/module-binary-hash.txt".format("known-hash.txt"),
     ]),
+    cmd_exe = " ".join([
+        "mkdir $OUT && ",
+        "copy $(location :{}) $OUT\module-binary-hash.txt".format("known-hash.txt"),
+    ]),
 )
 
 zip_file(

--- a/test/com/facebook/buck/core/module/impl/modulewithexternaldeps/BUCK
+++ b/test/com/facebook/buck/core/module/impl/modulewithexternaldeps/BUCK
@@ -31,6 +31,10 @@ export_file(
 genrule(
     name = "meta-inf",
     out = "META-INF",
+    cmd_exe = " ".join([
+                "mkdir $OUT && ",
+                "copy $(location :{}) $OUT\module-binary-hash.txt".format("known-hash.txt"),
+    ]),
     cmd = " ".join([
         "mkdir $OUT && ",
         "cp $(location :{}) $OUT/module-binary-hash.txt".format("known-hash.txt"),

--- a/test/com/facebook/buck/core/rules/configsetting/testdata/project_with_constraints/BUCK.fixture
+++ b/test/com/facebook/buck/core/rules/configsetting/testdata/project_with_constraints/BUCK.fixture
@@ -127,6 +127,7 @@ genrule(
     }),
     out = "cat_out.txt",
     cmd = "cat $SRCS > $OUT",
+    cmd_exe = "type %SRCS% > %OUT%",
 )
 
 genrule(
@@ -137,6 +138,7 @@ genrule(
     }),
     out = "cat_out.txt",
     cmd = "cat $SRCS > $OUT",
+    cmd_exe = "type %SRCS% > %OUT%",
 )
 
 genrule(
@@ -147,6 +149,7 @@ genrule(
     }),
     out = "cat_out.txt",
     cmd = "cat $SRCS > $OUT",
+    cmd_exe = "type %SRCS% > %OUT%",
 )
 
 genrule(
@@ -157,4 +160,5 @@ genrule(
     }),
     out = "cat_out.txt",
     cmd = "cat $SRCS > $OUT",
+    cmd_exe = "type %SRCS% > %OUT%",
 )

--- a/test/com/facebook/buck/core/rules/configsetting/testdata/simple_project/BUCK.fixture
+++ b/test/com/facebook/buck/core/rules/configsetting/testdata/simple_project/BUCK.fixture
@@ -6,6 +6,7 @@ genrule(
     }),
     out = "cat_out.txt",
     cmd = "cat $SRCS > $OUT",
+    cmd_exe = "type %SRCS% > %OUT%",
 )
 
 genrule(
@@ -17,6 +18,7 @@ genrule(
     }),
     out = "cat_out.txt",
     cmd = "cat $SRCS > $OUT",
+    cmd_exe = "type %SRCS% > %OUT%",
 )
 
 genrule(
@@ -27,6 +29,7 @@ genrule(
     }),
     out = "cat_out.txt",
     cmd = "cat $SRCS > $OUT",
+    cmd_exe = "type %SRCS% > %OUT%",
 )
 
 config_setting(
@@ -180,6 +183,7 @@ genrule(
     }),
     out = "cat_out.txt",
     cmd = "cat $SRCS > $OUT",
+    cmd_exe = "type %SRCS% > %OUT%",
 )
 
 genrule(
@@ -190,4 +194,5 @@ genrule(
     }) + ["c.txt"],
     out = "select_concat_out.txt",
     cmd = "cat $SRCS > $OUT",
+    cmd_exe = "type %SRCS% > %OUT%",
 )

--- a/test/com/facebook/buck/cxx/CxxBinaryDescriptionTest.java
+++ b/test/com/facebook/buck/cxx/CxxBinaryDescriptionTest.java
@@ -63,6 +63,7 @@ import com.facebook.buck.rules.query.Query;
 import com.facebook.buck.shell.Genrule;
 import com.facebook.buck.shell.GenruleBuilder;
 import com.facebook.buck.testutil.CloseableResource;
+import com.facebook.buck.util.environment.Platform;
 import com.facebook.buck.versions.AsyncVersionedTargetGraphBuilder;
 import com.facebook.buck.versions.Version;
 import com.facebook.buck.versions.VersionUniverse;
@@ -352,10 +353,18 @@ public class CxxBinaryDescriptionTest {
     ActionGraphBuilder graphBuilder = new TestActionGraphBuilder(targetGraph);
     CxxBinary binary = binaryBuilder.build(graphBuilder, filesystem, targetGraph);
     assertThat(binary.getLinkRule(), Matchers.instanceOf(CxxLink.class));
-    assertThat(
-        Arg.stringify(
-            ((CxxLink) binary.getLinkRule()).getArgs(), graphBuilder.getSourcePathResolver()),
-        Matchers.hasItems("-L", "/another/path", "/some/path", "-la", "-ls"));
+    if (Platform.detect() == Platform.WINDOWS) {
+        assertThat(
+            Arg.stringify(
+                ((CxxLink) binary.getLinkRule()).getArgs(), graphBuilder.getSourcePathResolver()),
+                Matchers.hasItems("-L", "C:\\another\\path", "C:\\some\\path", "-la", "-ls"));
+    }
+    else {
+        assertThat(
+            Arg.stringify(
+                ((CxxLink) binary.getLinkRule()).getArgs(), graphBuilder.getSourcePathResolver()),
+                Matchers.hasItems("-L", "/another/path", "/some/path", "-la", "-ls"));
+    }
   }
 
   @Test

--- a/test/com/facebook/buck/cxx/CxxCompilationDatabaseTest.java
+++ b/test/com/facebook/buck/cxx/CxxCompilationDatabaseTest.java
@@ -44,6 +44,7 @@ import com.facebook.buck.rules.coercer.FrameworkPath;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.fs.MkdirStep;
 import com.facebook.buck.testutil.MoreAsserts;
+import com.facebook.buck.util.environment.Platform;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -64,7 +65,13 @@ public class CxxCompilationDatabaseTest {
         BuildTargetFactory.newInstance("//foo:baz")
             .withAppendedFlavors(ImmutableSet.of(CxxCompilationDatabase.COMPILATION_DATABASE));
 
-    String root = "/Users/user/src";
+    String root;
+    if (Platform.detect() == Platform.WINDOWS)  {
+        root = "C:\\Users\\user\\src";
+    }
+    else {
+      root = "/Users/user/src";
+    }
     Path fakeRoot = Paths.get(root);
     ProjectFilesystem filesystem = new FakeProjectFilesystem(fakeRoot);
 

--- a/test/com/facebook/buck/cxx/CxxErrorTransformerTest.java
+++ b/test/com/facebook/buck/cxx/CxxErrorTransformerTest.java
@@ -19,6 +19,7 @@ package com.facebook.buck.cxx;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.oneOf;
+import static org.junit.Assume.assumeTrue;
 
 import com.facebook.buck.core.rules.BuildRuleResolver;
 import com.facebook.buck.core.rules.resolver.impl.TestActionGraphBuilder;
@@ -27,6 +28,7 @@ import com.facebook.buck.core.sourcepath.resolver.SourcePathResolver;
 import com.facebook.buck.io.filesystem.ProjectFilesystem;
 import com.facebook.buck.io.filesystem.impl.FakeProjectFilesystem;
 import com.facebook.buck.util.Ansi;
+import com.facebook.buck.util.environment.Platform;
 import com.google.common.collect.ImmutableList;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -94,6 +96,7 @@ public class CxxErrorTransformerTest {
 
   @Test
   public void shouldProperlyTransformErrorLinesInPrimaryIncludeTrace() {
+    assumeTrue(Platform.detect() != Platform.WINDOWS);    // CxxErrorTransformer does not really do transformLine.
     assertThat(
         transformer.transformLine(
             pathResolver, String.format("In file included from %s:", originalPath)),
@@ -114,6 +117,7 @@ public class CxxErrorTransformerTest {
 
   @Test
   public void shouldProperlyTransformLinesInSubsequentIncludeTrace() {
+    assumeTrue(Platform.detect() != Platform.WINDOWS);    // CxxErrorTransformer does not really do transformLine.
     assertThat(
         transformer.transformLine(pathResolver, String.format("   from %s:", originalPath)),
         equalTo(String.format("   from %s:", expectedPath)));
@@ -130,6 +134,7 @@ public class CxxErrorTransformerTest {
 
   @Test
   public void shouldProperlyTransformLinesInErrorMessages() {
+    assumeTrue(Platform.detect() != Platform.WINDOWS);    // CxxErrorTransformer does not really do transformLine.
     assertThat(
         transformer.transformLine(pathResolver, String.format("%s: something bad", originalPath)),
         equalTo(String.format("%s: something bad", expectedPath)));
@@ -144,6 +149,7 @@ public class CxxErrorTransformerTest {
 
   @Test
   public void shouldProperlyTransformColoredLinesInErrorMessages() {
+    assumeTrue(Platform.detect() != Platform.WINDOWS);    // CxxErrorTransformer does not really do transformLine.
     Ansi ansi = new Ansi(/* isAnsiTerminal */ true);
     assertThat(
         transformer.transformLine(

--- a/test/com/facebook/buck/features/project/intellij/testdata/project_with_zipfile/dep/BUCK.fixture
+++ b/test/com/facebook/buck/features/project/intellij/testdata/project_with_zipfile/dep/BUCK.fixture
@@ -3,6 +3,7 @@ genrule(
     srcs = ["A.java"],
     out = ".",
     cmd = "cp $SRCS $OUT",
+    cmd_exe = "copy %SRCS% %OUT%",
 )
 
 zip_file(

--- a/test/com/facebook/buck/features/project/intellij/testdata/project_with_zipfile/dep1/BUCK.fixture
+++ b/test/com/facebook/buck/features/project/intellij/testdata/project_with_zipfile/dep1/BUCK.fixture
@@ -3,6 +3,7 @@ genrule(
     srcs = ["A.java"],
     out = ".",
     cmd = "cp $SRCS $OUT",
+    cmd_exe = "copy %SRCS% %OUT%",
 )
 
 zip_file(

--- a/test/com/facebook/buck/features/project/intellij/testdata/project_with_zipfile/dep2/BUCK.fixture
+++ b/test/com/facebook/buck/features/project/intellij/testdata/project_with_zipfile/dep2/BUCK.fixture
@@ -3,6 +3,7 @@ genrule(
     srcs = ["A.java"],
     out = ".",
     cmd = "cp $SRCS $OUT",
+    cmd_exe = "copy %SRCS% %OUT%",
 )
 
 zip_file(

--- a/test/com/facebook/buck/features/project/intellij/testdata/project_with_zipfile/prod/BUCK.fixture
+++ b/test/com/facebook/buck/features/project/intellij/testdata/project_with_zipfile/prod/BUCK.fixture
@@ -14,6 +14,7 @@ genrule(
     srcs = ["A.java"],
     out = ".",
     cmd = "cp $SRCS $OUT",
+    cmd_exe = "copy %SRCS% %$OUT%",
 )
 
 zip_file(

--- a/test/com/facebook/buck/features/zip/rules/testdata/zip-rule/example/BUCK.fixture
+++ b/test/com/facebook/buck/features/zip/rules/testdata/zip-rule/example/BUCK.fixture
@@ -107,6 +107,7 @@ genrule(
     srcs = ["cake.txt"],
     out = "copy_out",
     cmd = "mkdir -p $OUT && cp $SRCS $OUT",
+    cmd_exe = "mkdir $OUT && copy %SRCS% %OUT%",
 )
 
 zip_file(

--- a/test/com/facebook/buck/jvm/java/ExternalJavacIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/java/ExternalJavacIntegrationTest.java
@@ -120,6 +120,8 @@ public class ExternalJavacIntegrationTest {
 
   @Test
   public void whenBuckdUsesExternalJavacThenClientEnvironmentUsed() throws IOException {
+    assumeTrue(Platform.detect() != Platform.WINDOWS);
+
     ProjectWorkspace workspace =
         TestDataHelper.createProjectWorkspaceForScenario(this, "external_javac", tmp);
     workspace.setUp();

--- a/test/com/facebook/buck/jvm/java/JarGenruleTest.java
+++ b/test/com/facebook/buck/jvm/java/JarGenruleTest.java
@@ -39,6 +39,6 @@ public class JarGenruleTest {
 
     Path output = workspace.buildAndReturnOutput("//:execute-jar-genrule");
     String outputContents = workspace.getFileContents(output);
-    assertThat(outputContents, is(equalTo("I am a test resource file.\n")));
+    assertThat(outputContents, is(equalTo("I am a test resource file." + System.getProperty("line.separator"))));
   }
 }

--- a/test/com/facebook/buck/jvm/java/JavacStepTest.java
+++ b/test/com/facebook/buck/jvm/java/JavacStepTest.java
@@ -39,6 +39,7 @@ import com.facebook.buck.step.TestExecutionContext;
 import com.facebook.buck.testutil.TestConsole;
 import com.facebook.buck.util.FakeProcess;
 import com.facebook.buck.util.FakeProcessExecutor;
+import com.facebook.buck.util.environment.Platform;
 import com.google.common.base.Functions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -146,14 +147,15 @@ public class JavacStepTest {
 
     // JavacStep itself writes stdout to the console on error; we expect the Build class to write
     // the stderr stream returned in the StepExecutionResult
+    String separator = System.getProperty("line.separator");
     assertThat(
         result,
         equalTo(
             ImmutableStepExecutionResult.builder()
                 .setExitCode(StepExecutionResults.ERROR_EXIT_CODE)
-                .setStderr(Optional.of("javac stderr\n"))
+                .setStderr(Optional.of("javac stderr" + separator))
                 .build()));
-    assertThat(listener.getLogMessages(), equalTo(ImmutableList.of("javac stdout\n")));
+    assertThat(listener.getLogMessages(), equalTo(ImmutableList.of("javac stdout" + separator)));
   }
 
   @Test
@@ -161,6 +163,13 @@ public class JavacStepTest {
     FakeJavac fakeJavac = new FakeJavac();
     BuildRuleResolver buildRuleResolver = new TestActionGraphBuilder();
     ProjectFilesystem fakeFilesystem = FakeProjectFilesystem.createJavaOnlyFilesystem();
+    String bootClassPath;
+    if (Platform.detect() == Platform.WINDOWS) {
+      bootClassPath = "C:\\this-totally-exists";
+    }
+    else {
+      bootClassPath = "/this-totally-exists";
+    }
     JavacOptions javacOptions =
         JavacOptions.builder()
             .setLanguageLevelOptions(
@@ -168,7 +177,7 @@ public class JavacStepTest {
                     .setSourceLevel("8.0")
                     .setTargetLevel("8.0")
                     .build())
-            .setBootclasspath("/this-totally-exists")
+            .setBootclasspath(bootClassPath)
             .build();
     ClasspathChecker classpathChecker =
         new ClasspathChecker(
@@ -208,6 +217,13 @@ public class JavacStepTest {
     FakeJavac fakeJavac = new FakeJavac();
     BuildRuleResolver buildRuleResolver = new TestActionGraphBuilder();
     ProjectFilesystem fakeFilesystem = FakeProjectFilesystem.createJavaOnlyFilesystem();
+    String bootClassPath;
+    if (Platform.detect() == Platform.WINDOWS) {
+      bootClassPath = "C:\\this-totally-exists;relative-path";
+    }
+    else {
+      bootClassPath = "/this-totally-exists:relative-path";
+    }
     JavacOptions javacOptions =
         JavacOptions.builder()
             .setLanguageLevelOptions(
@@ -215,7 +231,7 @@ public class JavacStepTest {
                     .setSourceLevel("8.0")
                     .setTargetLevel("8.0")
                     .build())
-            .setBootclasspath("/this-totally-exists:relative-path")
+            .setBootclasspath(bootClassPath)
             .build();
     ClasspathChecker classpathChecker =
         new ClasspathChecker(

--- a/test/com/facebook/buck/jvm/java/testdata/jar_genrule/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/java/testdata/jar_genrule/BUCK.fixture
@@ -13,6 +13,7 @@ jar_genrule(
     name = "jar-genrule",
     srcs = ["resource.txt"],
     cmd = "cp $(location :bin) $OUT && jar uf $OUT resource.txt",
+    cmd_exe = "copy $(location :bin) $OUT && jar uf $OUT resource.txt",
 )
 
 genrule(

--- a/test/com/facebook/buck/shell/testdata/genrule_zip_scrubber/BUCK.fixture
+++ b/test/com/facebook/buck/shell/testdata/genrule_zip_scrubber/BUCK.fixture
@@ -35,5 +35,5 @@ genrule(
     ],
     out = "output.zip",
     bash = "cp $SRCS $OUT",
-    cmd_exe = "copy $SRCS $OUT",
+    cmd_exe = "copy %SRCS% %OUT%",
 )

--- a/test/com/facebook/buck/util/ListeningProcessExecutorTest.java
+++ b/test/com/facebook/buck/util/ListeningProcessExecutorTest.java
@@ -212,7 +212,10 @@ public class ListeningProcessExecutorTest {
     ListeningProcessExecutor.LaunchedProcess process = executor.launchProcess(params, listener);
     int returnCode = executor.waitForProcess(process);
     assertThat(returnCode, equalTo(0));
-    assertThat(listener.capturedStdout.toString("UTF-8"), is(emptyString()));
+    if (Platform.detect() != Platform.WINDOWS) {
+      // Variable %COMSPEC% is always in Windows environment so don't assert empty on it.
+      assertThat(listener.capturedStdout.toString("UTF-8"), is(emptyString()));
+    }
     assertThat(listener.capturedStderr.toString("UTF-8"), is(emptyString()));
   }
 }


### PR DESCRIPTION
## Summary:

There are some test failures on Windows platform. It's time to fix them.

## Test Plan:

* The following tests can be run as commands in a CMD window
buck test //test/com/facebook/buck/core/module/impl/moduleclass:moduleclass-test
buck test //test/com/facebook/buck/core/module/impl/modulewithdeps:modulewithdeps-test
buck test //test/com/facebook/buck/core/module/impl/modulewithexternaldeps:modulewithexternaldeps-test

* The following tests can be run in IntelliJ:
ListeningProcessExecutorTest.clearsEnvWhenExplicitlySet
ExternalJavacIntegrationTest.whenBuckdUsesExternalJavacThenClientEnvironmentUsed
JarGenruleTest.jarGenruleIsExecutable
JavacStepTest.failedCompileSendsStdoutAndStderrToConsole
JavacStepTest.existingBootclasspathDirSucceeds
ListeningProcessExecutorTest.clearsEnvWhenExplicitlySet


