### PR TITLE
Fix building with Xcode 12.5

### DIFF
--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -2549,7 +2549,7 @@ public class ProjectGenerator {
 
       librarySearchPaths.add("$DT_TOOLCHAIN_DIR/usr/lib/swift/$PLATFORM_NAME");
       if (options.shouldLinkSystemSwift()) {
-        librarySearchPaths.add("$DT_TOOLCHAIN_DIR/usr/lib/swift-5.0/$PLATFORM_NAME");
+        librarySearchPaths.add("$DT_TOOLCHAIN_DIR/usr/lib/swift-5.2/$PLATFORM_NAME");
       }
     }
 

--- a/src/com/facebook/buck/features/apple/projectV2/XcodeNativeTargetGenerator.java
+++ b/src/com/facebook/buck/features/apple/projectV2/XcodeNativeTargetGenerator.java
@@ -1863,7 +1863,7 @@ public class XcodeNativeTargetGenerator {
       // folder changes in a future release this can be revisited.
       librarySearchPaths.add("$DT_TOOLCHAIN_DIR/usr/lib/swift/$PLATFORM_NAME");
       if (options.shouldLinkSystemSwift()) {
-        librarySearchPaths.add("$DT_TOOLCHAIN_DIR/usr/lib/swift-5.0/$PLATFORM_NAME");
+        librarySearchPaths.add("$DT_TOOLCHAIN_DIR/usr/lib/swift-5.2/$PLATFORM_NAME");
       }
     }
 

--- a/src/com/facebook/buck/swift/toolchain/impl/SwiftPlatformFactory.java
+++ b/src/com/facebook/buck/swift/toolchain/impl/SwiftPlatformFactory.java
@@ -139,10 +139,10 @@ public class SwiftPlatformFactory {
     }
 
     // Currently Xcode includes swift and swift-5.0 directories, and each contains different
-    // contents. Specifically, swift/platform contains the libswiftCompatibility50 and
+    // contents. Specifically, swift/platform contains the libswiftCompatibility51 and
     // libswiftCompatibilityDynamicReplacements libraries which are *also* necessary.
     Path swiftRuntimePath = toolchainPath.resolve("usr/lib/swift").resolve(platformName);
-    String libSwiftCompatibilityLibraryName = "libswiftCompatibility50.a";
+    String libSwiftCompatibilityLibraryName = "libswiftCompatibility51.a";
     LOG.debug("Searching for swift compatibility toolchain in %s", toolchainPath.toString());
     if (Files.exists(swiftRuntimePath.resolve(libSwiftCompatibilityLibraryName))) {
       LOG.debug("Found swift compatibility toolchain at %s", toolchainPath.toString());


### PR DESCRIPTION
1. Use the correct path for searching swift libraries
2. Update compatibility library to 51