### PR TITLE
Add support for java 11 builds in jitpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ You must be using Java 8 or 11 for this to compile successfully. If you see comp
 
 Pre-built binaries of buck for any buck `sha` can be downloaded from `https://jitpack.io/com/github/facebook/buck/<sha>/buck-<sha>.pex`. The very first time a version of buck is requested, it is built via [jitpack](https://jitpack.io/). As a result, it could take a few minutes for this initial binary to become available. Every subsequent request will just serve the built artifact directly. This functionality is available for any fork of buck as well, so you can fetch `https://jitpack.io/com/github/<github-user-or-org>/buck/<sha>/buck-<sha>.pex`
 
+For buck binaries built for JDK 11, modify end of the url to `buck-<sha>-java11.pex`.
+
 Feature Deprecation
 -------------------
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -8,3 +8,8 @@ install:
    - PEX=$(bin/buck build buck --show-output | awk '{print $2}')
    - SHA=$(git rev-parse HEAD)
    - mvn install:install-file -Dfile="$PEX" -DgroupId="$GROUP" -DartifactId="$ARTIFACT" -Dversion="$SHA" -Dpackaging="pex" -DgeneratePom=true
+   - export JAVA_HOME="/usr/lib/jvm/jdk-11"
+   - export PATH="/usr/lib/jvm/jdk-11:$PATH"
+   - ant clean && ant
+   - JAVA11_PEX=$(bin/buck build --config java.target_level=11 --config java.source_level=11 buck --show-output | awk '{print $2}')
+   - mvn install:install-file -Dfile="$JAVA11_PEX" -DgroupId="$GROUP" -DartifactId="$ARTIFACT" -Dversion="$SHA" -Dclassifier="java11" -Dpackaging="pex" -DgeneratePom=true


### PR DESCRIPTION
We may want to publish JDK 11 compatible deb etc. for each release as well on Github

Tested a successful build on my fork - https://jitpack.io/com/github/kageiit/buck/aa94591681/build.log