### PR TITLE
Allow 'Apple Distribution' code sign identities for iOS signing

### DIFF
--- a/src/com/facebook/buck/apple/toolchain/impl/CodeSignIdentityStoreFactory.java
+++ b/src/com/facebook/buck/apple/toolchain/impl/CodeSignIdentityStoreFactory.java
@@ -44,7 +44,7 @@ public class CodeSignIdentityStoreFactory implements ToolchainFactory<CodeSignId
 
   // Parse the fingerprint and name, but don't match invalid certificates (revoked, expired, etc).
   private static final Pattern CODE_SIGN_IDENTITY_PATTERN =
-      Pattern.compile("([A-F0-9]{40}) \"(iPhone.*|Apple Development.*)\"(?!.*\\(CSSMERR_.*\\))");
+      Pattern.compile("([A-F0-9]{40}) \"(iPhone.*|Apple (Development|Distribution).*)\"(?!.*\\(CSSMERR_.*\\))");
 
   /**
    * Construct a store by asking the system keychain for all stored code sign identities.

--- a/test/com/facebook/buck/apple/toolchain/impl/CodeSignIdentityStoreFactoryTest.java
+++ b/test/com/facebook/buck/apple/toolchain/impl/CodeSignIdentityStoreFactoryTest.java
@@ -56,7 +56,13 @@ public class CodeSignIdentityStoreFactoryTest {
                 + "\"Apple Development: Fizz Buzz (AAAAA12345)\" (CSSMERR_TP_CERT_REVOKED)\n"
                 + "  6) FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF "
                 + "\"Apple Development: Fizz Buzz (54321BBBBB)\" (CSSMERR_TP_CERT_EXPIRED)\n"
-                + "     6 valid identities found\n",
+                + "  7) EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE "
+                + "\"Apple Distribution: Fuss Bizz (12345BBBBB)\"\n"
+                + "  8) EEEEEEEEEEEEEEEEEEEEFFFFFFFFFFFFFFFFFFFF "
+                + "\"Apple Distribution: Fuss Bizz (BBBBB12345)\" (CSSMERR_TP_CERT_REVOKED)\n"
+                + "  9) FFFFFFFFFFFFFFFFFFFFAAAAAAAAAAAAAAAAAAAA "
+                + "\"Apple Distribution: Fuss Bizz (54321CCCCC)\" (CSSMERR_TP_CERT_EXPIRED)\n"
+                + "     9 valid identities found\n",
             "");
 
     FakeProcessExecutor processExecutor =
@@ -71,7 +77,10 @@ public class CodeSignIdentityStoreFactoryTest {
                 "iPhone Developer: Foo Bar (54321EDCBA)"),
             CodeSignIdentity.of(
                 CodeSignIdentity.toFingerprint("CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"),
-                "Apple Development: Fizz Buzz (12345AAAAA)"));
+                "Apple Development: Fizz Buzz (12345AAAAA)"),
+            CodeSignIdentity.of(
+                CodeSignIdentity.toFingerprint("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"),
+                "Apple Distribution: Fuss Bizz (12345BBBBB)"));
 
     assertThat(store.getIdentitiesSupplier().get(), equalTo(expected));
   }


### PR DESCRIPTION
Summary:
When buck searches for code signing identities it fails to process
Apple Distribution certificates new to Xcode 11, which can sign
both iOS and Mac binaries.