### PR TITLE
CircleCI Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ install_android_sdk: &install_android_sdk
     # Old version build-tools;23.0.2
     echo 'y' |sdkmanager --install "build-tools;28.0.0"
     echo 'y' |sdkmanager --install "platforms;android-23"
-    echo 'y' |sdkmanager --install "platforms;android-28"
+    echo 'y' |sdkmanager --install "platforms;android-27"
 
     # Install 32 bit libraries
     # https://stackoverflow.com/questions/36911709/cannot-run-program-aapt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,7 @@ jobs:
             cd ${BUCKROOT}
             export PATH=${ANDROIDSDK}/tools/bin:$PATH
             export ANDROID_SDK=${ANDROIDSDK}
+            export ANDROID_HOME=${ANDROIDSDK}
             set -eux
             ant travis
             ./scripts/travisci_test_java_file_format

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,13 @@ install_python: &install_python
     pyenv global 3.6.2 system
     python --version
 
+install_groovy: &install_groovy
+  name: Install Groovy
+  command: |
+    echo '' | sudo apt-add-repository ppa:groovy-dev/groovy
+    sudo apt-get update && sudo apt-get install groovy
+    groovy -version
+
 run_ant_build: &run_ant_build
   name: Run Ant Build
   command: |
@@ -44,11 +51,25 @@ run_ant_build: &run_ant_build
     export ANT_OPTS='-Xmx1000m'
     ant
 
+run_buck_build: &run_buck_build
+  name: Run Buck Build
+  command: |
+    cd ${BUCKROOT}
+    echo '-Xmx750m' > .buckjavaargs.local
+    export PATH=${ANDROIDSDK}/tools/bin:$PATH
+    export PATH="$(pyenv root)/shims:$PATH"
+    export ANDROID_SDK=${ANDROIDSDK}
+    set -eux
+    export TERM=dumb
+    ./bin/buck build buck --out ./new_buck.pex || { cat buck-out/log/buck-0.log; exit 1; }
+
 jobs:
   ci_build_openjdk8:
     environment:
       BUCKROOT: "/home/circleci/buck"
       ANDROIDSDK: "/home/circleci/android-sdk"
+      TERM: "dumb"
+      BUCK_NUM_THREADS: 3
     working_directory: "/home/circleci/buck"
     machine:
       image: ubuntu-1604:201903-01
@@ -65,21 +86,23 @@ jobs:
       - run:
           <<: *run_ant_build
       - run:
-          name: Run Buck Build
+          <<: *run_buck_build
+      - run:
+          name: Run Tests
           command: |
             cd ${BUCKROOT}
-            echo '-Xmx750m' > .buckjavaargs.local
             export PATH=${ANDROIDSDK}/tools/bin:$PATH
             export PATH="$(pyenv root)/shims:$PATH"
             export ANDROID_SDK=${ANDROIDSDK}
-            export TERM=dumb
-            ./bin/buck build buck --out ./new_buck.pex
-            export BUCK_NUM_THREADS=3
+            set -eux
             ./new_buck.pex build --num-threads=${BUCK_NUM_THREADS} src/... test/...
+
   ci_unit_groovy:
     environment:
       BUCKROOT: "/home/circleci/buck"
       ANDROIDSDK: "/home/circleci/android-sdk"
+      TERM: "dumb"
+      BUCK_NUM_THREADS: 3
     working_directory: "/home/circleci/buck"
     machine:
       image: ubuntu-1604:201903-01
@@ -89,6 +112,24 @@ jobs:
           <<: *install_openjdk8
       - run:
           <<: *install_androidsdk
+      - run:
+          <<: *install_groovy
+      - run:
+          <<: *install_golang
+      - run:
+          <<: *install_python
+      - run:
+          <<: *run_ant_build
+      - run:
+          name: Run Tests
+          command: |
+            cd ${BUCKROOT}
+            export PATH=${ANDROIDSDK}/tools/bin:$PATH
+            export PATH="$(pyenv root)/shims:$PATH"
+            export ANDROID_SDK=${ANDROIDSDK}
+            set -eux
+            ./new_buck.pex test --num-threads=${BUCK_NUM_THREADS} --all --test-selectors '!.*[Ii]ntegration.*'
+
 workflows:
   version: 2
   all_jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,6 +291,120 @@ jobs:
             ./new_buck.pex build --num-threads=$BUCK_NUM_THREADS //test/com/facebook/buck/android/...
             ./new_buck.pex test --num-threads=1 //test/com/facebook/buck/android/... --filter '.*[Ii]ntegration.*'
 
