### PR TITLE
Add support for Python #source-db internal flavor

### DIFF
--- a/.idea/runConfigurations/Debug_Buck.xml
+++ b/.idea/runConfigurations/Debug_Buck.xml
@@ -1,14 +1,15 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Debug Buck" type="Remote" factoryName="Remote" singleton="true">
+  <configuration default="false" name="Debug Buck" type="Remote" singleton="true">
     <option name="USE_SOCKET_TRANSPORT" value="true" />
     <option name="SERVER_MODE" value="false" />
-    <option name="SHMEM_ADDRESS" value="javadebug" />
+    <option name="SHMEM_ADDRESS" />
     <option name="HOST" value="localhost" />
     <option name="PORT" value="8888" />
+    <option name="AUTO_RESTART" value="false" />
     <RunnerSettings RunnerId="Debug">
       <option name="DEBUG_PORT" value="8888" />
       <option name="LOCAL" value="false" />
     </RunnerSettings>
-    <method />
+    <method v="2" />
   </configuration>
 </component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-    <component name="VcsDirectoryMappings">
-        <mapping directory="$PROJECT_DIR$/../../.." vcs="hg4idea" />
-    </component>
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
 </project>

--- a/docs/__buckconfig_common.soy
+++ b/docs/__buckconfig_common.soy
@@ -2550,6 +2550,15 @@
 
 
 /***/
+{template .python_check_srcs_ext}
+{call .entry_link}
+  {param section: 'python' /}
+  {param entry: 'check_srcs_ext' /}
+{/call}
+{/template}
+
+
+/***/
 {template .python_inplace_interpreter_flags}
 {call .entry_link}
   {param section: 'python' /}

--- a/docs/files-and-dirs/buckconfig.soy
+++ b/docs/files-and-dirs/buckconfig.soy
@@ -4474,6 +4474,27 @@ python -c "import platform; print( platform.python_version() )"
   {/param}
 {/call}
 
+{call buckconfig.entry}
+  {param section: 'python' /}
+  {param name: 'check_srcs_ext' /}
+  {param example_value: 'all' /}
+  {param description}
+    Whether and how to check for correct extensions for sources passed to the various
+    parameters for specifying Python sources (e.g. <code>srcs</code>).  Valid values are:
+    <ul>
+        <li>
+          <code>all</code>: require that all Python sources have `.py` extensions.
+        </li>
+        <li>
+          <code>generated</code>: require that only generated Python sources have `.py` extensions.
+        </li>
+        <li>
+          <code>none</code> (default): don't require that Python sources have `.py` extensions.
+        </li>
+    </ul>
+  {/param}
+{/call}
+
 
 {call buckconfig.section}
   {param name: 'repositories' /}

