### PR TITLE
[apple]: expose apple.use_short_names_for_targets_in_xcode.

### DIFF
--- a/src/com/facebook/buck/apple/AppleConfig.java
+++ b/src/com/facebook/buck/apple/AppleConfig.java
@@ -324,7 +324,7 @@ public class AppleConfig implements ConfigView<BuckConfig> {
   }
 
   public boolean shouldUseShortNamesForTargetsInXcodeProject() {
-    return delegate.getBooleanValue(APPLE_SECTION, "use_short_names_for_targets", true);
+    return delegate.getBooleanValue(APPLE_SECTION, "use_short_names_for_targets_in_xcode", true);
   }
 
   public boolean shouldUseSwiftDelegate() {

--- a/src/com/facebook/buck/apple/AppleConfig.java
+++ b/src/com/facebook/buck/apple/AppleConfig.java
@@ -323,6 +323,10 @@ public class AppleConfig implements ConfigView<BuckConfig> {
     return delegate.getBooleanValue(APPLE_SECTION, "generate_missing_umbrella_headers", false);
   }
 
+  public boolean shouldUseShortNamesForTargetsInXcodeProject() {
+    return delegate.getBooleanValue(APPLE_SECTION, "use_short_names_for_targets", true);
+  }
+
   public boolean shouldUseSwiftDelegate() {
     // TODO(mgd): Remove Swift delegation from Apple rules
     return delegate.getBooleanValue(APPLE_SECTION, "use_swift_delegate", true);

--- a/src/com/facebook/buck/features/apple/project/XCodeProjectCommandHelper.java
+++ b/src/com/facebook/buck/features/apple/project/XCodeProjectCommandHelper.java
@@ -379,6 +379,7 @@ public class XCodeProjectCommandHelper {
             .setShouldUseShortNamesForTargets(true)
             .setShouldCreateDirectoryStructure(combinedProject)
             .setShouldGenerateProjectSchemes(createProjectSchemes)
+            .setShouldUseShortNamesForTargets(appleConfig.shouldUseShortNamesForTargetsInXcodeProject())
             .build();
 
     LOG.debug("Xcode project generation: Generates workspaces for targets");


### PR DESCRIPTION
This is a convenience feature -- we prefer seeing the entire target name as xcode groups, so this small change exposes it as a configuration setting.