### PR TITLE
Update jitpack python 3 url to be compatible with older OS

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,7 +1,7 @@
 install:
    - set -exo pipefail
    - mkdir python_tmp
-   - wget https://github.com/kageiit/jitpack-python/releases/download/3.8/python-3.8.tar.gz -O python_tmp/python.tar.gz
+   - wget https://github.com/kageiit/jitpack-python/releases/download/3.8/python-3.8-ubuntu-16.tar.gz -O python_tmp/python.tar.gz
    - tar -C python_tmp -xf python_tmp/python.tar.gz --strip-components=1
    - export PATH="$PATH:python_tmp/bin"
    - ant


### PR DESCRIPTION
- Fixes #2478
- Also added build instructions at https://github.com/kageiit/jitpack-python/blob/master/README.md if anyone wants to build their own version in the future