### PR TITLE
Respect user input if abi_generation_mode is explicitly provided in java_library

### DIFF
--- a/src/com/facebook/buck/jvm/java/DefaultJavaLibraryRules.java
+++ b/src/com/facebook/buck/jvm/java/DefaultJavaLibraryRules.java
@@ -302,9 +302,14 @@ public abstract class DefaultJavaLibraryRules {
     if (args != null) {
       result = args.getAbiGenerationMode().orElse(null);
     }
-    if (result == null) {
-      result = Objects.requireNonNull(getConfiguredCompilerFactory()).getAbiGenerationMode();
+
+    // Respect user input if provided
+    if (result != null) {
+      return result;
     }
+
+    // Infer ABI generation mode based on properties of build target
+    result = Objects.requireNonNull(getConfiguredCompilerFactory()).getAbiGenerationMode();
 
     if (result == AbiGenerationMode.CLASS) {
       return result;


### PR DESCRIPTION
To improve performance, we've found that setting a couple of targets to abi_generation_mode='source' will improve build performance. However, buck currently silently overrides the user-provided ABI generation mode.

I'm not a domain expert here, so it's possible that there is good reason to silently override the user choice. This PR is both something I hope to merge upstream but also open conversation on. If there is a good reason to not do this change, I will change the PR to be one that documents why the override happens.

There is a cost to this change. Existing users may have been specifying the wrong ABI generation mode in their targets, and buck has been silently overriding the ABI generation mode. I feel that it is more intuitive to trust the user if they explicitly provide the mode in the java_library call, so I believe this is acceptable.