### PR TITLE
Memoize getImmediateClasspaths to prevent NP problem

### DIFF
--- a/src/com/facebook/buck/jvm/java/JavaLibraryClasspathProvider.java
+++ b/src/com/facebook/buck/jvm/java/JavaLibraryClasspathProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,30 @@ public class JavaLibraryClasspathProvider {
     outputJar.ifPresent(outputClasspathBuilder::add);
 
     return outputClasspathBuilder.build();
+  }
+
+  /**
+   * Group immediate exported dependencies and the specified output path jar.
+   *
+   * @param javaLibrary Java library
+   * @param outputJar output jar
+   * @return Immediate output jars
+   */
+  public static ImmutableSet<SourcePath> getImmediateClasspathJars(
+      JavaLibrary javaLibrary, Optional<SourcePath> outputJar) {
+    ImmutableSet.Builder<SourcePath> classpath = ImmutableSet.builder();
+    for (JavaLibrary rule : getExportedJavaLibraries(javaLibrary)) {
+      classpath.addAll(rule.getImmediateClasspaths());
+    }
+    outputJar.ifPresent(classpath::add);
+    return classpath.build();
+  }
+
+  static Iterable<JavaLibrary> getExportedJavaLibraries(JavaLibrary javaLibrary) {
+    if (javaLibrary instanceof ExportDependencies) {
+      return getJavaLibraryDeps(((ExportDependencies) javaLibrary).getExportedDeps());
+    }
+    return ImmutableSet.of();
   }
 
   public static ImmutableSet<JavaLibrary> getTransitiveClasspathDeps(JavaLibrary javaLibrary) {

--- a/test/com/facebook/buck/jvm/java/JavaLibraryClasspathProviderTest.java
+++ b/test/com/facebook/buck/jvm/java/JavaLibraryClasspathProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -161,6 +161,22 @@ public class JavaLibraryClasspathProviderTest extends AbiCompilationModeTest {
             getFullOutput(e) // c exports e
             ),
         JavaLibraryClasspathProvider.getOutputClasspathJars(
+                aLib, Optional.of(aLib.getSourcePathToOutput()))
+            .stream()
+            .map(resolver::getAbsolutePath)
+            .collect(ImmutableSet.toImmutableSet()));
+  }
+
+  @Test
+  public void getImmediateClasspathEntries() {
+    JavaLibrary aLib = (JavaLibrary) a;
+    assertEquals(
+        ImmutableSet.of(
+            getFullOutput(a),
+            getFullOutput(c), // a exports c
+            getFullOutput(e) // c exports e
+            ),
+        JavaLibraryClasspathProvider.getImmediateClasspathJars(
                 aLib, Optional.of(aLib.getSourcePathToOutput()))
             .stream()
             .map(resolver::getAbsolutePath)


### PR DESCRIPTION
Summary:
buck test gets stuck computing the action graph.
The getImmediateClasspaths is expensive because it traverse the dependency tree recomputing every nested subtree.

Method will have a memoized supplier, to prevent nested computation.

Reviewed By: bobyangyf