+  ci_android_ndk_16:
+    environment:
+      BUCKROOT: "/home/circleci/buck"
+      ANDROID_SDK: "/home/circleci/android-sdk"
+      TERM: "dumb"
+      BUCK_NUM_THREADS: 3
+    working_directory: "/home/circleci/buck"
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - run:
+          <<: *install_openjdk8
+      - run:
+          <<: *install_android_sdk
+      - run:
+          name: Install Android NDK 16
+          command: |
+            cd ${BUCKROOT}
+            export NDK_HOME="${HOME}/android-ndk-linux"
+            ./scripts/travisci_unzip_android_ndk.sh android-ndk-r16b
+      - run:
+          <<: *install_golang
+      - run:
+          <<: *install_python
+      - run:
+          <<: *run_ant_build
+      - run:
+          <<: *run_buck_build
+      - run:
+          name: Run Android NDK 16 Tests
+          command: |
+            export NDK_HOME="${HOME}/android-ndk-linux"
+            export ANDROID_HOME=${ANDROID_SDK}
+            set -eux
+            ./new_buck.pex build --num-threads=$BUCK_NUM_THREADS //test/com/facebook/buck/android/...
+            ./new_buck.pex test --num-threads=1 //test/com/facebook/buck/android/... --filter '.*[Ii]ntegration.*'
+
+  ci_android_ndk_16:
+    environment:
+      BUCKROOT: "/home/circleci/buck"
+      ANDROID_SDK: "/home/circleci/android-sdk"
+      TERM: "dumb"
+      BUCK_NUM_THREADS: 3
+    working_directory: "/home/circleci/buck"
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - run:
+          <<: *install_openjdk8
+      - run:
+          <<: *install_android_sdk
+      - run:
+          name: Install Android NDK 17
+          command: |
+            cd ${BUCKROOT}
+            export NDK_HOME="${HOME}/android-ndk-linux"
+            ./scripts/travisci_unzip_android_ndk.sh android-ndk-r17b
+      - run:
+          <<: *install_golang
+      - run:
+          <<: *install_python
+      - run:
+          <<: *run_ant_build
+      - run:
+          <<: *run_buck_build
+      - run:
+          name: Run Android NDK 17 Tests
+          command: |
+            export NDK_HOME="${HOME}/android-ndk-linux"
+            export ANDROID_HOME=${ANDROID_SDK}
+            set -eux
+            ./new_buck.pex build --num-threads=$BUCK_NUM_THREADS //test/com/facebook/buck/android/...
+            ./new_buck.pex test --num-threads=1 //test/com/facebook/buck/android/... --filter '.*[Ii]ntegration.*'
+
+  ci_android_ndk_16:
+    environment:
+      BUCKROOT: "/home/circleci/buck"
+      ANDROID_SDK: "/home/circleci/android-sdk"
+      TERM: "dumb"
+      BUCK_NUM_THREADS: 3
+    working_directory: "/home/circleci/buck"
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - run:
+          <<: *install_openjdk8
+      - run:
+          <<: *install_android_sdk
+      - run:
+          name: Install Android NDK 18
+          command: |
+            cd ${BUCKROOT}
+            export NDK_HOME="${HOME}/android-ndk-linux"
+            ./scripts/travisci_unzip_android_ndk.sh android-ndk-r18b
+      - run:
+          <<: *install_golang
+      - run:
+          <<: *install_python
+      - run:
+          <<: *run_ant_build
+      - run:
+          <<: *run_buck_build
+      - run:
+          name: Run Android NDK 18 Tests
+          command: |
+            export NDK_HOME="${HOME}/android-ndk-linux"
+            export ANDROID_HOME=${ANDROID_SDK}
+            set -eux
+            ./new_buck.pex build --num-threads=$BUCK_NUM_THREADS //test/com/facebook/buck/android/...
+            ./new_buck.pex test --num-threads=1 //test/com/facebook/buck/android/... --filter '.*[Ii]ntegration.*'
+
 workflows:
   version: 2
   all_jobs:
@@ -301,4 +415,7 @@ workflows:
       - ci_integration
       - ci_heavy_integration
       - ci_android_ndk_15
+      - ci_android_ndk_16
+      - ci_android_ndk_17
+      - ci_android_ndk_18
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,20 @@
 version: 2
 
 jobs:
-  ci_build:
+  ci_build_openjdk8:
     environment:
       BUCKROOT: "/home/circleci/buck"
       ANDROIDSDK: "/home/circleci/android-sdk"
     working_directory: "/home/circleci/buck"
     machine:
       image: ubuntu-1604:201903-01
-      java:
-        version: 'oraclejdk8'
     steps:
       - checkout
+      - run:
+          name: Install OpenJDK8
+          sudo apt-get update && sudo apt-get install openjdk-8-jdk
+          sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
+          java -version
       - run:
           name: Install Android SDK
           command: |
@@ -61,5 +64,5 @@ workflows:
   version: 2
   all_jobs:
     jobs:
-      - ci_build
+      - ci_build_openjdk8
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,49 @@
 version: 2
 
+install_openjdk8: &install_openjdk8
+  name: Install OpenJDK8
+  command: |
+    sudo apt-get update && sudo apt-get install openjdk-8-jdk
+    sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
+    java -version
+
+install_androidsdk: &install_androidsdk
+  name: Install Android SDK
+  command: |
+    mkdir ${ANDROIDSDK}
+    cd ${ANDROIDSDK}
+    wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip
+    unzip sdk-tools-linux-4333796.zip
+    export PATH=${ANDROIDSDK}/tools/bin:$PATH
+    echo 'y' |sdkmanager --install tools
+    echo 'y' |sdkmanager --install platform-tools
+    echo 'y' |sdkmanager --install "build-tools;23.0.2"
+    echo 'y' |sdkmanager --install "platforms;android-23"
+
+install_golang: &install_golang
+  name: Install GoLang 1.10.1
+  command: |
+    cd ~
+    wget https://storage.googleapis.com/golang/go1.10.1.linux-amd64.tar.gz
+    sudo tar -xzf go1.10.1.linux-amd64.tar.gz -C /usr/local
+    go version
+
+install_python: &install_python
+  name: Install Python 3.6.2
+  command: |
+    pyenv install -s 3.6.2
+    pyenv global 3.6.2 system
+    python --version
+
+run_ant_build: &run_ant_build
+  name: Run Ant Build
+  command: |
+    cd ${BUCKROOT}
+    set -eux
+    export TERM=dumb
+    export ANT_OPTS='-Xmx1000m'
+    ant
+
 jobs:
   ci_build_openjdk8:
     environment:
