### PR TITLE
Get Buck working for 3.10 (backport to main)

### DIFF
--- a/scripts/slice_trace.py
+++ b/scripts/slice_trace.py
@@ -16,8 +16,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import argparse
 import codecs
-import collections
-import json
 import math
 import os
 

--- a/third-party/py/pathlib/test_pathlib.py
+++ b/third-party/py/pathlib/test_pathlib.py
@@ -1,4 +1,3 @@
-import collections
 import io
 import os
 import errno
@@ -19,8 +18,10 @@ if sys.version_info < (2, 7):
         raise ImportError("unittest2 is required for tests on pre-2.7")
 
 try:
+    import collections.abc as collections_abc
     from test import support
 except ImportError:
+    import collections as collections_abc  # Fallback for  PY3.2.
     from test import test_support as support
 TESTFN = support.TESTFN
 
@@ -1395,7 +1396,7 @@ class _BasePathTest(object):
         P = self.cls
         p = P(BASE)
         it = p.glob("fileA")
-        self.assertIsInstance(it, collections.Iterator)
+        self.assertIsInstance(it, collections_abc.Iterator)
         _check(it, ["fileA"])
         _check(p.glob("fileB"), [])
         _check(p.glob("dir*/file*"), ["dirB/fileB", "dirC/fileC"])
@@ -1420,7 +1421,7 @@ class _BasePathTest(object):
         P = self.cls
         p = P(BASE)
         it = p.rglob("fileA")
-        self.assertIsInstance(it, collections.Iterator)
+        self.assertIsInstance(it, collections_abc.Iterator)
         # XXX cannot test because of symlink loops in the test setup
         #_check(it, ["fileA"])
         #_check(p.rglob("fileB"), ["dirB/fileB"])

--- a/third-party/py/pex/README.facebook
+++ b/third-party/py/pex/README.facebook
@@ -13,3 +13,5 @@ Local modifications:
  - Back-ported Python 3.6 compatibility commit c5ab73fd4d8e816e21a89d48c8d0c8095ef5a49c
  - Back-ported namespaced packages fix, commit 7d2dc7f500aa7ae227c3ddca4b278b807d353a5e
  - Fixed Python 3 issue with writing bytes to a text file (`with open(path, 'wb') as fp:` on line 68 in `compiler.py`)
+ - Imported from collections.abc instead of collections to support Python 3.10
+ - Back-ported removal of MarkerEvaluation from pieces of commit ba5633b3c7b9317b87130a2ea671d8c008a673d6 and a718819d2849196e902808301c9a95724510c5c1

--- a/third-party/py/pex/pex/base.py
+++ b/third-party/py/pex/pex/base.py
@@ -3,7 +3,10 @@
 
 from __future__ import absolute_import
 
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:  # For PY3.2
+    from collections import Iterable
 
 from pkg_resources import Requirement
 

--- a/third-party/py/pex/pex/link.py
+++ b/third-party/py/pex/pex/link.py
@@ -5,11 +5,16 @@ from __future__ import absolute_import
 
 import os
 import posixpath
-from collections import Iterable
 
 from .compatibility import string as compatible_string
 from .compatibility import PY3
 from .util import Memoizer
+
+
+try:
+    from collections.abc import Iterable
+except ImportError:  # For PY3.2
+    from collections import Iterable
 
 if PY3:
   import urllib.parse as urlparse

--- a/third-party/py/pex/pex/orderedset.py
+++ b/third-party/py/pex/pex/orderedset.py
@@ -8,10 +8,14 @@
 # modifications
 #
 
-import collections
+
+try:
+    import collections.abc as collections_abc
+except ImportError:  # For PY3.2
+    import collections as collections_abc
 
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(collections_abc.MutableSet):
   KEY, PREV, NEXT = range(3)
 
   def __init__(self, iterable=None):

--- a/third-party/py/pywatchman/pywatchman/pybser.py
+++ b/third-party/py/pywatchman/pywatchman/pybser.py
@@ -32,7 +32,6 @@ from __future__ import print_function
 # no unicode literals
 
 import binascii
-import collections
 import ctypes
 import struct
 import sys
@@ -40,6 +39,11 @@ import sys
 from . import (
     compat,
 )
+
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc  # Fallback for PY3.2.
 
 BSER_ARRAY = b'\x00'
 BSER_OBJECT = b'\x01'
@@ -177,8 +181,8 @@ class _bser_buffer(object):
             self.ensure_size(needed)
             struct.pack_into(b'=cd', self.buf, self.wpos, BSER_REAL, val)
             self.wpos += needed
-        elif isinstance(val, collections.Mapping) and \
-            isinstance(val, collections.Sized):
+        elif isinstance(val, collections_abc.Mapping) and \
+            isinstance(val, collections_abc.Sized):
             val_len = len(val)
             size = _int_size(val_len)
             needed = 2 + size
