### PR TITLE
Update sqlite to include ability to build buck on M1 chips. Currently, BUCK fails because sqlite-jdbc-3.20.0 doesn't support aarch64 but 3.39.2.0 does.

### DIFF
--- a/.idea/libraries/buck_lib.xml
+++ b/.idea/libraries/buck_lib.xml
@@ -36,7 +36,7 @@
       <root url="jar://$PROJECT_DIR$/third-party/java/jimfs/jimfs-1.1-sources.jar!/" />
       <root url="jar://$PROJECT_DIR$/third-party/java/android/ddmlib-25.3.0-sources.jar!/" />
       <root url="jar://$PROJECT_DIR$/third-party/java/errorprone/error_prone_annotations-2.0.19-sources.jar!/" />
-      <root url="jar://$PROJECT_DIR$/third-party/java/sqlite/sqlite-jdbc-3.20.0-sources.jar!/" />
+      <root url="jar://$PROJECT_DIR$/third-party/java/sqlite/sqlite-jdbc-3.39.2.0-sources.jar!/" />
       <root url="jar://$PROJECT_DIR$/third-party/java/nuprocess/nuprocess-2.0.1-sources.jar!/" />
       <root url="jar://$PROJECT_DIR$/third-party/java/nailgun/nailgun-server-1.0.1-sources.jar!/" />
       <root url="jar://$PROJECT_DIR$/third-party/java/jackson/jackson-annotations-2.9.7-sources.jar!/" />

--- a/.idea/libraries/sqlite.xml
+++ b/.idea/libraries/sqlite.xml
@@ -1,11 +1,11 @@
 <component name="libraryTable">
   <library name="sqlite">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/third-party/java/sqlite/sqlite-jdbc-3.20.0.jar!/" />
+      <root url="jar://$PROJECT_DIR$/third-party/java/sqlite/sqlite-jdbc-3.39.2.0.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$PROJECT_DIR$/third-party/java/sqlite/sqlite-jdbc-3.20.0-sources.jar!/" />
+      <root url="jar://$PROJECT_DIR$/third-party/java/sqlite/sqlite-jdbc-3.39.2.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/build.xml
+++ b/build.xml
@@ -155,7 +155,7 @@
     <include name="nailgun/nailgun-server-1.0.1.jar" />
     <include name="jna/jna-5.6.0.jar" />
     <include name="jna/jna-platform-5.6.0.jar" />
-    <include name="sqlite/sqlite-jdbc-3.20.0.jar" />
+    <include name="sqlite/sqlite-jdbc-3.39.2.0.jar" />
     <include name="bazel/bazel_deploy.jar" />
     <include name="remote-apis/remote-apis.jar" />
   </fileset>

--- a/programs/classpaths
+++ b/programs/classpaths
@@ -80,7 +80,7 @@ third-party/java/protobuf/protobuf-java-3.7.0.jar
 third-party/java/protobuf/protobuf-java-util-3.7.0.jar
 third-party/java/protobuf/protobuf-lite-3.0.1.jar
 third-party/java/slf4j/slf4j-jdk14-1.7.5.jar
-third-party/java/sqlite/sqlite-jdbc-3.20.0.jar
+third-party/java/sqlite/sqlite-jdbc-3.39.2.0.jar
 third-party/java/stringtemplate/ST-4.0.8.jar
 third-party/java/thrift/libthrift-0.12.0.jar
 third-party/java/xz-java-1.5/xz-1.5.jar

--- a/third-party/java/sqlite/BUCK
+++ b/third-party/java/sqlite/BUCK
@@ -1,10 +1,10 @@
 prebuilt_jar(
     name = "sqlite",
-    binary_jar = "sqlite-jdbc-3.20.0.jar",
+    binary_jar = "sqlite-jdbc-3.39.2.0.jar",
     licenses = [
         "LICENSE.txt",
     ],
-    source_jar = "sqlite-jdbc-3.20.0-sources.jar",
+    source_jar = "sqlite-jdbc-3.39.2.0-sources.jar",
     visibility = [
         "PUBLIC",
     ],

--- a/third-party/java/sqlite/fetch.sh
+++ b/third-party/java/sqlite/fetch.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-BIN_FILENAME="sqlite-jdbc-3.20.0.jar"
-BIN_URL="http://central.maven.org/maven2/org/xerial/sqlite-jdbc/3.20.0/sqlite-jdbc-3.20.0.jar"
-BIN_HASH="143b1c0a453c9a8f77be14209ea15391d1e0eb93348fcfabf03cc227b0edae73"
-SOURCE_FILENAME="sqlite-jdbc-3.20.0-sources.jar"
-SOURCE_URL="http://central.maven.org/maven2/org/xerial/sqlite-jdbc/3.20.0/sqlite-jdbc-3.20.0-sources.jar"
-SOURCE_HASH="db6a12de3990dac9eb5af4f97d01e160f0c875bdad88a5e28aee39467d915f4b"
+BIN_FILENAME="sqlite-jdbc-3.39.2.0.jar"
+BIN_URL="http://central.maven.org/maven2/org/xerial/sqlite-jdbc/3.39.2.0/sqlite-jdbc-3.39.2.0.jar"
+BIN_HASH="9a5c3bb5b4a99e68a3070fab72bd05ad46e350c39879fe56d046ada280ad4d48"
+SOURCE_FILENAME="sqlite-jdbc-3.39.2.0-sources.jar"
+SOURCE_URL="http://central.maven.org/maven2/org/xerial/sqlite-jdbc/3.39.2.0/sqlite-jdbc-3.39.2.0-sources.jar"
+SOURCE_HASH="3f449331c7343da3038b954803bcfdfb5130f45c45f2d2e238ab7dfd6735e43e"
 
 wget "$BIN_URL" -O "$BIN_FILENAME"
 REAL_BIN_HASH=$(shasum -a 256 "$BIN_FILENAME" | awk {'print $1'})


### PR DESCRIPTION
Update sqlite to include ability to build buck on M1 chips. Currently, BUCK fails because sqlite-jdbc-3.20.0 doesn't support aarch64 but 3.39.2.0 does. 