### PR TITLE
Add support for downloading prebuilt python library with maven coordinate

### DIFF
--- a/src/com/facebook/buck/file/downloader/impl/MavenUrlDecoder.java
+++ b/src/com/facebook/buck/file/downloader/impl/MavenUrlDecoder.java
@@ -129,6 +129,9 @@ public class MavenUrlDecoder {
 
       case "aar":
         return ".aar";
+      
+      case "egg":
+        return ".egg";
 
       case "exe":
         return ".exe";
@@ -153,6 +156,9 @@ public class MavenUrlDecoder {
 
       case "src":
         return "-sources.jar";
+
+      case "whl":
+        return ".whl";
 
       default:
         return String.format("-%s.jar", type);

--- a/test/com/facebook/buck/file/downloader/impl/MavenUrlDecoderTest.java
+++ b/test/com/facebook/buck/file/downloader/impl/MavenUrlDecoderTest.java
@@ -147,6 +147,30 @@ public class MavenUrlDecoderTest {
 
     assertEquals(expected, seen);
   }
+  
+  @Test
+  public void parseMvnUrlWithDefaultDomainAndEggType() throws URISyntaxException {
+    URI seen =
+        MavenUrlDecoder.toHttpUrl(
+            Optional.of("http://foo.bar"), new URI("mvn:org.apache.karaf:apache-karaf:egg:3.0.8"));
+
+    URI expected =
+        new URI("http://foo.bar/org/apache/karaf/apache-karaf/3.0.8/apache-karaf-3.0.8.egg");
+
+    assertEquals(expected, seen);
+  }
+  
+  @Test
+  public void parseMvnUrlWithDefaultDomainAndWhlType() throws URISyntaxException {
+    URI seen =
+        MavenUrlDecoder.toHttpUrl(
+            Optional.of("http://foo.bar"), new URI("mvn:org.apache.karaf:apache-karaf:whl:3.0.8"));
+
+    URI expected =
+        new URI("http://foo.bar/org/apache/karaf/apache-karaf/3.0.8/apache-karaf-3.0.8.whl");
+
+    assertEquals(expected, seen);
+  }
 
   @Test
   public void parseMvnUrlWithCustomDomain() throws URISyntaxException {


### PR DESCRIPTION
Prebuilt python libs: '.whl' and '.egg' , ref https://buck.build/rule/prebuilt_python_library.html#binary_src