### PR TITLE
(Rebase) Add snapshot_images_diff_path to apple_test

### DIFF
--- a/src/com/facebook/buck/apple/AppleTest.java
+++ b/src/com/facebook/buck/apple/AppleTest.java
@@ -348,41 +348,8 @@ public class AppleTest extends AbstractBuildRuleWithDeclaredAndExtraDeps
         destinationSpecifierArg = defaultDestinationSpecifier;
       }
 
-      Optional<String> snapshotReferenceImagesPath = Optional.empty();
-      if (this.snapshotReferenceImagesPath.isPresent()) {
-        if (this.snapshotReferenceImagesPath.get().isLeft()) {
-          snapshotReferenceImagesPath =
-              Optional.of(
-                  buildContext
-                      .getSourcePathResolver()
-                      .getAbsolutePath(this.snapshotReferenceImagesPath.get().getLeft())
-                      .toString());
-        } else if (this.snapshotReferenceImagesPath.get().isRight()) {
-          snapshotReferenceImagesPath =
-              Optional.of(
-                  getProjectFilesystem()
-                      .getPathForRelativePath(this.snapshotReferenceImagesPath.get().getRight())
-                      .toString());
-        }
-      }
-
-      Optional<String> snapshotImagesDiffPath = Optional.empty();
-      if (this.snapshotImagesDiffPath.isPresent()) {
-        if (this.snapshotImagesDiffPath.get().isLeft()) {
-          snapshotImagesDiffPath =
-            Optional.of(
-              buildContext
-                .getSourcePathResolver()
-                .getAbsolutePath(this.snapshotImagesDiffPath.get().getLeft())
-                .toString());
-        } else if (this.snapshotImagesDiffPath.get().isRight()) {
-          snapshotImagesDiffPath =
-            Optional.of(
-              getProjectFilesystem()
-                .getPathForRelativePath(this.snapshotImagesDiffPath.get().getRight())
-                .toString());
-        }
-      }
+      Optional<String> snapshotReferenceImagesPath = getAbsoluteSnapshotTestingArgumentPath(this.snapshotReferenceImagesPath, buildContext);
+      Optional<String> snapshotImagesDiffPath = getAbsoluteSnapshotTestingArgumentPath(this.snapshotImagesDiffPath, buildContext);
 
       XctoolRunTestsStep xctoolStep =
           new XctoolRunTestsStep(
@@ -476,6 +443,25 @@ public class AppleTest extends AbstractBuildRuleWithDeclaredAndExtraDeps
     }
 
     return new Pair<>(steps.build(), externalSpec.build());
+  }
+
+  private Optional<String> getAbsoluteSnapshotTestingArgumentPath(
+    Optional<Either<SourcePath, String>> snapshotTestArgument, BuildContext buildContext) {
+    if (snapshotTestArgument.isPresent()) {
+      if (snapshotTestArgument.get().isLeft()) {
+        return Optional.of(
+          buildContext
+            .getSourcePathResolver()
+            .getAbsolutePath(snapshotTestArgument.get().getLeft())
+            .toString());
+      } else if (snapshotTestArgument.get().isRight()) {
+        return Optional.of(
+          getProjectFilesystem()
+            .getPathForRelativePath(snapshotTestArgument.get().getRight())
+            .toString());
+      }
+    }
+    return Optional.empty();
   }
 
   static Optional<Path> extractBundlePathForBundle(

--- a/src/com/facebook/buck/apple/AppleTestDescription.java
+++ b/src/com/facebook/buck/apple/AppleTestDescription.java
@@ -421,6 +421,7 @@ public class AppleTestDescription
               AppleDeveloperDirectoryForTestsProvider.class),
           args.getIsUiTest(),
           args.getSnapshotReferenceImagesPath(),
+          args.getSnapshotImagesDiffPath(),
           appleConfig.useIdb(),
           appleConfig.getIdbPath());
     }
@@ -458,6 +459,7 @@ public class AppleTestDescription
                     .getDefaultTestRuleTimeoutMs()),
         args.getIsUiTest(),
         args.getSnapshotReferenceImagesPath(),
+        args.getSnapshotImagesDiffPath(),
         args.getEnv(),
         appleConfig.useIdb(),
         appleConfig.getIdbPath());
