### PR TITLE
Update OSX Java 8 installation instructions

### DIFF
--- a/docs/setup/getting_started.soy
+++ b/docs/setup/getting_started.soy
@@ -298,10 +298,13 @@ This automatically adds buck to Chocolatey's path, and lets you run commands jus
 # Install command line tools. NOTE: If you have Xcode installed, these may
 # already be installed.
 xcode-select --install
-# Install Java - this installs the JDK 8, a superset of the JRE
-brew tap caskroom/cask
-brew tap caskroom/versions
-brew cask install java8
+# Download and Install Java SE 8 from:
++# https://www.oracle.com/technetwork/java/javase/downloads/index.html.
++# This installs the JDK 8, a superset of the JRE.
++# Alternatively, install AdoptOpenJDK 8 with Homebrew Cask:
++brew tap homebrew/cask-cask
++brew tap homebrew/cask-versions
++brew cask install homebrew/cask-versions/adoptopenjdk8
 </pre>{/literal}
 
 <span><block class="mac ios" /></span>


### PR DESCRIPTION
Java 8 cask has been removed for a while. Workarounds include downloading it from Oracle's website or using another distributor like AdoptOpenJDK.

https://github.com/facebook/buck/issues/2323
https://github.com/Homebrew/homebrew-cask-versions/issues/7253
