### PR TITLE
resource leak due Files.list

### DIFF
--- a/src/com/facebook/buck/features/python/MovePythonWhlDataStep.java
+++ b/src/com/facebook/buck/features/python/MovePythonWhlDataStep.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * A {@link Step} that moves the contents of the {package}-{version}.data directory within an
@@ -56,11 +57,12 @@ public class MovePythonWhlDataStep implements Step {
     // to just list the couple of entries inside of the root of the extracted dir, rather than
     // parsing out the *.dist-info/METADATA file (we also would need the package name/version
     // anyways to find the .dist-info dir.
-    Optional<Path> dataDir =
-        Files.list(resolvedWhlDir)
-            .filter(
-                path -> path.getFileName().toString().endsWith(".data") && Files.isDirectory(path))
-            .findFirst();
+    Optional<Path> dataDir = null;
+    try(Stream<Path> list = Files.list(resolvedWhlDir)) {
+        dataDir = list.filter(
+                    path -> path.getFileName().toString().endsWith(".data") && Files.isDirectory(path))
+                            .findFirst();
+    }
     if (!dataDir.isPresent()) {
       return StepExecutionResults.SUCCESS;
     }


### PR DESCRIPTION
see 
https://github.com/facebook/buck/blob/5444652af489563ddaf595a634341dd14fd41399/src/com/facebook/buck/features/python/MovePythonWhlDataStep.java#L59


Files.list  will opendir and we should close it.

try(Stream<Path> list = Files.list()) is the most common practice 