### PR TITLE
Increase debugger poll timeout

### DIFF
--- a/tools/ideabuck/src/com/facebook/buck/intellij/ideabuck/configurations/TestExecutionState.java
+++ b/tools/ideabuck/src/com/facebook/buck/intellij/ideabuck/configurations/TestExecutionState.java
@@ -185,7 +185,7 @@ class TestExecutionState implements RunProfileState {
         new ExecutionEnvironmentBuilder(mProject, debugExecutor)
             .runProfile(runSettings.getConfiguration())
             .build();
-    final int pollTimeout = 3000;
+    final int pollTimeout = 30000;
     final DebugEnvironment environment =
         new DefaultDebugEnvironment(env, state, remoteConnection, pollTimeout);
 


### PR DESCRIPTION
This is a workaround for an issue we recently observed where IntelliJ is failing to attach debugger in some tests.

There is a possible ongoing race condition when running tests with the `--debug` flag where BUCK will try to attach the debugger too early and in some cases, mainly larger targets, it will fail.

IntelliJ [implementation](https://github.com/JetBrains/intellij-community/blob/master/java/debugger/impl/src/com/intellij/debugger/engine/DebugProcessImpl.java#L2225) has polling mechanism where it will retry the creation and attaching the debugger, increasing the pooling time to 30s is giving us enough time for BUCK to execute.

Once the polling timeout is reached to 0 and the debugger was not successfully attached the UX is bad since there is no feedback to the end user and the IJ/CLI are stuck in
`Debugging. Suspending JVM. Connect a JDWP debugger to port 5005 to proceed.`

This should _not_ have a negative impact on smaller targets where the debugger is attached almost instantly.