### PR TITLE
Add friend path ABI jars as required deps of Kotlin libraries

### DIFF
--- a/src/com/facebook/buck/jvm/groovy/GroovyConfiguredCompilerFactory.java
+++ b/src/com/facebook/buck/jvm/groovy/GroovyConfiguredCompilerFactory.java
@@ -18,6 +18,7 @@ package com.facebook.buck.jvm.groovy;
 
 import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.model.TargetConfiguration;
+import com.facebook.buck.core.rules.ActionGraphBuilder;
 import com.facebook.buck.core.rules.BuildRuleResolver;
 import com.facebook.buck.core.toolchain.ToolchainProvider;
 import com.facebook.buck.core.util.Optionals;
@@ -43,6 +44,7 @@ public class GroovyConfiguredCompilerFactory extends ConfiguredCompilerFactory {
   public CompileToJarStepFactory configure(
       @Nullable JvmLibraryArg args,
       JavacOptions javacOptions,
+      ActionGraphBuilder actionGraphBuilder,
       BuildRuleResolver buildRuleResolver,
       TargetConfiguration targetConfiguration,
       ToolchainProvider toolchainProvider) {

--- a/src/com/facebook/buck/jvm/java/ConfiguredCompilerFactory.java
+++ b/src/com/facebook/buck/jvm/java/ConfiguredCompilerFactory.java
@@ -18,6 +18,7 @@ package com.facebook.buck.jvm.java;
 
 import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.model.TargetConfiguration;
+import com.facebook.buck.core.rules.ActionGraphBuilder;
 import com.facebook.buck.core.rules.BuildRuleResolver;
 import com.facebook.buck.core.toolchain.ToolchainProvider;
 import com.facebook.buck.jvm.java.abi.AbiGenerationMode;
@@ -31,11 +32,12 @@ public abstract class ConfiguredCompilerFactory {
   // TODO(jkeljo): args is not actually Nullable in all subclasses, but it is also not
   // straightforward to create a safe "empty" default value. Find a fix.
   public abstract CompileToJarStepFactory configure(
-      @Nullable JvmLibraryArg args,
-      JavacOptions javacOptions,
-      BuildRuleResolver buildRuleResolver,
-      TargetConfiguration targetConfiguration,
-      ToolchainProvider toolchainProvider);
+    @Nullable JvmLibraryArg args,
+    JavacOptions javacOptions,
+    ActionGraphBuilder actionGraphBuilder,
+    BuildRuleResolver buildRuleResolver,
+    TargetConfiguration targetConfiguration,
+    ToolchainProvider toolchainProvider);
 
   public abstract Optional<ExtraClasspathProvider> getExtraClasspathProvider(
       ToolchainProvider toolchainProvider, TargetConfiguration toolchainTargetConfiguration);

--- a/src/com/facebook/buck/jvm/java/DefaultJavaLibraryRules.java
+++ b/src/com/facebook/buck/jvm/java/DefaultJavaLibraryRules.java
@@ -563,6 +563,7 @@ public abstract class DefaultJavaLibraryRules {
             getArgs(),
             getJavacOptions(),
             getActionGraphBuilder(),
+            getActionGraphBuilder(),
             getInitialBuildTarget().getTargetConfiguration(),
             getToolchainProvider());
   }
@@ -573,6 +574,7 @@ public abstract class DefaultJavaLibraryRules {
         .configure(
             getArgs(),
             getJavacOptionsForSourceOnlyAbi(),
+            getActionGraphBuilder(),
             getActionGraphBuilder(),
             getInitialBuildTarget().getTargetConfiguration(),
             getToolchainProvider());

--- a/src/com/facebook/buck/jvm/java/JavaConfiguredCompilerFactory.java
+++ b/src/com/facebook/buck/jvm/java/JavaConfiguredCompilerFactory.java
@@ -17,6 +17,7 @@
 package com.facebook.buck.jvm.java;
 
 import com.facebook.buck.core.model.TargetConfiguration;
+import com.facebook.buck.core.rules.ActionGraphBuilder;
 import com.facebook.buck.core.rules.BuildRuleResolver;
 import com.facebook.buck.core.toolchain.ToolchainProvider;
 import com.facebook.buck.jvm.java.abi.AbiGenerationMode;
@@ -86,6 +87,7 @@ public class JavaConfiguredCompilerFactory extends ConfiguredCompilerFactory {
   public CompileToJarStepFactory configure(
       @Nullable JvmLibraryArg arg,
       JavacOptions javacOptions,
+      ActionGraphBuilder actionGraphBuilder,
       BuildRuleResolver buildRuleResolver,
       TargetConfiguration targetConfiguration,
       ToolchainProvider toolchainProvider) {

--- a/src/com/facebook/buck/jvm/kotlin/KotlinConfiguredCompilerFactory.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinConfiguredCompilerFactory.java
@@ -21,6 +21,7 @@ import static java.util.Comparator.comparing;
 
 import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.model.TargetConfiguration;
+import com.facebook.buck.core.rules.ActionGraphBuilder;
 import com.facebook.buck.core.rules.BuildRule;
 import com.facebook.buck.core.rules.BuildRuleResolver;
 import com.facebook.buck.core.sourcepath.SourcePath;
@@ -82,6 +83,7 @@ public class KotlinConfiguredCompilerFactory extends ConfiguredCompilerFactory {
   public CompileToJarStepFactory configure(
       @Nullable JvmLibraryArg args,
       JavacOptions javacOptions,
+      ActionGraphBuilder actionGraphBuilder,
       BuildRuleResolver buildRuleResolver,
       TargetConfiguration targetConfiguration,
       ToolchainProvider toolchainProvider) {
@@ -94,7 +96,8 @@ public class KotlinConfiguredCompilerFactory extends ConfiguredCompilerFactory {
         pathToAbiGenerationPluginJar,
         condenseCompilerArguments(kotlinArgs),
         kotlinArgs.getKotlincPlugins(),
-        getFriendSourcePaths(buildRuleResolver, kotlinArgs.getFriendPaths(), kotlinBuckConfig),
+        getFriendSourcePaths(
+          actionGraphBuilder, buildRuleResolver, kotlinArgs.getFriendPaths(), kotlinBuckConfig),
         kotlinArgs.getAnnotationProcessingTool().orElse(AnnotationProcessingTool.KAPT),
         kotlinArgs.getKaptApOptions(),
         extraClasspathProviderSupplier.apply(toolchainProvider, targetConfiguration),
@@ -147,6 +150,7 @@ public class KotlinConfiguredCompilerFactory extends ConfiguredCompilerFactory {
   }
 
   private static ImmutableList<SourcePath> getFriendSourcePaths(
+      ActionGraphBuilder actionGraphBuilder,
       BuildRuleResolver buildRuleResolver,
       ImmutableSortedSet<BuildTarget> friendPaths,
       KotlinBuckConfig kotlinBuckConfig) {
@@ -157,13 +161,11 @@ public class KotlinConfiguredCompilerFactory extends ConfiguredCompilerFactory {
       if (shouldCompileAgainstAbis && rule instanceof HasJavaAbi) {
         Optional<BuildTarget> abiJarTarget = ((HasJavaAbi) rule).getAbiJar();
         if (abiJarTarget.isPresent()) {
-          Optional<BuildRule> abiJarRule = buildRuleResolver.getRuleOptional(abiJarTarget.get());
-          if (abiJarRule.isPresent()) {
-            SourcePath abiJarPath = abiJarRule.get().getSourcePathToOutput();
-            if (abiJarPath != null) {
-              sourcePaths.add(abiJarPath);
-              continue;
-            }
+          BuildRule abiJarRule = actionGraphBuilder.requireRule(abiJarTarget.get());
+          SourcePath abiJarPath = abiJarRule.getSourcePathToOutput();
+          if (abiJarPath != null) {
+            sourcePaths.add(abiJarPath);
+            continue;
           }
         }
       }

--- a/src/com/facebook/buck/jvm/scala/ScalaConfiguredCompilerFactory.java
+++ b/src/com/facebook/buck/jvm/scala/ScalaConfiguredCompilerFactory.java
@@ -18,6 +18,7 @@ package com.facebook.buck.jvm.scala;
 
 import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.model.TargetConfiguration;
+import com.facebook.buck.core.rules.ActionGraphBuilder;
 import com.facebook.buck.core.rules.BuildRuleResolver;
 import com.facebook.buck.core.toolchain.ToolchainProvider;
 import com.facebook.buck.core.toolchain.tool.Tool;
@@ -71,6 +72,7 @@ public class ScalaConfiguredCompilerFactory extends ConfiguredCompilerFactory {
   public CompileToJarStepFactory configure(
       @Nullable JvmLibraryArg arg,
       JavacOptions javacOptions,
+      ActionGraphBuilder actionGraphBuilder,
       BuildRuleResolver buildRuleResolver,
       TargetConfiguration targetConfiguration,
       ToolchainProvider toolchainProvider) {


### PR DESCRIPTION
In some cases, the Kotlin ABI jar for a dependency may not be already generated in the task graph, so when it is used as a friend path, it does not get picked up. This ensures that if a module is used as a friend path, that we add an explicit dependency on calculating its ABI jar so that we can use its absolute path in the friend path Kotlin compiler arg.

Resolves #2614 