### PR TITLE
Added timeout for ZipStepTest.handlesLargeFiles

### DIFF
--- a/test/com/facebook/buck/zip/ZipStepTest.java
+++ b/test/com/facebook/buck/zip/ZipStepTest.java
@@ -102,7 +102,7 @@ public class ZipStepTest {
     }
   }
 
-  @Test
+  @Test(timeout=600000)
   public void handlesLargeFiles() throws Exception {
     Path parent = tmp.newFolder("zipstep");
     Path out = parent.resolve("output.zip");


### PR DESCRIPTION
**Summary**
Currently buck tests have a default timeout of 3 minutes. That's not enough for some of the tests that take a long time to run on Travis CI, handlesLargeFiles is one of them.
The solution is to add a timeout to the individual tests (@Test(timeout=milliseconds)). This way the buck testrunner will give up timeout handling and let Junit to handle it for us.