### PR TITLE
[Apple] Fix Remove copy standard swift libraries step phase from AppClips bundle.

### DIFF
--- a/src/com/facebook/buck/apple/AppleBundle.java
+++ b/src/com/facebook/buck/apple/AppleBundle.java
@@ -612,7 +612,8 @@ public class AppleBundle extends AbstractBuildRule
           sdkPath,
           lipo,
           bundleBinaryPath,
-          destinations);
+          destinations,
+          isAppClip.orElse(false));
 
       for (BuildRule extraBinary : extraBinaries) {
         Path outputPath = getBundleBinaryPathForBuildRule(extraBinary);
@@ -667,7 +668,8 @@ public class AppleBundle extends AbstractBuildRule
           sdkPath,
           lipo,
           bundleBinaryPath,
-          destinations);
+          destinations,
+          isAppClip.orElse(false));
     }
 
     // Ensure the bundle directory is archived so we can fetch it later.
@@ -812,7 +814,8 @@ public class AppleBundle extends AbstractBuildRule
         sdkPath,
         lipo,
         bundleBinaryPath,
-        destinations);
+        destinations,
+        isAppClip.orElse(false));
   }
 
   private void copyAnotherCopyOfWatchKitStub(

--- a/src/com/facebook/buck/apple/AppleResourceProcessing.java
+++ b/src/com/facebook/buck/apple/AppleResourceProcessing.java
@@ -222,12 +222,14 @@ public class AppleResourceProcessing {
       Path sdkPath,
       Tool lipo,
       Path bundleBinaryPath,
-      AppleBundleDestinations destinations) {
+      AppleBundleDestinations destinations,
+      boolean isAppClip) {
     // It's apparently safe to run this even on a non-swift bundle (in that case, no libs
     // are copied over).
     boolean shouldCopySwiftStdlib =
         !bundleExtension.equals(AppleBundleExtension.APPEX.toFileExtension())
             && (!bundleExtension.equals(AppleBundleExtension.FRAMEWORK.toFileExtension())
+            && !isAppClip
                 || copySwiftStdlibToFrameworks);
 
     if (swiftStdlibTool.isPresent() && shouldCopySwiftStdlib) {

--- a/test/com/facebook/buck/apple/AppleBundleIntegrationTest.java
+++ b/test/com/facebook/buck/apple/AppleBundleIntegrationTest.java
@@ -1185,6 +1185,7 @@ public class AppleBundleIntegrationTest {
     assertTrue(Files.exists(appPath.resolve("Info.plist")));
 
     Path appClipPath = appPath.resolve("AppClips/Clip.app/");
+    
     assertTrue(Files.exists(appClipPath.resolve("Clip")));
     assertTrue(Files.exists(appClipPath.resolve("Info.plist")));
     assertFalse(Files.exists(appClipPath.resolve("Frameworks")));

--- a/test/com/facebook/buck/apple/AppleBundleIntegrationTest.java
+++ b/test/com/facebook/buck/apple/AppleBundleIntegrationTest.java
@@ -1187,6 +1187,8 @@ public class AppleBundleIntegrationTest {
     Path appClipPath = appPath.resolve("AppClips/Clip.app/");
     assertTrue(Files.exists(appClipPath.resolve("Clip")));
     assertTrue(Files.exists(appClipPath.resolve("Info.plist")));
+
+    assertFalse(Files.exists(appClipPath.resolve("Frameworks")));
   }
 
   @Test

--- a/test/com/facebook/buck/apple/AppleBundleIntegrationTest.java
+++ b/test/com/facebook/buck/apple/AppleBundleIntegrationTest.java
@@ -1187,7 +1187,6 @@ public class AppleBundleIntegrationTest {
     Path appClipPath = appPath.resolve("AppClips/Clip.app/");
     assertTrue(Files.exists(appClipPath.resolve("Clip")));
     assertTrue(Files.exists(appClipPath.resolve("Info.plist")));
-
     assertFalse(Files.exists(appClipPath.resolve("Frameworks")));
   }
 


### PR DESCRIPTION
Since AppClips only runs on iOS 14+ devices, those swift std libraries are not needed and it increases AppClips size to 10.8MB which is more than the AppClips size limit.