### PR TITLE
Allow disabling of the Xcode Modern Build System via .buckconfig

### DIFF
--- a/src/com/facebook/buck/apple/AppleConfig.java
+++ b/src/com/facebook/buck/apple/AppleConfig.java
@@ -488,6 +488,10 @@ public class AppleConfig implements ConfigView<BuckConfig> {
         .orElse(false);
   }
 
+  public boolean shouldUseModernBuildSystem() {
+    return delegate.getBooleanValue(APPLE_SECTION, "use_modern_build_system", true);
+  }
+
   @Value.Immutable
   @BuckStyleTuple
   interface AbstractApplePackageConfig {

--- a/src/com/facebook/buck/features/apple/project/WorkspaceAndProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/WorkspaceAndProjectGenerator.java
@@ -228,7 +228,10 @@ public class WorkspaceAndProjectGenerator {
 
     WorkspaceGenerator workspaceGenerator =
         new WorkspaceGenerator(
-            rootCell.getFilesystem(), combinedProject ? "project" : workspaceName, outputDirectory);
+            rootCell.getFilesystem(),
+            combinedProject ? "project" : workspaceName,
+            outputDirectory,
+            appleConfig);
 
     ImmutableMap.Builder<String, XcodeWorkspaceConfigDescriptionArg> schemeConfigsBuilder =
         ImmutableMap.builder();

--- a/src/com/facebook/buck/features/apple/project/WorkspaceGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/WorkspaceGenerator.java
@@ -16,6 +16,7 @@
 
 package com.facebook.buck.features.apple.project;
 
+import com.facebook.buck.apple.AppleConfig;
 import com.facebook.buck.core.exceptions.HumanReadableException;
 import com.facebook.buck.io.MoreProjectFilesystems;
 import com.facebook.buck.io.file.MorePaths;
@@ -53,6 +54,7 @@ class WorkspaceGenerator {
   private final ProjectFilesystem projectFilesystem;
   private final String workspaceName;
   private final Path outputDirectory;
+  private final AppleConfig appleConfig;
   private final SortedMap<String, WorkspaceNode> children;
 
   private static class WorkspaceNode {}
@@ -82,10 +84,14 @@ class WorkspaceGenerator {
   }
 
   public WorkspaceGenerator(
-      ProjectFilesystem projectFilesystem, String workspaceName, Path outputDirectory) {
+      ProjectFilesystem projectFilesystem,
+      String workspaceName,
+      Path outputDirectory,
+      AppleConfig appleConfig) {
     this.projectFilesystem = projectFilesystem;
     this.workspaceName = workspaceName;
     this.outputDirectory = outputDirectory;
+    this.appleConfig = appleConfig;
     this.children = new TreeMap<>();
   }
 
@@ -269,9 +275,15 @@ class WorkspaceGenerator {
             + "<plist version=\"1.0\">\n"
             + "<dict>\n"
             + "\t<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>\n"
-            + "\t<false/>\n"
-            + "</dict>\n"
-            + "</plist>";
+            + "\t<false/>\n";
+
+    if (!appleConfig.shouldUseModernBuildSystem()) {
+      workspaceSettings =
+          workspaceSettings + "\t<key>BuildSystemType</key>\n" + "\t<string>Original</string>\n";
+    }
+
+    workspaceSettings = workspaceSettings + "</dict>\n" + "</plist>";
+
     projectFilesystem.writeContentsToPath(workspaceSettings, workspaceSettingsPath);
     return projectWorkspaceDir;
   }

--- a/test/com/facebook/buck/features/apple/project/WorkspaceGeneratorTest.java
+++ b/test/com/facebook/buck/features/apple/project/WorkspaceGeneratorTest.java
@@ -25,7 +25,10 @@ import static org.junit.Assume.assumeTrue;
 import com.dd.plist.NSDictionary;
 import com.dd.plist.NSNumber;
 import com.dd.plist.NSObject;
+import com.dd.plist.NSString;
 import com.dd.plist.PropertyListParser;
+import com.facebook.buck.apple.AppleConfig;
+import com.facebook.buck.core.config.FakeBuckConfig;
 import com.facebook.buck.io.filesystem.ProjectFilesystem;
 import com.facebook.buck.io.filesystem.impl.FakeProjectFilesystem;
 import com.facebook.buck.util.environment.Platform;
@@ -47,6 +50,7 @@ import org.w3c.dom.Node;
 public class WorkspaceGeneratorTest {
   private SettableFakeClock clock;
   private ProjectFilesystem projectFilesystem;
+  private AppleConfig appleConfig;
   private WorkspaceGenerator generator;
 
   @Before
@@ -54,7 +58,8 @@ public class WorkspaceGeneratorTest {
     assumeTrue(Platform.detect() == Platform.MACOS || Platform.detect() == Platform.LINUX);
     clock = SettableFakeClock.DO_NOT_CARE;
     projectFilesystem = new FakeProjectFilesystem(clock);
-    generator = new WorkspaceGenerator(projectFilesystem, "ws", Paths.get("."));
+    appleConfig = FakeBuckConfig.builder().build().getView(AppleConfig.class);
+    generator = new WorkspaceGenerator(projectFilesystem, "ws", Paths.get("."), appleConfig);
   }
 
   @Test
@@ -170,7 +175,7 @@ public class WorkspaceGeneratorTest {
 
     {
       WorkspaceGenerator generator2 =
-          new WorkspaceGenerator(projectFilesystem, "ws", Paths.get("."));
+          new WorkspaceGenerator(projectFilesystem, "ws", Paths.get("."), appleConfig);
       generator2.addFilePath(Paths.get("./Project2.xcodeproj"));
       clock.setCurrentTimeMillis(64738);
       Path workspacePath2 = generator2.writeWorkspace();
@@ -193,7 +198,7 @@ public class WorkspaceGeneratorTest {
 
     {
       WorkspaceGenerator generator2 =
-          new WorkspaceGenerator(projectFilesystem, "ws", Paths.get("."));
+          new WorkspaceGenerator(projectFilesystem, "ws", Paths.get("."), appleConfig);
       generator2.addFilePath(Paths.get("./Project.xcodeproj"));
       clock.setCurrentTimeMillis(64738);
       Path workspacePath2 = generator2.writeWorkspace();
@@ -216,5 +221,28 @@ public class WorkspaceGeneratorTest {
         ((NSDictionary) object).get("IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded");
     assertThat(autocreate, instanceOf(NSNumber.class));
     assertThat(autocreate, equalTo(new NSNumber(false)));
+  }
+
+  @Test
+  public void workspaceEnabledForLegacyBuildSystem() throws Exception {
+    AppleConfig appleConfig =
+        FakeBuckConfig.builder()
+            .setSections("[apple]", "use_modern_build_system = false")
+            .build()
+            .getView(AppleConfig.class);
+
+    WorkspaceGenerator generator =
+        new WorkspaceGenerator(projectFilesystem, "ws", Paths.get("."), appleConfig);
+
+    Path workspacePath = generator.writeWorkspace();
+    Optional<String> settings =
+        projectFilesystem.readFileIfItExists(
+            workspacePath.resolve("xcshareddata/WorkspaceSettings.xcsettings"));
+    assertThat(settings.isPresent(), equalTo(true));
+    NSObject object = PropertyListParser.parse(settings.get().getBytes(Charsets.UTF_8));
+    assertThat(object, instanceOf(NSDictionary.class));
+    NSObject buildSystemType = ((NSDictionary) object).get("BuildSystemType");
+    assertThat(buildSystemType, instanceOf(NSString.class));
+    assertThat(buildSystemType, equalTo(new NSString("Original")));
   }
 }


### PR DESCRIPTION
We found that the Xcode Modern Build System (enabled by default as of Xcode 10) builds our apps significantly slower than the Legacy Build System. This PR enables the developer to select which Xcode build system to use via `.buckconfig`.