### PR TITLE
Make Buck Event View text nodes copyable

### DIFF
--- a/tools/ideabuck/src/com/facebook/buck/intellij/ideabuck/ui/tree/BuckTextNode.java
+++ b/tools/ideabuck/src/com/facebook/buck/intellij/ideabuck/ui/tree/BuckTextNode.java
@@ -66,4 +66,9 @@ public class BuckTextNode extends DefaultMutableTreeNode {
   public TextType getTextType() {
     return ((NodeObject) getUserObject()).getTextType();
   }
+
+  @Override
+  public String toString() {
+    return getText();
+  }
 }


### PR DESCRIPTION
Summary: Provide the node text in toString() so that copying the text with Cmd/Ctrl-C copies the content.

Reviewed By: sefar

