### PR TITLE
Fixing Kotlin ABI issues

### DIFF
--- a/src/com/facebook/buck/jvm/java/abi/AbiFilteringClassVisitor.java
+++ b/src/com/facebook/buck/jvm/java/abi/AbiFilteringClassVisitor.java
@@ -46,18 +46,17 @@ class AbiFilteringClassVisitor extends ClassVisitor {
   private boolean hasVisibleConstructor = false;
   private Set<String> includedInnerClasses = new HashSet<>();
   private List<String> nestMembers = new ArrayList<>();
-
-  public AbiFilteringClassVisitor(ClassVisitor cv, List<String> methodsWithRetainedBody) {
-    this(cv, methodsWithRetainedBody, null);
-  }
+  private final boolean isKotlinClass;
 
   public AbiFilteringClassVisitor(
       ClassVisitor cv,
       List<String> methodsWithRetainedBody,
-      @Nullable Set<String> referencedClassNames) {
+      @Nullable Set<String> referencedClassNames,
+      boolean isKotlinClass) {
     super(Opcodes.ASM7, cv);
     this.methodsWithRetainedBody = methodsWithRetainedBody;
     this.referencedClassNames = referencedClassNames;
+    this.isKotlinClass = isKotlinClass;
   }
 
   @Override
@@ -213,7 +212,7 @@ class AbiFilteringClassVisitor extends ClassVisitor {
       return false;
     }
 
-    return (access & (Opcodes.ACC_SYNTHETIC | Opcodes.ACC_BRIDGE)) != Opcodes.ACC_SYNTHETIC;
+    return (isKotlinClass || (access & (Opcodes.ACC_SYNTHETIC | Opcodes.ACC_BRIDGE)) != Opcodes.ACC_SYNTHETIC);
   }
 
   private boolean isInterface(int access) {

--- a/src/com/facebook/buck/jvm/kotlin/KotlinConfiguredCompilerFactory.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinConfiguredCompilerFactory.java
@@ -87,7 +87,7 @@ public class KotlinConfiguredCompilerFactory extends ConfiguredCompilerFactory {
       ToolchainProvider toolchainProvider) {
     CoreArg kotlinArgs = Objects.requireNonNull((CoreArg) args);
     Path pathToAbiGenerationPluginJar =
-        shouldGenerateSourceAbi() ? kotlinBuckConfig.getPathToAbiGenerationPluginJar() : null;
+        shouldGenerateSourceAbi(kotlinArgs, kotlinBuckConfig) ? kotlinBuckConfig.getPathToAbiGenerationPluginJar() : null;
     return new KotlincToJarStepFactory(
         kotlinBuckConfig.getKotlinc(),
         kotlinBuckConfig.getKotlinHomeLibraries(),
@@ -140,6 +140,10 @@ public class KotlinConfiguredCompilerFactory extends ConfiguredCompilerFactory {
   @Override
   public boolean sourceAbiCopiesFromLibraryTargetOutput() {
     return true;
+  }
+
+  private static boolean shouldGenerateSourceAbi(CoreArg kotlinArgs, KotlinBuckConfig kotlinBuckConfig) {
+    return kotlinArgs.getAbiGenerationMode().orElse(kotlinBuckConfig.getAbiGenerationMode()).isSourceAbi();
   }
 
   private static ImmutableList<SourcePath> getFriendSourcePaths(

--- a/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
@@ -294,9 +294,9 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
               .add(MODULE_NAME)
               .add(moduleName);
 
-      Path tmpSourceAbiFolder;
       if (abiGenerationPlugin != null) {
-        tmpSourceAbiFolder = JavaAbis.getTmpGenPathForSourceAbi(projectFilesystem, invokingRule);
+        Path tmpSourceAbiFolder = JavaAbis.getTmpGenPathForSourceAbi(projectFilesystem, invokingRule);
+        addCreateFolderStep(steps, projectFilesystem, buildContext, tmpSourceAbiFolder);
         extraArguments.add("-Xplugin=" + abiGenerationPlugin);
         extraArguments.add(
             "-P", "plugin:org.jetbrains.kotlin.jvm.abi:outputDir=" + tmpSourceAbiFolder);

--- a/test/com/facebook/buck/jvm/java/abi/AbiFilteringClassVisitorTest.java
+++ b/test/com/facebook/buck/jvm/java/abi/AbiFilteringClassVisitorTest.java
@@ -36,7 +36,7 @@ public class AbiFilteringClassVisitorTest {
   public void setUp() {
     mockVisitor = createMock(ClassVisitor.class);
     filteringVisitor =
-        new AbiFilteringClassVisitor(mockVisitor, ImmutableList.of(), ImmutableSet.of());
+        new AbiFilteringClassVisitor(mockVisitor, ImmutableList.of(), ImmutableSet.of(), false);
   }
 
   @Test
@@ -92,7 +92,7 @@ public class AbiFilteringClassVisitorTest {
   @Test
   public void testIncludesPrivateMethodsWhenRetained() {
     filteringVisitor =
-        new AbiFilteringClassVisitor(mockVisitor, ImmutableList.of("foo"), ImmutableSet.of());
+        new AbiFilteringClassVisitor(mockVisitor, ImmutableList.of("foo"), ImmutableSet.of(), false);
     testIncludesMethodWithAccess(Opcodes.ACC_PRIVATE);
   }
 
@@ -166,7 +166,7 @@ public class AbiFilteringClassVisitorTest {
   @Test
   public void testIncludesInnerClassEntryForReferencedOtherClassInnerClass() {
     filteringVisitor =
-        new AbiFilteringClassVisitor(mockVisitor, ImmutableList.of(), ImmutableSet.of("Bar$Inner"));
+        new AbiFilteringClassVisitor(mockVisitor, ImmutableList.of(), ImmutableSet.of("Bar$Inner"), false);
 
     visitClass(mockVisitor, "Foo");
     mockVisitor.visitInnerClass("Bar$Inner", "Bar", "Inner", Opcodes.ACC_PUBLIC);

--- a/test/com/facebook/buck/jvm/java/abi/StubJarTest.java
+++ b/test/com/facebook/buck/jvm/java/abi/StubJarTest.java
@@ -1612,7 +1612,10 @@ public class StubJarTest {
             "",
             "  // access flags 0x0",
             "  <init>(Lkotlin/jvm/functions/Function0;)V",
-            "}")
+            "",
+            "  // access flags 0x1011",
+            "  public final synthetic run()V",
+          "}")
         .createAndCheckStubJar();
   }
 


### PR DESCRIPTION
This addresses two bugs when dealing with ABI classes for Kotlin.

1. If you're using a mixed source set or a kt target without any kt files, the folder isn't generated to hold the abi class files. When an upstream target tries to consume this target, it fails because of a missing folder. This creates the temp folder if it's supporting source abi generation.

2. For Class ABIs, methods with synthetic parameters were stripped. The means that overrides become problematic across targets. This preserves more signatures in the case of Kotlin by keeping synthetic methods for Kotlin.

This has been tested and deployed on the internal Uber Buck fork.
