### PR TITLE
Support NDK r21e and r22

### DIFF
--- a/src/com/facebook/buck/android/toolchain/ndk/NdkCxxPlatformTargetConfiguration.java
+++ b/src/com/facebook/buck/android/toolchain/ndk/NdkCxxPlatformTargetConfiguration.java
@@ -62,14 +62,14 @@ public abstract class NdkCxxPlatformTargetConfiguration {
   }
 
   public ImmutableList<String> getAssemblerFlags(NdkCompilerType type) {
-    return getTargetCpuType().getAssemblerFlags(type);
+    return getTargetCpuType().getAssemblerFlags(type, getTargetAppPlatformLevel());
   }
 
   public ImmutableList<String> getCompilerFlags(NdkCompilerType type) {
-    return getTargetCpuType().getCompilerFlags(type);
+    return getTargetCpuType().getCompilerFlags(type, getTargetAppPlatformLevel());
   }
 
   public ImmutableList<String> getLinkerFlags(NdkCompilerType type) {
-    return getTargetCpuType().getLinkerFlags(type);
+    return getTargetCpuType().getLinkerFlags(type, getTargetAppPlatformLevel());
   }
 }

--- a/src/com/facebook/buck/android/toolchain/ndk/TargetCpuType.java
+++ b/src/com/facebook/buck/android/toolchain/ndk/TargetCpuType.java
@@ -45,13 +45,13 @@ public enum TargetCpuType {
     }
 
     @Override
