### PR TITLE
fix testng requiring annotations to set alwaysRun=true

### DIFF
--- a/test/com/facebook/buck/testrunner/TestNGIntegrationTest.java
+++ b/test/com/facebook/buck/testrunner/TestNGIntegrationTest.java
@@ -137,4 +137,14 @@ public class TestNGIntegrationTest {
 
     assertThat(filteredTestNGTestResult.getStderr(), not(containsString("SimpleFailingTest")));
   }
+
+  @Test
+  public void simpleBeforeAnnotationsTest() {
+
+    ProcessResult result =
+        workspace.runBuckCommand("test", "//test:simple-before-annotations-test").assertSuccess();
+    assertThat(result.getStderr(), containsString("SimpleBeforeAnnotationsTest"));
+    assertThat(result.getStderr(), containsString(" 1 Passed"));
+    assertThat(result.getStderr(), containsString(" 0 Failed"));
+  }
 }

--- a/test/com/facebook/buck/testrunner/testdata/simple_testng/test/BUCK.fixture
+++ b/test/com/facebook/buck/testrunner/testdata/simple_testng/test/BUCK.fixture
@@ -45,6 +45,15 @@ java_test(
 )
 
 java_test(
+    name = "simple-before-annotations-test",
+    srcs = ["SimpleBeforeAnnotationsTest.java"],
+    test_type = "testng",
+    deps = [
+        "buck//third-party/java/testng:testng",
+    ],
+)
+
+java_test(
     name = "injection-test",
     srcs = ["InjectionTest.java"],
     test_type = "testng",

--- a/test/com/facebook/buck/testrunner/testdata/simple_testng/test/SimpleBeforeAnnotationsTest.java
+++ b/test/com/facebook/buck/testrunner/testdata/simple_testng/test/SimpleBeforeAnnotationsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.example;
+
+import static org.testng.Assert.assertNotNull;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+@Test
+public class SimpleBeforeAnnotationsTest {
+
+  Long beforeMethodValue;
+  Long beforeClassValue;
+  Long beforeTestValue;
+
+  @BeforeMethod
+  public void beforeMethod() {
+    beforeMethodValue = System.currentTimeMillis();
+  }
+
+  @BeforeClass
+  public void beforeClass() {
+    beforeClassValue = System.currentTimeMillis();
+  }
+
+  @BeforeTest
+  public void beforeTest() {
+    beforeTestValue = System.currentTimeMillis();
+  }
+
+  @Test
+  public void beforeAnnotationsTest() {
+    assertNotNull(beforeClassValue);
+    assertNotNull(beforeTestValue);
+    assertNotNull(beforeMethodValue);
+  }
+}


### PR DESCRIPTION
Summary:
TestNG tests using Before/After annotations requires to be set alwaysRun=true, because a Filter disable the annotations preventing it to be executed when TestRunner is executing with --filter
It's an issue that projects on fbcode live with, but onboarding projects that use testng from maven/gradle will break.

This fix will allow Presto to start using buck.

Reviewed By: ericyuliu

