### PR TITLE
[apple] add apple.add_root_user_header_search_path_in_xcode.

### DIFF
--- a/src/com/facebook/buck/apple/AppleConfig.java
+++ b/src/com/facebook/buck/apple/AppleConfig.java
@@ -323,6 +323,10 @@ public class AppleConfig implements ConfigView<BuckConfig> {
     return delegate.getBooleanValue(APPLE_SECTION, "generate_missing_umbrella_headers", false);
   }
 
+  public boolean shouldAddRootUserHeaderSearchPathInXcodeProject() {
+    return delegate.getBooleanValue(APPLE_SECTION, "add_root_user_header_search_path_in_xcode", false);
+  }
+
   public boolean shouldUseSwiftDelegate() {
     // TODO(mgd): Remove Swift delegation from Apple rules
     return delegate.getBooleanValue(APPLE_SECTION, "use_swift_delegate", true);

--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -538,7 +538,13 @@ public class ProjectGenerator {
                 .getBuildConfigurationList()
                 .getBuildConfigurationsByName()
                 .getUnchecked(configName);
-        outputConfig.setBuildSettings(new NSDictionary());
+        NSDictionary settings = new NSDictionary();
+        if (appleConfig.shouldAddRootUserHeaderSearchPathInXcodeProject()) {
+          settings.put("ALWAYS_SEARCH_USER_PATHS", "NO");
+          settings.put("USER_HEADER_SEARCH_PATHS",
+            projectFilesystem.getRootPath().toString());
+        }
+        outputConfig.setBuildSettings(settings);
       }
 
       if (!options.shouldGenerateHeaderSymlinkTreesOnly()) {


### PR DESCRIPTION
A small ergonomic improvement; this `apple.add_root_user_header_search_path_in_xcode` adds the root to the header search path, which enables autocomplete for fully qualified non-modular imports (e.g. `<ROOT>/src/include/my_header.h`) to work.