### PR TITLE
adoptopenjdk is now called temurin

### DIFF
--- a/programs/java_lookup.py
+++ b/programs/java_lookup.py
@@ -24,11 +24,11 @@ from programs.subprocutils import which
 
 JDK_8_AND_UNDER_PATH_VERSION_REGEX_STRINGS = [
     r"jdk(?P<full>1\.(?P<major>\d+)(\.\d+(_\d+)?)?)(\.jdk)?",
-    r"adoptopenjdk-(?P<full>(?P<major>[6-8])(\.\d+(_\d+)?)?)(\.jdk|\.jre)?",
+    r"(?:adoptopenjdk|temurin)-(?P<full>(?P<major>[6-8])(\.\d+(_\d+)?)?)(\.jdk|\.jre)?",
 ]
 JDK_9_AND_OVER_PATH_VERSION_REGEX_STRINGS = [
     r"jdk-(?P<full>(?P<major>\d+)(\.\d+(\.\d+(_\d+)?)?)?)(\.jdk)?",
-    r"adoptopenjdk-(?P<full>(?P<major>9|\d{2,})(\.\d+(\.\d+(_\d+)?)?)?)(\.jdk|\.jre)?",
+    r"(?:adoptopenjdk|temurin)-(?P<full>(?P<major>9|\d{2,})(\.\d+(\.\d+(_\d+)?)?)?)(\.jdk|\.jre)?",
 ]
 
 JDK_8_AND_UNDER_PATH_VERSION_REGEXES = [


### PR DESCRIPTION
Support the new path format when trying to find java versions