### PR TITLE
External Kotlin bug fix, issue 2349

### DIFF
--- a/src/com/facebook/buck/jvm/kotlin/ExternalKotlinc.java
+++ b/src/com/facebook/buck/jvm/kotlin/ExternalKotlinc.java
@@ -43,11 +43,12 @@ import java.util.function.Supplier;
 
 /** kotlinc implemented as a separate binary. */
 public class ExternalKotlinc implements Kotlinc, AddsToRuleKey {
-  @AddToRuleKey private final String kotlinCompilerVersion;
+
   private static final KotlincVersion DEFAULT_VERSION = KotlincVersion.of("unknown version");
 
   private final Path pathToKotlinc;
   private final Supplier<KotlincVersion> version;
+  @AddToRuleKey private final String kotlinCompilerVersion;
 
   public ExternalKotlinc(Path pathToKotlinc) {
     this.pathToKotlinc = pathToKotlinc;

--- a/src/com/facebook/buck/jvm/kotlin/ExternalKotlinc.java
+++ b/src/com/facebook/buck/jvm/kotlin/ExternalKotlinc.java
@@ -43,7 +43,7 @@ import java.util.function.Supplier;
 
 /** kotlinc implemented as a separate binary. */
 public class ExternalKotlinc implements Kotlinc, AddsToRuleKey {
-
+  @AddToRuleKey private final String kotlinCompilerVersion;
   private static final KotlincVersion DEFAULT_VERSION = KotlincVersion.of("unknown version");
 
   private final Path pathToKotlinc;
@@ -73,11 +73,11 @@ public class ExternalKotlinc implements Kotlinc, AddsToRuleKey {
                 return KotlincVersion.of(output);
               }
             });
+    this.kotlinCompilerVersion = getKotlinCompilerVersion();
   }
 
   /** Returns the Kotlin version, or the path if version is unknown */
-  @AddToRuleKey
-  public String getKotlinCompilerVersion() {
+  private String getKotlinCompilerVersion() {
     if (DEFAULT_VERSION.equals(getVersion())) {
       // What we really want to do here is use a VersionedTool, however, this will suffice for now.
       return getShortName();


### PR DESCRIPTION
Summary
- When buck using external kotlinc, it encounters an internal error: "AddToRuleKey can only be applied to methods of Immutables." That's because ExternalKotlinc is not Immutableand AddToRuleKey can't be applied to one of its methods.
- The fix is to apply AddToRuleKey to a private field instead.