### PR TITLE
Improve jar/zip creation performance

### DIFF
--- a/src/com/facebook/buck/util/zip/ZipOutputStreams.java
+++ b/src/com/facebook/buck/util/zip/ZipOutputStreams.java
@@ -27,6 +27,9 @@ import java.nio.file.Path;
 
 public class ZipOutputStreams {
 
+  /** The size of the BufferedOutputStream used to wrap the underlying file. */
+  private static final int FILE_BUFFER_SIZE = 512 * 1024;
+
   private ZipOutputStreams() {
     // factory class
   }
@@ -39,7 +42,8 @@ public class ZipOutputStreams {
    * @param zipFile The file to write to.
    */
   public static CustomZipOutputStream newOutputStream(Path zipFile) throws IOException {
-    return newOutputStream(new BufferedOutputStream(Files.newOutputStream(zipFile)));
+    return newOutputStream(
+        new BufferedOutputStream(Files.newOutputStream(zipFile), FILE_BUFFER_SIZE));
   }
 
   /**
@@ -67,13 +71,15 @@ public class ZipOutputStreams {
   public static CustomZipOutputStream newOutputStream(Path zipFile, HandleDuplicates mode)
       throws IOException {
 
-    return newOutputStream(new BufferedOutputStream(Files.newOutputStream(zipFile)), mode);
+    return newOutputStream(
+        new BufferedOutputStream(Files.newOutputStream(zipFile), FILE_BUFFER_SIZE), mode);
   }
 
   public static CustomJarOutputStream newJarOutputStream(Path jarFile, HandleDuplicates mode)
       throws IOException {
 
-    return newJarOutputStream(new BufferedOutputStream(Files.newOutputStream(jarFile)), mode);
+    return newJarOutputStream(
+        new BufferedOutputStream(Files.newOutputStream(jarFile), FILE_BUFFER_SIZE), mode);
   }
 
   /**


### PR DESCRIPTION
 - For large jar files, free the per-entry `buffer` so it can be GC'ed.
 - Get rid of some unnecessary array copies. IMO it might be nice to wrap the entire `OutputStream` passed to `EntryAccounting` in a `CountingOutputStream` and just stop returning bytes written everywhere.
 - Increase the buffer size per entry to 8k and per file to 512k. The former shouldn't hurt since only one entry is live at a time per file (due to the first change). In total you would expect just around 520k of ram usage per file. Previously this would be somewhat unbounded, but for a zip file with 50k entries (this is Buck's jar) it would keep 8kb file buffer + 50000 * 1kb entry buffers - so around 50 megs. The actual build time for Buck's main jar is about the same, but if you build several large uberjars in parallel, there's fewer OOMs.