### PR TITLE
[apple] project: Add apple.skip_appex_copy_frameworks_in_xcode.

### DIFF
--- a/src/com/facebook/buck/apple/AppleConfig.java
+++ b/src/com/facebook/buck/apple/AppleConfig.java
@@ -323,6 +323,14 @@ public class AppleConfig implements ConfigView<BuckConfig> {
     return delegate.getBooleanValue(APPLE_SECTION, "generate_missing_umbrella_headers", false);
   }
 
+  /**
+   * If true, project generation will skip embedding transitive frameworks within the extension
+   * binary. This can be a significant disk-usage savings for many projects.
+   */
+  public boolean shouldSkipAppexCopyFrameworksInXcodeProject() {
+    return delegate.getBooleanValue(APPLE_SECTION, "skip_appex_copy_frameworks_in_xcode", false);
+  }
+
   public boolean shouldUseSwiftDelegate() {
     // TODO(mgd): Remove Swift delegation from Apple rules
     return delegate.getBooleanValue(APPLE_SECTION, "use_swift_delegate", true);

--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -830,7 +830,7 @@ public class ProjectGenerator {
                 : AppleBuildRules.RecursiveDependenciesMode.COPYING,
             targetNode,
             Optional.of(xcodeDescriptions.getXCodeDescriptions()));
-    if (bundleRequiresRemovalOfAllTransitiveFrameworks(targetNode)) {
+    if (bundleRequiresRemovalOfAllTransitiveFrameworks(targetNode, appleConfig)) {
       copiedRules = rulesWithoutFrameworkBundles(copiedRules);
     } else if (bundleRequiresAllTransitiveFrameworks(binaryNode, bundleLoaderNode)) {
       copiedRules =
@@ -4750,6 +4750,10 @@ public class ProjectGenerator {
     return hasExtension(arg, AppleBundleExtension.APP);
   }
 
+  private static boolean isAppExtension(HasAppleBundleFields arg) {
+    return hasExtension(arg, AppleBundleExtension.APPEX);
+  }
+
   private static boolean hasExtension(HasAppleBundleFields arg, AppleBundleExtension extension) {
     return arg.getExtension().isLeft() && arg.getExtension().getLeft().equals(extension);
   }
@@ -4766,8 +4770,10 @@ public class ProjectGenerator {
   }
 
   private static boolean bundleRequiresRemovalOfAllTransitiveFrameworks(
-      TargetNode<? extends HasAppleBundleFields> targetNode) {
-    return isFrameworkBundle(targetNode.getConstructorArg());
+      TargetNode<? extends HasAppleBundleFields> targetNode, AppleConfig config) {
+    return isFrameworkBundle(targetNode.getConstructorArg()) ||
+      (config.shouldSkipAppexCopyFrameworksInXcodeProject() &&
+        isAppExtension(targetNode.getConstructorArg()));
   }
 
   private static boolean bundleRequiresAllTransitiveFrameworks(


### PR DESCRIPTION
This change will prevent frameworks from being copied into appex binaries. This can save significant megabytes when building applications in xcode.