### PR TITLE
[apple_asset_catalog] Fix Messages Extension App Icons

### DIFF
--- a/src/com/facebook/buck/apple/ActoolStep.java
+++ b/src/com/facebook/buck/apple/ActoolStep.java
@@ -38,6 +38,7 @@ class ActoolStep extends ShellStep {
   private final Path outputPlist;
   private final Optional<String> appIcon;
   private final Optional<String> launchImage;
+  private final Optional<String> productType;
   private final AppleAssetCatalogsCompilationOptions compilationOptions;
 
   public ActoolStep(
@@ -51,6 +52,7 @@ class ActoolStep extends ShellStep {
       Path outputPlist,
       Optional<String> appIcon,
       Optional<String> launchImage,
+      Optional<String> productType,
       AppleAssetCatalogsCompilationOptions compilationOptions) {
     super(workingDirectory);
     this.applePlatformName = applePlatformName;
@@ -62,6 +64,7 @@ class ActoolStep extends ShellStep {
     this.outputPlist = outputPlist;
     this.appIcon = appIcon;
     this.launchImage = launchImage;
+    this.productType = productType;
     this.compilationOptions = compilationOptions;
   }
 
@@ -101,6 +104,10 @@ class ActoolStep extends ShellStep {
 
     if (launchImage.isPresent()) {
       commandBuilder.add("--launch-image", launchImage.get());
+    }
+
+    if (productType.isPresent()) {
+      commandBuilder.add("--product-type", productType.get());
     }
 
     if (compilationOptions.getNotices()) {

--- a/src/com/facebook/buck/apple/AppleAssetCatalog.java
+++ b/src/com/facebook/buck/apple/AppleAssetCatalog.java
@@ -73,6 +73,8 @@ public class AppleAssetCatalog extends AbstractBuildRule {
 
   @AddToRuleKey private final Optional<String> launchImage;
 
+  @AddToRuleKey private final Optional<String> productType;
+
   @AddToRuleKey private final AppleAssetCatalogsCompilationOptions compilationOptions;
 
   private final Supplier<SortedSet<BuildRule>> buildDepsSupplier;
@@ -103,6 +105,7 @@ public class AppleAssetCatalog extends AbstractBuildRule {
       ImmutableSortedSet<SourcePath> assetCatalogDirs,
       Optional<String> appIcon,
       Optional<String> launchImage,
+      Optional<String> productType,
       AppleAssetCatalogsCompilationOptions compilationOptions,
       String bundleName) {
     super(buildTarget, projectFilesystem);
@@ -117,6 +120,7 @@ public class AppleAssetCatalog extends AbstractBuildRule {
         BuildTargetPaths.getScratchPath(getProjectFilesystem(), buildTarget, "%s-output.plist");
     this.appIcon = appIcon;
     this.launchImage = launchImage;
+    this.productType = productType;
     this.compilationOptions = compilationOptions;
     this.buildDepsSupplier = BuildableSupport.buildDepsSupplier(this, ruleFinder);
   }
@@ -148,6 +152,7 @@ public class AppleAssetCatalog extends AbstractBuildRule {
             getProjectFilesystem().resolve(outputPlist),
             appIcon,
             launchImage,
+            productType,
             compilationOptions));
 
     buildableContext.recordArtifact(getOutputDir());

--- a/src/com/facebook/buck/apple/AppleBinaryDescription.java
+++ b/src/com/facebook/buck/apple/AppleBinaryDescription.java
@@ -404,6 +404,7 @@ public class AppleBinaryDescription
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
+        Optional.empty(),
         appleConfig.getCodesignTimeout(),
         swiftBuckConfig.getCopyStdlibToFrameworks(),
         cxxBuckConfig.shouldCacheStrip(),

--- a/src/com/facebook/buck/apple/AppleBundleDescription.java
+++ b/src/com/facebook/buck/apple/AppleBundleDescription.java
@@ -193,6 +193,7 @@ public class AppleBundleDescription
         args.getCodesignIdentity(),
         args.getIbtoolModuleFlag(),
         args.getIbtoolFlags(),
+        args.getXcodeProductType(),
         appleConfig.getCodesignTimeout(),
         swiftBuckConfig.getCopyStdlibToFrameworks(),
         cxxBuckConfig.shouldCacheStrip(),

--- a/src/com/facebook/buck/apple/AppleDescriptions.java
+++ b/src/com/facebook/buck/apple/AppleDescriptions.java
@@ -370,6 +370,7 @@ public class AppleDescriptions {
       BuildTarget buildTarget,
       ProjectFilesystem projectFilesystem,
       SourcePathRuleFinder ruleFinder,
+      Optional<String> productType,
       ApplePlatform applePlatform,
       String targetSDKVersion,
       Tool actool,
@@ -445,6 +446,7 @@ public class AppleDescriptions {
             assetCatalogDirs,
             appIcon,
             launchImage,
+            productType,
             appleAssetCatalogsCompilationOptions,
             MERGED_ASSET_CATALOG_NAME));
   }
@@ -627,6 +629,7 @@ public class AppleDescriptions {
       Optional<String> codesignAdhocIdentity,
       Optional<Boolean> ibtoolModuleFlag,
       Optional<ImmutableList<String>> ibtoolFlags,
+      Optional<String> productType,
       Duration codesignTimeout,
       boolean copySwiftStdlibToFrameworks,
       boolean cacheStrips,
@@ -707,6 +710,7 @@ public class AppleDescriptions {
             buildTargetWithoutBundleSpecificFlavors,
             projectFilesystem,
             graphBuilder,
+            productType,
             appleCxxPlatform.getAppleSdk().getApplePlatform(),
             appleCxxPlatform.getMinVersion(),
             appleCxxPlatform.getActool(),

--- a/src/com/facebook/buck/apple/AppleLibraryDescription.java
+++ b/src/com/facebook/buck/apple/AppleLibraryDescription.java
@@ -445,6 +445,7 @@ public class AppleLibraryDescription
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
+        Optional.empty(),
         appleConfig.getCodesignTimeout(),
         swiftBuckConfig.getCopyStdlibToFrameworks(),
         cxxBuckConfig.shouldCacheStrip(),

--- a/src/com/facebook/buck/apple/AppleTestDescription.java
+++ b/src/com/facebook/buck/apple/AppleTestDescription.java
@@ -341,6 +341,7 @@ public class AppleTestDescription
                         args.getCodesignIdentity(),
                         Optional.empty(),
                         Optional.empty(),
+                        Optional.empty(),
                         appleConfig.getCodesignTimeout(),
                         swiftBuckConfig.getCopyStdlibToFrameworks(),
                         cxxBuckConfig.shouldCacheStrip(),


### PR DESCRIPTION
Addresses https://github.com/facebook/buck/issues/2400

Currently, building Messages extensions with buck will not generate the Messages app icon correctly. This is because in order to do so, `actool` needs to know what product type it is creating an asset catalog + app icon for.

This change funnels the product type from `apple_bundle` into `AppleAssetCatalog` and `AcToolStep` so that `actool` is called with `--product-type <product type>` (needs to be `com.apple.product-type.app-extension.messages` for Messages extensions).