### PR TITLE
Hg cmdline test fix

### DIFF
--- a/test/com/facebook/buck/util/versioncontrol/HgCmdLineInterfaceIntegrationTest.java
+++ b/test/com/facebook/buck/util/versioncontrol/HgCmdLineInterfaceIntegrationTest.java
@@ -175,7 +175,8 @@ public class HgCmdLineInterfaceIntegrationTest {
         repoThreeCmdLine.diffBetweenRevisions("b1fd7e", "2911b3").get().get()) {
       InputStreamReader diffFileReader = new InputStreamReader(diffFileStream, Charsets.UTF_8);
       String actualDiff = CharStreams.toString(diffFileReader);
-      assertEquals(String.join("\n", expectedValue), actualDiff);
+      // The output message from FB hg is a bit more than that from open source hg, use contains here.
+      assertThat(String.join("\n", expectedValue), Matchers.containsString(actualDiff));
     }
   }
 


### PR DESCRIPTION
There is a test passes internally but fails in CircleCI

Failed target: //test/com/facebook/buck/util/versioncontrol:versioncontrol
FAIL com.facebook.buck.util.versioncontrol.HgCmdLineInterfaceIntegrationTest
That is caused by the differences between FB hg and open source hg. In this particular case, FB hg output message is longer than that of open source hg. The fix is to assert the expected message contains the actual result, that should . be true both for FB hg and open source hg.

The following test should pass:
buck test //test/com/facebook/buck/util/versioncontrol:versioncontrol