### PR TITLE
HG test diff between diffs fix

### DIFF
--- a/test/com/facebook/buck/util/versioncontrol/HgCmdLineInterfaceIntegrationTest.java
+++ b/test/com/facebook/buck/util/versioncontrol/HgCmdLineInterfaceIntegrationTest.java
@@ -175,7 +175,9 @@ public class HgCmdLineInterfaceIntegrationTest {
         repoThreeCmdLine.diffBetweenRevisions("b1fd7e", "2911b3").get().get()) {
       InputStreamReader diffFileReader = new InputStreamReader(diffFileStream, Charsets.UTF_8);
       String actualDiff = CharStreams.toString(diffFileReader);
-      assertEquals(String.join("\n", expectedValue), actualDiff);
+      // The output message from FB hg is a bit more than that from open source hg, use contains
+      // here.
+      assertThat(String.join("\n", expectedValue), Matchers.containsString(actualDiff));
     }
   }
 


### PR DESCRIPTION
Summary:
Failed target: //test/com/facebook/buck/util/versioncontrol:versioncontrol
FAIL com.facebook.buck.util.versioncontrol.HgCmdLineInterfaceIntegrationTest
That is caused by the differences between FB hg and open source hg. In this particular case, FB hg output message is longer than that of open source hg. The fix is to assert the expected message contains the actual result and make the test pass for both FB hg and open source hg.

Reviewed By: philipjameson

shipit-source-id: 43ba4de0c49d6a464ebce8fff46e7b2a8ec98731