### PR TITLE
make buck Python3 compatible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,7 +260,7 @@ jobs:
             cd "${BUCKROOT}"
             export PATH="${ANDROID_SDK}/tools/bin:${PATH}"
             export PATH="$(pyenv root)/shims:${PATH}"
-            export GROOVY_HOME=$HOME/.sdkman/candidates/groovy/current
+            export GROOVY_HOME="$HOME/.sdkman/candidates/groovy/current"
             set -eux
             ${BUCK_PEX_LOCATION} test --num-threads=$BUCK_NUM_THREADS --all --filter '^(?!(com.facebook.buck.android|com.facebook.buck.jvm.java)).*[Ii]ntegration.*'
 
@@ -563,10 +563,9 @@ jobs:
       - run:
           # There is an issue with python in macos 10.14.x. this step is a work around and should be removed later.
           # https://stackoverflow.com/questions/59269208/errorrootcode-for-hash-md5-was-not-found-not-able-to-use-any-hg-mercurial-co
-          name: Uninstall Python2
-          # Python2 was EOL on 1/1/2020, it does not work with Xcode 10.3.0
+          name: Reinstall Python2
           command: |
-            brew uninstall python@2
+            brew reinstall https://raw.githubusercontent.com/Homebrew/homebrew-core/86a44a0a552c673a05f11018459c9f5faae3becc/Formula/python@2.rb
       - run:
           <<: *run_ant_build
       - run:
@@ -577,7 +576,7 @@ jobs:
             cd "${BUCKROOT}"
             export PATH="${ANDROID_SDK}/tools/bin:${PATH}"
             export PATH="$(pyenv root)/shims:${PATH}"
-            export "GROOVY_HOME=$HOME/.sdkman/candidates/groovy/current"
+            export GROOVY_HOME="$HOME/.sdkman/candidates/groovy/current"
             export JAVA_HOME=`/usr/libexec/java_home`
             export PATH="${JAVA_HOME}/bin:${PATH}"
             set -ex

--- a/python-dsl/buck_parser/buck.py
+++ b/python-dsl/buck_parser/buck.py
@@ -303,7 +303,7 @@ class LazyBuildEnvPartial(object):
                     # Optimistically hope that name is the first arg. It generally is...
                     name = args[0]
                 raise IncorrectArgumentsException(
-                    self.func.func_name, name, missing_args, extra_args
+                    self.func.__name__, name, missing_args, extra_args
                 )
             raise
 

--- a/test/com/facebook/buck/cxx/testdata/platform_linker_flags/BUCK.fixture
+++ b/test/com/facebook/buck/cxx/testdata/platform_linker_flags/BUCK.fixture
@@ -3,7 +3,7 @@ TARGETS = {
     "macos": ["-Wl,-flat_namespace,-undefined,suppress"],
 }
 
-for target, flags in TARGETS.iteritems():
+for target, flags in TARGETS.items():
     cxx_binary(
         name = "binary_matches_default_exactly_" + target,
         srcs = [


### PR DESCRIPTION
The function attributes named func_X have been renamed to use the X form in Python3, https://docs.python.org/3/whatsnew/3.0.html#operators-and-special-methods and also built-in changes https://wiki.python.org/moin/Python3.0#Built-In_Changes.
The old names can't be used in Python3.
This PR changes the old names to new names to make buck Python3 compatible.
Python2 was EOL on 1/1/2020, Homebrew/homebrew-core#49796.