@@ -205,8 +209,8 @@ class _bser_buffer(object):
             for k, v in iteritems:
                 self.append_string(k)
                 self.append_recursive(v)
-        elif isinstance(val, collections.Iterable) and \
-            isinstance(val, collections.Sized):
+        elif isinstance(val, collections_abc.Iterable) and \
+            isinstance(val, collections_abc.Sized):
             val_len = len(val)
             size = _int_size(val_len)
             needed = 2 + size

--- a/third-party/py/pywatchman/tests/tests.py
+++ b/third-party/py/pywatchman/tests/tests.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 # no unicode literals
 
 import binascii
-import collections
 import inspect
 import unittest
 import os

--- a/third-party/py/setuptools/pkg_resources/_vendor/packaging/markers.py
+++ b/third-party/py/setuptools/pkg_resources/_vendor/packaging/markers.py
@@ -1,0 +1,221 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+from __future__ import absolute_import, division, print_function
+
+import operator
+import os
+import platform
+import sys
+
+from pkg_resources._vendor.pyparsing import ParseException, ParseResults, stringStart, stringEnd
+from pkg_resources._vendor.pyparsing import ZeroOrMore, Group, Forward, QuotedString
+from pkg_resources._vendor.pyparsing import Literal as L  # noqa
+
+from ._compat import string_types
+from .specifiers import Specifier, InvalidSpecifier
+
+
+__all__ = [
+    "InvalidMarker", "UndefinedComparison", "Marker", "default_environment",
+]
+
+
+class InvalidMarker(ValueError):
+    """
+    An invalid marker was found, users should refer to PEP 508.
+    """
+
+
+class UndefinedComparison(ValueError):
+    """
+    An invalid operation was attempted on a value that doesn't support it.
+    """
+
+
+class Node(object):
+    def __init__(self, value):
+        self.value = value
+    def __str__(self):
+        return str(self.value)
+    def __repr__(self):
+        return "<{0}({1!r})>".format(self.__class__.__name__, str(self))
+
+
+class Variable(Node):
+    pass
+
+
+class Value(Node):
+    pass
+
+VARIABLE = (
+    L("implementation_version") |
+    L("platform_python_implementation") |
+    L("implementation_name") |
+    L("python_full_version") |
+    L("platform_release") |
+    L("platform_version") |
+    L("platform_machine") |
+    L("platform_system") |
+    L("python_version") |
+    L("sys_platform") |
+    L("os_name") |
+    L("extra")
+)
+VARIABLE.setParseAction(lambda s, l, t: Variable(t[0]))
+
+VERSION_CMP = (
+    L("===") |
+    L("==") |
+    L(">=") |
+    L("<=") |
+    L("!=") |
+    L("~=") |
+    L(">") |
+    L("<")
+)
+MARKER_OP = VERSION_CMP | L("not in") | L("in")
+MARKER_VALUE = QuotedString("'") | QuotedString('"')
+MARKER_VALUE.setParseAction(lambda s, l, t: Value(t[0]))
+BOOLOP = L("and") | L("or")
+MARKER_VAR = VARIABLE | MARKER_VALUE
+MARKER_ITEM = Group(MARKER_VAR + MARKER_OP + MARKER_VAR)
+MARKER_ITEM.setParseAction(lambda s, l, t: tuple(t[0]))
+LPAREN = L("(").suppress()
+RPAREN = L(")").suppress()
+MARKER_EXPR = Forward()
+MARKER_ATOM = MARKER_ITEM | Group(LPAREN + MARKER_EXPR + RPAREN)
+MARKER_EXPR << MARKER_ATOM + ZeroOrMore(BOOLOP + MARKER_EXPR)
+MARKER = stringStart + MARKER_EXPR + stringEnd
+
+
+def _coerce_parse_result(results):
+    if isinstance(results, ParseResults):
+        return [_coerce_parse_result(i) for i in results]
+    else:
+        return results
+
+
+def _format_marker(marker, first=True):
+    assert isinstance(marker, (list, tuple, string_types))
+    # Sometimes we have a structure like [[...]] which is a single item list
+    # where the single item is itself it's own list. In that case we want skip
+    # the rest of this function so that we don't get extraneous () on the
+    # outside.
+    if (isinstance(marker, list) and len(marker) == 1
+            and isinstance(marker[0], (list, tuple))):
+        return _format_marker(marker[0])
+    if isinstance(marker, list):
+        inner = (_format_marker(m, first=False) for m in marker)
+        if first:
+            return " ".join(inner)
+        else:
+            return "(" + " ".join(inner) + ")"
+    elif isinstance(marker, tuple):
+        return '{0} {1} "{2}"'.format(*marker)
+    else:
+        return marker
+
+
+_operators = {
+    "in": lambda lhs, rhs: lhs in rhs,
+    "not in": lambda lhs, rhs: lhs not in rhs,
+    "<": operator.lt,
+    "<=": operator.le,
+    "==": operator.eq,
+    "!=": operator.ne,
+    ">=": operator.ge,
+    ">": operator.gt,
+}
+
+
+def _eval_op(lhs, op, rhs):
+    try:
+        spec = Specifier("".join([op, rhs]))
+    except InvalidSpecifier:
+        pass
+    else:
+        return spec.contains(lhs)
+    oper = _operators.get(op)
+    if oper is None:
+        raise UndefinedComparison(
+            "Undefined {0!r} on {1!r} and {2!r}.".format(op, lhs, rhs)
+        )
+    return oper(lhs, rhs)
+
+
+def _evaluate_markers(markers, environment):
+    groups = [[]]
+    for marker in markers:
+        assert isinstance(marker, (list, tuple, string_types))
+        if isinstance(marker, list):
+            groups[-1].append(_evaluate_markers(marker, environment))
+        elif isinstance(marker, tuple):
+            lhs, op, rhs = marker
+            if isinstance(lhs, Variable):
+                value = _eval_op(environment[lhs.value], op, rhs.value)
+            else:
+                value = _eval_op(lhs.value, op, environment[rhs.value])
+            groups[-1].append(value)
+        else:
+            assert marker in ["and", "or"]
+            if marker == "or":
+                groups.append([])
+    return any(all(item) for item in groups)
+
+
+def format_full_version(info):
+    version = '{0.major}.{0.minor}.{0.micro}'.format(info)
+    kind = info.releaselevel
+    if kind != 'final':
+        version += kind[0] + str(info.serial)
+    return version
+
+
+def default_environment():
+    if hasattr(sys, 'implementation'):
+        iver = format_full_version(sys.implementation.version)
+        implementation_name = sys.implementation.name
+    else:
+        iver = '0'
+        implementation_name = ''
+    return {
+        "implementation_name": implementation_name,
+        "implementation_version": iver,
+        "os_name": os.name,
+        "platform_machine": platform.machine(),
+        "platform_release": platform.release(),
+        "platform_system": platform.system(),
+        "platform_version": platform.version(),
+        "python_full_version": platform.python_version(),
+        "platform_python_implementation": platform.python_implementation(),
+        "python_version": platform.python_version()[:3],
+        "sys_platform": sys.platform,
+    }
+
+
+class Marker(object):
+    def __init__(self, marker):
+        try:
+            self._markers = _coerce_parse_result(MARKER.parseString(marker))
+        except ParseException:
+            self._markers = None
+        # We do this because we can't do raise ... from None in Python 2.x
+        if self._markers is None:
+            raise InvalidMarker("Invalid marker: {0!r}".format(marker))
+    def __str__(self):
+        return _format_marker(self._markers)
+    def __repr__(self):
+        return "<Marker({0!r})>".format(str(self))
+    def evaluate(self, environment=None):
+        """Evaluate a marker.
+        Return the boolean from evaluating the given marker against the
+        environment. environment is an optional argument to override all or
+        part of the determined environment.
+        The environment is determined from the current Python process.
+        """
+        current_environment = default_environment()
+        if environment is not None:
+            current_environment.update(environment)
+        return _evaluate_markers(self._markers, current_environment)

