### PR TITLE
Fix inefficient traversals in Java's getRuntimeDeps

### DIFF
--- a/src/com/facebook/buck/jvm/java/JavaBinary.java
+++ b/src/com/facebook/buck/jvm/java/JavaBinary.java
@@ -242,14 +242,7 @@ public class JavaBinary extends AbstractBuildRuleWithDeclaredAndExtraDeps
 
   @Override
   public Stream<BuildTarget> getRuntimeDeps(BuildRuleResolver buildRuleResolver) {
-    Stream<BuildTarget> transitiveRuntimeDeps = Stream.of();
-    for (JavaLibrary lib : getTransitiveClasspathDeps()) {
-      // Skip ourself to avoid infinite recursion.
-      if (lib == this) continue;
-
-      transitiveRuntimeDeps =
-          Stream.concat(transitiveRuntimeDeps, lib.getRuntimeDeps(buildRuleResolver));
-    }
-    return transitiveRuntimeDeps;
+    return getTransitiveClasspathDeps().stream()
+        .flatMap(lib -> lib.getRuntimeDeps(buildRuleResolver));
   }
 }

--- a/src/com/facebook/buck/jvm/java/PrebuiltJar.java
+++ b/src/com/facebook/buck/jvm/java/PrebuiltJar.java
@@ -275,15 +275,7 @@ public class PrebuiltJar extends AbstractBuildRuleWithDeclaredAndExtraDeps
 
   @Override
   public Stream<BuildTarget> getRuntimeDeps(BuildRuleResolver buildRuleResolver) {
-    Stream<BuildTarget> transitiveRuntimeDeps = Stream.of();
-    for (JavaLibrary lib : getTransitiveClasspathDeps()) {
-      // Skip ourself to avoid infinite recursion.
-      if (lib == this) continue;
-
-      transitiveRuntimeDeps =
-          Stream.concat(transitiveRuntimeDeps, lib.getRuntimeDeps(buildRuleResolver));
-    }
-    return transitiveRuntimeDeps;
+    return Stream.of();
   }
 
   @Override


### PR DESCRIPTION
 - `PrebuiltJar` attempted to transitively fetch runtime deps. This means that if you had a chain of prebuilt jars depending on each other, e.g. [binary] -> A -> B -> C -> D, we would attempt to traverse the runtime deps of A 1x, B 2x, C 3x and D 4x. This is unncessary as `JavaBinary` does the transitive traversal itself, so just stop doing it.
 - `JavaBinary` was resolving transitive runtime deps via `concat(A, concat(B, concat(C, ...)))`. This is extremely inefficient since `concat` adds another stack frame for every call which can result in `StackOverflowException`. Use `flatMap` instead.