### PR TITLE
Make tests pass in Python3

### DIFF
--- a/scripts/verify-javadoc.py
+++ b/scripts/verify-javadoc.py
@@ -41,7 +41,7 @@ def main(log_file):
     """Exit with a non-zero return code if line is not in the warning whitelist."""
     errors = []
     with open(log_file) as f:
-        for line in f.xreadlines():
+        for line in f:
             line = line.rstrip()
             # If there is a warning from `javadoc`, check whether it is in the whitelist.
             if "warning" in line.lower() and line not in WARNING_WHITELIST:

--- a/scripts/verify-test-files.py
+++ b/scripts/verify-test-files.py
@@ -30,6 +30,7 @@ import subprocess
 import sys
 import tempfile
 
+
 IGNORE_PREFIXES = [
     "buck-out",
     "intellij-out",

--- a/scripts/verify-test-files.py
+++ b/scripts/verify-test-files.py
@@ -103,7 +103,7 @@ def getOwningRulesData(repo_root, test_files):
             cwd=repo_root,
         )
         # Drop anything that appears before the JSON output.
-        cmd_output = cmd_output[cmd_output.index("[") :]
+        cmd_output = cmd_output[cmd_output.index(b"[") :]
         return json.loads(cmd_output)
     except ValueError as e:
         print("Problem parsing result to json", cmd_output)

--- a/test/com/facebook/buck/cxx/testdata/linker_extra_outputs_work/ld.py
+++ b/test/com/facebook/buck/cxx/testdata/linker_extra_outputs_work/ld.py
@@ -25,10 +25,10 @@ def main():
 
     # write the output path into the output file.
     with open(ns.output, "wb") as f:
-        f.write(ns.output.encode())
+        f.write(ns.output.encode("utf-8"))
 
     with open(ns.extra_output, "wb") as f:
-        f.write(ns.extra_output.encode())
+        f.write(ns.extra_output.encode("utf-8"))
 
 
 if __name__ == "__main__":

--- a/test/com/facebook/buck/cxx/testdata/linker_extra_outputs_work/ld.py
+++ b/test/com/facebook/buck/cxx/testdata/linker_extra_outputs_work/ld.py
@@ -25,10 +25,10 @@ def main():
 
     # write the output path into the output file.
     with open(ns.output, "wb") as f:
-        f.write(ns.output)
+        f.write(ns.output.encode())
 
     with open(ns.extra_output, "wb") as f:
-        f.write(ns.extra_output)
+        f.write(ns.extra_output.encode())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
- Fixed a couple of Python scripts that failed in Travis tests.
- Cause: They are not compatible with Python3.
After the fix, the following tests should succeed in Python2 and Python3 environments.
- ant travis
- com.facebook.buck.cxx.CxxLinkIntegrationTest