### PR TITLE
Fix jitpack using new python3 tar

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -2,7 +2,7 @@ install:
    - set -exo pipefail
    - mkdir python_tmp
    - wget https://github.com/kageiit/jitpack-python/releases/download/3.8/python-3.8-ubuntu-16.tar.gz -O python_tmp/python.tar.gz
-   - tar -C python_tmp -xf python_tmp/python.tar.gz --strip-components=1
+   - tar -C python_tmp -xf python_tmp/python.tar.gz
    - export PATH="$PATH:python_tmp/bin"
    - ant
    - PEX=$(bin/buck build buck --show-output | awk '{print $2}')


### PR DESCRIPTION
The updated python3 tar doesn't have a top-level `dist` directory, so there's no need to strip components when untarring.

Fixes: #2478