### PR TITLE
Added python3 to interpreter names

### DIFF
--- a/python-dsl/buck_parser/module_whitelist.py
+++ b/python-dsl/buck_parser/module_whitelist.py
@@ -75,7 +75,12 @@ class ImportWhitelistManager(object):
             name = name.split(".")[0]
 
         frame = util.get_caller_frame(skip=[__name__])
+        # __import__() can be called during the call to inspect.getframeinfo() and that should
+        # be handled by the ORIGINAL_IMPORT
+        current_import = builtins.__import__
+        builtins.__import__ = ORIGINAL_IMPORT
         filename = inspect.getframeinfo(frame).filename
+        builtins.__import__ = current_import
 
         # The import will be always allowed if it was not called from a project file.
         if name in self._import_whitelist or not self._path_predicate(filename):

--- a/src/com/facebook/buck/parser/ParserPythonInterpreterProvider.java
+++ b/src/com/facebook/buck/parser/ParserPythonInterpreterProvider.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 public class ParserPythonInterpreterProvider {
 
   private static final ImmutableList<String> PYTHON_INTERPRETER_NAMES =
-      ImmutableList.of("python2", "python");
+      ImmutableList.of("python3", "python", "python2");
 
   private final ParserConfig parserConfig;
   private final ExecutableFinder executableFinder;

--- a/test/com/facebook/buck/features/rust/RustLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/features/rust/RustLibraryIntegrationTest.java
@@ -17,6 +17,7 @@
 package com.facebook.buck.features.rust;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.either;
 import static org.junit.Assert.assertThat;
 
 import com.facebook.buck.testutil.ProcessResult;
@@ -96,7 +97,8 @@ public class RustLibraryIntegrationTest {
                 "rust.rustc_check_flags=-Dwarnings --cfg \"feature=\\\"warning\\\"\"",
                 "//messenger:messenger#check")
             .getStderr(),
-        containsString("error: method is never used: `unused`"));
+        either(containsString("error: method is never used: `unused`"))
+            .or(containsString("error: associated function is never used: `unused`")));
   }
 
   @Test

--- a/test/com/facebook/buck/features/rust/RustLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/features/rust/RustLibraryIntegrationTest.java
@@ -17,7 +17,6 @@
 package com.facebook.buck.features.rust;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.either;
 import static org.junit.Assert.assertThat;
 
 import com.facebook.buck.testutil.ProcessResult;
@@ -97,8 +96,7 @@ public class RustLibraryIntegrationTest {
                 "rust.rustc_check_flags=-Dwarnings --cfg \"feature=\\\"warning\\\"\"",
                 "//messenger:messenger#check")
             .getStderr(),
-        either(containsString("error: method is never used: `unused`"))
-            .or(containsString("error: associated function is never used: `unused`")));
+        containsString("error: method is never used: `unused`"));
   }
 
   @Test

--- a/test/com/facebook/buck/parser/ParserIntegrationTest.java
+++ b/test/com/facebook/buck/parser/ParserIntegrationTest.java
@@ -436,7 +436,7 @@ public class ParserIntegrationTest {
             "//python/implicit_in_extension_bzl:main",
             "-c",
             "parser.disable_implicit_native_rules=true"),
-        "NameError: global name 'java_library' is not defined",
+        "NameError: name 'java_library' is not defined",
         "extension.bzl\", line 5",
         "BUCK\", line 5");
     assertParseFailedWithSubstrings(


### PR DESCRIPTION
Added python3 to interpreter names and the search order should be "python3", "python", "python2".