### PR TITLE
CircleCI fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -804,17 +804,17 @@ jobs:
       - run:
           <<: *install_rust
       - run:
-          <<: *install_python
-      - run:
-          <<: *install_groovy
-      - run:
-          <<: *install_dlang
-      - run:
           # There is an issue with python in macos 10.14.x. this step is a work around and should be removed later.
           # https://stackoverflow.com/questions/59269208/errorrootcode-for-hash-md5-was-not-found-not-able-to-use-any-hg-mercurial-co
           name: Reinstall Python2
           command: |
             brew reinstall https://raw.githubusercontent.com/Homebrew/homebrew-core/86a44a0a552c673a05f11018459c9f5faae3becc/Formula/python@2.rb
+      - run:
+          <<: *install_python
+      - run:
+          <<: *install_groovy
+      - run:
+          <<: *install_dlang
       - run:
           <<: *run_ant_build
       - restore_cache:


### PR DESCRIPTION
CircleCI changed their setting, that caused python installed failed. Fixed it by explicitly installed one of the dependencies.