### PR TITLE
Flavor rule key in `SwiftCompile` should be stringified.

### DIFF
--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -108,7 +108,8 @@ public class SwiftCompile extends AbstractBuildRule implements SupportsInputBase
   private final Path headerPath;
   @AddToRuleKey private final ImmutableSet<FrameworkPath> frameworks;
   @AddToRuleKey private final AddsToRuleKeyFunction<FrameworkPath, Path> frameworkPathToSearchPath;
-  @AddToRuleKey private final Flavor flavor;
+  @AddToRuleKey(stringify = true)
+  private final Flavor flavor;
 
   @AddToRuleKey private final boolean enableObjcInterop;
   @AddToRuleKey private final Optional<SourcePath> bridgingHeader;


### PR DESCRIPTION
In https://github.com/facebook/buck/pull/2469, we added `@AddToRuleKey private final Flavor flavor;` in order to capture `cxxPlatform.getFlavor()` in `SwiftCompile` class.

However, Flavor is not a supported type for rulekey computation, and we have to use `@AddToRuleKey(stringify = true)` instead for this attribute.