### PR TITLE
Add support for point versions of adoptopenjdk

### DIFF
--- a/programs/java_lookup.py
+++ b/programs/java_lookup.py
@@ -24,11 +24,11 @@ from programs.subprocutils import which
 
 JDK_8_AND_UNDER_PATH_VERSION_REGEX_STRINGS = [
     r"jdk(?P<full>1\.(?P<major>\d+)(\.\d+(_\d+)?)?)(\.jdk)?",
-    r"adoptopenjdk-(?P<full>(?P<major>[6-8]))(\.jdk|\.jre)?",
+    r"adoptopenjdk-(?P<full>(?P<major>[6-8])(\.\d+(_\d+)?)?)(\.jdk|\.jre)?",
 ]
 JDK_9_AND_OVER_PATH_VERSION_REGEX_STRINGS = [
     r"jdk-(?P<full>(?P<major>\d+)(\.\d+(\.\d+(_\d+)?)?)?)(\.jdk)?",
-    r"adoptopenjdk-(?P<full>(?P<major>9|\d{2,}))(\.jdk|\.jre)?",
+    r"adoptopenjdk-(?P<full>(?P<major>9|\d{2,})(\.\d+(\.\d+(_\d+)?)?)?)(\.jdk|\.jre)?",
 ]
 
 JDK_8_AND_UNDER_PATH_VERSION_REGEXES = [

--- a/programs/test_java_lookup.py
+++ b/programs/test_java_lookup.py
@@ -118,11 +118,16 @@ class TestJavaPath(unittest.TestCase):
         os.mkdir(os.path.join(java_base_path, "adoptopenjdk-9.jdk"))
         os.mkdir(os.path.join(java_base_path, "adoptopenjdk-10.jdk"))
         os.mkdir(os.path.join(java_base_path, "adoptopenjdk-11.jdk"))
+        os.mkdir(os.path.join(java_base_path, "adoptopenjdk-11.0.2.jdk"))
         os.mkdir(os.path.join(java_base_path, "adoptopenjdk-12.jdk"))
 
         self.assertEquals(
             _get_java_path_for_highest_minor_version(java_base_path, 11),
-            os.path.join(java_base_path, "adoptopenjdk-11.jdk"),
+            os.path.join(java_base_path, "adoptopenjdk-11.0.2.jdk"),
+        )
+        self.assertEquals(
+            _get_java_path_for_highest_minor_version(java_base_path, 12),
+            os.path.join(java_base_path, "adoptopenjdk-12.jdk"),
         )
 
     def tearDown(self):


### PR DESCRIPTION
e.g. /Library/Java/JavaVirtualMachines/adoptopenjdk-13.0.2.jdk

Makes me wonder if buck should use `/usr/libexec/java_home -v 1.8` instead.