### PR TITLE
Fixing paths that fail during project generation

### DIFF
--- a/src/com/facebook/buck/core/path/BUCK
+++ b/src/com/facebook/buck/core/path/BUCK
@@ -2,7 +2,7 @@ java_library(
     name = "path",
     srcs = glob(["*.java"]),
     tests = [
-        "//test/com/facebook/buck/core/path:test",
+        "//test/com/facebook/buck/core/path:path",
     ],
     visibility = [
         "PUBLIC",

--- a/test/com/facebook/buck/core/module/impl/jarwithouthash/BUCK
+++ b/test/com/facebook/buck/core/module/impl/jarwithouthash/BUCK
@@ -30,7 +30,7 @@ genrule(
 
 # Running tests as a shell script to reconstruct the layout of modules and how they are loaded
 python_test(
-    name = "test",
+    name = "jarwithouthash-test",
     srcs = [
         "//test/com/facebook/buck/core/module/impl:test_app.py",
     ],


### PR DESCRIPTION
buck project --idea=Intellij was failing due to the two invalid paths that are fixed in this diff.

Example failure:
```
The rule //test/com/facebook/buck/core/path:test could not be found.
Please check the spelling and whether it is one of the 1 targets in /Users/tys/Uber/buck/test/com/facebook/buck/core/path/BUCK. (387 bytes)
1 similar targets in /Users/tys/Uber/buck/test/com/facebook/buck/core/path/BUCK are:
  //test/com/facebook/buck/core/path:path
```