@@ -11,44 +55,15 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install OpenJDK8
-          command: |
-            sudo apt-get update && sudo apt-get install openjdk-8-jdk
-            sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
-            java -version
+          <<: *install_openjdk8
       - run:
-          name: Install Android SDK
-          command: |
-            mkdir ${ANDROIDSDK}
-            cd ${ANDROIDSDK}
-            wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip
-            unzip sdk-tools-linux-4333796.zip
-            export PATH=${ANDROIDSDK}/tools/bin:$PATH
-            echo 'y' |sdkmanager --install tools
-            echo 'y' |sdkmanager --install platform-tools
-            echo 'y' |sdkmanager --install "build-tools;23.0.2"
-            echo 'y' |sdkmanager --install "platforms;android-23"
+          <<: *install_androidsdk
       - run:
-          name: Install GoLang 1.10.1
-          command: |
-            cd ~
-            wget https://storage.googleapis.com/golang/go1.10.1.linux-amd64.tar.gz
-            sudo tar -xzf go1.10.1.linux-amd64.tar.gz -C /usr/local
-            go version
+          <<: *install_golang
       - run:
-          name: Install Python 3.6.2
-          command: |
-            pyenv install -s 3.6.2
-            pyenv global 3.6.2 system
-            python --version
+          <<: *install_python
       - run:
-          name: Run Ant Build
-          command: |
-            cd ${BUCKROOT}
-            set -eux
-            export TERM=dumb
-            export ANT_OPTS='-Xmx1000m'
-            ant
+          <<: *run_ant_build
       - run:
           name: Run Buck Build
           command: |
@@ -61,9 +76,23 @@ jobs:
             ./bin/buck build buck --out ./new_buck.pex
             export BUCK_NUM_THREADS=3
             ./new_buck.pex build --num-threads=${BUCK_NUM_THREADS} src/... test/...
+  ci_unit_groovy:
+    environment:
+      BUCKROOT: "/home/circleci/buck"
+      ANDROIDSDK: "/home/circleci/android-sdk"
+    working_directory: "/home/circleci/buck"
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - run:
+          <<: *install_openjdk8
+      - run:
+          <<: *install_androidsdk
 workflows:
   version: 2
   all_jobs:
     jobs:
       - ci_build_openjdk8
+      - ci_unit_groovy
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,9 +198,16 @@ jobs:
       - run:
           <<: *install_python
       - run:
+          <<: *install_groovy
+      - run:
           <<: *run_ant_build
       - run:
           <<: *run_buck_build
+      - run:
+          name: Install 32 bit libraries
+          # https://stackoverflow.com/questions/36911709/cannot-run-program-aapt
+          # Needed to run Android build-tools
+          sudo apt-get install gcc-multilib lib32z1 lib32stdc++6
       - run:
           name: Run Tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ install_android_sdk: &install_android_sdk
     echo 'y' |sdkmanager --install "build-tools;28.0.0"
     echo 'y' |sdkmanager --install "platforms;android-23"
     echo 'y' |sdkmanager --install "platforms;android-27"
+    echo 'y' |sdkmanager --install "platforms;android-28"
 
     # Install 32 bit libraries
     # https://stackoverflow.com/questions/36911709/cannot-run-program-aapt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,10 @@ jobs:
       - checkout
       - run:
           name: Install OpenJDK8
-          sudo apt-get update && sudo apt-get install openjdk-8-jdk
-          sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
-          java -version
+          command: |
+            sudo apt-get update && sudo apt-get install openjdk-8-jdk
+            sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
+            java -version
       - run:
           name: Install Android SDK
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ install_android_sdk: &install_android_sdk
     echo 'y' |sdkmanager --install platform-tools
     # Old version build-tools;23.0.2
     echo 'y' |sdkmanager --install "build-tools;29.0.0"
+    echo 'y' |sdkmanager --install "platforms;android-23"
     echo 'y' |sdkmanager --install "platforms;android-28"
 
     # Install 32 bit libraries

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,8 @@ install_android_sdk: &install_android_sdk
     export PATH=${ANDROID_SDK}/tools/bin:$PATH
     echo 'y' |sdkmanager --install tools
     echo 'y' |sdkmanager --install platform-tools
-    echo 'y' |sdkmanager --install "build-tools;23.0.2"
+    # Old version build-tools;23.0.2
+    echo 'y' |sdkmanager --install "build-tools;29.0.0"
     echo 'y' |sdkmanager --install "platforms;android-23"
 
     # Install 32 bit libraries

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ install_groovy: &install_groovy
   command: |
     curl -s get.sdkman.io | bash
     source "$HOME/.sdkman/bin/sdkman-init.sh"
-    sdk install groovy 2.5.0
+    sdk install groovy 2.4.18
     groovy -version
 
 install_ghc: &install_ghc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,8 @@ install_android_sdk: &install_android_sdk
     echo 'y' |sdkmanager --install tools
     echo 'y' |sdkmanager --install platform-tools
     # Old version build-tools;23.0.2
-    echo 'y' |sdkmanager --install "build-tools;29.0.0"
-    echo 'y' |sdkmanager --install "platforms;android-23"
+    echo 'y' |sdkmanager --install "build-tools;28.0.3"
+    echo 'y' |sdkmanager --install "platforms;android-28"
 
     # Install 32 bit libraries
     # https://stackoverflow.com/questions/36911709/cannot-run-program-aapt
@@ -32,6 +32,7 @@ install_golang: &install_golang
     cd ~
     wget https://storage.googleapis.com/golang/go1.10.1.linux-amd64.tar.gz
     sudo tar -xzf go1.10.1.linux-amd64.tar.gz -C /usr/local