@@ -951,6 +953,9 @@ public class AppleTestDescription
 
     // for use with FBSnapshotTestcase, injects the path as FB_REFERENCE_IMAGE_DIR
     Optional<Either<SourcePath, String>> getSnapshotReferenceImagesPath();
+
+    // for use with FBSnapshotTestcase, injects the path as IMAGE_DIFF_DIR
+    Optional<Either<SourcePath, String>> getSnapshotImagesDiffPath();
 
     // Bundle related fields.
     ImmutableMap<String, String> getDestinationSpecifier();

--- a/src/com/facebook/buck/apple/AppleTestX.java
+++ b/src/com/facebook/buck/apple/AppleTestX.java
@@ -104,6 +104,7 @@ public class AppleTestX extends AbstractBuildRuleWithDeclaredAndExtraDeps
       AppleDeveloperDirectoryForTestsProvider appleDeveloperDirectoryForTestsProvider,
       boolean isUiTest,
       Optional<Either<SourcePath, String>> snapshotReferenceImagesPath,
+      Optional<Either<SourcePath, String>> snapshotImagesDiffPath,
       boolean useIdb,
       Path idbPath) {
     super(buildTarget, projectFilesystem, params);
@@ -121,6 +122,7 @@ public class AppleTestX extends AbstractBuildRuleWithDeclaredAndExtraDeps
             appleDeveloperDirectoryForTestsProvider,
             isUiTest,
             snapshotReferenceImagesPath,
+            snapshotImagesDiffPath,
             useIdb,
             idbPath);
 
@@ -248,6 +250,7 @@ public class AppleTestX extends AbstractBuildRuleWithDeclaredAndExtraDeps
     public static final String DEFAULT_DESTINATION = "default_destination";
     public static final String DEVELOPER_DIRECTORY_FOR_TESTS = "developer_directory_for_tests";
     public static final String SNAPSHOT_REFERENCE_IMG_PATH = "snapshot_reference_img_path";
+    public static final String SNAPSHOT_IMAGES_DIFF_PATH = "SNAPSHOT_IMAGES_DIFF_PATH";
 
     private static final String UI_TEST_TARGET_APP = "ui_test_target_app";
     private static final String TEST_HOST_APP = "test_host_app";
@@ -270,6 +273,7 @@ public class AppleTestX extends AbstractBuildRuleWithDeclaredAndExtraDeps
 
     @AddToRuleKey private final boolean isUiTest;
     private final Optional<Either<SourcePath, String>> snapshotReferenceImagesPath;
+    private final Optional<Either<SourcePath, String>> snapshotImagesDiffPath;
     private final boolean useIdb;
     private final Path idbPath;
 
@@ -285,6 +289,7 @@ public class AppleTestX extends AbstractBuildRuleWithDeclaredAndExtraDeps
         AppleDeveloperDirectoryForTestsProvider appleDeveloperDirectoryForTestsProvider,
         boolean isUiTest,
         Optional<Either<SourcePath, String>> snapshotReferenceImagesPath,
+        Optional<Either<SourcePath, String>> snapshotImagesDiffPath,
         boolean useIdb,
         Path idbPath) {
       this.testHostApp = testHostApp;
@@ -298,6 +303,7 @@ public class AppleTestX extends AbstractBuildRuleWithDeclaredAndExtraDeps
       this.appleDeveloperDirectoryForTestsProvider = appleDeveloperDirectoryForTestsProvider;
       this.isUiTest = isUiTest;
       this.snapshotReferenceImagesPath = snapshotReferenceImagesPath;
+      this.snapshotImagesDiffPath = snapshotImagesDiffPath;
       this.useIdb = useIdb;
       this.idbPath = idbPath;
     }
@@ -340,6 +346,19 @@ public class AppleTestX extends AbstractBuildRuleWithDeclaredAndExtraDeps
                       return filesystem.getPathForRelativePath(pathOrStr.getRight()).toString();
                     })
                 .orElse(""));
