### PR TITLE
[apple] Stop propagating underlying libraries when using resources_from_deps.

### DIFF
--- a/src/com/facebook/buck/apple/AppleBuildRules.java
+++ b/src/com/facebook/buck/apple/AppleBuildRules.java
@@ -164,7 +164,13 @@ public final class AppleBuildRules {
                   .map(TargetNode::getConstructorArg)
                   .map(arg -> targetGraph.getAll(arg.getResourcesFromDeps()));
           if (iterable.isPresent()) {
-            return iterable.get().iterator();
+            if (mode == RecursiveDependenciesMode.LINKING) {
+              // If this is a resource dependency, we should not be providing
+              // the underlying libraries for linking
+              return Collections.emptyIterator();
+            } else {
+              return iterable.get().iterator();
+            }
           }
 
           // Stop traversal for rules outside the specific set.

--- a/test/com/facebook/buck/apple/AppleResourceBuilder.java
+++ b/test/com/facebook/buck/apple/AppleResourceBuilder.java
@@ -20,6 +20,7 @@ import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.model.targetgraph.AbstractNodeBuilder;
 import com.facebook.buck.core.rules.BuildRule;
 import com.facebook.buck.core.sourcepath.SourcePath;
+import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 
 public class AppleResourceBuilder
@@ -49,6 +50,11 @@ public class AppleResourceBuilder
 
   public AppleResourceBuilder setVariants(Set<SourcePath> variants) {
     getArgForPopulating().setVariants(variants);
+    return this;
+  }
+
+  public AppleResourceBuilder setResourcesFromDeps(Set<BuildTarget> deps) {
+    getArgForPopulating().setResourcesFromDeps(deps);
     return this;
   }
 }


### PR DESCRIPTION
We observed that the `resources_from_deps` would propagate linkables for the transitive dependencies into a resultant binary. With this change, `resources_from_deps` will only include resources, not the actual linkable results.