+    rm go1.10.1.linux-amd64.tar.gz
     go version
 
 install_python: &install_python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ install_openjdk8: &install_openjdk8
     sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
     java -version
 
-install_androidsdk: &install_androidsdk
+install_android_sdk: &install_android_sdk
   name: Install Android SDK
   command: |
     mkdir ${ANDROID_SDK}
@@ -91,7 +91,7 @@ jobs:
       - run:
           <<: *install_openjdk8
       - run:
-          <<: *install_androidsdk
+          <<: *install_android_sdk
       - run:
           <<: *install_golang
       - run:
@@ -101,7 +101,7 @@ jobs:
       - run:
           <<: *run_buck_build
       - run:
-          name: Run Tests
+          name: Run Build Tests
           command: |
             cd ${BUCKROOT}
             export PATH=${ANDROID_SDK}/tools/bin:$PATH
@@ -123,7 +123,7 @@ jobs:
       - run:
           <<: *install_openjdk8
       - run:
-          <<: *install_androidsdk
+          <<: *install_android_sdk
       - run:
           <<: *install_groovy
       - run:
@@ -135,7 +135,7 @@ jobs:
       - run:
           <<: *run_buck_build
       - run:
-          name: Run Tests
+          name: Run Unit Tests
           command: |
             cd ${BUCKROOT}
             export PATH=${ANDROID_SDK}/tools/bin:$PATH
@@ -158,7 +158,7 @@ jobs:
       - run:
           <<: *install_openjdk8
       - run:
-          <<: *install_androidsdk
+          <<: *install_android_sdk
       - run:
           <<: *install_golang
       - run:
@@ -168,7 +168,7 @@ jobs:
       - run:
           <<: *run_buck_build
       - run:
-          name: Run Tests
+          name: Run Ant Tests
           command: |
             cd ${BUCKROOT}
             export PATH=${ANDROID_SDK}/tools/bin:$PATH
@@ -191,7 +191,7 @@ jobs:
       - run:
           <<: *install_openjdk8
       - run:
-          <<: *install_androidsdk
+          <<: *install_android_sdk
       - run:
           <<: *install_ghc
       - run:
@@ -205,7 +205,7 @@ jobs:
       - run:
           <<: *run_buck_build
       - run:
-          name: Run Tests
+          name: Run Integration Tests
           command: |
             cd ${BUCKROOT}
             export PATH=${ANDROID_SDK}/tools/bin:$PATH
@@ -213,6 +213,44 @@ jobs:
             export GROOVY_HOME=$HOME/.sdkman/candidates/groovy/current
             set -eux
             ./new_buck.pex test --num-threads=$BUCK_NUM_THREADS --all --filter '^(?!(com.facebook.buck.android|com.facebook.buck.jvm.java)).*[Ii]ntegration.*'
+
+  ci_heavy_integration:
+    environment:
+      BUCKROOT: "/home/circleci/buck"
+      ANDROID_SDK: "/home/circleci/android-sdk"
+      TERM: "dumb"
+      BUCK_NUM_THREADS: 3
+    working_directory: "/home/circleci/buck"
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - run:
+          <<: *install_openjdk8
+      - run:
+          <<: *install_android_sdk
+      - run:
+          name: Install Android NDK
+          command: |
+            cd ${BUCKROOT}
+            export NDK_HOME="${HOME}/android-ndk-linux"
+            ./scripts/travisci_install_android_ndk.sh
+      - run:
+          <<: *install_golang
+      - run:
+          <<: *install_python
+      - run:
+          <<: *run_ant_build
+      - run:
+          <<: *run_buck_build
+      - run:
+          name: Run Heavy Integration Tests
+          command: |
+            export NDK_HOME="${HOME}/android-ndk-linux"
+            export ANDROID_HOME=${ANDROID_SDK}
+            set -eux
+            ./new_buck.pex build --num-threads=$BUCK_NUM_THREADS //test/com/facebook/buck/android/... //test/com/facebook/buck/jvm/java/...
+            ./new_buck.pex test --num-threads=1 //test/com/facebook/buck/android/... //test/com/facebook/buck/jvm/java/... --filter '.*[Ii]ntegration.*'
 
 workflows:
   version: 2
@@ -222,4 +260,5 @@ workflows:
       - ci_unit_groovy
       - ci_ant
       - ci_integration
+      - ci_heavy_integration
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,25 @@
+version: 2
+
+jobs:
+  ci_build:
+    machine
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - run:
+          name: Run Ant Build
+          command: |
+            set -eux
+            export TERM=dumb
+            export ANT_OPTS='-Xmx1000m'
+            export BUCK_PEX_LOCATION="./new_buck.pex"
+            echo '-Xmx750m' > .buckjavaargs.local
+            pyenv install -s 3.6.2
+            pyenv global 3.6.2 system
+            export PATH="$(pyenv root)/shims:$PATH"
+            sudo apt update && sudo apt install android-sdk
+            ant
+            ./bin/buck build buck --out ./new_buck.pex
+workflows:
+  all_jobs:
+    jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,14 +81,17 @@ run_buck_build: &run_buck_build
 jobs:
   ci_build_openjdk8:
     environment:
+      # Use string constant for values, no environment variables 
       BUCKROOT: "/home/circleci/buck"
       ANDROID_SDK: "/home/circleci/android-sdk"
       TERM: "dumb"
       BUCK_NUM_THREADS: 3
     working_directory: "/home/circleci/buck"
     machine:
+      # linux VM
       image: ubuntu-1604:201903-01
     steps:
+      # Steps run sequentially in separate shells
       - checkout
       - run:
           <<: *install_openjdk8
