### PR TITLE
Don't use `parser` module if `symbol` doesn't exist as well.

### DIFF
--- a/third-party/py/setuptools/pkg_resources/__init__.py
+++ b/third-party/py/setuptools/pkg_resources/__init__.py
@@ -29,7 +29,6 @@ import stat
 import functools
 import pkgutil
 import token
-import symbol
 import operator
 import platform
 import collections
@@ -80,6 +79,7 @@ else:
     importlib_machinery = None
 
 try:
+    import symbol
     import parser
 except ImportError:
     pass


### PR DESCRIPTION
Python 3.10 removed the `parser` and the `symbol` modules that were deprecated for a while now.
There's a fallback implementation with markerlib for `parser` but we were not checking for the lack of the `symbol` module as well.