### PR TITLE
fix: Remove extraneous .buckconfig check that causes infinite loop

### DIFF
--- a/programs/gen_buck_info.py
+++ b/programs/gen_buck_info.py
@@ -52,8 +52,6 @@ def main(argv):
     candidate_paths = []
     vcs_module = None
     while vcs_module is None and os.path.dirname(path) != path:
-        while not os.path.exists(os.path.join(path, ".buckconfig")):
-            path = os.path.dirname(path)
         for vcs_dir, module in SUPPORTED_VCS.items():
             if os.path.exists(os.path.join(path, vcs_dir)):
                 vcs_module = module


### PR DESCRIPTION
This fixes #2462. I've tested it on my local machine, although I don't see any place to add integration tests/smoke tests for the installer.