@@ -415,6 +418,7 @@ jobs:
 workflows:
   version: 2
   all_jobs:
+    # jobs run in parallel
     jobs:
       - ci_build_openjdk8
       - ci_unit_groovy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,10 @@ install_python: &install_python
 install_groovy: &install_groovy
   name: Install Groovy
   command: |
-    #echo -e '\x0D' | sudo apt-add-repository ppa:groovy-dev/groovy
-    sudo apt-get update && sudo apt-get install groovy
+    #sudo apt-get update && sudo apt-get install groovy
+    curl -s get.sdkman.io | bash
+    source "$HOME/.sdkman/bin/sdkman-init.sh"
+    sdk install groovy 2.5.0
     groovy -version
 
 run_ant_build: &run_ant_build
@@ -129,6 +131,7 @@ jobs:
             export PATH=${ANDROIDSDK}/tools/bin:$PATH
             export PATH="$(pyenv root)/shims:$PATH"
             export ANDROID_SDK=${ANDROIDSDK}
+            export GROOVY_HOME=$HOME/.sdkman/candidates/groovy/current
             set -eux
             ./new_buck.pex test --num-threads=${BUCK_NUM_THREADS} --all --test-selectors '!.*[Ii]ntegration.*'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,6 @@ install_android_sdk: &install_android_sdk
     # Old version build-tools;23.0.2
     echo 'y' |sdkmanager --install "build-tools;28.0.0"
     echo 'y' |sdkmanager --install "platforms;android-23"
-    echo 'y' |sdkmanager --install "platforms;android-27"
-    echo 'y' |sdkmanager --install "platforms;android-28"
 
     # Install 32 bit libraries
     # https://stackoverflow.com/questions/36911709/cannot-run-program-aapt
@@ -361,6 +359,12 @@ jobs:
           <<: *run_ant_build
       - run:
           <<: *run_buck_build
+      - run:
+          name: Need android-27 and android-28 to run the tests, install them. 
+          command: |
+            export PATH=${ANDROID_SDK}/tools/bin:$PATH
+            echo 'y' |sdkmanager --install "platforms;android-27"
+            echo 'y' |sdkmanager --install "platforms;android-28"
       - run:
           name: Run Android NDK 17 Tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,11 +38,18 @@ install_python: &install_python
 install_groovy: &install_groovy
   name: Install Groovy
   command: |
-    #sudo apt-get update && sudo apt-get install groovy
     curl -s get.sdkman.io | bash
     source "$HOME/.sdkman/bin/sdkman-init.sh"
     sdk install groovy 2.5.0
     groovy -version
+
+install_ghc: &install_ghc
+  name: Install Ghc
+  command: |
+    sudo apt-get update
+    sudo apt-get install ghc
+    sudo apt-get install -y ghc-dynamic
+    sudo apt-get install -y ghc-haddock
 
 run_ant_build: &run_ant_build
   name: Run Ant Build
@@ -168,6 +175,42 @@ jobs:
             set -eux
             ant travis
             ./scripts/travisci_test_java_file_format
+
+  ci_integration:
+    environment:
+      BUCKROOT: "/home/circleci/buck"
+      ANDROIDSDK: "/home/circleci/android-sdk"
+      TERM: "dumb"
+      BUCK_NUM_THREADS: 3
+    working_directory: "/home/circleci/buck"
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - run:
+          <<: *install_openjdk8
+      - run:
+          <<: *install_androidsdk
+      - run:
+          <<: *install_ghc
+      - run:
+          <<: *install_golang
+      - run:
+          <<: *install_python
+      - run:
+          <<: *run_ant_build
+      - run:
+          <<: *run_buck_build
+      - run:
+          name: Run Tests
+          command: |
+            cd ${BUCKROOT}
+            export PATH=${ANDROIDSDK}/tools/bin:$PATH
+            export PATH="$(pyenv root)/shims:$PATH"
+            export ANDROID_SDK=${ANDROIDSDK}
+            export GROOVY_HOME=$HOME/.sdkman/candidates/groovy/current
+            set -eux
+            ./new_buck.pex test --num-threads=$BUCK_NUM_THREADS --all --filter '^(?!(com.facebook.buck.android|com.facebook.buck.jvm.java)).*[Ii]ntegration.*'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,8 @@ jobs:
     working_directory: "/home/circleci/buck"
     machine:
       image: ubuntu-1604:201903-01
+      java:
+        version: 'oraclejdk8'
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ install_android_sdk: &install_android_sdk
     echo 'y' |sdkmanager --install tools
     echo 'y' |sdkmanager --install platform-tools
     # Old version build-tools;23.0.2
-    echo 'y' |sdkmanager --install "build-tools;29.0.0"
+    echo 'y' |sdkmanager --install "build-tools;28.0.0"
     echo 'y' |sdkmanager --install "platforms;android-23"
     echo 'y' |sdkmanager --install "platforms;android-28"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ install_android_sdk: &install_android_sdk
     echo 'y' |sdkmanager --install tools
     echo 'y' |sdkmanager --install platform-tools
     # Old version build-tools;23.0.2
-    echo 'y' |sdkmanager --install "build-tools;28.0.3"
+    echo 'y' |sdkmanager --install "build-tools;29.0.0"
     echo 'y' |sdkmanager --install "platforms;android-28"
 
     # Install 32 bit libraries

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,5 +21,7 @@ jobs:
             ant
             ./bin/buck build buck --out ./new_buck.pex
 workflows:
+  version: 2
   all_jobs:
     jobs:
+      - ci_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,9 @@ install_python: &install_python
 install_groovy: &install_groovy
   name: Install Groovy
   command: |