-    public ImmutableList<String> getAssemblerFlags(NdkCompilerType compiler) {
+    public ImmutableList<String> getAssemblerFlags(NdkCompilerType compiler, int androidPlatformLevel) {
       switch (compiler) {
         case GCC:
           return armeabiArchFlags;
         case CLANG:
           return ImmutableList.<String>builder()
-              .add("-target", "armv5te-none-linux-androideabi")
+              .add("-target", "armv5te-none-linux-androideabi" + String.valueOf(androidPlatformLevel))
               .addAll(armeabiArchFlags)
               .build();
       }
@@ -59,13 +59,13 @@ public enum TargetCpuType {
     }
 
     @Override
-    public ImmutableList<String> getCompilerFlags(NdkCompilerType compiler) {
+    public ImmutableList<String> getCompilerFlags(NdkCompilerType compiler, int androidPlatformLevel) {
       switch (compiler) {
         case GCC:
           return ImmutableList.<String>builder().add("-Os").addAll(armeabiArchFlags).build();
         case CLANG:
           return ImmutableList.<String>builder()
-              .add("-target", "armv5te-none-linux-androideabi", "-Os")
+              .add("-target", "armv5te-none-linux-androideabi" + String.valueOf(androidPlatformLevel), "-Os")
               .addAll(armeabiArchFlags)
               .build();
       }
@@ -73,13 +73,13 @@ public enum TargetCpuType {
     }
 
     @Override
-    public ImmutableList<String> getLinkerFlags(NdkCompilerType compiler) {
+    public ImmutableList<String> getLinkerFlags(NdkCompilerType compiler, int androidPlatformLevel) {
       switch (compiler) {
         case GCC:
           return ImmutableList.of("-march=armv5te", "-Wl,--fix-cortex-a8");
         case CLANG:
           return ImmutableList.of(
-              "-target", "armv5te-none-linux-androideabi", "-march=armv5te", "-Wl,--fix-cortex-a8");
+              "-target", "armv5te-none-linux-androideabi" + String.valueOf(androidPlatformLevel), "-march=armv5te", "-Wl,--fix-cortex-a8");
       }
       throw new AssertionError();
     }
@@ -109,13 +109,13 @@ public enum TargetCpuType {
     }
 
     @Override
-    public ImmutableList<String> getAssemblerFlags(NdkCompilerType compiler) {
+    public ImmutableList<String> getAssemblerFlags(NdkCompilerType compiler, int androidPlatformLevel) {
       switch (compiler) {
         case GCC:
           return armeabiv7ArchFlags;
         case CLANG:
           return ImmutableList.<String>builder()
-              .add("-target", "armv7-none-linux-androideabi")
+              .add("-target", "armv7-none-linux-androideabi" + String.valueOf(androidPlatformLevel))
               .addAll(armeabiv7ArchFlags)
               .build();
       }
@@ -123,7 +123,7 @@ public enum TargetCpuType {
     }
 
     @Override
-    public ImmutableList<String> getCompilerFlags(NdkCompilerType compiler) {
+    public ImmutableList<String> getCompilerFlags(NdkCompilerType compiler, int androidPlatformLevel) {
       switch (compiler) {
         case GCC:
           return ImmutableList.<String>builder()
@@ -132,7 +132,7 @@ public enum TargetCpuType {
               .build();
         case CLANG:
           return ImmutableList.<String>builder()
-              .add("-target", "armv7-none-linux-androideabi", "-Os")
+              .add("-target", "armv7-none-linux-androideabi" + String.valueOf(androidPlatformLevel), "-Os")
               .addAll(armeabiv7ArchFlags)
               .build();
       }
@@ -140,12 +140,12 @@ public enum TargetCpuType {
     }
 
     @Override
-    public ImmutableList<String> getLinkerFlags(NdkCompilerType compiler) {
+    public ImmutableList<String> getLinkerFlags(NdkCompilerType compiler, int androidPlatformLevel) {
       switch (compiler) {
         case GCC:
           return ImmutableList.of();
         case CLANG:
-          return ImmutableList.of("-target", "armv7-none-linux-androideabi");
+          return ImmutableList.of("-target", "armv7-none-linux-androideabi" + String.valueOf(androidPlatformLevel));
       }
       throw new AssertionError();
     }
@@ -174,13 +174,13 @@ public enum TargetCpuType {
     }
 
     @Override
-    public ImmutableList<String> getAssemblerFlags(NdkCompilerType compiler) {
+    public ImmutableList<String> getAssemblerFlags(NdkCompilerType compiler, int androidPlatformLevel) {
       switch (compiler) {
         case GCC:
           return arm64ArchFlags;
         case CLANG:
           return ImmutableList.<String>builder()
-              .add("-target", "aarch64-none-linux-android")
+              .add("-target", "aarch64-none-linux-android" + String.valueOf(androidPlatformLevel))
               .addAll(arm64ArchFlags)
               .build();
       }
@@ -188,7 +188,7 @@ public enum TargetCpuType {
     }
 
     @Override
-    public ImmutableList<String> getCompilerFlags(NdkCompilerType compiler) {
+    public ImmutableList<String> getCompilerFlags(NdkCompilerType compiler, int androidPlatformLevel) {
       switch (compiler) {
         case GCC:
           return ImmutableList.<String>builder()
@@ -201,7 +201,7 @@ public enum TargetCpuType {
               .build();
         case CLANG:
           return ImmutableList.<String>builder()
-              .add("-target", "aarch64-none-linux-android")
+              .add("-target", "aarch64-none-linux-android" + String.valueOf(androidPlatformLevel))
               .add("-O2")
               .add("-fomit-frame-pointer")
               .add("-fstrict-aliasing")
@@ -212,12 +212,12 @@ public enum TargetCpuType {
     }
 
     @Override
-    public ImmutableList<String> getLinkerFlags(NdkCompilerType compiler) {
+    public ImmutableList<String> getLinkerFlags(NdkCompilerType compiler, int androidPlatformLevel) {
       switch (compiler) {
         case GCC:
           return ImmutableList.of();
         case CLANG:
-          return ImmutableList.of("-target", "aarch64-none-linux-android");
+          return ImmutableList.of("-target", "aarch64-none-linux-android" + String.valueOf(androidPlatformLevel));
       }
       throw new AssertionError();
     }
@@ -244,34 +244,34 @@ public enum TargetCpuType {
     }
 
     @Override
-    public ImmutableList<String> getAssemblerFlags(NdkCompilerType compiler) {
+    public ImmutableList<String> getAssemblerFlags(NdkCompilerType compiler, int androidPlatformLevel) {
       switch (compiler) {
         case GCC:
           return ImmutableList.of();
         case CLANG:
-          return ImmutableList.of("-target", "i686-none-linux-android");
+          return ImmutableList.of("-target", "i686-none-linux-android" + String.valueOf(androidPlatformLevel));
       }
       throw new AssertionError();
     }
 
     @Override
-    public ImmutableList<String> getCompilerFlags(NdkCompilerType compiler) {
+    public ImmutableList<String> getCompilerFlags(NdkCompilerType compiler, int androidPlatformLevel) {
       switch (compiler) {
         case GCC:
           return ImmutableList.of("-funswitch-loops", "-finline-limit=300", "-O2");
         case CLANG:
-          return ImmutableList.of("-target", "i686-none-linux-android", "-O2");
+          return ImmutableList.of("-target", "i686-none-linux-android" + String.valueOf(androidPlatformLevel), "-O2");
       }
       throw new AssertionError();
     }
 
     @Override
-    public ImmutableList<String> getLinkerFlags(NdkCompilerType compiler) {
+    public ImmutableList<String> getLinkerFlags(NdkCompilerType compiler, int androidPlatformLevel) {
       switch (compiler) {
         case GCC:
           return ImmutableList.of();
         case CLANG:
-          return ImmutableList.of("-target", "i686-none-linux-android");
+          return ImmutableList.of("-target", "i686-none-linux-android" + String.valueOf(androidPlatformLevel));
       }
       throw new AssertionError();
     }
@@ -298,34 +298,34 @@ public enum TargetCpuType {
     }
 
     @Override
-    public ImmutableList<String> getAssemblerFlags(NdkCompilerType compiler) {
+    public ImmutableList<String> getAssemblerFlags(NdkCompilerType compiler, int androidPlatformLevel) {
       switch (compiler) {
         case GCC:
           return ImmutableList.of();
         case CLANG:
-          return ImmutableList.of("-target", "x86_64-none-linux-android");
+          return ImmutableList.of("-target", "x86_64-none-linux-android" + String.valueOf(androidPlatformLevel));
       }
       throw new AssertionError();
     }
 
     @Override
-    public ImmutableList<String> getCompilerFlags(NdkCompilerType compiler) {
+    public ImmutableList<String> getCompilerFlags(NdkCompilerType compiler, int androidPlatformLevel) {
       switch (compiler) {
         case GCC:
           return ImmutableList.of("-funswitch-loops", "-finline-limit=300", "-O2");
         case CLANG:
-          return ImmutableList.of("-target", "x86_64-none-linux-android", "-O2");
+          return ImmutableList.of("-target", "x86_64-none-linux-android" + String.valueOf(androidPlatformLevel), "-O2");
       }
       throw new AssertionError();
     }
 
     @Override
-    public ImmutableList<String> getLinkerFlags(NdkCompilerType compiler) {
+    public ImmutableList<String> getLinkerFlags(NdkCompilerType compiler, int androidPlatformLevel) {
       switch (compiler) {
         case GCC:
           return ImmutableList.of();
         case CLANG:
-          return ImmutableList.of("-target", "x86_64-none-linux-android");
+          return ImmutableList.of("-target", "x86_64-none-linux-android" + String.valueOf(androidPlatformLevel));
       }
       throw new AssertionError();
     }
@@ -352,17 +352,17 @@ public enum TargetCpuType {
     }
 
     @Override
-    public ImmutableList<String> getAssemblerFlags(NdkCompilerType compiler) {
+    public ImmutableList<String> getAssemblerFlags(NdkCompilerType compiler, int androidPlatformLevel) {
       throw new AssertionError();
     }
 
     @Override
-    public ImmutableList<String> getCompilerFlags(NdkCompilerType compiler) {
+    public ImmutableList<String> getCompilerFlags(NdkCompilerType compiler, int androidPlatformLevel) {
       throw new AssertionError();
     }
 
     @Override
-    public ImmutableList<String> getLinkerFlags(NdkCompilerType compiler) {
+    public ImmutableList<String> getLinkerFlags(NdkCompilerType compiler, int androidPlatformLevel) {
       throw new AssertionError();
     }
   };
@@ -375,9 +375,9 @@ public enum TargetCpuType {
 
   public abstract NdkToolchainTarget getToolchainTarget();
 
-  public abstract ImmutableList<String> getAssemblerFlags(NdkCompilerType compiler);
+  public abstract ImmutableList<String> getAssemblerFlags(NdkCompilerType compiler, int androidPlatformLevel);
 
-  public abstract ImmutableList<String> getCompilerFlags(NdkCompilerType compiler);
+  public abstract ImmutableList<String> getCompilerFlags(NdkCompilerType compiler, int androidPlatformLevel);
 
-  public abstract ImmutableList<String> getLinkerFlags(NdkCompilerType compiler);
+  public abstract ImmutableList<String> getLinkerFlags(NdkCompilerType compiler, int androidPlatformLevel);
 }

--- a/src/com/facebook/buck/android/toolchain/ndk/impl/AndroidNdkResolver.java
+++ b/src/com/facebook/buck/android/toolchain/ndk/impl/AndroidNdkResolver.java
@@ -47,7 +47,7 @@ public class AndroidNdkResolver extends BaseAndroidToolchainResolver {
   private static final Logger LOG = Logger.get(AndroidNdkResolver.class);
 
   /** Android NDK versions starting with this number are not supported. */
-  private static final String NDK_MIN_UNSUPPORTED_VERSION = "22";
+  private static final String NDK_MIN_UNSUPPORTED_VERSION = "23";
 
   // Pre r11 NDKs store the version at RELEASE.txt.
   @VisibleForTesting static final String NDK_PRE_R11_VERSION_FILENAME = "RELEASE.TXT";

--- a/src/com/facebook/buck/android/toolchain/ndk/impl/NdkCxxPlatforms.java
+++ b/src/com/facebook/buck/android/toolchain/ndk/impl/NdkCxxPlatforms.java
@@ -150,12 +150,17 @@ public class NdkCxxPlatforms {
           "-Wl,--as-needed");
 
   private static final Pattern NDK_MAJOR_VERSION_PATTERN = Pattern.compile("^[rR]?(\\d+).*");
+  private static final Pattern NDK_MINOR_VERSION_PATTERN = Pattern.compile("^[rR]?\\d+\\.(\\d+).*");
 
   // Utility class, do not instantiate.
   private NdkCxxPlatforms() {}
 
   static int getNdkMajorVersion(String ndkVersion) {
     return Integer.parseInt(NDK_MAJOR_VERSION_PATTERN.matcher(ndkVersion).replaceAll("$1"));
+  }
+  
+  static int getNdkMinorVersion(String ndkVersion) {
+    return Integer.parseInt(NDK_MINOR_VERSION_PATTERN.matcher(ndkVersion).replaceAll("$1"));
   }
 
   public static NdkCompilerType getDefaultCompilerTypeForNdk(String ndkVersion) {
@@ -172,6 +177,7 @@ public class NdkCxxPlatforms {
 
   public static String getDefaultClangVersionForNdk(String ndkVersion) {
     int ndkMajorVersion = getNdkMajorVersion(ndkVersion);
+    int ndkMinorVersion = getNdkMinorVersion(ndkVersion);
     if (ndkMajorVersion < 11) {
       return "3.5";
     } else if (ndkMajorVersion < 15) {
@@ -186,8 +192,12 @@ public class NdkCxxPlatforms {
       return "8.0.2";
     } else if (ndkMajorVersion < 21) {
       return "8.0.7";
-    } else {
+    } else if (ndkMajorVersion < 22 && ndkMinorVersion < 4 ) { // NDK up to r21d
       return "9.0.8";
+    } else if (ndkMajorVersion < 22 && ndkMinorVersion >= 4 ) { //NDK r21e
+      return "9.0.9";
+    } else { // NDK r22 and +
+      return "11.0.5";
     }
   }
 
@@ -1137,6 +1147,7 @@ public class NdkCxxPlatforms {
                     "{gcc_compiler_version}", targetConfiguration.getCompiler().getGccVersion());
             s = s.replace("{hostname}", hostName);
             s = s.replace("{target_platform}", targetConfiguration.getTargetAppPlatform());
+            s = s.replace("{target_platform_level}", String.valueOf(targetConfiguration.getTargetAppPlatformLevel()));
             s = s.replace("{target_arch}", targetConfiguration.getTargetArch().toString());
             s = s.replace("{target_arch_abi}", targetConfiguration.getTargetArchAbi().toString());
           }
@@ -1197,7 +1208,13 @@ public class NdkCxxPlatforms {
 
     /** @return the path to arch-specific include files; only use with unified headers */
     Path getArchSpecificIncludes() {
-      return processDirectoryPathPattern("sysroot/usr/include/{toolchain_target}");
+      // <ndk_root>/sysroot and platforms directory has changed location see 
+      // https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#Sysroot
+      if(ndkMajorVersion > 21) {
+          return processDirectoryPathPattern("toolchains/llvm/prebuilt/{hostname}/sysroot/usr/include/{toolchain_target}");
+      } else {
+        return processDirectoryPathPattern("sysroot/usr/include/{toolchain_target}");
+      }
     }
 
     /**
@@ -1206,13 +1223,26 @@ public class NdkCxxPlatforms {
      */
     Path getIncludeSysroot() {
       if (isUnifiedHeaders()) {
-        return processDirectoryPathPattern("sysroot");
+        // <ndk_root>/sysroot and platforms directory has changed location see 
+        // https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#Sysroot
+        if(ndkMajorVersion > 21) {
+            return processDirectoryPathPattern("toolchains/llvm/prebuilt/{hostname}/sysroot");
+        } else {
+          return processDirectoryPathPattern("sysroot");
+        }
       }
       return getPlatformSysroot();
     }
 
     Path getPlatformSysroot() {
-      return processDirectoryPathPattern("platforms/{target_platform}/arch-{target_arch}");
+      // <ndk_root>/sysroot and platforms directory has changed location see 
+      // https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#Sysroot
+      if(ndkMajorVersion > 21) {
+        return processDirectoryPathPattern("toolchains/llvm/prebuilt/{hostname}/sysroot");
+        //return processDirectoryPathPattern("toolchains/llvm/prebuilt/{hostname}/sysroot/usr/lib/{toolchain_target}/{target_platform_level}");
+      } else {
+        return processDirectoryPathPattern("platforms/{target_platform}/arch-{target_arch}");
+      }
     }
 
     Path getLibexecGccToolPath() {

--- a/test/com/facebook/buck/android/toolchain/ndk/impl/AndroidNdkResolverTest.java
+++ b/test/com/facebook/buck/android/toolchain/ndk/impl/AndroidNdkResolverTest.java
@@ -440,12 +440,12 @@ public class AndroidNdkResolverTest {
     Path expectedPath =
         createTmpNdkVersions(
             NDK_POST_R11_VERSION_FILENAME,
-            "ndk-dir-r20",
-            "Pkg.Desc = Android NDK\nPkg.Revision = 20.0.5594570",
             "ndk-dir-r21",
-            "Pkg.Desc = Android NDK\nPkg.Revision = 21.0.6113669",
-            "ndk-dir-r22-xxx",
-            "Pkg.Desc = Android NDK\nPkg.Revision = 22.0.5000000")[1];
+            "Pkg.Desc = Android NDK\nPkg.Revision = 21.4.7075529", // r21e
+            "ndk-dir-r22",
+            "Pkg.Desc = Android NDK\nPkg.Revision = 22.0.7026061",
+            "ndk-dir-r23-xxx",
+            "Pkg.Desc = Android NDK\nPkg.Revision = 23.0.5000000")[1];
     AndroidNdkResolver resolver =
         new AndroidNdkResolver(
             tmpDir.getRoot().getFileSystem(),


### PR DESCRIPTION
This PR add support for NDK r21e and r22. The NDK r22 comes with some changes related to include paths. The target parameter need to contain the platform level version in order for Clang to be able to locate the includes.