### PR TITLE
Added application_region and application_language properties to xcode_workspace_config

### DIFF
--- a/src/com/facebook/buck/apple/xcode/XCScheme.java
+++ b/src/com/facebook/buck/apple/xcode/XCScheme.java
@@ -255,6 +255,8 @@ public class XCScheme {
     private final Optional<ImmutableMap<String, String>> environmentVariables;
     private final Optional<BuildableReference> expandVariablesBasedOn;
     private final Optional<String> notificationPayloadFile;
+    private final Optional<String> applicationLanguage;
+    private final Optional<String> applicationRegion;
 
     public LaunchAction(
         BuildableReference buildableReference,
@@ -267,7 +269,9 @@ public class XCScheme {
         Optional<BuildableReference> expandVariablesBasedOn,
         Optional<ImmutableList<SchemePrePostAction>> preActions,
         Optional<ImmutableList<SchemePrePostAction>> postActions,
-        Optional<String> notificationPayloadFile) {
+        Optional<String> notificationPayloadFile,
+        Optional<String> applicationLanguage,
+        Optional<String> applicationRegion) {
       super(preActions, postActions);
       this.buildableReference = buildableReference;
       this.buildConfiguration = buildConfiguration;
@@ -278,6 +282,8 @@ public class XCScheme {
       this.environmentVariables = environmentVariables;
       this.expandVariablesBasedOn = expandVariablesBasedOn;
       this.notificationPayloadFile = notificationPayloadFile;
+      this.applicationLanguage = applicationLanguage;
+      this.applicationRegion = applicationRegion;
     }
 
     public BuildableReference getBuildableReference() {
@@ -314,6 +320,14 @@ public class XCScheme {
 
     public Optional<BuildableReference> getExpandVariablesBasedOn() {
       return expandVariablesBasedOn;
+    }
+
+    public Optional<String> getApplicationLanguage() {
+      return applicationLanguage;
+    }
+
+    public Optional<String> getApplicationRegion() {
+      return applicationRegion;
     }
   }
 
@@ -359,18 +373,24 @@ public class XCScheme {
     private final String buildConfiguration;
     private final Optional<ImmutableMap<String, String>> environmentVariables;
     private final Optional<BuildableReference> expandVariablesBasedOn;
+    private final Optional<String> applicationLanguage;
+    private final Optional<String> applicationRegion;
 
     public TestAction(
         String buildConfiguration,
         Optional<ImmutableMap<String, String>> environmentVariables,
         Optional<BuildableReference> expandVariablesBasedOn,
         Optional<ImmutableList<SchemePrePostAction>> preActions,
-        Optional<ImmutableList<SchemePrePostAction>> postActions) {
+        Optional<ImmutableList<SchemePrePostAction>> postActions,
+        Optional<String> applicationLanguage,
+        Optional<String> applicationRegion) {
       super(preActions, postActions);
       this.testables = new ArrayList<>();
       this.buildConfiguration = buildConfiguration;
       this.environmentVariables = environmentVariables;
       this.expandVariablesBasedOn = expandVariablesBasedOn;
+      this.applicationLanguage = applicationLanguage;
+      this.applicationRegion = applicationRegion;
     }
 
     public void addTestableReference(TestableReference testable) {
@@ -391,6 +411,14 @@ public class XCScheme {
 
     public Optional<BuildableReference> getExpandVariablesBasedOn() {
       return expandVariablesBasedOn;
+    }
+
+    public Optional<String> getApplicationLanguage() {
+      return applicationRegion;
+    }
+
+    public Optional<String> getApplicationRegion() {
+      return applicationRegion;
     }
   }
 

--- a/src/com/facebook/buck/apple/xcode/XCScheme.java
+++ b/src/com/facebook/buck/apple/xcode/XCScheme.java
@@ -414,7 +414,7 @@ public class XCScheme {
     }
 
     public Optional<String> getApplicationLanguage() {
-      return applicationRegion;
+      return applicationLanguage;
     }
 
     public Optional<String> getApplicationRegion() {

--- a/src/com/facebook/buck/features/apple/common/XcodeWorkspaceConfigDescription.java
+++ b/src/com/facebook/buck/features/apple/common/XcodeWorkspaceConfigDescription.java
@@ -100,9 +100,9 @@ public class XcodeWorkspaceConfigDescription
     Optional<ImmutableMap<SchemeActionType, ImmutableMap<String, String>>>
         getEnvironmentVariables();
 
-    Optional<ImmutableMap<String, String>> getApplicationLanguage();
+    Optional<String> getApplicationLanguage();
 
-    Optional<ImmutableMap<String, String>> getApplicationRegion();
+    Optional<String> getApplicationRegion();
 
     Optional<ImmutableMap<SchemeActionType, BuildTarget>> getExpandVariablesBasedOn();
 

--- a/src/com/facebook/buck/features/apple/common/XcodeWorkspaceConfigDescription.java
+++ b/src/com/facebook/buck/features/apple/common/XcodeWorkspaceConfigDescription.java
@@ -100,6 +100,10 @@ public class XcodeWorkspaceConfigDescription
     Optional<ImmutableMap<SchemeActionType, ImmutableMap<String, String>>>
         getEnvironmentVariables();
 
+    Optional<ImmutableMap<String, String>> getApplicationLanguage();
+
+    Optional<ImmutableMap<String, String>> getApplicationRegion();
+
     Optional<ImmutableMap<SchemeActionType, BuildTarget>> getExpandVariablesBasedOn();
 
     /**

--- a/src/com/facebook/buck/features/apple/project/SchemeGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/SchemeGenerator.java
@@ -304,8 +304,8 @@ class SchemeGenerator {
                         AdditionalActions.POST_SCHEME_ACTIONS,
                         primaryBuildReference),
                     notificationPayloadFile,
-                    applicationRegion,
-                    applicationLanguage));
+                    applicationLanguage,
+                    applicationRegion));
 
         profileAction =
             Optional.of(

--- a/src/com/facebook/buck/features/apple/project/SchemeGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/SchemeGenerator.java
@@ -471,14 +471,6 @@ class SchemeGenerator {
       testableElem.appendChild(refElem);
     }
 
-    if (testAction.getApplicationLanguage().isPresent()) {
-      testActionElem.setAttribute("language", testAction.getApplicationLanguage().get());
-    }
-
-    if (testAction.getApplicationRegion().isPresent()) {
-      testActionElem.setAttribute("region", testAction.getApplicationRegion().get());
-    }
-
     if (testAction.getEnvironmentVariables().isPresent()) {
       if (testAction.getExpandVariablesBasedOn().isPresent()) {
         Element expandBasedOnElement =
@@ -491,6 +483,14 @@ class SchemeGenerator {
       Element environmentVariablesElement =
           serializeEnvironmentVariables(doc, testAction.getEnvironmentVariables().get());
       testActionElem.appendChild(environmentVariablesElement);
+    }
+
+    if (testAction.getApplicationLanguage().isPresent()) {
+      testActionElem.setAttribute("language", testAction.getApplicationLanguage().get());
+    }
+
+    if (testAction.getApplicationRegion().isPresent()) {
+      testActionElem.setAttribute("region", testAction.getApplicationRegion().get());
     }
 
     return testActionElem;

--- a/src/com/facebook/buck/features/apple/project/SchemeGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/SchemeGenerator.java
@@ -93,6 +93,8 @@ class SchemeGenerator {
           ImmutableMap<
               SchemeActionType, ImmutableMap<XCScheme.AdditionalActions, ImmutableList<String>>>>
       additionalSchemeActions;
+  private final Optional<String> applicationLanguage;
+  private final Optional<String> applicationRegion;
 
   public SchemeGenerator(
       ProjectFilesystem projectFilesystem,
@@ -117,7 +119,9 @@ class SchemeGenerator {
           additionalSchemeActions,
       XCScheme.LaunchAction.LaunchStyle launchStyle,
       Optional<XCScheme.LaunchAction.WatchInterface> watchInterface,
-      Optional<String> notificationPayloadFile) {
+      Optional<String> notificationPayloadFile,
+      Optional<String> applicationLanguage,
+      Optional<String> applicationRegion) {
     this.projectFilesystem = projectFilesystem;
     this.primaryTarget = primaryTarget;
     this.watchInterface = watchInterface;
@@ -137,6 +141,8 @@ class SchemeGenerator {
     this.expandVariablesBasedOn = expandVariablesBasedOn;
     this.additionalSchemeActions = additionalSchemeActions;
     this.notificationPayloadFile = notificationPayloadFile;
+    this.applicationLanguage = applicationLanguage;
+    this.applicationRegion = applicationRegion;
 
     LOG.verbose(
         "Generating scheme with build targets %s, test build targets %s, test bundle targets %s",
@@ -259,7 +265,9 @@ class SchemeGenerator {
             additionalCommandsForSchemeAction(
                 SchemeActionType.TEST,
                 AdditionalActions.POST_SCHEME_ACTIONS,
-                primaryBuildReference));
+                primaryBuildReference),
+            applicationLanguage,
+            applicationRegion);
 
     for (PBXTarget target : orderedRunTestTargets) {
       XCScheme.BuildableReference buildableReference =
@@ -295,7 +303,9 @@ class SchemeGenerator {
                         SchemeActionType.LAUNCH,
                         AdditionalActions.POST_SCHEME_ACTIONS,
                         primaryBuildReference),
-                    notificationPayloadFile));
+                    notificationPayloadFile,
+                    applicationRegion,
+                    applicationLanguage));
 
         profileAction =
             Optional.of(
@@ -461,6 +471,14 @@ class SchemeGenerator {
       testableElem.appendChild(refElem);
     }
 
+    if (testAction.getApplicationLanguage().isPresent()) {
+      testActionElem.setAttribute("language", testAction.getApplicationLanguage().get());
+    }
+
+    if (testAction.getApplicationRegion().isPresent()) {
+      testActionElem.setAttribute("region", testAction.getApplicationRegion().get());
+    }
+
     if (testAction.getEnvironmentVariables().isPresent()) {
       if (testAction.getExpandVariablesBasedOn().isPresent()) {
         Element expandBasedOnElement =
@@ -549,6 +567,14 @@ class SchemeGenerator {
       Element environmentVariablesElement =
           serializeEnvironmentVariables(doc, launchAction.getEnvironmentVariables().get());
       launchActionElem.appendChild(environmentVariablesElement);
+    }
+
+    if (launchAction.getApplicationLanguage().isPresent()) {
+      launchActionElem.setAttribute("language", launchAction.getApplicationLanguage().get());
+    }
+
+    if (launchAction.getApplicationRegion().isPresent()) {
+      launchActionElem.setAttribute("region", launchAction.getApplicationRegion().get());
     }
 
     return launchActionElem;

--- a/src/com/facebook/buck/features/apple/project/WorkspaceAndProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/WorkspaceAndProjectGenerator.java
@@ -1272,6 +1272,8 @@ public class WorkspaceAndProjectGenerator {
     Optional<XCScheme.LaunchAction.WatchInterface> watchInterface = Optional.empty();
     Optional<String> notificationPayloadFile = Optional.empty();
     Optional<Boolean> wasCreatedForAppExtension = Optional.empty();
+    Optional<String> applicationLanguage = Optional.empty();
+    Optional<String> applicationRegion = Optional.empty();
 
     if (schemeConfigArg.isPresent()) {
       environmentVariables = schemeConfigArg.get().getEnvironmentVariables();
@@ -1280,6 +1282,8 @@ public class WorkspaceAndProjectGenerator {
       watchInterface = schemeConfigArg.get().getWatchInterface();
       notificationPayloadFile = schemeConfigArg.get().getNotificationPayloadFile();
       wasCreatedForAppExtension = schemeConfigArg.get().getWasCreatedForAppExtension();
+      applicationLanguage = schemeConfigArg.get().getApplicationLanguage();
+      applicationRegion = schemeConfigArg.get().getApplicationRegion();
     }
 
     return new SchemeGenerator(
@@ -1301,6 +1305,8 @@ public class WorkspaceAndProjectGenerator {
         additionalSchemeActions,
         launchStyle,
         watchInterface,
-        notificationPayloadFile);
+        notificationPayloadFile,
+        applicationLanguage,
+        applicationRegion);
   }
 }

--- a/src/com/facebook/buck/features/apple/projectV2/SchemeGenerator.java
+++ b/src/com/facebook/buck/features/apple/projectV2/SchemeGenerator.java
@@ -93,6 +93,8 @@ class SchemeGenerator {
   private Optional<
           ImmutableMap<SchemeActionType, ImmutableMap<AdditionalActions, ImmutableList<String>>>>
       additionalSchemeActions;
+  private final Optional<String> applicationLanguage;
+  private final Optional<String> applicationRegion;
 
   public SchemeGenerator(
       ProjectFilesystem projectFilesystem,
@@ -116,7 +118,9 @@ class SchemeGenerator {
           additionalSchemeActions,
       XCScheme.LaunchAction.LaunchStyle launchStyle,
       Optional<XCScheme.LaunchAction.WatchInterface> watchInterface,
-      Optional<String> notificationPayloadFile) {
+      Optional<String> notificationPayloadFile,
+      Optional<String> applicationLanguage,
+      Optional<String> applicationRegion) {
     this.projectFilesystem = projectFilesystem;
     this.primaryTarget = primaryTarget;
     this.watchInterface = watchInterface;
@@ -136,6 +140,8 @@ class SchemeGenerator {
     this.expandVariablesBasedOn = expandVariablesBasedOn;
     this.additionalSchemeActions = additionalSchemeActions;
     this.notificationPayloadFile = notificationPayloadFile;
+    this.applicationLanguage = applicationLanguage;
+    this.applicationRegion = applicationRegion;
 
     LOG.verbose(
         "Generating scheme with build targets %s, test build targets %s, test bundle targets %s",
@@ -254,7 +260,9 @@ class SchemeGenerator {
             additionalCommandsForSchemeAction(
                 SchemeActionType.TEST,
                 AdditionalActions.POST_SCHEME_ACTIONS,
-                primaryBuildReference));
+                primaryBuildReference),
+            applicationLanguage,
+            applicationRegion);
 
     for (PBXTarget target : orderedRunTestTargets) {
       XCScheme.BuildableReference buildableReference =
@@ -290,7 +298,9 @@ class SchemeGenerator {
                         SchemeActionType.LAUNCH,
                         AdditionalActions.POST_SCHEME_ACTIONS,
                         primaryBuildReference),
-                    notificationPayloadFile));
+                    notificationPayloadFile,
+                    applicationLanguage,
+                    applicationRegion));
 
         profileAction =
             Optional.of(
@@ -512,6 +522,14 @@ class SchemeGenerator {
       testActionElem.appendChild(environmentVariablesElement);
     }
 
+    if (testAction.getApplicationLanguage().isPresent()) {
+      testActionElem.setAttribute("language", testAction.getApplicationLanguage().get());
+    }
+
+    if (testAction.getApplicationRegion().isPresent()) {
+      testActionElem.setAttribute("region", testAction.getApplicationRegion().get());
+    }
+
     return testActionElem;
   }
 
@@ -586,6 +604,14 @@ class SchemeGenerator {
       Element environmentVariablesElement =
           serializeEnvironmentVariables(doc, launchAction.getEnvironmentVariables().get());
       launchActionElem.appendChild(environmentVariablesElement);
+    }
+
+    if (launchAction.getApplicationLanguage().isPresent()) {
+      launchActionElem.setAttribute("language", launchAction.getApplicationLanguage().get());
+    }
+
+    if (launchAction.getApplicationRegion().isPresent()) {
+      launchActionElem.setAttribute("region", launchAction.getApplicationRegion().get());
     }
 
     return launchActionElem;

--- a/src/com/facebook/buck/features/apple/projectV2/SchemeGenerator.java
+++ b/src/com/facebook/buck/features/apple/projectV2/SchemeGenerator.java
@@ -529,7 +529,6 @@ class SchemeGenerator {
     if (testAction.getApplicationRegion().isPresent()) {
       testActionElem.setAttribute("region", testAction.getApplicationRegion().get());
     }
-
     return testActionElem;
   }
 

--- a/src/com/facebook/buck/features/apple/projectV2/WorkspaceAndProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/projectV2/WorkspaceAndProjectGenerator.java
@@ -948,6 +948,8 @@ public class WorkspaceAndProjectGenerator {
     Optional<XCScheme.LaunchAction.WatchInterface> watchInterface = Optional.empty();
     Optional<String> notificationPayloadFile = Optional.empty();
     Optional<Boolean> wasCreatedForAppExtension = Optional.empty();
+    Optional<String> applicationLanguage = Optional.empty();
+    Optional<String> applicationRegion = Optional.empty();
 
     if (schemeConfigArg.isPresent()) {
       environmentVariables = schemeConfigArg.get().getEnvironmentVariables();
@@ -956,6 +958,8 @@ public class WorkspaceAndProjectGenerator {
       watchInterface = schemeConfigArg.get().getWatchInterface();
       notificationPayloadFile = schemeConfigArg.get().getNotificationPayloadFile();
       wasCreatedForAppExtension = schemeConfigArg.get().getWasCreatedForAppExtension();
+      applicationLanguage = schemeConfigArg.get().getApplicationLanguage();
+      applicationRegion = schemeConfigArg.get().getApplicationRegion();
     }
 
     return new SchemeGenerator(
@@ -977,6 +981,9 @@ public class WorkspaceAndProjectGenerator {
         additionalSchemeActions,
         launchStyle,
         watchInterface,
-        notificationPayloadFile);
+        notificationPayloadFile,
+        applicationLanguage,
+        applicationRegion
+        );
   }
 }

--- a/test/com/facebook/buck/features/apple/project/SchemeGeneratorTest.java
+++ b/test/com/facebook/buck/features/apple/project/SchemeGeneratorTest.java
@@ -131,7 +131,9 @@ public class SchemeGeneratorTest {
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notificationPayloadFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
     String schemeXml = projectFilesystem.readFileIfItExists(schemePath).get();
@@ -218,7 +220,9 @@ public class SchemeGeneratorTest {
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notificationPayloadFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
     String schemeXml = projectFilesystem.readFileIfItExists(schemePath).get();
@@ -314,7 +318,9 @@ public class SchemeGeneratorTest {
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notificationPayloadFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
     String schemeXml = projectFilesystem.readFileIfItExists(schemePath).get();
@@ -375,28 +381,30 @@ public class SchemeGeneratorTest {
 
     Path pbxprojectPath = Paths.get("foo/Foo.xcodeproj/project.pbxproj");
     targetToProjectPathMapBuilder.put(rootTarget, pbxprojectPath);
-
     SchemeGenerator schemeGenerator =
-        new SchemeGenerator(
-            projectFilesystem,
-            Optional.of(rootTarget),
-            ImmutableSet.of(rootTarget),
-            ImmutableSet.of(),
-            ImmutableSet.of(),
-            "TestScheme",
-            Paths.get("_gen/Foo.xcworkspace/scshareddata/xcshemes"),
-            false /* parallelizeBuild */,
-            Optional.empty() /* wasCreatedForAppExtension */,
-            Optional.empty() /* runnablePath */,
-            Optional.empty() /* remoteRunnablePath */,
-            SchemeActionType.DEFAULT_CONFIG_NAMES,
-            targetToProjectPathMapBuilder.build(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            XCScheme.LaunchAction.LaunchStyle.AUTO,
-            Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notificationPayloadFile */);
+      new SchemeGenerator(
+        projectFilesystem,
+        Optional.of(rootTarget),
+        ImmutableSet.of(rootTarget),
+        ImmutableSet.of(),
+        ImmutableSet.of(),
+        "TestScheme",
+        Paths.get("_gen/Foo.xcworkspace/scshareddata/xcshemes"),
+        false /* parallelizeBuild */,
+        Optional.empty() /* wasCreatedForAppExtension */,
+        Optional.empty() /* runnablePath */,
+        Optional.empty() /* remoteRunnablePath */,
+        SchemeActionType.DEFAULT_CONFIG_NAMES,
+        targetToProjectPathMapBuilder.build(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        XCScheme.LaunchAction.LaunchStyle.AUTO,
+        Optional.empty(), /* watchAdapter */
+        Optional.empty(), /* notificationPayloadFile */
+        Optional.empty(), /* applicationRegion */
+        Optional.empty() /* applicationLanguage */);
+
 
     Path schemePath = schemeGenerator.writeScheme();
 
@@ -460,7 +468,9 @@ public class SchemeGeneratorTest {
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notificationPayloadFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
 
@@ -548,7 +558,9 @@ public class SchemeGeneratorTest {
               Optional.empty(),
               XCScheme.LaunchAction.LaunchStyle.AUTO,
               Optional.empty(), /* watchAdapter */
-              Optional.empty() /* notificationPayloadFile */);
+              Optional.empty(), /* notificationPayloadFile */
+              Optional.empty(), /* applicationRegion */
+              Optional.empty() /* applicationLanguage */);
 
       Path schemePath = schemeGenerator.writeScheme();
       assertThat(
@@ -587,7 +599,9 @@ public class SchemeGeneratorTest {
               Optional.empty(),
               XCScheme.LaunchAction.LaunchStyle.AUTO,
               Optional.empty(), /* watchAdapter */
-              Optional.empty() /* notificationPayloadFile */);
+              Optional.empty(), /* notificationPayloadFile */
+              Optional.empty(), /* applicationRegion */
+              Optional.empty() /* applicationLanguage */);
 
       Path schemePath = schemeGenerator.writeScheme();
       assertThat(
@@ -629,7 +643,9 @@ public class SchemeGeneratorTest {
               Optional.empty(),
               XCScheme.LaunchAction.LaunchStyle.AUTO,
               Optional.empty(), /* watchAdapter */
-              Optional.empty() /* notificationPayloadFile */);
+              Optional.empty(), /* notificationPayloadFile */
+              Optional.empty(), /* applicationRegion */
+              Optional.empty() /* applicationLanguage */);
 
       Path schemePath = schemeGenerator.writeScheme();
       assertThat(
@@ -668,7 +684,9 @@ public class SchemeGeneratorTest {
               Optional.empty(),
               XCScheme.LaunchAction.LaunchStyle.AUTO,
               Optional.empty(), /* watchAdapter */
-              Optional.empty() /* notificationPayloadFile */);
+              Optional.empty(), /* notificationPayloadFile */
+              Optional.empty(), /* applicationRegion */
+              Optional.empty() /* applicationLanguage */);
       Path schemePath = schemeGenerator.writeScheme();
       assertThat(
           projectFilesystem.getLastModifiedTime(schemePath), equalTo(FileTime.fromMillis(49152L)));
@@ -731,7 +749,9 @@ public class SchemeGeneratorTest {
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notificationPayloadFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
     String schemeXml = projectFilesystem.readFileIfItExists(schemePath).get();
@@ -841,7 +861,9 @@ public class SchemeGeneratorTest {
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notificationPayloadFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
 
@@ -895,7 +917,9 @@ public class SchemeGeneratorTest {
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* payloadNotificationFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
 
@@ -978,7 +1002,9 @@ public class SchemeGeneratorTest {
             Optional.of(schemeActions),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notificationPayloadFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
 
@@ -1055,7 +1081,9 @@ public class SchemeGeneratorTest {
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notifcationPayloadFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
 
@@ -1119,7 +1147,9 @@ public class SchemeGeneratorTest {
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notificationPayloadFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
 
@@ -1137,6 +1167,70 @@ public class SchemeGeneratorTest {
     Node envVar = envVariableList.item(0);
     assertThat(envVar.getAttributes().getNamedItem("key").getNodeValue(), equalTo("ENV_VARIABLE"));
     assertThat(envVar.getAttributes().getNamedItem("value").getNodeValue(), equalTo("IS_SET"));
+  }
+
+  @Test
+  public void serializesRegionAndLanguage() throws Exception {
+    ImmutableMap.Builder<PBXTarget, Path> targetToProjectPathMapBuilder = ImmutableMap.builder();
+
+    PBXTarget rootTarget =
+      new PBXNativeTarget("rootRule", AbstractPBXObjectFactory.DefaultFactory());
+    rootTarget.setGlobalID("rootGID");
+    rootTarget.setProductReference(
+      new PBXFileReference(
+        "root.a", "root.a", PBXReference.SourceTree.BUILT_PRODUCTS_DIR, Optional.empty()));
+    rootTarget.setProductType(ProductTypes.STATIC_LIBRARY);
+
+    Path pbxprojectPath = Paths.get("foo/Foo.xcodeproj/project.pbxproj");
+    targetToProjectPathMapBuilder.put(rootTarget, pbxprojectPath);
+
+    String region = "pt-BR";
+    String language = "pt";
+
+    SchemeGenerator schemeGenerator =
+      new SchemeGenerator(
+        projectFilesystem,
+        Optional.of(rootTarget),
+        ImmutableSet.of(rootTarget),
+        ImmutableSet.of(),
+        ImmutableSet.of(),
+        "TestScheme",
+        Paths.get("_gen/Foo.xcworkspace/scshareddata/xcshemes"),
+        true /* parallelizeBuild */,
+        Optional.empty() /* wasCreatedForAppExtension */,
+        Optional.empty() /* runnablePath */,
+        Optional.empty() /* remoteRunnablePath */,
+        SchemeActionType.DEFAULT_CONFIG_NAMES,
+        targetToProjectPathMapBuilder.build(),
+        Optional.empty() /* environmentVariables */,
+        Optional.empty(),
+        Optional.empty(),
+        XCScheme.LaunchAction.LaunchStyle.AUTO,
+        Optional.empty(), /* watchAdapter */
+        Optional.empty(), /* notificationPayloadFile */
+        Optional.of(region),
+        Optional.of(language));
+
+    Path schemePath = schemeGenerator.writeScheme();
+
+    DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+    DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+    Document scheme = dBuilder.parse(projectFilesystem.newFileInputStream(schemePath));
+
+    XPathFactory xpathFactory = XPathFactory.newInstance();
+    XPath buildActionXpath = xpathFactory.newXPath();
+
+    XPathExpression launchActionExpr = buildActionXpath.compile("//LaunchAction");
+    XPathExpression testActionExpr = buildActionXpath.compile("//TestAction");
+
+    Node launchActionNode = (Node) launchActionExpr.evaluate(scheme, XPathConstants.NODE);
+    Node testActionNode = (Node) testActionExpr.evaluate(scheme, XPathConstants.NODE);
+
+    assertThat(launchActionNode.getAttributes().getNamedItem("language").getNodeValue(), equalTo("pt-BR"));
+    assertThat(launchActionNode.getAttributes().getNamedItem("region").getNodeValue(), equalTo("pt"));
+
+    assertThat(testActionNode.getAttributes().getNamedItem("language").getNodeValue(), equalTo("pt-BR"));
+    assertThat(testActionNode.getAttributes().getNamedItem("region").getNodeValue(), equalTo("pt"));
   }
 
   /**
@@ -1179,7 +1273,9 @@ public class SchemeGeneratorTest {
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notificationPayloadFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
 
@@ -1243,7 +1339,9 @@ public class SchemeGeneratorTest {
               Optional.empty(),
               XCScheme.LaunchAction.LaunchStyle.AUTO,
               Optional.empty(), /* watchAdapter */
-              Optional.empty() /* notificationPayloadFile */);
+              Optional.empty(), /* notificationPayloadFile */
+              Optional.empty(), /* applicationRegion */
+              Optional.empty() /* applicationLanguage */);
 
       Path schemePath = schemeGenerator.writeScheme();
 

--- a/test/com/facebook/buck/features/apple/projectV2/SchemeGeneratorTest.java
+++ b/test/com/facebook/buck/features/apple/projectV2/SchemeGeneratorTest.java
@@ -131,7 +131,9 @@ public class SchemeGeneratorTest {
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notificationPayloadFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationLanguage */
+            Optional.empty()  /* applicationRegion */);
 
     Path schemePath = schemeGenerator.writeScheme();
     String schemeXml = projectFilesystem.readFileIfItExists(schemePath).get();
@@ -218,7 +220,9 @@ public class SchemeGeneratorTest {
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notificationPayloadFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
     String schemeXml = projectFilesystem.readFileIfItExists(schemePath).get();
@@ -314,7 +318,9 @@ public class SchemeGeneratorTest {
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notificationPayloadFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
     String schemeXml = projectFilesystem.readFileIfItExists(schemePath).get();
@@ -396,7 +402,9 @@ public class SchemeGeneratorTest {
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notificationPayloadFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
 
@@ -460,7 +468,9 @@ public class SchemeGeneratorTest {
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notificationPayloadFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
 
@@ -548,7 +558,9 @@ public class SchemeGeneratorTest {
               Optional.empty(),
               XCScheme.LaunchAction.LaunchStyle.AUTO,
               Optional.empty(), /* watchAdapter */
-              Optional.empty() /* notificationPayloadFile */);
+              Optional.empty(), /* notificationPayloadFile */
+              Optional.empty(), /* applicationRegion */
+              Optional.empty() /* applicationLanguage */);
 
       Path schemePath = schemeGenerator.writeScheme();
       assertThat(
@@ -587,7 +599,9 @@ public class SchemeGeneratorTest {
               Optional.empty(),
               XCScheme.LaunchAction.LaunchStyle.AUTO,
               Optional.empty(), /* watchAdapter */
-              Optional.empty() /* notificationPayloadFile */);
+              Optional.empty(), /* notificationPayloadFile */
+              Optional.empty(), /* applicationRegion */
+              Optional.empty() /* applicationLanguage */);
 
       Path schemePath = schemeGenerator.writeScheme();
       assertThat(
@@ -629,7 +643,9 @@ public class SchemeGeneratorTest {
               Optional.empty(),
               XCScheme.LaunchAction.LaunchStyle.AUTO,
               Optional.empty(), /* watchAdapter */
-              Optional.empty() /* notificationPayloadFile */);
+              Optional.empty(), /* notificationPayloadFile */
+              Optional.empty(), /* applicationRegion */
+              Optional.empty() /* applicationLanguage */);
 
       Path schemePath = schemeGenerator.writeScheme();
       assertThat(
@@ -668,7 +684,9 @@ public class SchemeGeneratorTest {
               Optional.empty(),
               XCScheme.LaunchAction.LaunchStyle.AUTO,
               Optional.empty(), /* watchAdapter */
-              Optional.empty() /* notificationPayloadFile */);
+              Optional.empty(), /* notificationPayloadFile */
+              Optional.empty(), /* applicationRegion */
+              Optional.empty() /* applicationLanguage */);
       Path schemePath = schemeGenerator.writeScheme();
       assertThat(
           projectFilesystem.getLastModifiedTime(schemePath), equalTo(FileTime.fromMillis(49152L)));
@@ -731,7 +749,9 @@ public class SchemeGeneratorTest {
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notificationPayloadFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
     String schemeXml = projectFilesystem.readFileIfItExists(schemePath).get();
@@ -841,7 +861,9 @@ public class SchemeGeneratorTest {
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notificationPayloadFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
 
@@ -895,7 +917,9 @@ public class SchemeGeneratorTest {
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* payloadNotificationFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
 
@@ -978,7 +1002,9 @@ public class SchemeGeneratorTest {
             Optional.of(schemeActions),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notificationPayloadFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
 
@@ -1055,7 +1081,9 @@ public class SchemeGeneratorTest {
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notifcationPayloadFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
 
@@ -1119,7 +1147,9 @@ public class SchemeGeneratorTest {
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notificationPayloadFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
 
@@ -1137,6 +1167,70 @@ public class SchemeGeneratorTest {
     Node envVar = envVariableList.item(0);
     assertThat(envVar.getAttributes().getNamedItem("key").getNodeValue(), equalTo("ENV_VARIABLE"));
     assertThat(envVar.getAttributes().getNamedItem("value").getNodeValue(), equalTo("IS_SET"));
+  }
+
+  @Test
+  public void serializesRegionAndLanguage() throws Exception {
+    ImmutableMap.Builder<PBXTarget, Path> targetToProjectPathMapBuilder = ImmutableMap.builder();
+
+    PBXTarget rootTarget =
+      new PBXNativeTarget("rootRule", AbstractPBXObjectFactory.DefaultFactory());
+    rootTarget.setGlobalID("rootGID");
+    rootTarget.setProductReference(
+      new PBXFileReference(
+        "root.a", "root.a", PBXReference.SourceTree.BUILT_PRODUCTS_DIR, Optional.empty()));
+    rootTarget.setProductType(ProductTypes.STATIC_LIBRARY);
+
+    Path pbxprojectPath = Paths.get("foo/Foo.xcodeproj/project.pbxproj");
+    targetToProjectPathMapBuilder.put(rootTarget, pbxprojectPath);
+
+    String region = "pt-BR";
+    String language = "pt";
+
+    SchemeGenerator schemeGenerator =
+      new SchemeGenerator(
+        projectFilesystem,
+        Optional.of(rootTarget),
+        ImmutableSet.of(rootTarget),
+        ImmutableSet.of(),
+        ImmutableSet.of(),
+        "TestScheme",
+        Paths.get("_gen/Foo.xcworkspace/scshareddata/xcshemes"),
+        true /* parallelizeBuild */,
+        Optional.empty() /* wasCreatedForAppExtension */,
+        Optional.empty() /* runnablePath */,
+        Optional.empty() /* remoteRunnablePath */,
+        SchemeActionType.DEFAULT_CONFIG_NAMES,
+        targetToProjectPathMapBuilder.build(),
+        Optional.empty() /* environmentVariables */,
+        Optional.empty(),
+        Optional.empty(),
+        XCScheme.LaunchAction.LaunchStyle.AUTO,
+        Optional.empty(), /* watchAdapter */
+        Optional.empty(), /* notificationPayloadFile */
+        Optional.of(region),
+        Optional.of(language));
+
+    Path schemePath = schemeGenerator.writeScheme();
+
+    DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+    DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+    Document scheme = dBuilder.parse(projectFilesystem.newFileInputStream(schemePath));
+
+    XPathFactory xpathFactory = XPathFactory.newInstance();
+    XPath buildActionXpath = xpathFactory.newXPath();
+
+    XPathExpression launchActionExpr = buildActionXpath.compile("//LaunchAction");
+    XPathExpression testActionExpr = buildActionXpath.compile("//TestAction");
+
+    Node launchActionNode = (Node) launchActionExpr.evaluate(scheme, XPathConstants.NODE);
+    Node testActionNode = (Node) testActionExpr.evaluate(scheme, XPathConstants.NODE);
+
+    assertThat(launchActionNode.getAttributes().getNamedItem("language").getNodeValue(), equalTo("pt-BR"));
+    assertThat(launchActionNode.getAttributes().getNamedItem("region").getNodeValue(), equalTo("pt"));
+
+    assertThat(testActionNode.getAttributes().getNamedItem("language").getNodeValue(), equalTo("pt-BR"));
+    assertThat(testActionNode.getAttributes().getNamedItem("region").getNodeValue(), equalTo("pt"));
   }
 
   @Test
@@ -1179,7 +1273,9 @@ public class SchemeGeneratorTest {
         Optional.empty(),
         XCScheme.LaunchAction.LaunchStyle.AUTO,
         Optional.empty(), /* watchAdapter */
-        Optional.empty() /* notificationPayloadFile */);
+        Optional.empty(), /* notificationPayloadFile */
+        Optional.empty(), /* applicationRegion */
+        Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
 
@@ -1242,7 +1338,9 @@ public class SchemeGeneratorTest {
             Optional.empty(),
             XCScheme.LaunchAction.LaunchStyle.AUTO,
             Optional.empty(), /* watchAdapter */
-            Optional.empty() /* notificationPayloadFile */);
+            Optional.empty(), /* notificationPayloadFile */
+            Optional.empty(), /* applicationRegion */
+            Optional.empty() /* applicationLanguage */);
 
     Path schemePath = schemeGenerator.writeScheme();
 
@@ -1306,7 +1404,9 @@ public class SchemeGeneratorTest {
               Optional.empty(),
               XCScheme.LaunchAction.LaunchStyle.AUTO,
               Optional.empty(), /* watchAdapter */
-              Optional.empty() /* notificationPayloadFile */);
+              Optional.empty(), /* notificationPayloadFile */
+              Optional.empty(), /* applicationRegion */
+              Optional.empty() /* applicationLanguage */);
 
       Path schemePath = schemeGenerator.writeScheme();
 


### PR DESCRIPTION
This PR proposes to add application_region and application_language properties at xcode_workspace_config to TEST and LAUNCH actions of xcsheme.

<img width="311" alt="Captura de Tela 2020-08-10 às 3 10 34 PM" src="https://user-images.githubusercontent.com/6426451/89815795-bd045880-db1b-11ea-835c-f40ea7fd770c.png">

Results:

<img width="782" alt="Captura de Tela 2020-08-10 às 3 11 48 PM" src="https://user-images.githubusercontent.com/6426451/89815849-d7d6cd00-db1b-11ea-9f04-5f9341e670c1.png">