-    echo -e '\x0D' | sudo apt-add-repository ppa:groovy-dev/groovy
-    sudo apt-get update && sudo apt-get install groovy
+    #echo -e '\x0D' | sudo apt-add-repository ppa:groovy-dev/groovy
+    #sudo apt-get update && 
+    sudo apt-get install groovy
     groovy -version
 
 run_ant_build: &run_ant_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,6 +253,44 @@ jobs:
             ./new_buck.pex build --num-threads=$BUCK_NUM_THREADS //test/com/facebook/buck/android/... //test/com/facebook/buck/jvm/java/...
             ./new_buck.pex test --num-threads=1 //test/com/facebook/buck/android/... //test/com/facebook/buck/jvm/java/... --filter '.*[Ii]ntegration.*'
 
+  ci_android_ndk_15:
+    environment:
+      BUCKROOT: "/home/circleci/buck"
+      ANDROID_SDK: "/home/circleci/android-sdk"
+      TERM: "dumb"
+      BUCK_NUM_THREADS: 3
+    working_directory: "/home/circleci/buck"
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - run:
+          <<: *install_openjdk8
+      - run:
+          <<: *install_android_sdk
+      - run:
+          name: Install Android NDK 15
+          command: |
+            cd ${BUCKROOT}
+            export NDK_HOME="${HOME}/android-ndk-linux"
+            ./scripts/travisci_unzip_android_ndk.sh android-ndk-r15c
+      - run:
+          <<: *install_golang
+      - run:
+          <<: *install_python
+      - run:
+          <<: *run_ant_build
+      - run:
+          <<: *run_buck_build
+      - run:
+          name: Run Android NDK 15 Tests
+          command: |
+            export NDK_HOME="${HOME}/android-ndk-linux"
+            export ANDROID_HOME=${ANDROID_SDK}
+            set -eux
+            ./new_buck.pex build --num-threads=$BUCK_NUM_THREADS //test/com/facebook/buck/android/...
+            ./new_buck.pex test --num-threads=1 //test/com/facebook/buck/android/... --filter '.*[Ii]ntegration.*'
+
 workflows:
   version: 2
   all_jobs:
@@ -262,4 +300,5 @@ workflows:
       - ci_ant
       - ci_integration
       - ci_heavy_integration
+      - ci_android_ndk_15
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,26 +2,62 @@ version: 2
 
 jobs:
   ci_build:
-    machine
+    environment:
+      BUCKROOT: "/home/circleci/buck"
+      ANDROIDSDK: "/home/circleci/android-sdk"
+    working_directory: "/home/circleci/buck"
+    machine:
       image: ubuntu-1604:201903-01
     steps:
       - checkout
       - run:
+          name: Install Android SDK
+          command: |
+            mkdir ${ANDROIDSDK}
+            cd ${ANDROIDSDK}
+            wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip
+            unzip sdk-tools-linux-4333796.zip
+            export PATH=${ANDROIDSDK}/tools/bin:$PATH
+            echo 'y' |sdkmanager --install tools
+            echo 'y' |sdkmanager --install platform-tools
+            echo 'y' |sdkmanager --install "build-tools;23.0.2"
+            echo 'y' |sdkmanager --install "platforms;android-23"
+      - run:
+          name: Install GoLang 1.10.1
+          command: |
+            cd ~
+            wget https://storage.googleapis.com/golang/go1.10.1.linux-amd64.tar.gz
+            sudo tar -xzf go1.10.1.linux-amd64.tar.gz -C /usr/local
+            go version
+      - run:
+          name: Install Python 3.6.2
+          command: |
+            pyenv install -s 3.6.2
+            pyenv global 3.6.2 system
+            python --version
+      - run:
           name: Run Ant Build
           command: |
+            cd ${BUCKROOT}
             set -eux
             export TERM=dumb
             export ANT_OPTS='-Xmx1000m'
-            export BUCK_PEX_LOCATION="./new_buck.pex"
-            echo '-Xmx750m' > .buckjavaargs.local
-            pyenv install -s 3.6.2
-            pyenv global 3.6.2 system
-            export PATH="$(pyenv root)/shims:$PATH"
-            sudo apt update && sudo apt install android-sdk
             ant
+      - run:
+          name: Run Buck Build
+          command: |
+            cd ${BUCKROOT}
+            echo '-Xmx750m' > .buckjavaargs.local
+            export PATH=${ANDROIDSDK}/tools/bin:$PATH
+            export PATH="$(pyenv root)/shims:$PATH"
+            export ANDROID_SDK=${ANDROIDSDK}
+            export TERM=dumb
             ./bin/buck build buck --out ./new_buck.pex
+            export BUCK_NUM_THREADS=3
+            ./new_buck.pex build --num-threads=${BUCK_NUM_THREADS} src/... test/...
 workflows:
   version: 2
   all_jobs:
     jobs:
       - ci_build
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,7 @@ install_groovy: &install_groovy
   name: Install Groovy
   command: |
     #echo -e '\x0D' | sudo apt-add-repository ppa:groovy-dev/groovy
-    #sudo apt-get update && 
-    sudo apt-get install groovy
+    sudo apt-get update && sudo apt-get install groovy
     groovy -version
 
 run_ant_build: &run_ant_build
@@ -121,6 +120,8 @@ jobs:
           <<: *install_python
       - run:
           <<: *run_ant_build
+      - run:
+          <<: *run_buck_build
       - run:
           name: Run Tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,7 +329,7 @@ jobs:
             ./new_buck.pex build --num-threads=$BUCK_NUM_THREADS //test/com/facebook/buck/android/...
             ./new_buck.pex test --num-threads=1 //test/com/facebook/buck/android/... --filter '.*[Ii]ntegration.*'
 
