### PR TITLE
[Fix] Strip symlink root from headers module map

### DIFF
--- a/src/com/facebook/buck/apple/clang/ModuleMapFactory.java
+++ b/src/com/facebook/buck/apple/clang/ModuleMapFactory.java
@@ -43,10 +43,11 @@ public class ModuleMapFactory {
       String moduleName,
       ModuleMapMode moduleMapMode,
       UmbrellaHeaderModuleMap.SwiftMode swiftMode,
-      Set<Path> headerPaths) {
+      Set<Path> headerPaths,
+      Path symlinkRoot) {
     switch (moduleMapMode) {
       case HEADERS:
-        String stripPrefix = moduleName + "/";
+        String stripPrefix = symlinkRoot.toString() + "/" + moduleName + "/";
         List<String> headerNames =
             headerPaths.stream()
                 .map(

--- a/src/com/facebook/buck/cxx/toolchain/HeaderSymlinkTreeWithModuleMap.java
+++ b/src/com/facebook/buck/cxx/toolchain/HeaderSymlinkTreeWithModuleMap.java
@@ -95,7 +95,8 @@ public final class HeaderSymlinkTreeWithModuleMap extends HeaderSymlinkTree {
                       containsSwiftHeader(paths, moduleName)
                           ? UmbrellaHeaderModuleMap.SwiftMode.INCLUDE_SWIFT_HEADER
                           : UmbrellaHeaderModuleMap.SwiftMode.NO_SWIFT,
-                      getLinks().keySet())));
+                      getLinks().keySet(),
+                      BuildTargetPaths.getGenPath(getProjectFilesystem(), getBuildTarget(), "%s/" + moduleName))));
 
           Path umbrellaHeaderPath = Paths.get(moduleName, moduleName + ".h");
           if (moduleMapMode.shouldGenerateMissingUmbrellaHeader()

--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -3173,7 +3173,8 @@ public class ProjectGenerator {
                       moduleName.get(),
                       moduleMapMode,
                       UmbrellaHeaderModuleMap.SwiftMode.INCLUDE_SWIFT_HEADER,
-                      headerPaths)
+                      headerPaths,
+                      headerSymlinkTreeRoot)
                   .render(),
               headerSymlinkTreeRoot.resolve(moduleName.get()).resolve("module.modulemap"));
           projectFilesystem.writeContentsToPath(
@@ -3181,7 +3182,8 @@ public class ProjectGenerator {
                       moduleName.get(),
                       moduleMapMode,
                       UmbrellaHeaderModuleMap.SwiftMode.EXCLUDE_SWIFT_HEADER,
-                      headerPaths)
+                      headerPaths,
+                      headerSymlinkTreeRoot)
                   .render(),
               headerSymlinkTreeRoot.resolve(moduleName.get()).resolve("objc.modulemap"));
 
@@ -3204,7 +3206,8 @@ public class ProjectGenerator {
                       moduleName.get(),
                       moduleMapMode,
                       UmbrellaHeaderModuleMap.SwiftMode.NO_SWIFT,
-                      headerPaths)
+                      headerPaths,
+                      headerSymlinkTreeRoot)
                   .render(),
               headerSymlinkTreeRoot.resolve(moduleName.get()).resolve("module.modulemap"));
         }


### PR DESCRIPTION
**Background**
When using `modulemap_mode = HEADERS`, buck was successfully building the module map but it would include the header symlink root in the header path which would cause it to not be found in the xcode header search paths. ie. it would look like
`header "gen/out/folder/anotherfolder/module_name/HeaderTest.h"`
when it should actually be
`header "HeaderTest.h"`

**Change**
Strip out symlink root along with module name from headers generation