--- a/src/com/facebook/buck/features/python/BUCK
+++ b/src/com/facebook/buck/features/python/BUCK
@@ -47,6 +47,7 @@ java_library_with_plugins(
         "//src/com/facebook/buck/unarchive:unarchive",
         "//src/com/facebook/buck/util:process_executor",
         "//src/com/facebook/buck/util:util",
+        "//src/com/facebook/buck/util/function:function",
         "//src/com/facebook/buck/util/json:json",
         "//src/com/facebook/buck/util/stream:stream",
         "//src/com/facebook/buck/util/unarchive:unarchive",

--- a/src/com/facebook/buck/features/python/PythonBinaryDescription.java
+++ b/src/com/facebook/buck/features/python/PythonBinaryDescription.java
@@ -25,12 +25,14 @@ import com.facebook.buck.core.description.attr.ImplicitDepsInferringDescription;
 import com.facebook.buck.core.exceptions.HumanReadableException;
 import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.model.Flavor;
+import com.facebook.buck.core.model.FlavorConvertible;
 import com.facebook.buck.core.model.FlavorDomain;
 import com.facebook.buck.core.model.Flavored;
 import com.facebook.buck.core.model.InternalFlavor;
 import com.facebook.buck.core.model.TargetConfiguration;
 import com.facebook.buck.core.model.impl.BuildTargetPaths;
 import com.facebook.buck.core.rules.ActionGraphBuilder;
+import com.facebook.buck.core.rules.BuildRule;
 import com.facebook.buck.core.rules.BuildRuleCreationContextWithTargetGraph;
 import com.facebook.buck.core.rules.BuildRuleParams;
 import com.facebook.buck.core.rules.DescriptionWithTargetGraph;
@@ -89,6 +91,27 @@ public class PythonBinaryDescription
   static FlavorDomain<PythonBuckConfig.PackageStyle> PACKAGE_STYLE =
       FlavorDomain.from("Package Style", PythonBuckConfig.PackageStyle.class);
 
+  static FlavorDomain<BinaryType> BINARY_TYPE = FlavorDomain.from("Binary Type", BinaryType.class);
+
+  /** Ways of building this binary. */
+  enum BinaryType implements FlavorConvertible {
+    /** Compile the sources in this library into bytecode. */
+    EXECUTABLE(InternalFlavor.of("binary")),
+    SOURCE_DB(InternalFlavor.of("source-db")),
+    ;
+
+    private final Flavor flavor;
+
+    BinaryType(Flavor flavor) {
+      this.flavor = flavor;
+    }
+
+    @Override
+    public Flavor getFlavor() {
+      return flavor;
+    }
+  }
+
   public PythonBinaryDescription(
       ToolchainProvider toolchainProvider,
       PythonBuckConfig pythonBuckConfig,
@@ -110,7 +133,7 @@ public class PythonBinaryDescription
   @Override
   public Optional<ImmutableSet<FlavorDomain<?>>> flavorDomains(
       TargetConfiguration toolchainTargetConfiguration) {
-    return Optional.of(ImmutableSet.of(PACKAGE_STYLE));
+    return Optional.of(ImmutableSet.of(PACKAGE_STYLE, BINARY_TYPE));
   }
 
   public static SourcePath createEmptyInitModule(
@@ -289,7 +312,7 @@ public class PythonBinaryDescription
   }
 
   @Override
-  public PythonBinary createBuildRule(
+  public BuildRule createBuildRule(
       BuildRuleCreationContextWithTargetGraph context,
       BuildTarget buildTarget,
       BuildRuleParams params,
@@ -349,12 +372,31 @@ public class PythonBinaryDescription
 
     ProjectFilesystem projectFilesystem = context.getProjectFilesystem();
 
-    // Build up the list of all components going into the python binary.
-    PythonPackagable root =
-        ImmutablePythonBinaryPackagable.of(
-            buildTarget,
-            projectFilesystem,
-            PythonUtil.getDeps(pythonPlatform, cxxPlatform, args.getDeps(), args.getPlatformDeps())
+    switch (BINARY_TYPE.getValue(buildTarget).orElse(BinaryType.EXECUTABLE)) {
+      case SOURCE_DB:
+        {
+          return PythonSourceDatabase.from(
+              buildTarget,
+              context.getProjectFilesystem(),
+              context.getActionGraphBuilder(),
+              pythonPlatform,
+              cxxPlatform,
+              modules.orElseGet(() -> PythonMappedComponents.of(ImmutableSortedMap.of())),
+              PythonUtil.getParamForPlatform(
+                      pythonPlatform, cxxPlatform, args.getDeps(), args.getPlatformDeps())
+                  .stream()
+                  .map(graphBuilder::getRule)
+                  .collect(ImmutableList.toImmutableList()));
+        }
+      case EXECUTABLE:
+        {
+
+          // Build up the list of all components going into the python binary.
+          PythonPackagable root =
+              ImmutablePythonBinaryPackagable.of(
+                  buildTarget,
+                  projectFilesystem,
+                  PythonUtil.getDeps(pythonPlatform, cxxPlatform, args.getDeps(), args.getPlatformDeps())
                 .stream()
                 .map(graphBuilder::getRule)
                 .collect(ImmutableList.toImmutableList()),
@@ -362,24 +404,24 @@ public class PythonBinaryDescription
             Optional.empty(),
             args.getZipSafe());
 
-    CellPathResolver cellRoots = context.getCellPathResolver();
-    StringWithMacrosConverter macrosConverter =
-        StringWithMacrosConverter.of(
-            buildTarget,
-            cellRoots.getCellNameResolver(),
-            graphBuilder,
-            PythonUtil.macroExpanders(context.getTargetGraph()));
-    PythonPackageComponents allPackageComponents =
-        PythonUtil.getAllComponents(
-            cellRoots,
-            buildTarget,
-            projectFilesystem,
-            params,
-            graphBuilder,
-            root,
-            pythonPlatform,
-            cxxBuckConfig,
-            cxxPlatform,
+          CellPathResolver cellRoots = context.getCellPathResolver();
+          StringWithMacrosConverter macrosConverter =
+              StringWithMacrosConverter.of(
+                  buildTarget,
+                  cellRoots.getCellNameResolver(),
+                  graphBuilder,
+                  PythonUtil.macroExpanders(context.getTargetGraph()));
+          PythonPackageComponents allPackageComponents =
+              PythonUtil.getAllComponents(
+                  cellRoots,
+                  buildTarget,
+                  projectFilesystem,
+                  params,
+                  graphBuilder,
+                  root,
+                  pythonPlatform,
+                  cxxBuckConfig,
+                  cxxPlatform,
             args.getLinkerFlags().stream()
                 .map(macrosConverter::convert)
                 .collect(ImmutableList.toImmutableList()),
@@ -399,7 +441,10 @@ public class PythonBinaryDescription
         allPackageComponents,
         args.getBuildArgs(),
         getPackageStyle(buildTarget, args),
-        PythonUtil.getPreloadNames(graphBuilder, cxxPlatform, args.getPreloadDeps()));
+        PythonUtil.getPreloadNames(graphBuilder, cxxPlatform, args.getPreloadDeps()));}
+      default:
+        throw new IllegalStateException();
+    }
   }
 
   @Override

--- a/src/com/facebook/buck/features/python/PythonBinaryDescription.java
+++ b/src/com/facebook/buck/features/python/PythonBinaryDescription.java
@@ -313,10 +313,13 @@ public class PythonBinaryDescription
           graphBuilder.getSourcePathResolver().getSourcePathName(buildTarget, args.getMain().get());
       Path main = baseModule.resolve(mainName);
       mainModule = PythonUtil.toModuleName(buildTarget, main.toString());
+      SourcePath mainSrc = args.getMain().get();
+      PythonUtil.checkSrcExt(
+          pythonBuckConfig.getSrcExtCheckStyle(), graphBuilder, "main", main, mainSrc);
       modules =
           Optional.of(
               PythonMappedComponents.of(
-                  ImmutableSortedMap.of(baseModule.resolve(mainName), args.getMain().get())));
+                  ImmutableSortedMap.of(baseModule.resolve(mainName), mainSrc)));
     } else {
       mainModule = args.getMainModule().get();
       modules = Optional.empty();

--- a/src/com/facebook/buck/features/python/PythonBuckConfig.java
+++ b/src/com/facebook/buck/features/python/PythonBuckConfig.java
@@ -19,6 +19,7 @@ package com.facebook.buck.features.python;
 import com.facebook.buck.core.config.BuckConfig;
 import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.model.Flavor;
+import com.facebook.buck.core.model.FlavorConvertible;
 import com.facebook.buck.core.model.InternalFlavor;
 import com.facebook.buck.core.model.TargetConfiguration;
 import com.facebook.buck.core.rules.BuildRuleResolver;
@@ -146,16 +147,27 @@ public class PythonBuckConfig {
     return delegate.getPathSourcePath(pythonPath);
   }
 
-  public enum PackageStyle {
-    STANDALONE {
+  public enum PackageStyle implements FlavorConvertible {
+    STANDALONE(InternalFlavor.of("standalone")) {
       @Override
       public boolean isInPlace() {
         return false;
       }
     },
-    INPLACE,
-    INPLACE_LITE,
+    INPLACE(InternalFlavor.of("inplace")),
+    INPLACE_LITE(InternalFlavor.of("inplace-lite")),
     ;
+
+    private final Flavor flavor;
+
+    PackageStyle(Flavor flavor) {
+      this.flavor = flavor;
+    }
+
+    @Override
+    public Flavor getFlavor() {
+      return flavor;
+    }
 
     public boolean isInPlace() {
       return true;

--- a/src/com/facebook/buck/features/python/PythonBuckConfig.java
+++ b/src/com/facebook/buck/features/python/PythonBuckConfig.java
@@ -147,6 +147,22 @@ public class PythonBuckConfig {
     return delegate.getPathSourcePath(pythonPath);
   }
 
+  /** How to verify extensions (e.g. `.py`) for sources passed to the various `srcs` parameters. */
+  public enum SrcExtCheckStyle {
+    /** Check that all Python sources have valid source extensions. */
+    ALL,
+    /** Check that all generated Python sources have valid source extensions. */
+    GENERATED,
+    /** Don't check source extensions. */
+    NONE,
+  }
+
+  public SrcExtCheckStyle getSrcExtCheckStyle() {
+    return delegate
+        .getEnum(SECTION, "check_srcs_ext", SrcExtCheckStyle.class)
+        .orElse(SrcExtCheckStyle.NONE);
+  }
+
   public enum PackageStyle implements FlavorConvertible {
     STANDALONE(InternalFlavor.of("standalone")) {
       @Override

--- a/src/com/facebook/buck/features/python/PythonComponentsGroup.java
+++ b/src/com/facebook/buck/features/python/PythonComponentsGroup.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.buck.features.python;
+
+import com.facebook.buck.core.model.BuildTarget;
+import com.facebook.buck.core.rulekey.AddToRuleKey;
+import com.facebook.buck.core.rulekey.AddsToRuleKey;
+import com.facebook.buck.core.sourcepath.resolver.SourcePathResolverAdapter;
+import com.facebook.buck.core.util.immutables.BuckStyleValue;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@BuckStyleValue
+public abstract class PythonComponentsGroup implements AddsToRuleKey {
+
+  // Python modules as map of their module name to location of the source.
+  @AddToRuleKey
+  public abstract ImmutableMap<BuildTarget, ImmutableList<PythonComponents>> getComponents();
+
+  public Iterable<PythonComponents> values() {
+    return Iterables.concat(getComponents().values());
+  }
+
+  public PythonResolvedComponentsGroup resolve(SourcePathResolverAdapter resolver) {
+    ImmutablePythonResolvedComponentsGroup.Builder builder =
+        ImmutablePythonResolvedComponentsGroup.builder();
+    getComponents()
+        .forEach(
+            (target, components) ->
+                components.forEach(
+                    c -> builder.putComponents(target, c.resolvePythonComponents(resolver))));
+    return builder.build();
+  }
+
+  public static class Builder {
+
+    private final Map<BuildTarget, ImmutableList.Builder<PythonComponents>> allComponents =
+        new LinkedHashMap<>();
+
+    public Builder putComponent(BuildTarget owner, PythonComponents components) {
+      if (!allComponents.containsKey(owner)) {
+        allComponents.put(owner, ImmutableList.builder());
+      }
+      allComponents.get(owner).add(components);
+      return this;
+    }
+
+    public ImmutablePythonComponentsGroup build() {
+      return ImmutablePythonComponentsGroup.of(
+          allComponents.entrySet().stream()
+              .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, e -> e.getValue().build())));
+    }
+  }
+}

--- a/src/com/facebook/buck/features/python/PythonDescriptionsProvider.java
+++ b/src/com/facebook/buck/features/python/PythonDescriptionsProvider.java
@@ -42,7 +42,7 @@ public class PythonDescriptionsProvider implements DescriptionProvider {
     return Arrays.asList(
         pythonBinaryDescription,
         new PrebuiltPythonLibraryDescription(toolchainProvider),
-        new PythonLibraryDescription(toolchainProvider),
+        new PythonLibraryDescription(toolchainProvider, pyConfig),
         new PythonTestDescription(
             toolchainProvider, pythonBinaryDescription, pyConfig, cxxBuckConfig),
         new PythonTestRunnerDescription(),

--- a/src/com/facebook/buck/features/python/PythonInPlaceBinary.java
+++ b/src/com/facebook/buck/features/python/PythonInPlaceBinary.java
@@ -159,7 +159,7 @@ public class PythonInPlaceBinary extends PythonBinary implements HasRuntimeDeps 
               .add("PYTHON_INTERPRETER_FLAGS", pythonPlatform.getInplaceBinaryInterpreterFlags());
 
       // Only add platform-specific values when the binary includes native libraries.
-      if (components.getNativeLibraries().isEmpty()) {
+      if (components.getNativeLibraries().getComponents().isEmpty()) {
         st.add("NATIVE_LIBS_ENV_VAR", "None");
         st.add("NATIVE_LIBS_DIR", "None");
       } else {

--- a/src/com/facebook/buck/features/python/PythonLibraryDescription.java
+++ b/src/com/facebook/buck/features/python/PythonLibraryDescription.java
@@ -45,6 +45,7 @@ import com.facebook.buck.features.python.toolchain.PythonPlatformsProvider;
 import com.facebook.buck.rules.coercer.PatternMatchedCollection;
 import com.facebook.buck.rules.coercer.SourceSortedSet;
 import com.facebook.buck.rules.coercer.VersionMatchedCollection;
+import com.facebook.buck.versions.HasVersionUniverse;
 import com.facebook.buck.versions.Version;
 import com.facebook.buck.versions.VersionPropagator;
 import com.google.common.collect.ImmutableList;
@@ -100,6 +101,43 @@ public class PythonLibraryDescription
     return PythonLibraryDescriptionArg.class;
   }
 
+  private PythonPlatform getPythonPlatform(
+      BuildTarget target, PythonLibraryDescription.AbstractPythonLibraryDescriptionArg args) {
+    FlavorDomain<PythonPlatform> pythonPlatforms =
+        toolchainProvider
+            .getByName(
+                PythonPlatformsProvider.DEFAULT_NAME,
+                target.getTargetConfiguration(),
+                PythonPlatformsProvider.class)
+            .getPythonPlatforms();
+    return pythonPlatforms
+        .getValue(target)
+        .orElseGet(
+            () ->
+                pythonPlatforms.getValue(
+                    args.getPlatform()
+                        .<Flavor>map(InternalFlavor::of)
+                        .orElseThrow(IllegalArgumentException::new)));
+  }
+
+  private UnresolvedCxxPlatform getCxxPlatform(
+      BuildTarget target, PythonLibraryDescription.AbstractPythonLibraryDescriptionArg args) {
+    CxxPlatformsProvider cxxPlatformsProvider =
+        toolchainProvider.getByName(
+            CxxPlatformsProvider.DEFAULT_NAME,
+            target.getTargetConfiguration(),
+            CxxPlatformsProvider.class);
+    FlavorDomain<UnresolvedCxxPlatform> cxxPlatforms =
+        cxxPlatformsProvider.getUnresolvedCxxPlatforms();
+    return cxxPlatforms
+        .getValue(target)
+        .orElseGet(
+            () ->
+                args.getCxxPlatform()
+                    .map(cxxPlatforms::getValue)
+                    .orElseThrow(IllegalArgumentException::new));
+  }
+
   @Override
   public BuildRule createBuildRule(
       BuildRuleCreationContextWithTargetGraph context,
@@ -110,32 +148,17 @@ public class PythonLibraryDescription
     Optional<Map.Entry<Flavor, LibraryType>> optionalType =
         LIBRARY_TYPE.getFlavorAndValue(buildTarget);
     if (optionalType.isPresent()) {
-      Map.Entry<Flavor, PythonPlatform> pythonPlatform =
-          getPythonPlatforms(buildTarget.getTargetConfiguration())
-              .getFlavorAndValue(buildTarget)
-              .orElseThrow(IllegalArgumentException::new);
-      FlavorDomain<UnresolvedCxxPlatform> cxxPlatforms =
-          toolchainProvider
-              .getByName(
-                  CxxPlatformsProvider.DEFAULT_NAME,
-                  buildTarget.getTargetConfiguration(),
-                  CxxPlatformsProvider.class)
-              .getUnresolvedCxxPlatforms();
-      Map.Entry<Flavor, UnresolvedCxxPlatform> cxxPlatform =
-          cxxPlatforms.getFlavorAndValue(buildTarget).orElseThrow(IllegalArgumentException::new);
+      PythonPlatform pythonPlatform = getPythonPlatform(buildTarget, args);
+      UnresolvedCxxPlatform cxxPlatform = getCxxPlatform(buildTarget, args);
       CxxPlatform resolvedCxxPlatform =
-          cxxPlatform
-              .getValue()
-              .resolve(context.getActionGraphBuilder(), buildTarget.getTargetConfiguration());
+          cxxPlatform.resolve(
+              context.getActionGraphBuilder(), buildTarget.getTargetConfiguration());
       BuildTarget baseTarget =
           buildTarget.withoutFlavors(
-              optionalType.get().getKey(), pythonPlatform.getKey(), cxxPlatform.getKey());
+              optionalType.get().getKey(), pythonPlatform.getFlavor(), cxxPlatform.getFlavor());
       Optional<PythonMappedComponents> sources =
           getSources(
-              context.getActionGraphBuilder(),
-              baseTarget,
-              pythonPlatform.getValue(),
-              resolvedCxxPlatform);
+              context.getActionGraphBuilder(), baseTarget, pythonPlatform, resolvedCxxPlatform);
 
       switch (optionalType.get().getValue()) {
         case COMPILE:
@@ -143,7 +166,7 @@ public class PythonLibraryDescription
               buildTarget,
               context.getProjectFilesystem(),
               context.getActionGraphBuilder(),
-              pythonPlatform.getValue().getEnvironment(),
+              pythonPlatform.getEnvironment(),
               sources.orElseThrow(
                   () ->
                       new HumanReadableException(
@@ -155,13 +178,13 @@ public class PythonLibraryDescription
                 buildTarget,
                 context.getProjectFilesystem(),
                 context.getActionGraphBuilder(),
-                pythonPlatform.getValue(),
+                pythonPlatform,
                 resolvedCxxPlatform,
                 sources.orElseGet(() -> PythonMappedComponents.of(ImmutableSortedMap.of())),
                 getPackageDeps(
                     context.getActionGraphBuilder(),
                     baseTarget,
-                    pythonPlatform.getValue(),
+                    pythonPlatform,
                     resolvedCxxPlatform));
           }
       }
@@ -429,5 +452,9 @@ public class PythonLibraryDescription
   }
 
   @RuleArg
-  interface AbstractPythonLibraryDescriptionArg extends CoreArg {}
+  interface AbstractPythonLibraryDescriptionArg extends CoreArg, HasVersionUniverse {
+    Optional<String> getPlatform();
+
+    Optional<Flavor> getCxxPlatform();
+  }
 }

--- a/src/com/facebook/buck/features/python/PythonLibraryDescription.java
+++ b/src/com/facebook/buck/features/python/PythonLibraryDescription.java
@@ -65,6 +65,7 @@ public class PythonLibraryDescription
         Flavored {
 
   private final ToolchainProvider toolchainProvider;
+  private final PythonBuckConfig pythonBuckConfig;
 
   private static final FlavorDomain<MetadataType> METADATA_TYPE =
       FlavorDomain.from("Python Metadata Type", MetadataType.class);
@@ -72,8 +73,11 @@ public class PythonLibraryDescription
   private static final FlavorDomain<LibraryType> LIBRARY_TYPE =
       FlavorDomain.from("Python Library Type", LibraryType.class);
 
-  public PythonLibraryDescription(ToolchainProvider toolchainProvider) {
+  public PythonLibraryDescription(
+      ToolchainProvider toolchainProvider,
+      PythonBuckConfig pythonBuckConfig) {
     this.toolchainProvider = toolchainProvider;
+    this.pythonBuckConfig = pythonBuckConfig;
   }
 
   @Override
@@ -214,6 +218,7 @@ public class PythonLibraryDescription
                       .getValue()
                       .resolve(graphBuilder, buildTarget.getTargetConfiguration()),
                   selectedVersions,
+                  pythonBuckConfig.getSrcExtCheckStyle(),
                   args);
           return Optional.of(
                   components.isEmpty()

--- a/src/com/facebook/buck/features/python/PythonPackageComponents.java
+++ b/src/com/facebook/buck/features/python/PythonPackageComponents.java
@@ -30,11 +30,7 @@ import com.facebook.buck.core.util.immutables.BuckStyleValue;
 import com.facebook.buck.step.fs.SymlinkPaths;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.ListMultimap;
-import com.google.common.collect.MultimapBuilder;
-import com.google.common.collect.Multimaps;
-import java.util.Objects;
+import com.google.common.collect.Streams;
 import java.util.Optional;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
@@ -45,15 +41,15 @@ public abstract class PythonPackageComponents implements AddsToRuleKey {
 
   // Python modules as map of their module name to location of the source.
   @AddToRuleKey
-  public abstract ImmutableListMultimap<BuildTarget, PythonComponents> getModules();
+  public abstract PythonComponentsGroup getModules();
 
   // Resources to include in the package.
   @AddToRuleKey
-  public abstract ImmutableListMultimap<BuildTarget, PythonComponents> getResources();
+  public abstract PythonComponentsGroup getResources();
 
   // Native libraries to include in the package.
   @AddToRuleKey
-  public abstract ImmutableListMultimap<BuildTarget, PythonComponents> getNativeLibraries();
+  public abstract PythonComponentsGroup getNativeLibraries();
 
   @AddToRuleKey
   public abstract Optional<SourcePath> getDefaultInitPy();
@@ -76,17 +72,12 @@ public abstract class PythonPackageComponents implements AddsToRuleKey {
 
   public PythonResolvedPackageComponents resolve(SourcePathResolverAdapter resolver) {
     return ImmutablePythonResolvedPackageComponents.builder()
-        .putAllModules(
-            Multimaps.transformValues(
-                getModules(), c -> Objects.requireNonNull(c).resolvePythonComponents(resolver)))
-        .putAllResources(
-            Multimaps.transformValues(
-                getResources(), c -> Objects.requireNonNull(c).resolvePythonComponents(resolver)))
-        .putAllNativeLibraries(
-            Multimaps.transformValues(
-                getNativeLibraries(),
-                c -> Objects.requireNonNull(c).resolvePythonComponents(resolver)))
-        .setDefaultInitPy(getDefaultInitPy().map(resolver::getAbsolutePath))
+        .setModules(getModules().resolve(resolver))
+        .setResources(getResources().resolve(resolver))
+        .setNativeLibraries(getNativeLibraries().resolve(resolver))
+        .setDefaultInitPy(
+            getDefaultInitPy()
+                .map(resolver::getAbsolutePath))
         .setZipSafe(isZipSafe())
         .build();
   }
@@ -95,15 +86,15 @@ public abstract class PythonPackageComponents implements AddsToRuleKey {
     return new SymlinkPack(
         ImmutableList.<Symlinks>builder()
             .addAll(
-                getModules().values().stream()
+                Streams.stream(getModules().values())
                     .map(PythonComponents::asSymlinks)
                     .collect(ImmutableList.toImmutableList()))
             .addAll(
-                getResources().values().stream()
+                Streams.stream(getResources().values())
                     .map(PythonComponents::asSymlinks)
                     .collect(ImmutableList.toImmutableList()))
             .addAll(
-                getNativeLibraries().values().stream()
+                Streams.stream(getNativeLibraries().values())
                     .map(PythonComponents::asSymlinks)
                     .collect(ImmutableList.toImmutableList()))
             .build()) {
@@ -140,26 +131,24 @@ public abstract class PythonPackageComponents implements AddsToRuleKey {
    */
   public static class Builder {
 
-    private final ListMultimap<BuildTarget, PythonComponents> modules =
-        MultimapBuilder.treeKeys().arrayListValues().build();
-    private final ListMultimap<BuildTarget, PythonComponents> resources =
-        MultimapBuilder.treeKeys().arrayListValues().build();
-    private final ListMultimap<BuildTarget, PythonComponents> nativeLibraries =
-        MultimapBuilder.treeKeys().arrayListValues().build();
+    private final PythonComponentsGroup.Builder modules = new PythonComponentsGroup.Builder();
+    private final PythonComponentsGroup.Builder resources = new PythonComponentsGroup.Builder();
+    private final PythonComponentsGroup.Builder nativeLibraries =
+        new PythonComponentsGroup.Builder();
     private Optional<Boolean> zipSafe = Optional.empty();
 
     public Builder putModules(BuildTarget owner, PythonComponents components) {
-      modules.put(owner, components);
+      modules.putComponent(owner, components);
       return this;
     }
 
     public Builder putResources(BuildTarget owner, PythonComponents components) {
-      resources.put(owner, components);
+      resources.putComponent(owner, components);
       return this;
     }
 
     public Builder putNativeLibraries(BuildTarget owner, PythonComponents components) {
-      nativeLibraries.put(owner, components);
+      nativeLibraries.putComponent(owner, components);
       return this;
     }
 
@@ -173,7 +162,7 @@ public abstract class PythonPackageComponents implements AddsToRuleKey {
 
     public PythonPackageComponents build() {
       return ImmutablePythonPackageComponents.of(
-          modules, resources, nativeLibraries, Optional.empty(), zipSafe);
+          modules.build(), resources.build(), nativeLibraries.build(), Optional.empty(), zipSafe);
     }
   }
 }

--- a/src/com/facebook/buck/features/python/PythonResolvedComponentsGroup.java
+++ b/src/com/facebook/buck/features/python/PythonResolvedComponentsGroup.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.buck.features.python;
+
+import com.facebook.buck.core.exceptions.HumanReadableException;
+import com.facebook.buck.core.model.BuildTarget;
+import com.facebook.buck.core.rulekey.AddToRuleKey;
+import com.facebook.buck.core.util.immutables.BuckStyleValueWithBuilder;
+import com.facebook.buck.io.file.MorePaths;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Sets;
+import com.google.common.io.ByteStreams;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+@BuckStyleValueWithBuilder
+public abstract class PythonResolvedComponentsGroup {
+
+  @AddToRuleKey
+  abstract ImmutableMultimap<BuildTarget, PythonComponents.Resolved> getComponents();
+
+  private static HumanReadableException createDuplicateError(
+      String type, Path destination, BuildTarget sourceA, BuildTarget sourceB) {
+    return new HumanReadableException(
+        "found duplicate entries for %s %s when creating python package (%s and %s)",
+        type, destination, sourceA, sourceB);
+  }
+
+  // Return whether two files are identical.
+  private static boolean areFilesTheSame(Path a, Path b) throws IOException {
+    if (a.equals(b)) {
+      return true;
+    }
+
+    final long totalSize = Files.size(a);
+    if (totalSize != Files.size(b)) {
+      return false;
+    }
+
+    try (InputStream ia = Files.newInputStream(a);
+        InputStream ib = Files.newInputStream(b)) {
+      final int bufSize = 8192;
+      final byte[] aBuf = new byte[bufSize];
+      final byte[] bBuf = new byte[bufSize];
+      for (int toRead = (int) totalSize; toRead > 0; ) {
+        final int chunkSize = Integer.min(toRead, bufSize);
+        ByteStreams.readFully(ia, aBuf, 0, chunkSize);
+        ByteStreams.readFully(ib, bBuf, 0, chunkSize);
+        for (int idx = 0; idx < chunkSize; idx++) {
+          if (aBuf[idx] != bBuf[idx]) {
+            return false;
+          }
+        }
+        toRead -= chunkSize;
+      }
+    }
+
+    return true;
+  }
+
+  // Helper to walk sets of components contributed from different rules and merge them, throwin an
+  // error on duplicates.
+  public void forEachComponent(String type, PythonComponents.Resolved.ComponentConsumer consumer)
+      throws IOException {
+    Map<Path, Path> seen = new HashMap<>();
+    Map<Path, BuildTarget> sources = new HashMap<>();
+    for (Map.Entry<BuildTarget, PythonComponents.Resolved> entry : getComponents().entries()) {
+      entry
+          .getValue()
+          .forEachPythonComponent(
+              (destination, source) -> {
+                Path existing = seen.put(destination, source);
+                if (existing == null) {
+                  sources.put(destination, entry.getKey());
+                  consumer.accept(destination, source);
+                } else if (!areFilesTheSame(existing, source)) {
+                  throw createDuplicateError(
+                      type,
+                      destination,
+                      entry.getKey(),
+                      Objects.requireNonNull(sources.get(destination)));
+                }
+              });
+    }
+  }
+
+  /** Run {@code consumer} on all modules, throwing an error on duplicates. */
+  public void forEachModule(
+      Optional<Path> defaultInitPy, PythonComponents.Resolved.ComponentConsumer consumer)
+      throws IOException {
+    Set<Path> packages = new HashSet<>();
+    Set<Path> packagesWithInit = new HashSet<>();
+
+    forEachComponent(
+        "module",
+        (destination, source) -> {
+
+          // Record all packages that do and don't contain an `__init__.py`.
+          String ext = MorePaths.getFileExtension(destination);
+          if (defaultInitPy.isPresent()
+                  // TODO(agallagher): This shouldn't be necessary, but currently, prebuilt module
+                  // dirs can include files that aren't really modules.
+                  // TODO(agallagher): Why do we need to handle `.pyi` types too?
+                  && (PythonUtil.isModuleExt(ext))
+              || ext.equals("pyi")) {
+            // Record all "packages" we see as we go.
+            for (Path pkg = destination.getParent();
+                pkg != null && !packages.contains(pkg);
+                pkg = pkg.getParent()) {
+              packages.add(pkg);
+            }
+            // Record all existing `__init__.py` files.
+            if (destination.getFileName().toString().equals(PythonUtil.INIT_PY)) {
+              packagesWithInit.add(destination.getParent());
+            }
+          }
+
+          consumer.accept(destination, source);
+        });
+
+    // If a default `__init__.py` is provided, use for all packages w/o one.
+    if (defaultInitPy.isPresent()) {
+      for (Path pkg : Sets.difference(packages, packagesWithInit)) {
+        consumer.accept(pkg.resolve(PythonUtil.INIT_PY), defaultInitPy.get());
+      }
+    }
+  }
+}

--- a/src/com/facebook/buck/features/python/PythonResolvedPackageComponents.java
+++ b/src/com/facebook/buck/features/python/PythonResolvedPackageComponents.java
@@ -16,26 +16,13 @@
 
 package com.facebook.buck.features.python;
 
-import com.facebook.buck.core.exceptions.HumanReadableException;
-import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.util.immutables.BuckStyleValueWithBuilder;
-import com.facebook.buck.io.file.MorePaths;
 import com.facebook.buck.step.fs.SymlinkPaths;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Sets;
-import com.google.common.io.ByteStreams;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * Contains Python components (e.g. modules, resources) to be used by an executing Python binary
@@ -44,137 +31,32 @@ import java.util.Set;
 @BuckStyleValueWithBuilder
 abstract class PythonResolvedPackageComponents {
 
-  protected abstract ImmutableMultimap<BuildTarget, PythonComponents.Resolved> getModules();
+  protected abstract PythonResolvedComponentsGroup getModules();
 
-  protected abstract ImmutableMultimap<BuildTarget, PythonComponents.Resolved> getResources();
+  protected abstract PythonResolvedComponentsGroup getResources();
 
-  protected abstract ImmutableMultimap<BuildTarget, PythonComponents.Resolved> getNativeLibraries();
+  protected abstract PythonResolvedComponentsGroup getNativeLibraries();
 
   protected abstract Optional<Path> getDefaultInitPy();
 
   protected abstract Optional<Boolean> isZipSafe();
 
-  private HumanReadableException createDuplicateError(
-      String type, Path destination, BuildTarget sourceA, BuildTarget sourceB) {
-    return new HumanReadableException(
-        "found duplicate entries for %s %s when creating python package (%s and %s)",
-        type, destination, sourceA, sourceB);
-  }
-
-  // Return whether two files are identical.
-  private boolean areFilesTheSame(Path a, Path b) throws IOException {
-    if (a.equals(b)) {
-      return true;
-    }
-
-    final long totalSize = Files.size(a);
-    if (totalSize != Files.size(b)) {
-      return false;
-    }
-
-    try (InputStream ia = Files.newInputStream(a);
-        InputStream ib = Files.newInputStream(b)) {
-      final int bufSize = 8192;
-      final byte[] aBuf = new byte[bufSize];
-      final byte[] bBuf = new byte[bufSize];
-      for (int toRead = (int) totalSize; toRead > 0; ) {
-        final int chunkSize = Integer.min(toRead, bufSize);
-        ByteStreams.readFully(ia, aBuf, 0, chunkSize);
-        ByteStreams.readFully(ib, bBuf, 0, chunkSize);
-        for (int idx = 0; idx < chunkSize; idx++) {
-          if (aBuf[idx] != bBuf[idx]) {
-            return false;
-          }
-        }
-        toRead -= chunkSize;
-      }
-    }
-
-    return true;
-  }
-
-  // Helper to walk sets of components contributed from different rules and merge them, throwin an
-  // error on duplicates.
-  private void forEachComponent(
-      String type,
-      Iterable<Map.Entry<BuildTarget, PythonComponents.Resolved>> components,
-      PythonComponents.Resolved.ComponentConsumer consumer)
-      throws IOException {
-    Map<Path, Path> seen = new HashMap<>();
-    Map<Path, BuildTarget> sources = new HashMap<>();
-    for (Map.Entry<BuildTarget, PythonComponents.Resolved> entry : components) {
-      entry
-          .getValue()
-          .forEachPythonComponent(
-              (destination, source) -> {
-                Path existing = seen.put(destination, source);
-                if (existing == null) {
-                  sources.put(destination, entry.getKey());
-                  consumer.accept(destination, source);
-                } else if (!areFilesTheSame(existing, source)) {
-                  throw createDuplicateError(
-                      type,
-                      destination,
-                      entry.getKey(),
-                      Objects.requireNonNull(sources.get(destination)));
-                }
-              });
-    }
-  }
-
   /** Run {@code consumer} on all modules, throwing an error on duplicates. */
   public void forEachModule(PythonComponents.Resolved.ComponentConsumer consumer)
       throws IOException {
-    Set<Path> packages = new HashSet<>();
-    Set<Path> packagesWithInit = new HashSet<>();
-
-    forEachComponent(
-        "module",
-        getModules().entries(),
-        (destination, source) -> {
-
-          // Record all packages that do and don't contain an `__init__.py`.
-          String ext = MorePaths.getFileExtension(destination);
-          if (getDefaultInitPy().isPresent()
-                  // TODO(agallagher): This shouldn't be necessary, but currently, prebuilt module
-                  // dirs
-                  //  can include files that aren't really modules.
-                  // TODO(agallagher): Why do we need to handle `.pyi` types too?
-                  && (PythonUtil.isModuleExt(ext))
-              || ext.equals("pyi")) {
-            // Record all "packages" we see as we go.
-            for (Path pkg = destination.getParent();
-                pkg != null && !packages.contains(pkg);
-                pkg = pkg.getParent()) {
-              packages.add(pkg);
-            }
-            // Record all existing `__init__.py` files.
-            if (destination.getFileName().toString().equals(PythonUtil.INIT_PY)) {
-              packagesWithInit.add(destination.getParent());
-            }
-          }
-
-          consumer.accept(destination, source);
-        });
-
-    // If a default `__init__.py` is provided, use for all packages w/o one.
-    if (getDefaultInitPy().isPresent()) {
-      for (Path pkg : Sets.difference(packages, packagesWithInit)) {
-        consumer.accept(pkg.resolve(PythonUtil.INIT_PY), getDefaultInitPy().get());
-      }
-    }
+    getModules().forEachModule(getDefaultInitPy(), consumer);
   }
 
   /** Run {@code consumer} on all resources, throwing an error on duplicates. */
   public void forEachResource(PythonComponents.Resolved.ComponentConsumer consumer)
       throws IOException {
-    forEachComponent("resource", getResources().entries(), consumer);
+    getResources().forEachComponent("resource", consumer);
   }
 
   /** Run {@code consumer} on all native libraries, throwing an error on duplicates. */
   public void forEachNativeLibrary(PythonComponents.Resolved.ComponentConsumer consumer)
       throws IOException {
-    forEachComponent("native library", getNativeLibraries().entries(), consumer);
+    getNativeLibraries().forEachComponent("native library", consumer);
   }
 
   @VisibleForTesting

--- a/src/com/facebook/buck/features/python/PythonSourceDatabase.java
+++ b/src/com/facebook/buck/features/python/PythonSourceDatabase.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.buck.features.python;
+
+import com.facebook.buck.core.build.context.BuildContext;
+import com.facebook.buck.core.build.execution.context.ExecutionContext;
+import com.facebook.buck.core.model.BuildTarget;
+import com.facebook.buck.core.rulekey.AddToRuleKey;
+import com.facebook.buck.core.rules.ActionGraphBuilder;
+import com.facebook.buck.core.rules.BuildRule;
+import com.facebook.buck.core.rules.BuildRuleResolver;
+import com.facebook.buck.core.rules.SourcePathRuleFinder;
+import com.facebook.buck.core.rules.attr.HasRuntimeDeps;
+import com.facebook.buck.core.rules.common.BuildableSupport;
+import com.facebook.buck.core.sourcepath.SourcePath;
+import com.facebook.buck.cxx.toolchain.CxxPlatform;
+import com.facebook.buck.features.python.toolchain.PythonPlatform;
+import com.facebook.buck.io.BuildCellRelativePath;
+import com.facebook.buck.io.filesystem.ProjectFilesystem;
+import com.facebook.buck.rules.modern.BuildCellRelativePathFactory;
+import com.facebook.buck.rules.modern.Buildable;
+import com.facebook.buck.rules.modern.ModernBuildRule;
+import com.facebook.buck.rules.modern.OutputPath;
+import com.facebook.buck.rules.modern.OutputPathResolver;
+import com.facebook.buck.step.AbstractExecutionStep;
+import com.facebook.buck.step.Step;
+import com.facebook.buck.step.StepExecutionResult;
+import com.facebook.buck.step.fs.RmStep;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class PythonSourceDatabase extends ModernBuildRule<PythonSourceDatabase.Impl>
+    implements HasRuntimeDeps {
+
+  private final PythonComponents sources;
+  private final PythonComponentsGroup dependencies;
+
+  private PythonSourceDatabase(
+      BuildTarget buildTarget,
+      ProjectFilesystem filesystem,
+      SourcePathRuleFinder ruleFinder,
+      PythonComponents sources,
+      PythonComponentsGroup dependencies) {
+    super(buildTarget, filesystem, ruleFinder, new Impl(sources, dependencies));
+    this.sources = sources;
+    this.dependencies = dependencies;
+  }
+
+  static PythonSourceDatabase from(
+      BuildTarget target,
+      ProjectFilesystem filesystem,
+      ActionGraphBuilder graphBuilder,
+      PythonPlatform pythonPlatform,
+      CxxPlatform cxxPlatform,
+      PythonComponents sources,
+      Iterable<BuildRule> firstOrderDeps) {
+    PythonComponentsGroup.Builder builder = new PythonComponentsGroup.Builder();
+    PythonUtil.forEachDependency(
+        graphBuilder,
+        pythonPlatform,
+        cxxPlatform,
+        firstOrderDeps,
+        packagable ->
+            packagable
+                .getPythonModules(pythonPlatform, cxxPlatform, graphBuilder)
+                .ifPresent(modules -> builder.putComponent(packagable.getBuildTarget(), modules)),
+        extension -> {},
+        linkable -> {});
+    return new PythonSourceDatabase(target, filesystem, graphBuilder, sources, builder.build());
+  }
+
+  @Override
+  public SourcePath getSourcePathToOutput() {
+    return getSourcePath(Impl.OUTPUT_PATH);
+  }
+
+  @Override
+  public Stream<BuildTarget> getRuntimeDeps(BuildRuleResolver buildRuleResolver) {
+    return Streams.concat(
+            BuildableSupport.deriveDeps(sources, buildRuleResolver),
+            BuildableSupport.deriveDeps(dependencies, buildRuleResolver))
+        .map(BuildRule::getBuildTarget);
+  }
+
+  static class Impl implements Buildable {
+
+    private static final OutputPath OUTPUT_PATH = new OutputPath("db.json");
+
+    // TODO(agallagher): We technically don't need build time deps on everything here to just
+    // generate the DB, since it just needs to materialize the paths (and runtime deps above
+    // makes sure all source deps are materialized eventually).
+    @AddToRuleKey private final PythonComponents sources;
+    @AddToRuleKey private final PythonComponentsGroup dependencies;
+
+    public Impl(PythonComponents sources, PythonComponentsGroup dependencies) {
+      this.sources = sources;
+      this.dependencies = dependencies;
+    }
+
+    @Override
+    public ImmutableList<Step> getBuildSteps(
+        BuildContext buildContext,
+        ProjectFilesystem filesystem,
+        OutputPathResolver outputPathResolver,
+        BuildCellRelativePathFactory buildCellPathFactory) {
+      return ImmutableList.of(
+          RmStep.of(BuildCellRelativePath.of(outputPathResolver.resolvePath(OUTPUT_PATH))),
+          new AbstractExecutionStep("write-source-db") {
+
+            private final Path output = outputPathResolver.resolvePath(OUTPUT_PATH);
+            private final PythonComponents.Resolved resolvedSources =
+                sources.resolvePythonComponents(buildContext.getSourcePathResolver());
+            private final PythonResolvedComponentsGroup resolvedDependencies =
+                dependencies.resolve(buildContext.getSourcePathResolver());
+
+            @Override
+            public StepExecutionResult execute(ExecutionContext context) throws IOException {
+              try (OutputStream stream =
+                  new BufferedOutputStream(
+                      Files.newOutputStream(context.getBuildCellRootPath().resolve(output)))) {
+                PythonSourceDatabaseEntry.serialize(
+                    resolvedSources,
+                    resolvedDependencies,
+                    Optional.of(context.getBuildCellRootPath()),
+                    stream);
+              }
+              return StepExecutionResult.of(0);
+            }
+          });
+    }
+  }
+}

--- a/src/com/facebook/buck/features/python/PythonSourceDatabaseEntry.java
+++ b/src/com/facebook/buck/features/python/PythonSourceDatabaseEntry.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.buck.features.python;
+
+import static java.nio.charset.Charset.defaultCharset;
+
+import com.facebook.buck.core.exceptions.HumanReadableException;
+import com.facebook.buck.core.util.immutables.BuckStyleValue;
+import com.facebook.buck.util.json.ObjectMappers;
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+@BuckStyleValue
+@JsonSerialize(as = ImmutablePythonSourceDatabaseEntry.class)
+@JsonDeserialize(as = ImmutablePythonSourceDatabaseEntry.class)
+public abstract class PythonSourceDatabaseEntry {
+
+  public abstract ImmutableMap<String, String> getSources();
+
+  public abstract ImmutableMap<String, String> getDependencies();
+
+  private static Path maybeRelativize(Optional<Path> workingDir, Path path) {
+    if (!workingDir.isPresent()) {
+      return path;
+    }
+    Path relPath = workingDir.get().relativize(path);
+    if (relPath.isAbsolute()) {
+      throw new HumanReadableException("Cannot relativize %s against %s", path, workingDir.get());
+    }
+    return relPath;
+  }
+
+  public static void serialize(
+      PythonComponents.Resolved sources,
+      PythonResolvedComponentsGroup dependencies,
+      Optional<Path> workingDir,
+      OutputStream stream)
+      throws IOException {
+
+    JsonFactory factory = new JsonFactory();
+    try (JsonGenerator generator = factory.createGenerator(stream, JsonEncoding.UTF8)) {
+      generator.writeStartObject();
+
+      // Serialize the sources.
+      generator.writeFieldName("sources");
+      generator.writeStartObject();
+      sources.forEachPythonComponent(
+          (dst, src) ->
+              generator.writeStringField(
+                  dst.toString(), maybeRelativize(workingDir, src).toString()));
+      generator.writeEndObject();
+
+      // Serialize all depencencies.
+      generator.writeFieldName("dependencies");
+      generator.writeStartObject();
+      dependencies.forEachModule(
+          Optional.empty(),
+          (dst, src) ->
+              generator.writeStringField(
+                  dst.toString(), maybeRelativize(workingDir, src).toString()));
+      generator.writeEndObject();
+
+      generator.writeEndObject();
+    }
+  }
+
+  public static PythonSourceDatabaseEntry parse(Path compilationDatabase) throws IOException {
+    try (Reader fileReader = Files.newBufferedReader(compilationDatabase, defaultCharset())) {
+      return ObjectMappers.READER
+          .forType(new TypeReference<PythonSourceDatabaseEntry>() {})
+          .readValue(fileReader);
+    }
+  }
+}

--- a/src/com/facebook/buck/features/python/PythonTestDescription.java
+++ b/src/com/facebook/buck/features/python/PythonTestDescription.java
@@ -26,6 +26,7 @@ import com.facebook.buck.core.description.attr.ImplicitDepsInferringDescription;
 import com.facebook.buck.core.exceptions.HumanReadableException;
 import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.model.Flavor;
+import com.facebook.buck.core.model.FlavorConvertible;
 import com.facebook.buck.core.model.FlavorDomain;
 import com.facebook.buck.core.model.Flavored;
 import com.facebook.buck.core.model.InternalFlavor;
@@ -98,6 +99,27 @@ public class PythonTestDescription
   public static final Flavor BINARY_FLAVOR = InternalFlavor.of("binary");
   private static final String DEFAULT_TEST_MAIN_NAME = "__test_main__.py";
 
+  static FlavorDomain<TestType> TEST_TYPE = FlavorDomain.from("Binary Type", TestType.class);
+
+  /** Ways of building this binary. */
+  enum TestType implements FlavorConvertible {
+    /** Compile the sources in this library into bytecode. */
+    TEST(InternalFlavor.of("test")),
+    SOURCE_DB(InternalFlavor.of("source-db")),
+    ;
+
+    private final Flavor flavor;
+
+    TestType(Flavor flavor) {
+      this.flavor = flavor;
+    }
+
+    @Override
+    public Flavor getFlavor() {
+      return flavor;
+    }
+  }
+
   private final ToolchainProvider toolchainProvider;
   private final PythonBinaryDescription binaryDescription;
   private final PythonBuckConfig pythonBuckConfig;
@@ -122,7 +144,7 @@ public class PythonTestDescription
   @Override
   public Optional<ImmutableSet<FlavorDomain<?>>> flavorDomains(
       TargetConfiguration toolchainTargetConfiguration) {
-    return Optional.of(ImmutableSet.of(PythonBinaryDescription.PACKAGE_STYLE));
+    return Optional.of(ImmutableSet.of(PythonBinaryDescription.PACKAGE_STYLE, TEST_TYPE));
   }
 
   @VisibleForTesting
@@ -345,34 +367,49 @@ public class PythonTestDescription
             .map(graphBuilder::getRule)
             .collect(ImmutableList.toImmutableList());
 
-    // Build up the list of everything going into the python test.
-    PythonPackagable root =
-        ImmutablePythonBinaryPackagable.of(
-            buildTarget,
-            projectFilesystem,
-            deps,
-            Optional.of(PythonMappedComponents.of(modules)),
-            Optional.of(PythonMappedComponents.of(ImmutableSortedMap.copyOf(resources))),
-            args.getZipSafe());
+    switch (TEST_TYPE.getValue(buildTarget).orElse(TestType.TEST)) {
+      case SOURCE_DB:
+        {
+          return PythonSourceDatabase.from(
+              buildTarget,
+              context.getProjectFilesystem(),
+              context.getActionGraphBuilder(),
+              pythonPlatform,
+              cxxPlatform,
+              PythonMappedComponents.of(modules),
+              deps);
+        }
+      case TEST:
+        {
 
-    CellPathResolver cellRoots = context.getCellPathResolver();
-    StringWithMacrosConverter macrosConverter =
-        StringWithMacrosConverter.of(
-            buildTarget,
-            cellRoots.getCellNameResolver(),
-            graphBuilder,
-            PythonUtil.macroExpanders(context.getTargetGraph()));
-    PythonPackageComponents allComponents =
-        PythonUtil.getAllComponents(
-            cellRoots,
-            buildTarget,
-            projectFilesystem,
-            params,
-            graphBuilder,
-            root,
-            pythonPlatform,
-            cxxBuckConfig,
-            cxxPlatform,
+          // Build up the list of everything going into the python test.
+          PythonPackagable root =
+              ImmutablePythonBinaryPackagable.of(
+                  buildTarget,
+                  projectFilesystem,
+                  deps,
+                  Optional.of(PythonMappedComponents.of(modules)),
+                  Optional.of(PythonMappedComponents.of(ImmutableSortedMap.copyOf(resources))),
+                  args.getZipSafe());
+
+          CellPathResolver cellRoots = context.getCellPathResolver();
+          StringWithMacrosConverter macrosConverter =
+              StringWithMacrosConverter.of(
+                  buildTarget,
+                  cellRoots.getCellNameResolver(),
+                  graphBuilder,
+                  PythonUtil.macroExpanders(context.getTargetGraph()));
+          PythonPackageComponents allComponents =
+              PythonUtil.getAllComponents(
+                  cellRoots,
+                  buildTarget,
+                  projectFilesystem,
+                  params,
+                  graphBuilder,
+                  root,
+                  pythonPlatform,
+                  cxxBuckConfig,
+                  cxxPlatform,
             args.getLinkerFlags().stream()
                 .map(macrosConverter::convert)
                 .collect(ImmutableList.toImmutableList()),
@@ -380,118 +417,125 @@ public class PythonTestDescription
             args.getPreloadDeps(),
             args.getCompile().orElse(false));
 
-    // Build the PEX using a python binary rule with the minimum dependencies.
-    PythonBinary binary =
-        binaryDescription.createPackageRule(
-            cellRoots,
-            buildTarget.withAppendedFlavors(BINARY_FLAVOR),
-            projectFilesystem,
-            params,
-            graphBuilder,
-            pythonPlatform,
-            cxxPlatform,
-            mainModule,
-            args.getExtension(),
-            allComponents,
-            args.getBuildArgs(),
-            getPackageStyle(buildTarget, args),
-            PythonUtil.getPreloadNames(graphBuilder, cxxPlatform, args.getPreloadDeps()));
-    graphBuilder.addToIndex(binary);
+          // Build the PEX using a python binary rule with the minimum dependencies.
+          PythonBinary binary =
+              binaryDescription.createPackageRule(
+                  cellRoots,
+                  buildTarget.withAppendedFlavors(BINARY_FLAVOR),
+                  projectFilesystem,
+                  params,
+                  graphBuilder,
+                  pythonPlatform,
+                  cxxPlatform,
+                  mainModule,
+                  args.getExtension(),
+                  allComponents,
+                  args.getBuildArgs(),
+                  getPackageStyle(buildTarget, args),
+                  PythonUtil.getPreloadNames(graphBuilder, cxxPlatform, args.getPreloadDeps()));
+          graphBuilder.addToIndex(binary);
 
-    if (testRunner.isPresent()) {
-      Preconditions.checkState(
-          args.getSpecs().isPresent(), "Specs must be present when runner is present.");
-      return PythonTestX.from(
-          buildTarget,
-          projectFilesystem,
-          params,
-          binary,
-          args.getLabels(),
-          args.getContacts(),
-          TestRunnerSpecCoercer.coerce(args.getSpecs().get(), macrosConverter));
-    }
-
-    ImmutableList.Builder<Pair<Float, ImmutableSet<Path>>> neededCoverageBuilder =
-        ImmutableList.builder();
-    for (NeededCoverageSpec coverageSpec : args.getNeededCoverage()) {
-      BuildRule buildRule = graphBuilder.getRule(coverageSpec.getBuildTarget());
-      if (deps.contains(buildRule) && buildRule instanceof PythonLibrary) {
-        PythonLibrary pythonLibrary = (PythonLibrary) buildRule;
-        ImmutableSortedSet<Path> paths;
-        if (coverageSpec.getPathName().isPresent()) {
-          Path path =
-              coverageSpec
-                  .getBuildTarget()
-                  .getCellRelativeBasePath()
-                  .getPath()
-                  .toPath(projectFilesystem.getFileSystem())
-                  .resolve(coverageSpec.getPathName().get());
-          if (!pythonLibrary
-              .getPythonModules(pythonPlatform, cxxPlatform, graphBuilder)
-              .map(PythonMappedComponents::getComponents)
-              .map(Map::keySet)
-              .orElseGet(ImmutableSet::of)
-              .contains(path)) {
-            throw new HumanReadableException(
-                "%s: path %s specified in needed_coverage not found in target %s",
-                buildTarget, path, buildRule.getBuildTarget());
+          if (testRunner.isPresent()) {
+            Preconditions.checkState(
+                args.getSpecs().isPresent(), "Specs must be present when runner is present.");
+            return PythonTestX.from(
+                buildTarget,
+                projectFilesystem,
+                params,
+                binary,
+                args.getLabels(),
+                args.getContacts(),
+                TestRunnerSpecCoercer.coerce(args.getSpecs().get(), macrosConverter));
           }
-          paths = ImmutableSortedSet.of(path);
-        } else {
-          paths =
-              pythonLibrary
-                  .getPythonModules(pythonPlatform, cxxPlatform, graphBuilder)
-                  .map(PythonMappedComponents::getComponents)
-                  .map(ImmutableSortedMap::keySet)
-                  .orElseGet(ImmutableSortedSet::of);
+
+          ImmutableList.Builder<Pair<Float, ImmutableSet<Path>>> neededCoverageBuilder =
+              ImmutableList.builder();
+          for (NeededCoverageSpec coverageSpec : args.getNeededCoverage()) {
+            BuildRule buildRule = graphBuilder.getRule(coverageSpec.getBuildTarget());
+            if (deps.contains(buildRule) && buildRule instanceof PythonLibrary) {
+              PythonLibrary pythonLibrary = (PythonLibrary) buildRule;
+              ImmutableSortedSet<Path> paths;
+              if (coverageSpec.getPathName().isPresent()) {
+                Path path =
+                    coverageSpec
+                        .getBuildTarget()
+                        .getCellRelativeBasePath()
+                        .getPath()
+                        .toPath(projectFilesystem.getFileSystem())
+                        .resolve(coverageSpec.getPathName().get());
+                if (!pythonLibrary
+                    .getPythonModules(pythonPlatform, cxxPlatform, graphBuilder)
+                    .map(PythonMappedComponents::getComponents)
+                    .map(Map::keySet)
+                    .orElseGet(ImmutableSet::of)
+                    .contains(path)) {
+                  throw new HumanReadableException(
+                      "%s: path %s specified in needed_coverage not found in target %s",
+                      buildTarget, path, buildRule.getBuildTarget());
+                }
+                paths = ImmutableSortedSet.of(path);
+              } else {
+                paths =
+                    pythonLibrary
+                        .getPythonModules(pythonPlatform, cxxPlatform, graphBuilder)
+                        .map(PythonMappedComponents::getComponents)
+                        .map(ImmutableSortedMap::keySet)
+                        .orElseGet(ImmutableSortedSet::of);
+              }
+              neededCoverageBuilder.add(
+                  new Pair<>(coverageSpec.getNeededCoverageRatioPercentage() / 100.f, paths));
+            } else {
+              throw new HumanReadableException(
+                  "%s: needed_coverage requires a python library dependency. Found %s instead",
+                  buildTarget, buildRule);
+            }
+          }
+
+          Function<BuildRuleResolver, ImmutableMap<String, Arg>> testEnv =
+              (ruleResolverInner) ->
+                  ImmutableMap.copyOf(
+                      Maps.transformValues(args.getEnv(), macrosConverter::convert));
+
+          // Additional CXX Targets used to generate CXX coverage.
+          ImmutableSet<UnflavoredBuildTarget> additionalCoverageTargets =
+              RichStream.from(args.getAdditionalCoverageTargets())
+                  .map(BuildTarget::getUnflavoredBuildTarget)
+                  .collect(ImmutableSet.toImmutableSet());
+          ImmutableSortedSet<SourcePath> additionalCoverageSourcePaths =
+              additionalCoverageTargets.isEmpty()
+                  ? ImmutableSortedSet.of()
+                  : binary
+                      .getRuntimeDeps(graphBuilder)
+                      .filter(
+                          target ->
+                              additionalCoverageTargets.contains(target.getUnflavoredBuildTarget()))
+                      .map(DefaultBuildTargetSourcePath::of)
+                      .collect(ImmutableSortedSet.toImmutableSortedSet(Ordering.natural()));
+
+          // Generate and return the python test rule, which depends on the python binary rule
+          // above.
+          return PythonTest.from(
+              buildTarget,
+              projectFilesystem,
+              params,
+              graphBuilder,
+              testEnv,
+              binary,
+              args.getLabels(),
+              neededCoverageBuilder.build(),
+              additionalCoverageSourcePaths,
+              args.getTestRuleTimeoutMs()
+                  .map(Optional::of)
+                  .orElse(
+                      cxxBuckConfig
+                          .getDelegate()
+                          .getView(TestBuckConfig.class)
+                          .getDefaultTestRuleTimeoutMs()),
+              args.getContacts());
         }
-        neededCoverageBuilder.add(
-            new Pair<>(coverageSpec.getNeededCoverageRatioPercentage() / 100.f, paths));
-      } else {
-        throw new HumanReadableException(
-            "%s: needed_coverage requires a python library dependency. Found %s instead",
-            buildTarget, buildRule);
-      }
+      default:
+        throw new IllegalStateException();
     }
-
-    Function<BuildRuleResolver, ImmutableMap<String, Arg>> testEnv =
-        (ruleResolverInner) ->
-            ImmutableMap.copyOf(Maps.transformValues(args.getEnv(), macrosConverter::convert));
-
-    // Additional CXX Targets used to generate CXX coverage.
-    ImmutableSet<UnflavoredBuildTarget> additionalCoverageTargets =
-        RichStream.from(args.getAdditionalCoverageTargets())
-            .map(BuildTarget::getUnflavoredBuildTarget)
-            .collect(ImmutableSet.toImmutableSet());
-    ImmutableSortedSet<SourcePath> additionalCoverageSourcePaths =
-        additionalCoverageTargets.isEmpty()
-            ? ImmutableSortedSet.of()
-            : binary
-                .getRuntimeDeps(graphBuilder)
-                .filter(
-                    target -> additionalCoverageTargets.contains(target.getUnflavoredBuildTarget()))
-                .map(DefaultBuildTargetSourcePath::of)
-                .collect(ImmutableSortedSet.toImmutableSortedSet(Ordering.natural()));
-
-    // Generate and return the python test rule, which depends on the python binary rule above.
-    return PythonTest.from(
-        buildTarget,
-        projectFilesystem,
-        params,
-        graphBuilder,
-        testEnv,
-        binary,
-        args.getLabels(),
-        neededCoverageBuilder.build(),
-        additionalCoverageSourcePaths,
-        args.getTestRuleTimeoutMs()
-            .map(Optional::of)
-            .orElse(
-                cxxBuckConfig
-                    .getDelegate()
-                    .getView(TestBuckConfig.class)
-                    .getDefaultTestRuleTimeoutMs()),
-        args.getContacts());
   }
 
   private Optional<PythonTestRunner> maybeGetTestRunner(

--- a/src/com/facebook/buck/features/python/PythonTestDescription.java
+++ b/src/com/facebook/buck/features/python/PythonTestDescription.java
@@ -285,7 +285,13 @@ public class PythonTestDescription
 
     ImmutableMap<Path, SourcePath> srcs =
         PythonUtil.parseModules(
-            buildTarget, graphBuilder, pythonPlatform, cxxPlatform, selectedVersions, args);
+            buildTarget,
+            graphBuilder,
+            pythonPlatform,
+            cxxPlatform,
+            selectedVersions,
+            pythonBuckConfig.getSrcExtCheckStyle(),
+            args);
 
     ImmutableMap<Path, SourcePath> resources =
         PythonUtil.parseResources(

--- a/src/com/facebook/buck/features/python/PythonUtil.java
+++ b/src/com/facebook/buck/features/python/PythonUtil.java
@@ -125,6 +125,25 @@ public class PythonUtil {
     }
   }
 
+  /**
+   * @return the merged list of all items for the given platform, from the given platform-agnostic
+   *     and platform-specific params.
+   */
+  public static <T, C extends Collection<T>> ImmutableList<T> getParamForPlatform(
+    PythonPlatform pythonPlatform,
+    CxxPlatform cxxPlatform,
+    C param,
+    PatternMatchedCollection<C> platformParam) {
+    return RichStream.from(param)
+      .concat(
+        platformParam.getMatchingValues(pythonPlatform.getFlavor().toString()).stream()
+          .flatMap(Collection::stream))
+      .concat(
+        platformParam.getMatchingValues(cxxPlatform.getFlavor().toString()).stream()
+          .flatMap(Collection::stream))
+      .toImmutableList();
+  }
+
   public static ImmutableList<BuildTarget> getDeps(
       PythonPlatform pythonPlatform,
       CxxPlatform cxxPlatform,

--- a/src/com/facebook/buck/features/python/PythonUtil.java
+++ b/src/com/facebook/buck/features/python/PythonUtil.java
@@ -73,6 +73,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class PythonUtil {
@@ -278,6 +279,47 @@ public class PythonUtil {
     return PathFormatter.pathWithUnixSeparators(name).replace('/', '.');
   }
 
+  static void forEachDependency(
+      ActionGraphBuilder graphBuilder,
+      PythonPlatform pythonPlatform,
+      CxxPlatform cxxPlatform,
+      Iterable<?> roots,
+      Consumer<PythonPackagable> packagableConsumer,
+      Consumer<CxxPythonExtension> extensionConsumer,
+      Consumer<NativeLinkableGroup> nativeLinkableConsumer) {
+
+    // Walk all our transitive deps to build our complete package that we'll
+    // turn into an executable.
+    new AbstractBreadthFirstTraversal<Object>(roots) {
+      private final ImmutableList<BuildRule> empty = ImmutableList.of();
+
+      @Override
+      public Iterable<?> visit(Object node) {
+        Iterable<?> deps = empty;
+
+        if (node instanceof CxxPythonExtension) {
+          CxxPythonExtension extension = (CxxPythonExtension) node;
+          extensionConsumer.accept(extension);
+          List<BuildRule> cxxpydeps = new ArrayList<>();
+          for (BuildRule dep :
+              extension.getPythonPackageDeps(pythonPlatform, cxxPlatform, graphBuilder)) {
+            if (dep instanceof PythonPackagable) {
+              cxxpydeps.add(dep);
+            }
+          }
+          deps = cxxpydeps;
+        } else if (node instanceof PythonPackagable) {
+          PythonPackagable packagable = (PythonPackagable) node;
+          packagableConsumer.accept(packagable);
+          return packagable.getPythonPackageDeps(pythonPlatform, cxxPlatform, graphBuilder);
+        } else if (node instanceof NativeLinkableGroup) {
+          nativeLinkableConsumer.accept((NativeLinkableGroup) node);
+        }
+        return deps;
+      }
+    }.start();
+  }
+
   static PythonPackageComponents getAllComponents(
       CellPathResolver cellPathResolver,
       BuildTarget buildTarget,
@@ -302,30 +344,12 @@ public class PythonUtil {
 
     // Walk all our transitive deps to build our complete package that we'll
     // turn into an executable.
-    new AbstractBreadthFirstTraversal<Object>(
-        Iterables.concat(ImmutableList.of(binary), graphBuilder.getAllRules(preloadDeps))) {
-      private final ImmutableList<BuildRule> empty = ImmutableList.of();
-
-      @Override
-      public Iterable<?> visit(Object node) {
-        Iterable<?> deps = empty;
-
-        if (node instanceof CxxPythonExtension) {
-          CxxPythonExtension extension = (CxxPythonExtension) node;
-          NativeLinkTarget target =
-              extension.getNativeLinkTarget(pythonPlatform, cxxPlatform, graphBuilder, false);
-          extensions.put(target.getBuildTarget(), extension);
-          omnibusRoots.addIncludedRoot(target);
-          List<BuildRule> cxxpydeps = new ArrayList<>();
-          for (BuildRule dep :
-              extension.getPythonPackageDeps(pythonPlatform, cxxPlatform, graphBuilder)) {
-            if (dep instanceof PythonPackagable) {
-              cxxpydeps.add(dep);
-            }
-          }
-          deps = cxxpydeps;
-        } else if (node instanceof PythonPackagable) {
-          PythonPackagable packagable = (PythonPackagable) node;
+    forEachDependency(
+        graphBuilder,
+        pythonPlatform,
+        cxxPlatform,
+        Iterables.concat(ImmutableList.of(binary), graphBuilder.getAllRules(preloadDeps)),
+        (PythonPackagable packagable) -> {
           packagable
               .getPythonModules(pythonPlatform, cxxPlatform, graphBuilder)
               .ifPresent(modules -> allComponents.putModules(packagable.getBuildTarget(), modules));
@@ -340,11 +364,11 @@ public class PythonUtil {
               .ifPresent(
                   resources -> allComponents.putResources(packagable.getBuildTarget(), resources));
           allComponents.addZipSafe(packagable.isPythonZipSafe());
-          Iterable<BuildRule> packagableDeps =
-              packagable.getPythonPackageDeps(pythonPlatform, cxxPlatform, graphBuilder);
           if (nativeLinkStrategy == NativeLinkStrategy.MERGED
               && packagable.doesPythonPackageDisallowOmnibus(
                   pythonPlatform, cxxPlatform, graphBuilder)) {
+            Iterable<BuildRule> packagableDeps =
+                packagable.getPythonPackageDeps(pythonPlatform, cxxPlatform, graphBuilder);
             for (BuildRule dep : packagableDeps) {
               if (dep instanceof NativeLinkableGroup) {
                 NativeLinkable linkable =
@@ -354,16 +378,18 @@ public class PythonUtil {
               }
             }
           }
-          deps = packagableDeps;
-        } else if (node instanceof NativeLinkableGroup) {
-          NativeLinkable linkable =
-              ((NativeLinkableGroup) node).getNativeLinkable(cxxPlatform, graphBuilder);
+        },
+        extension -> {
+          NativeLinkTarget target =
+              extension.getNativeLinkTarget(pythonPlatform, cxxPlatform, graphBuilder, false);
+          extensions.put(target.getBuildTarget(), extension);
+          omnibusRoots.addIncludedRoot(target);
+        },
+        linkableGroup -> {
+          NativeLinkable linkable = linkableGroup.getNativeLinkable(cxxPlatform, graphBuilder);
           nativeLinkableRoots.put(linkable.getBuildTarget(), linkable);
           omnibusRoots.addPotentialRoot(linkable, false);
-        }
-        return deps;
-      }
-    }.start();
+        });
 
     // For the merged strategy, build up the lists of included native linkable roots, and the
     // excluded native linkable roots.

--- a/src/com/facebook/buck/util/function/TriConsumer.java
+++ b/src/com/facebook/buck/util/function/TriConsumer.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.buck.util.function;
+
+@FunctionalInterface
+public interface TriConsumer<T, U, V> {
+  void accept(T t, U u, V v);
+}

--- a/test/com/facebook/buck/features/python/PexStepTest.java
+++ b/test/com/facebook/buck/features/python/PexStepTest.java
@@ -61,20 +61,39 @@ public class PexStepTest {
 
   private static final PythonResolvedPackageComponents COMPONENTS =
       ImmutablePythonResolvedPackageComponents.builder()
-          .putModules(
-              TARGET,
-              new PythonMappedComponents.Resolved(
-                  ImmutableSortedMap.of(Paths.get("m"), Paths.get("/src/m"))))
-          .putModules(TARGET, new PythonModuleDirComponents.Resolved(Paths.get("/tmp/dir1.whl")))
-          .putModules(TARGET, new PythonModuleDirComponents.Resolved(Paths.get("/tmp/dir2.whl")))
-          .putResources(
-              TARGET,
-              new PythonMappedComponents.Resolved(
-                  ImmutableSortedMap.of(Paths.get("r"), Paths.get("/src/r"))))
-          .putNativeLibraries(
-              TARGET,
-              new PythonMappedComponents.Resolved(
-                  ImmutableSortedMap.of(Paths.get("n.so"), Paths.get("/src/n.so"))))
+          .setModules(
+              ImmutablePythonResolvedComponentsGroup.builder()
+                  .putComponents(
+                      TARGET,
+                      new PythonMappedComponents.Resolved(
+                          ImmutableSortedMap.of(
+                              Paths.get("m"), Paths.get("/src/m"))))
+                  .putComponents(
+                      TARGET,
+                      new PythonModuleDirComponents.Resolved(
+                          Paths.get("/tmp/dir1.whl").toAbsolutePath()))
+                  .putComponents(
+                      TARGET,
+                      new PythonModuleDirComponents.Resolved(
+                          Paths.get("/tmp/dir2.whl").toAbsolutePath()))
+                  .build())
+          .setResources(
+              ImmutablePythonResolvedComponentsGroup.builder()
+                  .putComponents(
+                      TARGET,
+                      new PythonMappedComponents.Resolved(
+                          ImmutableSortedMap.of(
+                              Paths.get("r"), Paths.get("/src/r"))))
+                  .build())
+          .setNativeLibraries(
+              ImmutablePythonResolvedComponentsGroup.builder()
+                  .putComponents(
+                      TARGET,
+                      new PythonMappedComponents.Resolved(
+                          ImmutableSortedMap.of(
+                              Paths.get("n.so"),
+                              Paths.get("/src/n.so"))))
+                  .build())
           .build();
   private static final ImmutableSortedSet<String> PRELOAD_LIBRARIES = ImmutableSortedSet.of();
 
@@ -154,14 +173,19 @@ public class PexStepTest {
             ImmutablePythonResolvedPackageComponents.builder()
                 .from(COMPONENTS)
                 .setModules(
-                    ImmutableMultimap.of(
-                        TARGET,
-                        new PythonMappedComponents.Resolved(
-                            ImmutableSortedMap.of(Paths.get("m"), Paths.get("/src/m"))),
-                        TARGET,
-                        new PythonModuleDirComponents.Resolved(realDir1),
-                        TARGET,
-                        new PythonModuleDirComponents.Resolved(realDir2)))
+                    ImmutablePythonResolvedComponentsGroup.builder()
+                        .setComponents(
+                            ImmutableMultimap.of(
+                                TARGET,
+                                new PythonMappedComponents.Resolved(
+                                    ImmutableSortedMap.of(
+                                        Paths.get("m"),
+                                        Paths.get("/src/m"))),
+                                TARGET,
+                                new PythonModuleDirComponents.Resolved(realDir1),
+                                TARGET,
+                                new PythonModuleDirComponents.Resolved(realDir2)))
+                        .build())
                 .build(),
             PRELOAD_LIBRARIES);
 

--- a/test/com/facebook/buck/features/python/PythonBinaryDescriptionTest.java
+++ b/test/com/facebook/buck/features/python/PythonBinaryDescriptionTest.java
@@ -1034,6 +1034,31 @@ public class PythonBinaryDescriptionTest {
     }
   }
 
+  @Test
+  public void sourceDb() {
+    PythonLibraryBuilder libraryBuilder =
+        new PythonLibraryBuilder(BuildTargetFactory.newInstance("//:lib"))
+            .setSrcs(
+                SourceSortedSet.ofUnnamedSources(
+                    ImmutableSortedSet.of(FakeSourcePath.of("lib.py"))));
+    PythonBinaryBuilder ruleBuilder =
+        PythonBinaryBuilder.create(BuildTargetFactory.newInstance("//:rule"))
+            .setDeps(ImmutableSortedSet.of(libraryBuilder.getTarget()))
+            .setMain(FakeSourcePath.of("rule.py"));
+    TargetGraph targetGraph =
+        TargetGraphFactory.newInstance(ruleBuilder.build(), libraryBuilder.build());
+    ActionGraphBuilder graphBuilder = new TestActionGraphBuilder(targetGraph);
+    BuildRule db =
+        graphBuilder.requireRule(
+            ruleBuilder
+                .getTarget()
+                .withAppendedFlavors(
+                    PythonTestUtils.PYTHON_PLATFORM.getFlavor(),
+                    CxxPlatformUtils.DEFAULT_PLATFORM.getFlavor(),
+                    PythonLibraryDescription.LibraryType.SOURCE_DB.getFlavor()));
+    assertThat(db, Matchers.instanceOf(PythonSourceDatabase.class));
+  }
+
   private RuleKey calculateRuleKey(BuildRuleResolver ruleResolver, BuildRule rule) {
     DefaultRuleKeyFactory ruleKeyFactory =
         new DefaultRuleKeyFactory(

--- a/test/com/facebook/buck/features/python/PythonBinaryDescriptionTest.java
+++ b/test/com/facebook/buck/features/python/PythonBinaryDescriptionTest.java
@@ -547,7 +547,8 @@ public class PythonBinaryDescriptionTest {
     extensionBuilder.build(graphBuilder, filesystem, targetGraph);
     PythonBinary binary = binaryBuilder.build(graphBuilder, filesystem, targetGraph);
 
-    assertThat(binary.getComponents().getNativeLibraries().entries(), Matchers.empty());
+    assertThat(
+        binary.getComponents().getNativeLibraries().getComponents().keySet(), Matchers.empty());
     assertThat(
         Iterables.transform(
             binary

--- a/test/com/facebook/buck/features/python/PythonBinaryDescriptionTest.java
+++ b/test/com/facebook/buck/features/python/PythonBinaryDescriptionTest.java
@@ -82,6 +82,7 @@ import com.facebook.buck.step.Step;
 import com.facebook.buck.util.cache.FileHashCacheMode;
 import com.facebook.buck.util.cache.impl.StackedFileHashCache;
 import com.facebook.buck.util.environment.Platform;
+import com.facebook.buck.util.types.Pair;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -1010,6 +1011,27 @@ public class PythonBinaryDescriptionTest {
             Matchers.hasItem(graphBuilder.getSourcePathResolver().getAbsolutePath(libASrc)),
             Matchers.not(
                 Matchers.hasItem(graphBuilder.getSourcePathResolver().getAbsolutePath(libBSrc)))));
+  }
+
+  @Test
+  public void packageStyleFlavor() {
+    for (Pair<PythonBuckConfig.PackageStyle, ? extends Class<?>> style :
+        ImmutableList.of(
+            new Pair<>(PythonBuckConfig.PackageStyle.INPLACE, PythonInPlaceBinary.class),
+            new Pair<>(PythonBuckConfig.PackageStyle.STANDALONE, PythonPackagedBinary.class))) {
+      PythonBinaryBuilder pythonBinaryBuilder =
+          PythonBinaryBuilder.create(BuildTargetFactory.newInstance("//:bin"))
+              .setMainModule("main");
+      TargetGraph targetGraph = TargetGraphFactory.newInstance(pythonBinaryBuilder.build());
+      ActionGraphBuilder graphBuilder = new TestActionGraphBuilder(targetGraph);
+      PythonBinary pythonBinary =
+          (PythonBinary)
+              graphBuilder.requireRule(
+                  pythonBinaryBuilder
+                      .getTarget()
+                      .withAppendedFlavors(style.getFirst().getFlavor()));
+      assertThat(pythonBinary, Matchers.instanceOf(style.getSecond()));
+    }
   }
 
   private RuleKey calculateRuleKey(BuildRuleResolver ruleResolver, BuildRule rule) {

--- a/test/com/facebook/buck/features/python/PythonBinaryIntegrationTest.java
+++ b/test/com/facebook/buck/features/python/PythonBinaryIntegrationTest.java
@@ -635,4 +635,15 @@ public class PythonBinaryIntegrationTest {
             Matchers.matchesRegex("foo/bar/(__pycache__/)?mod(.cpython-3[0-9])?.pyc"),
             Matchers.matchesRegex("(__pycache__/)?main(.cpython-3[0-9])?.pyc")));
   }
+
+  @Test
+  public void sourceDb() throws Exception {
+    workspace = TestDataHelper.createProjectWorkspaceForScenario(this, "python_source_db", tmp);
+    workspace.setUp();
+    assertThat(
+        PythonSourceDatabaseEntry.parse(workspace.buildAndReturnOutput("//:bin#source-db")),
+        equalTo(
+            ImmutablePythonSourceDatabaseEntry.ofImpl(
+                ImmutableMap.of("bin.py", "bin.py"), ImmutableMap.of("foo.py", "foo.py"))));
+  }
 }

--- a/test/com/facebook/buck/features/python/PythonLibraryBuilder.java
+++ b/test/com/facebook/buck/features/python/PythonLibraryBuilder.java
@@ -16,6 +16,7 @@
 
 package com.facebook.buck.features.python;
 
+import com.facebook.buck.core.config.FakeBuckConfig;
 import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.model.FlavorDomain;
 import com.facebook.buck.core.model.targetgraph.AbstractNodeBuilder;
@@ -52,7 +53,8 @@ public class PythonLibraryBuilder
                     CxxPlatformsProvider.DEFAULT_NAME,
                     CxxPlatformsProvider.of(
                         CxxPlatformUtils.DEFAULT_UNRESOLVED_PLATFORM, cxxPlatforms))
-                .build()),
+                .build(),
+            new PythonBuckConfig(FakeBuckConfig.empty())),
         target);
   }
 

--- a/test/com/facebook/buck/features/python/PythonLibraryDescriptionTest.java
+++ b/test/com/facebook/buck/features/python/PythonLibraryDescriptionTest.java
@@ -402,4 +402,31 @@ public class PythonLibraryDescriptionTest {
         Iterables.transform(nativeLibs, Object::toString),
         Matchers.containsInAnyOrder("libdep.so", "libcxx.so"));
   }
+
+  @Test
+  public void sourceDb() {
+    PythonLibraryBuilder libraryBuilder =
+        new PythonLibraryBuilder(BuildTargetFactory.newInstance("//:lib"))
+            .setSrcs(
+                SourceSortedSet.ofUnnamedSources(
+                    ImmutableSortedSet.of(FakeSourcePath.of("lib.py"))));
+    PythonLibraryBuilder ruleBuilder =
+        new PythonLibraryBuilder(BuildTargetFactory.newInstance("//:rule"))
+            .setDeps(ImmutableSortedSet.of(libraryBuilder.getTarget()))
+            .setSrcs(
+                SourceSortedSet.ofUnnamedSources(
+                    ImmutableSortedSet.of(FakeSourcePath.of("rule.py"))));
+    TargetGraph targetGraph =
+        TargetGraphFactory.newInstance(ruleBuilder.build(), libraryBuilder.build());
+    ActionGraphBuilder graphBuilder = new TestActionGraphBuilder(targetGraph);
+    BuildRule db =
+        graphBuilder.requireRule(
+            ruleBuilder
+                .getTarget()
+                .withAppendedFlavors(
+                    PythonTestUtils.PYTHON_PLATFORM.getFlavor(),
+                    CxxPlatformUtils.DEFAULT_PLATFORM.getFlavor(),
+                    PythonLibraryDescription.LibraryType.SOURCE_DB.getFlavor()));
+    assertThat(db, Matchers.instanceOf(PythonSourceDatabase.class));
+  }
 }

--- a/test/com/facebook/buck/features/python/PythonLibraryIntegrationTest.java
+++ b/test/com/facebook/buck/features/python/PythonLibraryIntegrationTest.java
@@ -133,4 +133,16 @@ public class PythonLibraryIntegrationTest {
             .collect(Collectors.toList()),
         Matchers.hasSize(1));
   }
+
+  @Test
+  public void sourceDb() throws Exception {
+    workspace = TestDataHelper.createProjectWorkspaceForScenario(this, "python_source_db", tmp);
+    workspace.setUp();
+    assertThat(
+        PythonSourceDatabaseEntry.parse(
+            workspace.buildAndReturnOutput("//:bar#source-db,default,py-default")),
+        Matchers.equalTo(
+            ImmutablePythonSourceDatabaseEntry.ofImpl(
+                ImmutableMap.of("bar.py", "bar.py"), ImmutableMap.of("foo.py", "foo.py"))));
+  }
 }

--- a/test/com/facebook/buck/features/python/PythonTestDescriptionTest.java
+++ b/test/com/facebook/buck/features/python/PythonTestDescriptionTest.java
@@ -648,6 +648,33 @@ public class PythonTestDescriptionTest {
     }
   }
 
+  @Test
+  public void sourceDb() {
+    PythonLibraryBuilder libraryBuilder =
+        new PythonLibraryBuilder(BuildTargetFactory.newInstance("//:lib"))
+            .setSrcs(
+                SourceSortedSet.ofUnnamedSources(
+                    ImmutableSortedSet.of(FakeSourcePath.of("lib.py"))));
+    PythonTestBuilder ruleBuilder =
+        PythonTestBuilder.create(BuildTargetFactory.newInstance("//:rule"))
+            .setDeps(ImmutableSortedSet.of(libraryBuilder.getTarget()))
+            .setSrcs(
+                SourceSortedSet.ofUnnamedSources(
+                    ImmutableSortedSet.of(FakeSourcePath.of("rule.py"))));
+    TargetGraph targetGraph =
+        TargetGraphFactory.newInstance(ruleBuilder.build(), libraryBuilder.build());
+    ActionGraphBuilder graphBuilder = new TestActionGraphBuilder(targetGraph);
+    BuildRule db =
+        graphBuilder.requireRule(
+            ruleBuilder
+                .getTarget()
+                .withAppendedFlavors(
+                    PythonTestUtils.PYTHON_PLATFORM.getFlavor(),
+                    CxxPlatformUtils.DEFAULT_PLATFORM.getFlavor(),
+                    PythonLibraryDescription.LibraryType.SOURCE_DB.getFlavor()));
+    assertThat(db, Matchers.instanceOf(PythonSourceDatabase.class));
+  }
+
   private RuleKey calculateRuleKey(BuildRuleResolver ruleResolver, BuildRule rule) {
     DefaultRuleKeyFactory ruleKeyFactory =
         new DefaultRuleKeyFactory(

--- a/test/com/facebook/buck/features/python/PythonTestIntegrationTest.java
+++ b/test/com/facebook/buck/features/python/PythonTestIntegrationTest.java
@@ -52,10 +52,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -372,5 +374,15 @@ public class PythonTestIntegrationTest {
   public void queryTargets() {
     ProcessResult result = workspace.runBuckCommand("test", "//query_targets:t");
     result.assertSuccess();
+  }
+
+  @Test
+  public void sourceDb() throws Exception {
+    workspace = TestDataHelper.createProjectWorkspaceForScenario(this, "python_source_db", tmp);
+    workspace.setUp();
+    PythonSourceDatabaseEntry entry =
+        PythonSourceDatabaseEntry.parse(workspace.buildAndReturnOutput("//:test#source-db"));
+    assertThat(entry.getSources().keySet(), Matchers.hasItem("test.py"));
+    assertThat(entry.getDependencies(), equalTo(ImmutableMap.of("foo.py", "foo.py")));
   }
 }

--- a/test/com/facebook/buck/features/python/PythonUtilTest.java
+++ b/test/com/facebook/buck/features/python/PythonUtilTest.java
@@ -17,18 +17,31 @@
 package com.facebook.buck.features.python;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
+import com.facebook.buck.core.exceptions.HumanReadableException;
 import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.model.BuildTargetFactory;
+import com.facebook.buck.core.model.targetgraph.TargetGraph;
+import com.facebook.buck.core.model.targetgraph.TargetGraphFactory;
+import com.facebook.buck.core.rules.ActionGraphBuilder;
 import com.facebook.buck.core.rules.resolver.impl.TestActionGraphBuilder;
 import com.facebook.buck.core.sourcepath.FakeSourcePath;
 import com.facebook.buck.core.sourcepath.SourcePath;
 import com.facebook.buck.cxx.toolchain.CxxPlatformUtils;
 import com.facebook.buck.rules.coercer.SourceSortedSet;
+import com.facebook.buck.shell.Genrule;
+import com.facebook.buck.shell.GenruleBuilder;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
 import java.nio.file.Path;
+import java.util.Optional;
+import java.util.function.Consumer;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 public class PythonUtilTest {
@@ -46,7 +59,7 @@ public class PythonUtilTest {
         ImmutableList.of(
             SourceSortedSet.ofNamedSources(
                 ImmutableSortedMap.of("hello.py", FakeSourcePath.of("goodbye.py")))),
-        srcsBuilder::put);
+        (parameter, name, src) -> srcsBuilder.put(name, src));
     ImmutableMap<Path, SourcePath> srcs = srcsBuilder.build();
     assertEquals(
         ImmutableMap.<Path, SourcePath>of(
@@ -57,5 +70,95 @@ public class PythonUtilTest {
                 .resolve("hello.py"),
             FakeSourcePath.of("goodbye.py")),
         srcs);
+  }
+
+  @Test
+  public void checkSrcExt() {
+    BuildTarget target = BuildTargetFactory.newInstance("//foo:bar");
+    PythonLibraryDescription.CoreArg args =
+        new PythonLibraryBuilder(target)
+            .setSrcs(
+                SourceSortedSet.ofUnnamedSources(
+                    ImmutableSortedSet.of(FakeSourcePath.of("foo.json"))))
+            .build()
+            .getConstructorArg();
+
+    // Create Python source args.
+    Consumer<PythonBuckConfig.SrcExtCheckStyle> parseSources =
+        style ->
+            PythonUtil.parseModules(
+                target,
+                new TestActionGraphBuilder(),
+                PythonTestUtils.PYTHON_PLATFORM,
+                CxxPlatformUtils.DEFAULT_PLATFORM,
+                Optional.empty(),
+                style,
+                args);
+
+    // Don't check any sources.
+    parseSources.accept(PythonBuckConfig.SrcExtCheckStyle.NONE);
+
+    // Check generated sources.
+    parseSources.accept(PythonBuckConfig.SrcExtCheckStyle.GENERATED);
+
+    // Check all sources.
+    try {
+      parseSources.accept(PythonBuckConfig.SrcExtCheckStyle.ALL);
+      fail("expected to throw");
+    } catch (HumanReadableException e) {
+      assertThat(e.getMessage(), Matchers.containsString("invalid source extension"));
+    }
+  }
+
+  @Test
+  public void checkGeneratedSrcExt() {
+    // Setup a generated source.
+    GenruleBuilder genruleBuilder =
+        GenruleBuilder.newGenruleBuilder(BuildTargetFactory.newInstance("//:gen"))
+            .setOut("foo.json");
+    TargetGraph targetGraph = TargetGraphFactory.newInstance(genruleBuilder.build());
+    ActionGraphBuilder graphBuilder = new TestActionGraphBuilder(targetGraph);
+    Genrule genrule = (Genrule) graphBuilder.requireRule(genruleBuilder.getTarget());
+
+    // Create Python source args.
+    BuildTarget target = BuildTargetFactory.newInstance("//foo:bar");
+    PythonLibraryDescription.CoreArg args =
+        new PythonLibraryBuilder(target)
+            .setSrcs(
+                SourceSortedSet.ofUnnamedSources(
+                    ImmutableSortedSet.of(
+                        Preconditions.checkNotNull(genrule.getSourcePathToOutput()))))
+            .build()
+            .getConstructorArg();
+
+    Consumer<PythonBuckConfig.SrcExtCheckStyle> parseSources =
+        style ->
+            PythonUtil.parseModules(
+                target,
+                graphBuilder,
+                PythonTestUtils.PYTHON_PLATFORM,
+                CxxPlatformUtils.DEFAULT_PLATFORM,
+                Optional.empty(),
+                style,
+                args);
+
+    // Don't check any sources.
+    parseSources.accept(PythonBuckConfig.SrcExtCheckStyle.NONE);
+
+    // Check generated sources.
+    try {
+      parseSources.accept(PythonBuckConfig.SrcExtCheckStyle.GENERATED);
+      fail("expected to throw");
+    } catch (HumanReadableException e) {
+      assertThat(e.getMessage(), Matchers.containsString("invalid source extension"));
+    }
+
+    // Check all sources.
+    try {
+      parseSources.accept(PythonBuckConfig.SrcExtCheckStyle.ALL);
+      fail("expected to throw");
+    } catch (HumanReadableException e) {
+      assertThat(e.getMessage(), Matchers.containsString("invalid source extension"));
+    }
   }
 }

--- a/test/com/facebook/buck/features/python/testdata/python_source_db/BUCK.fixture
+++ b/test/com/facebook/buck/features/python/testdata/python_source_db/BUCK.fixture
@@ -1,0 +1,34 @@
+python_library(
+    name = "foo",
+    srcs = [
+        "foo.py",
+    ],
+)
+
+python_library(
+    name = "bar",
+    srcs = [
+        "bar.py",
+    ],
+    deps = [
+        ":foo",
+    ],
+)
+
+python_binary(
+    name = "bin",
+    main = "bin.py",
+    deps = [
+        ":foo",
+    ],
+)
+
+python_test(
+    name = "test",
+    srcs = [
+        "test.py",
+    ],
+    deps = [
+        ":foo",
+    ],
+)

--- a/test/com/facebook/buck/features/python/testdata/python_source_db/bar.py
+++ b/test/com/facebook/buck/features/python/testdata/python_source_db/bar.py
@@ -1,0 +1,1 @@
+import foo

--- a/test/com/facebook/buck/features/python/testdata/python_source_db/bin.py
+++ b/test/com/facebook/buck/features/python/testdata/python_source_db/bin.py
@@ -1,0 +1,1 @@
+import foo

--- a/test/com/facebook/buck/features/python/testdata/python_source_db/test.py
+++ b/test/com/facebook/buck/features/python/testdata/python_source_db/test.py
@@ -1,0 +1,1 @@
+import foo


### PR DESCRIPTION
This adds support for running [pyre](https://github.com/facebook/pyre-check) in buck mode.

See the cherry-picked commit messages in this PR for more information.

Test plan:

```
ant
bin/buck build //programs:gen_buck_info#source-db
alias buck=`realpath bin/buck`
cd $personal_project
buck build $personal_target#source-db
buck run $personal_target -- --help
pyre
```

All of the above exit 0!