### PR TITLE
[TestNG] Don't fail if TestNG runs in parallel

### DIFF
--- a/src/com/facebook/buck/testrunner/BaseRunner.java
+++ b/src/com/facebook/buck/testrunner/BaseRunner.java
@@ -28,6 +28,7 @@ import java.io.PrintWriter; // NOPMD can't depend on Guava
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -82,7 +83,7 @@ public abstract class BaseRunner {
    * The test result file is written as XML to avoid introducing a dependency on JSON (see class
    * overview).
    */
-  protected void writeResult(String testClassName, List<TestResult> results)
+  protected void writeResult(String testClassName, Collection<TestResult> results)
       throws IOException, ParserConfigurationException, TransformerException {
     // XML writer logic taken from:
     // http://www.genedavis.com/library/xml/java_dom_xml_creation.jsp

--- a/src/com/facebook/buck/testrunner/TestNGRunner.java
+++ b/src/com/facebook/buck/testrunner/TestNGRunner.java
@@ -25,12 +25,12 @@ import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.testng.IAnnotationTransformer;
@@ -60,11 +60,11 @@ public final class TestNGRunner extends BaseRunner {
 
       Class<?> testClass = Class.forName(className);
 
-      List<TestResult> results;
+      Collection<TestResult> results;
       if (!mightBeATestClass(testClass)) {
         results = Collections.emptyList();
       } else {
-        results = new ArrayList<>();
+        results = new ConcurrentLinkedQueue<>();
         TestNG testng = new TestNG();
         testng.setUseDefaultListeners(false);
         testng.addListener(new FilteringAnnotationTransformer(results));
@@ -155,9 +155,9 @@ public final class TestNGRunner extends BaseRunner {
   }
 
   public class FilteringAnnotationTransformer implements IAnnotationTransformer {
-    final List<TestResult> results;
+    final Collection<TestResult> results;
 
-    FilteringAnnotationTransformer(List<TestResult> results) {
+    FilteringAnnotationTransformer(Collection<TestResult> results) {
       this.results = results;
     }
 
@@ -199,13 +199,13 @@ public final class TestNGRunner extends BaseRunner {
   }
 
   private static class TestListener implements ITestListener, IConfigurationListener {
-    private final List<TestResult> results;
+    private final Collection<TestResult> results;
     private boolean mustRestoreStdoutAndStderr;
     private PrintStream originalOut, originalErr, stdOutStream, stdErrStream;
     private ByteArrayOutputStream rawStdOutBytes, rawStdErrBytes;
     private Map<IClass, Throwable> failedConfigurationTestClasses = new HashMap<>();
 
-    public TestListener(List<TestResult> results) {
+    public TestListener(Collection<TestResult> results) {
       this.results = results;
     }
 

--- a/src/com/facebook/buck/testrunner/TestNGRunner.java
+++ b/src/com/facebook/buck/testrunner/TestNGRunner.java
@@ -64,6 +64,8 @@ public final class TestNGRunner extends BaseRunner {
       if (!mightBeATestClass(testClass)) {
         results = Collections.emptyList();
       } else {
+        // TestNG can run a test class's tests in parallel via DataProvider.
+        // Use concurrency-safe collection to avoid comodification errors. 
         results = new ConcurrentLinkedQueue<>();
         TestNG testng = new TestNG();
         testng.setUseDefaultListeners(false);

--- a/src/com/facebook/buck/testrunner/TestNGRunner.java
+++ b/src/com/facebook/buck/testrunner/TestNGRunner.java
@@ -51,7 +51,7 @@ import org.testng.reporters.JUnitReportReporter;
 import org.testng.reporters.SuiteHTMLReporter;
 import org.testng.reporters.XMLReporter;
 
-/** Class that runs a set of TestNG tests and writes the results to a directory. */
+/** Class that runs a set of TestNG tests and outputs the results to a directory. */
 public final class TestNGRunner extends BaseRunner {
 
   @Override

--- a/test/com/facebook/buck/util/concurrent/JobLimiterTest.java
+++ b/test/com/facebook/buck/util/concurrent/JobLimiterTest.java
@@ -68,8 +68,8 @@ public class JobLimiterTest {
     }
 
     // Two jobs should start.
-    assertTrue(jobStarted.tryAcquire(100, TimeUnit.MILLISECONDS));
-    assertTrue(jobStarted.tryAcquire(100, TimeUnit.MILLISECONDS));
+    assertTrue(jobStarted.tryAcquire(200, TimeUnit.MILLISECONDS));
+    assertTrue(jobStarted.tryAcquire(200, TimeUnit.MILLISECONDS));
 
     assertEquals(2, jobsRunning.get());
 


### PR DESCRIPTION
For TestNG, a `@Test` method can run concurrently using a `@DataProvider`:
```
@DataProvider(name = "testList", parallel = true)
```

This causes an exception in Buck as follows:
```
java.util.ConcurrentModificationException
	at java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1042)
	at java.base/java.util.ArrayList$Itr.next(ArrayList.java:996)
	at com.facebook.buck.testrunner.BaseRunner.writeResult(BaseRunner.java:100)
	at com.facebook.buck.testrunner.TestNGRunner.run(TestNGRunner.java:96)
	at com.facebook.buck.testrunner.BaseRunner.runAndExit(BaseRunner.java:301)
	at com.facebook.buck.testrunner.TestNGMain.main(TestNGMain.java:48)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at com.facebook.buck.jvm.java.runner.FileClassPathRunner.main(FileClassPathRunner.java:88)
```

The fix is to simply move the test runner's collection of test results to be a concurrency-safe collection. I use `ConcurrentLinkedQueue`: this should be faster than explicit synchronized blocks or using `Collections.synchronizedList()`. 