### PR TITLE
[docs] Fix instructions for Java install with Homebrew 

### DIFF
--- a/docs/setup/getting_started.soy
+++ b/docs/setup/getting_started.soy
@@ -302,7 +302,7 @@ xcode-select --install
 # Download and Install Java SE 8 from:
 +# https://www.oracle.com/technetwork/java/javase/downloads/index.html.
 +# This installs the JDK 8, a superset of the JRE.
-+# Alternatively, install AdoptOpenJDK 8 with Homebrew Cask:
++# Alternatively, install AdoptOpenJDK 8 with Homebrew:
 +brew tap AdoptOpenJDK/openjdk
 +brew install --cask adoptopenjdk8
 </pre>{/literal}

--- a/docs/setup/getting_started.soy
+++ b/docs/setup/getting_started.soy
@@ -303,9 +303,8 @@ xcode-select --install
 +# https://www.oracle.com/technetwork/java/javase/downloads/index.html.
 +# This installs the JDK 8, a superset of the JRE.
 +# Alternatively, install AdoptOpenJDK 8 with Homebrew Cask:
-+brew tap homebrew/cask-cask
-+brew tap homebrew/cask-versions
-+brew cask install homebrew/cask-versions/adoptopenjdk8
++brew tap AdoptOpenJDK/openjdk
++brew install --cask adoptopenjdk8
 </pre>{/literal}
 
 <span><block class="mac ios" /></span>


### PR DESCRIPTION
The current doc use `homebrew/cask-cask` instructions, and cask was changed.

The current instructions to install java with Homebrew doesn't work, **and mysteriously it requests your github email and password 🤔🏴‍☠️.**
This PR change the docs to install java using https://github.com/AdoptOpenJDK/homebrew-openjdk with correct cask command in homebrew.