-  ci_android_ndk_16:
+  ci_android_ndk_17:
     environment:
       BUCKROOT: "/home/circleci/buck"
       ANDROID_SDK: "/home/circleci/android-sdk"
@@ -367,7 +367,7 @@ jobs:
             ./new_buck.pex build --num-threads=$BUCK_NUM_THREADS //test/com/facebook/buck/android/...
             ./new_buck.pex test --num-threads=1 //test/com/facebook/buck/android/... --filter '.*[Ii]ntegration.*'
 
-  ci_android_ndk_16:
+  ci_android_ndk_18:
     environment:
       BUCKROOT: "/home/circleci/buck"
       ANDROID_SDK: "/home/circleci/android-sdk"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,11 +10,11 @@ install_openjdk8: &install_openjdk8
 install_androidsdk: &install_androidsdk
   name: Install Android SDK
   command: |
-    mkdir ${ANDROIDSDK}
-    cd ${ANDROIDSDK}
+    mkdir ${ANDROID_SDK}
+    cd ${ANDROID_SDK}
     wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip
     unzip sdk-tools-linux-4333796.zip
-    export PATH=${ANDROIDSDK}/tools/bin:$PATH
+    export PATH=${ANDROID_SDK}/tools/bin:$PATH
     echo 'y' |sdkmanager --install tools
     echo 'y' |sdkmanager --install platform-tools
     echo 'y' |sdkmanager --install "build-tools;23.0.2"
@@ -70,9 +70,8 @@ run_buck_build: &run_buck_build
   command: |
     cd ${BUCKROOT}
     echo '-Xmx1024m' > .buckjavaargs.local
-    export PATH=${ANDROIDSDK}/tools/bin:$PATH
+    export PATH=${ANDROID_SDK}/tools/bin:$PATH
     export PATH="$(pyenv root)/shims:$PATH"
-    export ANDROID_SDK=${ANDROIDSDK}
     set -eux
     export TERM=dumb
     ./bin/buck build buck --out ./new_buck.pex || { cat buck-out/log/buck-0.log; exit 1; }
@@ -81,7 +80,7 @@ jobs:
   ci_build_openjdk8:
     environment:
       BUCKROOT: "/home/circleci/buck"
-      ANDROIDSDK: "/home/circleci/android-sdk"
+      ANDROID_SDK: "/home/circleci/android-sdk"
       TERM: "dumb"
       BUCK_NUM_THREADS: 3
     working_directory: "/home/circleci/buck"
@@ -105,16 +104,15 @@ jobs:
           name: Run Tests
           command: |
             cd ${BUCKROOT}
-            export PATH=${ANDROIDSDK}/tools/bin:$PATH
+            export PATH=${ANDROID_SDK}/tools/bin:$PATH
             export PATH="$(pyenv root)/shims:$PATH"
-            export ANDROID_SDK=${ANDROIDSDK}
             set -eux
             ./new_buck.pex build --num-threads=${BUCK_NUM_THREADS} src/... test/...
 
   ci_unit_groovy:
     environment:
       BUCKROOT: "/home/circleci/buck"
-      ANDROIDSDK: "/home/circleci/android-sdk"
+      ANDROID_SDK: "/home/circleci/android-sdk"
       TERM: "dumb"
       BUCK_NUM_THREADS: 3
     working_directory: "/home/circleci/buck"
@@ -140,9 +138,8 @@ jobs:
           name: Run Tests
           command: |
             cd ${BUCKROOT}
-            export PATH=${ANDROIDSDK}/tools/bin:$PATH
+            export PATH=${ANDROID_SDK}/tools/bin:$PATH
             export PATH="$(pyenv root)/shims:$PATH"
-            export ANDROID_SDK=${ANDROIDSDK}
             export GROOVY_HOME=$HOME/.sdkman/candidates/groovy/current
             set -eux
             ./new_buck.pex test --num-threads=${BUCK_NUM_THREADS} --all --test-selectors '!.*[Ii]ntegration.*'
@@ -150,7 +147,7 @@ jobs:
   ci_ant:
     environment:
       BUCKROOT: "/home/circleci/buck"
-      ANDROIDSDK: "/home/circleci/android-sdk"
+      ANDROID_SDK: "/home/circleci/android-sdk"
       TERM: "dumb"
       BUCK_NUM_THREADS: 3
     working_directory: "/home/circleci/buck"
@@ -174,9 +171,8 @@ jobs:
           name: Run Tests
           command: |
             cd ${BUCKROOT}
-            export PATH=${ANDROIDSDK}/tools/bin:$PATH
-            export ANDROID_SDK=${ANDROIDSDK}
-            export ANDROID_HOME=${ANDROIDSDK}
+            export PATH=${ANDROID_SDK}/tools/bin:$PATH
+            export ANDROID_HOME=${ANDROID_SDK}
             set -eux
             ant travis
             ./scripts/travisci_test_java_file_format
@@ -184,7 +180,7 @@ jobs:
   ci_integration:
     environment:
       BUCKROOT: "/home/circleci/buck"
-      ANDROIDSDK: "/home/circleci/android-sdk"
+      ANDROID_SDK: "/home/circleci/android-sdk"
       TERM: "dumb"
       BUCK_NUM_THREADS: 3
     working_directory: "/home/circleci/buck"
@@ -212,9 +208,8 @@ jobs:
           name: Run Tests
           command: |
             cd ${BUCKROOT}