+
+        generator.writeStringField(
+          SNAPSHOT_IMAGES_DIFF_PATH,
+          snapshotImagesDiffPath
+            .map(
+              pathOrStr -> {
+                if (pathOrStr.isLeft()) {
+                  return sourcePathResolver.getAbsolutePath(pathOrStr.getLeft()).toString();
+                }
+
+                return filesystem.getPathForRelativePath(pathOrStr.getRight()).toString();
+              })
+            .orElse(""));
 
         generator.writeObjectField(
             UI_TEST_TARGET_APP,

--- a/src/com/facebook/buck/apple/AppleTestX.java
+++ b/src/com/facebook/buck/apple/AppleTestX.java
@@ -250,7 +250,7 @@ public class AppleTestX extends AbstractBuildRuleWithDeclaredAndExtraDeps
     public static final String DEFAULT_DESTINATION = "default_destination";
     public static final String DEVELOPER_DIRECTORY_FOR_TESTS = "developer_directory_for_tests";
     public static final String SNAPSHOT_REFERENCE_IMG_PATH = "snapshot_reference_img_path";
-    public static final String SNAPSHOT_IMAGES_DIFF_PATH = "SNAPSHOT_IMAGES_DIFF_PATH";
+    public static final String SNAPSHOT_IMAGES_DIFF_PATH = "snapshot_images_diff_path";
 
     private static final String UI_TEST_TARGET_APP = "ui_test_target_app";
     private static final String TEST_HOST_APP = "test_host_app";

--- a/src/com/facebook/buck/apple/XctoolRunTestsStep.java
+++ b/src/com/facebook/buck/apple/XctoolRunTestsStep.java
@@ -74,6 +74,7 @@ class XctoolRunTestsStep implements Step {
       Executors.newSingleThreadScheduledExecutor();
   private static final String XCTOOL_ENV_VARIABLE_PREFIX = "XCTOOL_TEST_ENV_";
   private static final String FB_REFERENCE_IMAGE_DIR = "FB_REFERENCE_IMAGE_DIR";
+  private static final String IMAGE_DIFF_DIR = "IMAGE_DIFF_DIR";
 
   private final ProjectFilesystem filesystem;
 
@@ -96,6 +97,7 @@ class XctoolRunTestsStep implements Step {
   private final Optional<String> logLevel;
   private final Optional<Long> timeoutInMs;
   private final Optional<String> snapshotReferenceImagesPath;
+  private final Optional<String> snapshotImagesDiffPath;
   private final Map<Path, Map<Path, Path>> appTestPathsToTestHostAppPathsToTestTargetAppPaths;
   private final boolean isUsingXCodeBuildTool;
 
@@ -172,7 +174,8 @@ class XctoolRunTestsStep implements Step {
       Optional<String> logLevelEnvironmentVariable,
       Optional<String> logLevel,
       Optional<Long> timeoutInMs,
-      Optional<String> snapshotReferenceImagesPath) {
+      Optional<String> snapshotReferenceImagesPath,
+      Optional<String> snapshotImagesDiffPath) {
     Preconditions.checkArgument(
         !(logicTestBundlePaths.isEmpty()
             && appTestBundleToHostAppPaths.isEmpty()
@@ -207,6 +210,7 @@ class XctoolRunTestsStep implements Step {
     this.logLevel = logLevel;
     this.timeoutInMs = timeoutInMs;
     this.snapshotReferenceImagesPath = snapshotReferenceImagesPath;
+    this.snapshotImagesDiffPath = snapshotImagesDiffPath;
     // Super hacky, but xcodebuildtool is an alternative wrapper
     // around xcodebuild and forwarding the -f arguments only makes
     // sense in that context.
@@ -238,6 +242,11 @@ class XctoolRunTestsStep implements Step {
     if (snapshotReferenceImagesPath.isPresent()) {
       environment.put(
           XCTOOL_ENV_VARIABLE_PREFIX + FB_REFERENCE_IMAGE_DIR, snapshotReferenceImagesPath.get());
+    }
+
+    if (snapshotImagesDiffPath.isPresent()) {
+      environment.put(
+        XCTOOL_ENV_VARIABLE_PREFIX + IMAGE_DIFF_DIR, snapshotImagesDiffPath.get());
     }
 
     environment.putAll(this.environmentOverrides);

--- a/test/com/facebook/buck/apple/XctoolRunTestsStepTest.java
+++ b/test/com/facebook/buck/apple/XctoolRunTestsStepTest.java
@@ -76,6 +76,7 @@ public class XctoolRunTestsStepTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
     ProcessExecutorParams xctoolParams =
         ProcessExecutorParams.builder()
@@ -123,6 +124,7 @@ public class XctoolRunTestsStepTest {
             AppleDeveloperDirectoryForTestsProvider.of(Paths.get("/path/to/developer/dir")),
             TestSelectorList.EMPTY,
             false,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
@@ -185,6 +187,7 @@ public class XctoolRunTestsStepTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     ProcessExecutorParams xctoolParams =
@@ -242,6 +245,7 @@ public class XctoolRunTestsStepTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     ProcessExecutorParams xctoolParams =
@@ -292,6 +296,7 @@ public class XctoolRunTestsStepTest {
             AppleDeveloperDirectoryForTestsProvider.of(Paths.get("/path/to/developer/dir")),
             TestSelectorList.EMPTY,
             false,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
@@ -354,6 +359,7 @@ public class XctoolRunTestsStepTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     ProcessExecutorParams xctoolParams =
@@ -409,6 +415,7 @@ public class XctoolRunTestsStepTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     ProcessExecutorParams xctoolParams =
@@ -458,6 +465,7 @@ public class XctoolRunTestsStepTest {
             AppleDeveloperDirectoryForTestsProvider.of(Paths.get("/path/to/developer/dir")),
             TestSelectorList.builder().addRawSelectors("#.*Magic.*").build(),
             false,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
@@ -554,6 +562,7 @@ public class XctoolRunTestsStepTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     ProcessExecutorParams xctoolListOnlyParams =
@@ -615,6 +624,7 @@ public class XctoolRunTestsStepTest {
             AppleDeveloperDirectoryForTestsProvider.of(Paths.get("/path/to/developer/dir")),
             TestSelectorList.builder().addRawSelectors("Blargh#Xyzzy").build(),
             false,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
@@ -682,7 +692,8 @@ public class XctoolRunTestsStepTest {
             Optional.of("TEST_LOG_LEVEL"),
             Optional.of("verbose"),
             Optional.empty(),
-            Optional.of("/path/to/snapshotimages"));
+            Optional.of("/path/to/snapshotimages"),
+            Optional.of("/path/to/snapshotdiffimages"));
     ProcessExecutorParams xctoolParams =
         ProcessExecutorParams.builder()
             .setCommand(
@@ -698,12 +709,14 @@ public class XctoolRunTestsStepTest {
             // This is the important part of this test: only if the process is executed
             // with a matching environment will the test pass.
             .setEnvironment(
-                ImmutableMap.of(
-                    "DEVELOPER_DIR", "/path/to/developer/dir",
-                    "XCTOOL_TEST_ENV_TEST_LOG_PATH", "/path/to/test-logs",
-                    "XCTOOL_TEST_ENV_TEST_LOG_LEVEL", "verbose",
-                    "XCTOOL_TEST_ENV_FB_REFERENCE_IMAGE_DIR", "/path/to/snapshotimages",
-                    "LLVM_PROFILE_FILE", "/tmp/some.profraw"))
+                ImmutableMap.<String, String>builder()
+                  .put("DEVELOPER_DIR", "/path/to/developer/dir")
+                  .put("XCTOOL_TEST_ENV_TEST_LOG_PATH", "/path/to/test-logs")
+                  .put("XCTOOL_TEST_ENV_TEST_LOG_LEVEL", "verbose")
+                  .put("XCTOOL_TEST_ENV_FB_REFERENCE_IMAGE_DIR", "/path/to/snapshotimages")
+                  .put("XCTOOL_TEST_ENV_IMAGE_DIFF_DIR", "/path/to/snapshotdiffimages")
+                  .put("LLVM_PROFILE_FILE", "/tmp/some.profraw")
+                .build())
             .setDirectory(projectFilesystem.getRootPath().getPath())
             .setRedirectOutput(ProcessBuilder.Redirect.PIPE)
             .build();


### PR DESCRIPTION
This is a rebase from [`Add snapshot_images_diff_path to apple_test` by @rockbruno](https://github.com/facebook/buck/pull/2280)

This adds snapshot_images_diff_path as an argument to apple_test. It is meant to be a complement of snapshot_reference_images_path so we can get snapshot failure diffs by sending IMAGE_DIFF_DIR to xctool.