### PR TITLE
Do not override SWIFT_OBJC_INTERFACE_HEADER_NAME

### DIFF
--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -1721,8 +1721,11 @@ public class ProjectGenerator {
           s -> extraSettingsBuilder.put("PRODUCT_MODULE_NAME", getModuleName(targetNode)));
 
       if (hasSwiftVersionArg && containsSwiftCode && isFocusedOnTarget) {
-        extraSettingsBuilder.put(
-            "SWIFT_OBJC_INTERFACE_HEADER_NAME", getSwiftObjCGeneratedHeaderName(buildTargetNode));
+        // Do not override user's value
+        if (!extraSettingsBuilder.build().containsKey("SWIFT_OBJC_INTERFACE_HEADER_NAME")) {
+          extraSettingsBuilder.put(
+              "SWIFT_OBJC_INTERFACE_HEADER_NAME", getSwiftObjCGeneratedHeaderName(buildTargetNode));
+        }
 
         if (swiftBuckConfig.getProjectWMO()) {
           // We must disable "Index While Building" as there's a bug in the LLVM infra which


### PR DESCRIPTION
Sometimes the name of `*-Swift.h` header should be customized.
However, Buck always overrides user's value that fails to build a project in Xcode.
This patch intends to avoid automatically setting the value if a user has already configured one.