--- a/third-party/py/setuptools/pkg_resources/tests/test_markers.py
+++ b/third-party/py/setuptools/pkg_resources/tests/test_markers.py
@@ -6,11 +6,6 @@ except ImportError:
 from pkg_resources import evaluate_marker
 
 
-@mock.patch.dict('pkg_resources.MarkerEvaluation.values',
-	python_full_version=mock.Mock(return_value='2.7.10'))
-def test_lexicographic_ordering():
-	"""
-	Although one might like 2.7.10 to be greater than 2.7.3,
-	the marker spec only supports lexicographic ordering.
-	"""
-	assert evaluate_marker("python_full_version > '2.7.3'") is False
+@mock.patch('platform.python_version', return_value='2.7.10')
+def test_ordering(python_version_mock):
+    assert evaluate_marker("python_full_version > '2.7.3'") is True


### PR DESCRIPTION
Cherry-picked from https://github.com/facebook/buck/commit/1ae1e6c078255529930a31e49f55e5bfff7b9d3f (#2696)

Fixes: https://github.com/facebook/buck/issues/2678

Test plan:

I ran `buck` for a personal project that uses py3.10 syntax (`Foo | None`) and it was able to build and run correctly

Original commit message:

On 3.10 some `collections` classes have been moved to
`collections.abc` and it causes Buck 1 to crash. This diff fixes those
instances.

Really pex should be upgraded, but I made an attempt and it was very difficult
due to our custom changes to pex.

Reviewed By: bigfootjon

fbshipit-source-id: 15a7bb96e664d5169b12de09e9157571782c861f