### PR TITLE
Fixed "Unable to resolve dependency jdk8 (= 8.0.172)"

### DIFF
--- a/tools/release/platforms/chocolatey/buck.nuspec
+++ b/tools/release/platforms/chocolatey/buck.nuspec
@@ -19,7 +19,7 @@
     <releaseNotes></releaseNotes>
     <dependencies>
       <dependency id="python3" version="[3.6.2, 4.0)" />
-      <dependency id="jdk8" version="8.0.172" />
+      <dependency id="jdk8" version="8.0.211" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Fixed "Unable to resolve dependency jdk8 (= 8.0.172)"
There is an error in the verification process in Chocolatey. Upgrade jdk8 to "8.0.211"