### PR TITLE
Create schemes for APP_EXTENSION subtypes

### DIFF
--- a/src/com/facebook/buck/features/apple/project/WorkspaceAndProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/WorkspaceAndProjectGenerator.java
@@ -858,9 +858,9 @@ public class WorkspaceAndProjectGenerator {
       return false;
     }
 
-    // Only create schemes for APP_EXTENSION.
+    // Only create schemes for APP_EXTENSION or its subtypes. (e.g. iMesage apps)
     ProductType productType = ProductType.of(bundleArg.getXcodeProductType().get());
-    return productType.equals(ProductTypes.APP_EXTENSION);
+    return productType.toString().startsWith(ProductTypes.APP_EXTENSION.toString());
   }
 
   /**


### PR DESCRIPTION
Buck will not auto-create schemes for app extensions that are subtypes of the `APP_EXTENSION` (`com.apple.product-type.app-extension `) type. Those are, among others, the iMessage apps. (`com.apple.product-type.app-extension.messages`)

To avoid adding all possible extension types to the `ProductTypes`, this PR modifies scheme creation to check if the product type BEGINS with the parent extension type. Open to other suggestions on how to fix this if this is deemed too hacky!