### PR TITLE
Use original JUnit test class name instead of suite class in test XML report

### DIFF
--- a/src/com/facebook/buck/test/TestCaseSummary.java
+++ b/src/com/facebook/buck/test/TestCaseSummary.java
@@ -29,6 +29,7 @@ public class TestCaseSummary implements TestCaseSummaryExternalInterface<TestRes
   private static final int MAX_STATUS_WIDTH = 7;
 
   private final String testCaseName;
+  private final boolean testSuite;
   private final ImmutableList<TestResultSummary> testResults;
   private final boolean isDryRun;
   private final boolean hasAssumptionViolations;
@@ -38,7 +39,15 @@ public class TestCaseSummary implements TestCaseSummaryExternalInterface<TestRes
   private final long totalTime;
 
   public TestCaseSummary(String testCaseName, List<TestResultSummary> testResults) {
+    this(testCaseName, false, testResults);
+  }
+
+  public TestCaseSummary(
+      String testCaseName,
+      boolean testSuite,
+      List<TestResultSummary> testResults) {
     this.testCaseName = testCaseName;
+    this.testSuite = testSuite;
     this.testResults = ImmutableList.copyOf(testResults);
 
     boolean isDryRun = false;
@@ -108,6 +117,11 @@ public class TestCaseSummary implements TestCaseSummaryExternalInterface<TestRes
   @Override
   public long getTotalTime() {
     return totalTime;
+  }
+
+  /** @return whether this summary represents a suite of tests or a single class */
+  public boolean isTestSuite() {
+    return testSuite;
   }
 
   /** @return a one-line, printable summary */

--- a/src/com/facebook/buck/test/XmlTestResultParser.java
+++ b/src/com/facebook/buck/test/XmlTestResultParser.java
@@ -139,6 +139,7 @@ public class XmlTestResultParser {
     Element root = doc.getDocumentElement();
     Preconditions.checkState("testcase".equals(root.getTagName()));
     String testCaseName = root.getAttribute("name");
+    boolean testSuite = false;
 
     NodeList testElements = doc.getElementsByTagName("test");
     List<TestResultSummary> testResults = Lists.newArrayListWithCapacity(testElements.getLength());
@@ -176,13 +177,20 @@ public class XmlTestResultParser {
         stdErr = null;
       }
 
+      String actualTestCaseName = node.getAttribute("suite");
+      if (actualTestCaseName != null && !actualTestCaseName.isEmpty()) {
+        testSuite |= !actualTestCaseName.equals(testCaseName);
+      } else {
+        actualTestCaseName = testCaseName;
+      }
+
       TestResultSummary testResult =
           new TestResultSummary(
-              testCaseName, testName, type, time, message, stacktrace, stdOut, stdErr);
+              actualTestCaseName, testName, type, time, message, stacktrace, stdOut, stdErr);
       testResults.add(testResult);
     }
 
-    return new TestCaseSummary(testCaseName, testResults);
+    return new TestCaseSummary(testCaseName, testSuite, testResults);
   }
 
   private static String createDetailedExceptionMessage(Path xmlFile, String xmlFileContents) {


### PR DESCRIPTION
As discussed in https://github.com/facebook/buck/issues/2623, this change will use the original test class name instead of the test suite name when generating the test output XML when run against a JUnit suite. I've based this change on the `dev` branch as it doesn't seem the kind of thing that needs to hit the stable branch urgently.

I've tried to keep the change as small as possible by overloading the `TestCaseSummary` constructor to default the new `testSuite` parameter to `false`, so that all the other usages of this aren't affected, but if it's better to push this default up to the places where this class is instantiated then I can do that instead!

**One thing to note:** I originally built this change on top of `master`, but figured that it was probably better suited to `dev`. It all seemed to work for me on the stable build, however since rebasing the change onto the `dev` branch I can no longer build the project? I don't know if this is because I'm trying to build using the latest Buck release, but it gives me an error parsing `buck/programs/defs.bzl` (`name 'name' is not defined`).