### PR TITLE
[ci] Fix circle ci for Mac

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ install_openjdk8: &install_openjdk8
       sudo apt-get update && sudo apt-get install openjdk-8-jdk
       sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
     elif [ "${PLATFORM}" == "macos" ]; then
-      brew cask install adoptopenjdk8
+      brew install --cask adoptopenjdk8
     fi
     java -version
 


### PR DESCRIPTION
`brew cask install` is no longer valid, change to `brew install --cask`