-            export PATH=${ANDROIDSDK}/tools/bin:$PATH
+            export PATH=${ANDROID_SDK}/tools/bin:$PATH
             export PATH="$(pyenv root)/shims:$PATH"
-            export ANDROID_SDK=${ANDROIDSDK}
             export GROOVY_HOME=$HOME/.sdkman/candidates/groovy/current
             set -eux
             ./new_buck.pex test --num-threads=$BUCK_NUM_THREADS --all --filter '^(?!(com.facebook.buck.android|com.facebook.buck.jvm.java)).*[Ii]ntegration.*'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ install_python: &install_python
 install_groovy: &install_groovy
   name: Install Groovy
   command: |
-    echo '' | sudo apt-add-repository ppa:groovy-dev/groovy
+    echo -e '\x0D' | sudo apt-add-repository ppa:groovy-dev/groovy
     sudo apt-get update && sudo apt-get install groovy
     groovy -version
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,4 +174,5 @@ workflows:
     jobs:
       - ci_build_openjdk8
       - ci_unit_groovy
+      - ci_ant
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,4 +219,5 @@ workflows:
       - ci_build_openjdk8
       - ci_unit_groovy
       - ci_ant
+      - ci_integration
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ run_buck_build: &run_buck_build
   name: Run Buck Build
   command: |
     cd ${BUCKROOT}
-    echo '-Xmx750m' > .buckjavaargs.local
+    echo '-Xmx1024m' > .buckjavaargs.local
     export PATH=${ANDROIDSDK}/tools/bin:$PATH
     export PATH="$(pyenv root)/shims:$PATH"
     export ANDROID_SDK=${ANDROIDSDK}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,11 @@ install_androidsdk: &install_androidsdk
     echo 'y' |sdkmanager --install "build-tools;23.0.2"
     echo 'y' |sdkmanager --install "platforms;android-23"
 
+    # Install 32 bit libraries
+    # https://stackoverflow.com/questions/36911709/cannot-run-program-aapt
+    # Needed to run Android build-tools
+    sudo apt-get install gcc-multilib lib32z1 lib32stdc++6
+
 install_golang: &install_golang
   name: Install GoLang 1.10.1
   command: |
@@ -203,12 +208,6 @@ jobs:
           <<: *run_ant_build
       - run:
           <<: *run_buck_build
-      - run:
-          name: Install 32 bit libraries
-          # https://stackoverflow.com/questions/36911709/cannot-run-program-aapt
-          # Needed to run Android build-tools
-          command: |
-            sudo apt-get install gcc-multilib lib32z1 lib32stdc++6
       - run:
           name: Run Tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,39 @@ jobs:
             set -eux
             ./new_buck.pex test --num-threads=${BUCK_NUM_THREADS} --all --test-selectors '!.*[Ii]ntegration.*'
 
+  ci_ant:
+    environment:
+      BUCKROOT: "/home/circleci/buck"
+      ANDROIDSDK: "/home/circleci/android-sdk"
+      TERM: "dumb"
+      BUCK_NUM_THREADS: 3
+    working_directory: "/home/circleci/buck"
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - run:
+          <<: *install_openjdk8
+      - run:
+          <<: *install_androidsdk
+      - run:
+          <<: *install_golang
+      - run:
+          <<: *install_python
+      - run:
+          <<: *run_ant_build
+      - run:
+          <<: *run_buck_build
+      - run:
+          name: Run Tests
+          command: |
+            cd ${BUCKROOT}
+            export PATH=${ANDROIDSDK}/tools/bin:$PATH
+            export ANDROID_SDK=${ANDROIDSDK}
+            set -eux
+            ant travis
+            ./scripts/travisci_test_java_file_format
+
 workflows:
   version: 2
   all_jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,8 @@ jobs:
           name: Install 32 bit libraries
           # https://stackoverflow.com/questions/36911709/cannot-run-program-aapt
           # Needed to run Android build-tools
-          sudo apt-get install gcc-multilib lib32z1 lib32stdc++6
+          command: |
+            sudo apt-get install gcc-multilib lib32z1 lib32stdc++6
       - run:
           name: Run Tests
           command: |

--- a/test/com/facebook/buck/zip/ZipStepTest.java
+++ b/test/com/facebook/buck/zip/ZipStepTest.java
@@ -102,7 +102,7 @@ public class ZipStepTest {
     }
   }
 
-  @Test
+  @Test(timeout=600000)
   public void handlesLargeFiles() throws Exception {
     Path parent = tmp.newFolder("zipstep");
     Path out = parent.resolve("output.zip");


### PR DESCRIPTION
**Summary** 

- Ported TravisCI jobs to CircleCI except for the one that requires Oracle JDK because Oracle JDK can't be installed on CircleCI VMs:

  1. CI_ACTION=build, OpenJDK 8 --> CircleCI job "ci_build_openjdk8"
  2. CI_ACTION=unit GROOVY_HOME=/usr/share/groovy/ --> CircleCI job "ci_unit_groovy"
  3. CI_ACTION=ant --> CircleCI job "ci_ant"
  4. CI_ACTION=integration GROOVY_HOME=/usr/share/groovy/ --> "ci_integration"
  5. CI_ACTION=heavy_integration --> CircleCI job "ci_heavy_integration"
  6. CI_ACTION=android_ndk_15 --> CircleCI job "ci_android_ndk_15"
  7. CI_ACTION=android_ndk_16 --> CircleCI job "ci_android_ndk_16"
  8. CI_ACTION=android_ndk_17 --> CircleCI job "ci_android_ndk_17"
  9. CI_ACTION=android_ndk_18 --> CircleCI job "ci_android_ndk_18"

- Fixed all the failed tests, CircleCI jobs are all green.
