### PR TITLE
Fix Appstore Connect publication

### DIFF
--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -2351,7 +2351,6 @@ public class ProjectGenerator {
                         bundleExtension -> {
                           switch (bundleExtension) {
                             case APP:
-                            case APPEX:
                             case PLUGIN:
                             case BUNDLE:
                             case XCTEST:
@@ -2362,6 +2361,7 @@ public class ProjectGenerator {
                               // a Swift runtime, so it must get bundled to ensure they run.
                               return true;
 
+                            case APPEX:
                             case FRAMEWORK:
                             case DSYM:
                               return false;


### PR DESCRIPTION
There should not be a **Framewrok** directory inside an app plugin to publish the IPA file to the Appstore Connect:

> ERROR ITMS-90206: "Invalid Bundle. The bundle at 'XXX.app/PlugIns/NotificationService.appex' contains disallowed file 'Frameworks'."