### PR TITLE
Fix typo in tutorial documentation

### DIFF
--- a/docs/learning/tutorial.soy
+++ b/docs/learning/tutorial.soy
@@ -245,7 +245,7 @@ pub fn take_payment() {
 </pre>{/literal}
 
 <p>
-  Now we need a build file that defines a build rule to compile this Java code, so we create an <code><a href="rule/rust_binary.html">rust_binary()</a></code> rule in <code>BUCK</code>:
+  Now we need a build file that defines a build rule to compile this rust code, so we create an <code><a href="rule/rust_binary.html">rust_binary()</a></code> rule in <code>BUCK</code>:
 {literal}<pre>
 echo "rust_binary(
     name = 'restaurant',


### PR DESCRIPTION
The documentation for Rust have an occurrence of Java.