### PR TITLE
[apple] Add "umbrella" suffix to default umbrella header name

### DIFF
--- a/src/com/facebook/buck/apple/clang/UmbrellaHeaderModuleMap.java
+++ b/src/com/facebook/buck/apple/clang/UmbrellaHeaderModuleMap.java
@@ -40,7 +40,7 @@ public class UmbrellaHeaderModuleMap implements ModuleMap {
   @Nullable private String generatedModule;
   private static final String template =
       "module <module_name> {\n"
-          + "    umbrella header \"<module_name>.h\"\n"
+          + "    umbrella header \"<umbrella_name>.h\"\n"
           + "\n"
           + "    export *\n"
           + "    module * { export * }\n"
@@ -71,6 +71,7 @@ public class UmbrellaHeaderModuleMap implements ModuleMap {
       ST st =
           new ST(template)
               .add("module_name", moduleName)
+              .add("umbrella_name", moduleName + "-umbrella")
               .add("include_swift_header", false)
               .add("exclude_swift_header", false);
       switch (swiftMode) {

--- a/src/com/facebook/buck/cxx/toolchain/HeaderSymlinkTreeWithModuleMap.java
+++ b/src/com/facebook/buck/cxx/toolchain/HeaderSymlinkTreeWithModuleMap.java
@@ -97,7 +97,7 @@ public final class HeaderSymlinkTreeWithModuleMap extends HeaderSymlinkTree {
                           : UmbrellaHeaderModuleMap.SwiftMode.NO_SWIFT,
                       getLinks().keySet())));
 
-          Path umbrellaHeaderPath = Paths.get(moduleName, moduleName + ".h");
+          Path umbrellaHeaderPath = Paths.get(moduleName, moduleName + "-umbrella.h");
           if (moduleMapMode.shouldGenerateMissingUmbrellaHeader()
               && !paths.contains(umbrellaHeaderPath)) {
             builder.add(

--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -3237,8 +3237,8 @@ public class ProjectGenerator {
             .map(Path::getFileName)
             .map(Path::toString)
             .collect(ImmutableList.toImmutableList());
-    if (!headerPathStrings.contains(moduleName + ".h")) {
-      Path umbrellaPath = headerSymlinkTreeRoot.resolve(Paths.get(moduleName, moduleName + ".h"));
+    if (!headerPathStrings.contains(moduleName + "-umbrella.h")) {
+      Path umbrellaPath = headerSymlinkTreeRoot.resolve(Paths.get(moduleName, moduleName + "-umbrella.h"));
       Preconditions.checkState(!projectFilesystem.exists(umbrellaPath));
       projectFilesystem.writeContentsToPath(
           new UmbrellaHeader(moduleName, headerPathStrings).render(), umbrellaPath);


### PR DESCRIPTION
In our project we have some both internal and external dependencies in Obj-C with manually created "umbrella" files. They are interfere with BUCK generated "ModuleName.h" umbrella files. One example of such dependency is https://github.com/yapstudios/YapDatabase/blob/master/YapDatabase/YapDatabase.h

This PR will add *ModuleName*"-umbrella.h" suffix to avoid this issue. This behaviour will be similar to CocoaPods 