### PR TITLE
[apple] xcode: change defaultConfigurationIsVisible from bool -> string.

### DIFF
--- a/src/com/facebook/buck/apple/xcode/xcodeproj/XCConfigurationList.java
+++ b/src/com/facebook/buck/apple/xcode/xcodeproj/XCConfigurationList.java
@@ -30,14 +30,14 @@ import java.util.Optional;
 public class XCConfigurationList extends PBXProjectItem {
   private List<XCBuildConfiguration> buildConfigurations;
   private Optional<String> defaultConfigurationName;
-  private boolean defaultConfigurationIsVisible;
+  private String defaultConfigurationIsVisible;
 
   private final LoadingCache<String, XCBuildConfiguration> buildConfigurationsByName;
 
   public XCConfigurationList(AbstractPBXObjectFactory objectFactory) {
     buildConfigurations = new ArrayList<>();
     defaultConfigurationName = Optional.empty();
-    defaultConfigurationIsVisible = false;
+    defaultConfigurationIsVisible = "0";
 
     buildConfigurationsByName =
         CacheBuilder.newBuilder()

--- a/test/com/facebook/buck/features/apple/project/testdata/generating_root_directory_project/Project.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/generating_root_directory_project/Project.xcodeproj/project.pbxproj.expected
@@ -386,7 +386,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04EADDF308200000000</key>
 		<dict>
@@ -452,7 +452,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C8479350C8E2F900000000</key>
 		<dict>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_focus/Apps/Apps.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_focus/Apps/Apps.xcodeproj/project.pbxproj.expected
@@ -219,7 +219,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04EFEC3CBA900000000</key>
 		<dict>
@@ -283,7 +283,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C84793001F3E9200000000</key>
 		<dict>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_focus/Libraries/Dep1/Dep1.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_focus/Libraries/Dep1/Dep1.xcodeproj/project.pbxproj.expected
@@ -219,7 +219,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E79CC7D5400000000</key>
 		<dict>
@@ -250,7 +250,7 @@
 			<array>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E79CC7D5500000000</key>
 		<dict>
@@ -314,7 +314,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C847930020722200000000</key>
 		<dict>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_focus/Libraries/Dep2/Dep2.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_focus/Libraries/Dep2/Dep2.xcodeproj/project.pbxproj.expected
@@ -205,7 +205,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E0020722300000000</key>
 		<dict>
@@ -269,7 +269,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C847930020722300000000</key>
 		<dict>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_focus_pattern/Apps/Apps.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_focus_pattern/Apps/Apps.xcodeproj/project.pbxproj.expected
@@ -219,7 +219,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E0E6F340F00000000</key>
 		<dict>
@@ -283,7 +283,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C84793001F3E9200000000</key>
 		<dict>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_focus_pattern/Libraries/Dep1/Dep1.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_focus_pattern/Libraries/Dep1/Dep1.xcodeproj/project.pbxproj.expected
@@ -301,7 +301,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E79CC7D5400000000</key>
 		<dict>
@@ -371,7 +371,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E79CC7D5500000000</key>
 		<dict>
@@ -435,7 +435,7 @@
 				<string>49524373A439BFE700000002</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C847930020722200000000</key>
 		<dict>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_focus_pattern_cell/Apps/Apps.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_focus_pattern_cell/Apps/Apps.xcodeproj/project.pbxproj.expected
@@ -219,7 +219,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E0E6F340F00000000</key>
 		<dict>
@@ -283,7 +283,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C84793001F3E9200000000</key>
 		<dict>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_focus_pattern_cell/bar/Dep2/Dep2.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_focus_pattern_cell/bar/Dep2/Dep2.xcodeproj/project.pbxproj.expected
@@ -205,7 +205,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E0020722300000000</key>
 		<dict>
@@ -269,7 +269,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C847930020722300000000</key>
 		<dict>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_focus_with_tests/Dep1/Dep1.xcodeproj/project.pbxproj
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_focus_with_tests/Dep1/Dep1.xcodeproj/project.pbxproj
@@ -178,7 +178,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E0020722200000000</key>
 		<dict>
@@ -231,7 +231,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C847930020722200000000</key>
 		<dict>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_focus_with_tests/Tests/Tests.xcodeproj/project.pbxproj
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_focus_with_tests/Tests/Tests.xcodeproj/project.pbxproj
@@ -192,7 +192,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E04CF5E0100000000</key>
 		<dict>
@@ -245,7 +245,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C8479304CF5E0100000000</key>
 		<dict>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_halide/Apps/Apps.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_halide/Apps/Apps.xcodeproj/project.pbxproj.expected
@@ -614,7 +614,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E0E6F340F00000000</key>
 		<dict>
@@ -704,7 +704,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E0BC2E52700000000</key>
 		<dict>
@@ -791,7 +791,7 @@
 				<string>49524373A439BFE700000002</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04EC17EBCB700000000</key>
 		<dict>
@@ -878,7 +878,7 @@
 				<string>49524373A439BFE700000003</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04EA17B1C7900000000</key>
 		<dict>
@@ -943,7 +943,7 @@
 				<string>49524373A439BFE700000004</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C84793001F3E9200000000</key>
 		<dict>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_with_unique_library_names/Apps/Apps.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_with_unique_library_names/Apps/Apps.xcodeproj/project.pbxproj.expected
@@ -314,7 +314,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E0E6F340F00000000</key>
 		<dict>
@@ -380,7 +380,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C84793001F3E9200000000</key>
 		<dict>

--- a/test/com/facebook/buck/features/apple/project/testdata/project_with_unique_library_names/Libraries/Libraries.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/project/testdata/project_with_unique_library_names/Libraries/Libraries.xcodeproj/project.pbxproj.expected
@@ -345,7 +345,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E0020722200000000</key>
 		<dict>
@@ -432,7 +432,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E0020722300000000</key>
 		<dict>
@@ -497,7 +497,7 @@
 				<string>49524373A439BFE700000002</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C84793A7E3D27900000000</key>
 		<dict>

--- a/test/com/facebook/buck/features/apple/projectV2/testdata/generating_root_directory_project/Project.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/projectV2/testdata/generating_root_directory_project/Project.xcodeproj/project.pbxproj.expected
@@ -386,7 +386,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04EADDF308200000000</key>
 		<dict>
@@ -452,7 +452,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C8479350C8E2F900000000</key>
 		<dict>

--- a/test/com/facebook/buck/features/apple/projectV2/testdata/project_focus/Apps/Apps.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/projectV2/testdata/project_focus/Apps/Apps.xcodeproj/project.pbxproj.expected
@@ -219,7 +219,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04EFEC3CBA900000000</key>
 		<dict>
@@ -283,7 +283,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C84793001F3E9200000000</key>
 		<dict>

--- a/test/com/facebook/buck/features/apple/projectV2/testdata/project_focus/Libraries/Dep1/Dep1.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/projectV2/testdata/project_focus/Libraries/Dep1/Dep1.xcodeproj/project.pbxproj.expected
@@ -219,7 +219,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E79CC7D5400000000</key>
 		<dict>
@@ -250,7 +250,7 @@
 			<array>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E79CC7D5500000000</key>
 		<dict>
@@ -314,7 +314,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C847930020722200000000</key>
 		<dict>

--- a/test/com/facebook/buck/features/apple/projectV2/testdata/project_focus/Libraries/Dep2/Dep2.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/projectV2/testdata/project_focus/Libraries/Dep2/Dep2.xcodeproj/project.pbxproj.expected
@@ -205,7 +205,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E0020722300000000</key>
 		<dict>
@@ -269,7 +269,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C847930020722300000000</key>
 		<dict>

--- a/test/com/facebook/buck/features/apple/projectV2/testdata/project_focus_pattern/Apps/TestApp.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/projectV2/testdata/project_focus_pattern/Apps/TestApp.xcodeproj/project.pbxproj.expected
@@ -417,7 +417,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E79CC7D5400000000</key>
 		<dict>
@@ -508,7 +508,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E79CC7D5500000000</key>
 		<dict>
@@ -599,7 +599,7 @@
 				<string>49524373A439BFE700000002</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E0E6F340F00000000</key>
 		<dict>
@@ -670,7 +670,7 @@
 				<string>49524373A439BFE700000003</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C847930E6F340F00000000</key>
 		<dict>

--- a/test/com/facebook/buck/features/apple/projectV2/testdata/project_focus_with_tests/Dep1/Dep1.xcodeproj/project.pbxproj
+++ b/test/com/facebook/buck/features/apple/projectV2/testdata/project_focus_with_tests/Dep1/Dep1.xcodeproj/project.pbxproj
@@ -172,7 +172,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E0020722200000000</key>
 		<dict>
@@ -225,7 +225,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C847930020722200000000</key>
 		<dict>

--- a/test/com/facebook/buck/features/apple/projectV2/testdata/project_focus_with_tests/Tests/Tests.xcodeproj/project.pbxproj
+++ b/test/com/facebook/buck/features/apple/projectV2/testdata/project_focus_with_tests/Tests/Tests.xcodeproj/project.pbxproj
@@ -186,7 +186,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E04CF5E0100000000</key>
 		<dict>
@@ -233,7 +233,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C8479304CF5E0100000000</key>
 		<dict>

--- a/test/com/facebook/buck/features/apple/projectV2/testdata/project_halide/Apps/TestApp.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/projectV2/testdata/project_halide/Apps/TestApp.xcodeproj/project.pbxproj.expected
@@ -501,7 +501,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E0E6F340F00000000</key>
 		<dict>
@@ -608,7 +608,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E9350A4F000000000</key>
 		<dict>
@@ -700,7 +700,7 @@
 				<string>49524373A439BFE700000002</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E0BC2E52700000000</key>
 		<dict>
@@ -807,7 +807,7 @@
 				<string>49524373A439BFE700000003</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04EC17EBCB700000000</key>
 		<dict>
@@ -915,7 +915,7 @@
 				<string>49524373A439BFE700000004</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04EA17B1C7900000000</key>
 		<dict>
@@ -987,7 +987,7 @@
 				<string>49524373A439BFE700000005</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C847930E6F340F00000000</key>
 		<dict>

--- a/test/com/facebook/buck/features/apple/projectV2/testdata/project_with_unique_library_names/Apps/TestApp.xcodeproj/project.pbxproj.expected
+++ b/test/com/facebook/buck/features/apple/projectV2/testdata/project_with_unique_library_names/Apps/TestApp.xcodeproj/project.pbxproj.expected
@@ -503,7 +503,7 @@
 				<string>49524373A439BFE700000000</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E0020722200000000</key>
 		<dict>
@@ -611,7 +611,7 @@
 				<string>49524373A439BFE700000001</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E0020722300000000</key>
 		<dict>
@@ -703,7 +703,7 @@
 				<string>49524373A439BFE700000002</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E0E6F340F00000000</key>
 		<dict>
@@ -810,7 +810,7 @@
 				<string>49524373A439BFE700000003</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>E66DC04E9350A4F000000000</key>
 		<dict>
@@ -882,7 +882,7 @@
 				<string>49524373A439BFE700000004</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
-			<false/>
+			<string>0</string>
 		</dict>
 		<key>96C847930E6F340F00000000</key>
 		<dict>


### PR DESCRIPTION
This is a small fix that makes the xcodeprojs more correct; moving defaultConfigurationIsVisible from a float/number to String.