### PR TITLE
Allow apps to depend on other apps in iOS UI tests

### DIFF
--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -1614,6 +1614,12 @@ public class ProjectGenerator {
           BuildTarget testTarget = bundleLoaderNode.get().getBuildTarget();
           extraSettingsBuilder.put("TEST_TARGET_NAME", getXcodeTargetName(testTarget));
           addPBXTargetDependency(target, testTarget);
+          for (BuildTarget depTarget : buildTargetNode.getDeclaredDeps()) {
+            Object depArg = targetGraph.get(depTarget).getConstructorArg();
+            if (depArg instanceof HasAppleBundleFields && isApp((HasAppleBundleFields) depArg)) {
+              addPBXTargetDependency(target, depTarget);
+            }
+          }
         } else {
           throw new HumanReadableException(
               "The test rule '%s' is configured with 'is_ui_test' but has no test_host_app",
@@ -4699,8 +4705,15 @@ public class ProjectGenerator {
   }
 
   private static boolean isFrameworkBundle(HasAppleBundleFields arg) {
-    return arg.getExtension().isLeft()
-        && arg.getExtension().getLeft().equals(AppleBundleExtension.FRAMEWORK);
+    return hasExtension(arg, AppleBundleExtension.FRAMEWORK);
+  }
+
+  private static boolean isApp(HasAppleBundleFields arg) {
+    return hasExtension(arg, AppleBundleExtension.APP);
+  }
+
+  private static boolean hasExtension(HasAppleBundleFields arg, AppleBundleExtension extension) {
+    return arg.getExtension().isLeft() && arg.getExtension().getLeft().equals(extension);
   }
 
   private static boolean isModularAppleLibrary(TargetNode<?> libraryNode) {


### PR DESCRIPTION
To test correct inter-op with third party applications, we often us helper "sidecar" apps in our UI tests at Dropbox. During the UI tests, they need to be built and installed together with the main app. This works well from command line, but currently fails in Xcode.

This PR enables Buck to build these additional apps and include them as a part of the XCUITest bundle both in Xcode, and in the CLI.