### PR TITLE
Travis CI fixes

### DIFF
--- a/test/com/facebook/buck/android/AaptPackageResourcesIntegrationTest.java
+++ b/test/com/facebook/buck/android/AaptPackageResourcesIntegrationTest.java
@@ -56,13 +56,13 @@ public class AaptPackageResourcesIntegrationTest {
     filesystem = TestProjectFilesystems.createProjectFilesystem(workspace.getDestPath());
   }
 
-  @Test
+  @Test(timeout=600000)
   public void testIgnoredFileIsIgnoredByAapt() throws Exception {
     AssumeAndroidPlatform.get(workspace).assumeSdkIsAvailable();
     workspace.runBuckBuild("//apps/sample:app_deps_resource_with_ignored_file").assertSuccess();
   }
 
-  @Test
+  @Test(timeout=600000)
   public void testAaptPackageIsScrubbed() throws IOException {
     AssumeAndroidPlatform.get(workspace).assumeSdkIsAvailable();
     workspace.runBuckBuild(MAIN_BUILD_TARGET).assertSuccess();

--- a/test/com/facebook/buck/android/AndroidResourceFilterIntegrationTest.java
+++ b/test/com/facebook/buck/android/AndroidResourceFilterIntegrationTest.java
@@ -84,7 +84,7 @@ public class AndroidResourceFilterIntegrationTest {
     filesystem = TestProjectFilesystems.createProjectFilesystem(workspace.getDestPath());
   }
 
-  @Test
+  @Test(timeout=600000)
   public void testApkWithoutResourceFilter() throws IOException {
     String target = "//apps/sample:app";
     ProcessResult result = workspace.runBuckCommand("build", target);
@@ -107,7 +107,7 @@ public class AndroidResourceFilterIntegrationTest {
     }
   }
 
-  @Test
+  @Test(timeout=600000)
   public void testApkWithMdpiFilter() throws IOException {
     String target = "//apps/sample:app_mdpi";
     ProcessResult result = workspace.runBuckCommand("build", target);
@@ -130,7 +130,7 @@ public class AndroidResourceFilterIntegrationTest {
     }
   }
 
-  @Test
+  @Test(timeout=600000)
   public void testModifyingImageRebuildsResourcesFilter() throws IOException {
     String target = "//apps/sample:app_mdpi";
     ProcessResult result = workspace.runBuckBuild(target);
@@ -164,7 +164,7 @@ public class AndroidResourceFilterIntegrationTest {
     assertNotEquals(firstImageCrc, secondImageCrc);
   }
 
-  @Test
+  @Test(timeout=600000)
   public void testApkWithXhdpiAndHdpiFilter() throws IOException {
     String target = "//apps/sample:app_hdpi_xhdpi";
     ProcessResult result = workspace.runBuckCommand("build", target);
@@ -187,7 +187,7 @@ public class AndroidResourceFilterIntegrationTest {
     }
   }
 
-  @Test
+  @Test(timeout=600000)
   public void testPostFilterResourcesCmd() throws IOException {
     String target = "//apps/sample:app_post_filter_cmd";
     ProcessResult result = workspace.runBuckBuild(target);
@@ -243,12 +243,12 @@ public class AndroidResourceFilterIntegrationTest {
     assertTrue("Didn't find custom_drawables line", foundCustomDrawables);
   }
 
-  @Test
+  @Test(timeout=600000)
   public void testPostFilterResourcesAndBanDuplicates() {
     workspace.runBuckBuild("//apps/sample:app_post_filter_no_dups").assertSuccess();
   }
 
-  @Test
+  @Test(timeout=600000)
   public void testApkWithStringsAsAssets() throws IOException {
     String target = "//apps/sample:app_comp_str";
     ProcessResult result = workspace.runBuckCommand("build", target);
@@ -263,7 +263,7 @@ public class AndroidResourceFilterIntegrationTest {
     zipInspector.assertFileExists("assets/strings/fr.fbstr");
   }
 
-  @Test
+  @Test(timeout=600000)
   public void testStringArtifactsAreCached() throws IOException {
     workspace.enableDirCache();
     workspace.runBuckBuild("//apps/sample:app_comp_str").assertSuccess();
@@ -282,7 +282,7 @@ public class AndroidResourceFilterIntegrationTest {
     workspace.runBuckBuild("//apps/sample:app_comp_str").assertSuccess();
   }
 
-  @Test
+  @Test(timeout=600000)
   public void testApkWithStringsAsAssetsAndResourceFilter() throws IOException {
     String target = "//apps/sample:app_comp_str_xhdpi";
     ProcessResult result = workspace.runBuckBuild(target);
@@ -307,7 +307,7 @@ public class AndroidResourceFilterIntegrationTest {
     }
   }
 
-  @Test
+  @Test(timeout=600000)
   public void testAsset() throws IOException {
     workspace.enableDirCache();
     String target = "//apps/sample:app";
@@ -336,7 +336,7 @@ public class AndroidResourceFilterIntegrationTest {
     assertNotEquals("Rebuilt APK file must include the new asset file.", firstCrc, secondCrc);
   }
 
-  @Test
+  @Test(timeout=600000)
   public void testEnglishBuildDoesntContainFrenchStrings()
       throws IOException, InterruptedException {
     String target = "//apps/sample:app";
@@ -360,7 +360,7 @@ public class AndroidResourceFilterIntegrationTest {
     assertEquals(1, matchingLines);
   }
 
-  @Test
+  @Test(timeout=600000)
   public void testEnglishBuildDoesntContainFrenchStringsAapt2()
       throws IOException, InterruptedException {
     // TODO(dreiss): Remove this when aapt2 is everywhere.

--- a/test/com/facebook/buck/android/AndroidResourceLibraryDepIntegrationTest.java
+++ b/test/com/facebook/buck/android/AndroidResourceLibraryDepIntegrationTest.java
@@ -39,7 +39,7 @@ public class AndroidResourceLibraryDepIntegrationTest {
     workspace.setUp();
   }
 
-  @Test
+  @Test(timeout=600000)
   public void testModifyingLibraryDependencyDoesNotCauseRebuilt() throws IOException {
     AssumeAndroidPlatform.get(workspace).assumeSdkIsAvailable();
     String appTarget = "//apps/sample:app_res_lib_dep";

--- a/test/com/facebook/buck/android/MultipleBuildConfigIntegrationTest.java
+++ b/test/com/facebook/buck/android/MultipleBuildConfigIntegrationTest.java
@@ -35,7 +35,7 @@ public class MultipleBuildConfigIntegrationTest {
   @Rule public TemporaryPaths tmp = new TemporaryPaths();
 
   /** Regression test for https://github.com/facebook/buck/issues/187. */
-  @Test
+  @Test(timeout=6000000)
   public void testAndroidBinarySupportsMultipleBuildConfigs() throws IOException {
     ProjectWorkspace workspace =
         TestDataHelper.createProjectWorkspaceForScenario(this, "android_project", tmp);

--- a/test/com/facebook/buck/android/MultipleResourcePackageIntegrationTest.java
+++ b/test/com/facebook/buck/android/MultipleResourcePackageIntegrationTest.java
@@ -44,7 +44,7 @@ public class MultipleResourcePackageIntegrationTest {
     filesystem = TestProjectFilesystems.createProjectFilesystem(workspace.getDestPath());
   }
 
-  @Test
+  @Test(timeout=600000)
   public void testRDotJavaFilesPerPackage() throws IOException {
     AssumeAndroidPlatform.get(workspace).assumeSdkIsAvailable();
     workspace.runBuckBuild("//apps/sample:app_with_multiple_rdot_java_packages").assertSuccess();

--- a/test/com/facebook/buck/android/RobolectricTestRuleIntegrationTest.java
+++ b/test/com/facebook/buck/android/RobolectricTestRuleIntegrationTest.java
@@ -94,7 +94,7 @@ public class RobolectricTestRuleIntegrationTest {
     workspace.runBuckTest("//java/com/sample/lib:test_robolectric_runtime_dep").assertSuccess();
   }
 
-  @Test
+  @Test(timeout=600000)
   public void robolectricTestBuildsWithBinaryResources() throws IOException {
     workspace =
         TestDataHelper.createProjectWorkspaceForScenario(this, "android_project", tmpFolder);

--- a/test/com/facebook/buck/zip/ZipStepTest.java
+++ b/test/com/facebook/buck/zip/ZipStepTest.java
@@ -102,7 +102,7 @@ public class ZipStepTest {
     }
   }
 
-  @Test
+  @Test(timeout=600000)
   public void handlesLargeFiles() throws Exception {
     Path parent = tmp.newFolder("zipstep");
     Path out = parent.resolve("output.zip");


### PR DESCRIPTION
**Summary**
Currently buck tests have a default timeout of 3 minutes. That's not enough for some of the tests that take a long time to run on Travis CI, handlesLargeFiles is one of them.
The solution is to add a timeout to the individual tests (@test(timeout=milliseconds)). This way the buck testrunner will give up timeout handling and let Junit to handle it for us.