### PR TITLE
Add support for OpenJDK in JAVA_HOME detection

### DIFF
--- a/programs/java_lookup.py
+++ b/programs/java_lookup.py
@@ -81,20 +81,19 @@ def _get_java_path_for_highest_minor_version(base_path, desired_major_version):
         if desired_major_version <= 8
         else JDK_9_AND_OVER_PATH_VERSION_REGEXES
     )
-    for _, dirs, _ in os.walk(base_path):
-        for dir in dirs:
-            for regex in regexes:
-                match = regex.match(dir)
-                if match:
-                    major_version = int(match.group('major'))
-                    if major_version == desired_major_version:
-                        version_string = match.group('full')
-                        version = tuple(
-                            map(int, version_string.replace("_", ".").split("."))
-                        )
-                        if not max_version or version > max_version:
-                            max_version = version
-                            max_dir = dir
+    for dir in sorted(os.listdir(base_path)):
+        for regex in regexes:
+            match = regex.match(dir)
+            if match:
+                major_version = int(match.group('major'))
+                if major_version == desired_major_version:
+                    version_string = match.group('full')
+                    version = tuple(
+                        map(int, version_string.replace("_", ".").split("."))
+                    )
+                    if not max_version or version > max_version:
+                        max_version = version
+                        max_dir = dir
 
     return os.path.join(base_path, max_dir) if max_dir else None
 

--- a/programs/test_java_lookup.py
+++ b/programs/test_java_lookup.py
@@ -84,6 +84,18 @@ class TestJavaPath(unittest.TestCase):
             os.path.join(java_base_path, "jdk1.8.1_100"),
         )
 
+    def test_openjdk_8_highest_version_lookup(self):
+        java_base_path = tempfile.mkdtemp()
+        os.mkdir(os.path.join(java_base_path, "adoptopenjdk-7.jdk"))
+        os.mkdir(os.path.join(java_base_path, "adoptopenjdk-8.jdk"))
+        os.mkdir(os.path.join(java_base_path, "adoptopenjdk-9.jdk"))
+        os.mkdir(os.path.join(java_base_path, "adoptopenjdk-18.jdk"))
+
+        self.assertEquals(
+            _get_java_path_for_highest_minor_version(java_base_path, 8),
+            os.path.join(java_base_path, "adoptopenjdk-8.jdk"),
+        )
+
     def test_java_11_highest_version_lookup(self):
         java_base_path = tempfile.mkdtemp()
         os.mkdir(os.path.join(java_base_path, "jdk-10.0.1"))
@@ -97,6 +109,20 @@ class TestJavaPath(unittest.TestCase):
         self.assertEquals(
             _get_java_path_for_highest_minor_version(java_base_path, 11),
             os.path.join(java_base_path, "jdk-11.0.2_200"),
+        )
+
+    def test_openjdk_11_highest_version_lookup(self):
+        java_base_path = tempfile.mkdtemp()
+        os.mkdir(os.path.join(java_base_path, "adoptopenjdk-7.jdk"))
+        os.mkdir(os.path.join(java_base_path, "adoptopenjdk-8.jdk"))
+        os.mkdir(os.path.join(java_base_path, "adoptopenjdk-9.jdk"))
+        os.mkdir(os.path.join(java_base_path, "adoptopenjdk-10.jdk"))
+        os.mkdir(os.path.join(java_base_path, "adoptopenjdk-11.jdk"))
+        os.mkdir(os.path.join(java_base_path, "adoptopenjdk-12.jdk"))
+
+        self.assertEquals(
+            _get_java_path_for_highest_minor_version(java_base_path, 11),
+            os.path.join(java_base_path, "adoptopenjdk-11.jdk"),
         )
 
     def tearDown(self):


### PR DESCRIPTION
adoptopenjdk installs as /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk & /Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk for example.