### PR TITLE
Add support for NDK version 21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ macos_environment: &macos_environment
   TERM: "dumb"
   BUCK_NUM_THREADS: 3
   BUCK_PEX_LOCATION: "./new_buck.pex"
-  JAVA_HOME: "/usr/local/Cellar/openjdk@8/1.8.0+322"
+  JAVA_HOME: "/usr/local/Cellar/openjdk@8/1.8.0+345"
 
 windows_environment: &windows_environment
   PLATFORM: "windows"
@@ -1004,7 +1004,7 @@ jobs:
             export PATH="${ANDROID_SDK}/tools/bin:${PATH}"
             export PATH="$(pyenv root)/shims:${PATH}"
             export GROOVY_HOME="$HOME/.sdkman/candidates/groovy/current"
-            export JAVA_HOME="/usr/local/Cellar/openjdk@8/1.8.0+322"
+            export JAVA_HOME="/usr/local/Cellar/openjdk@8/1.8.0+345"
             export PATH="${JAVA_HOME}/bin:${PATH}"
             source ~/dlang/dmd-2.091.0/activate
             export PATH="${HOME}/.cargo/bin:${PATH}"
@@ -1062,7 +1062,7 @@ jobs:
           command: |
             export NDK_HOME="${HOME}/android-ndk-${PLATFORM}"
             export ANDROID_HOME="${ANDROID_SDK}"
-            export JAVA_HOME="/usr/local/Cellar/openjdk@8/1.8.0+322"
+            export JAVA_HOME="/usr/local/Cellar/openjdk@8/1.8.0+345"
             export PATH="${JAVA_HOME}/bin:${PATH}"
             source ~/dlang/dmd-2.091.0/activate
             export PATH="${HOME}/.cargo/bin:${PATH}"

--- a/src/com/facebook/buck/android/toolchain/ndk/impl/NdkCxxPlatforms.java
+++ b/src/com/facebook/buck/android/toolchain/ndk/impl/NdkCxxPlatforms.java
@@ -160,7 +160,12 @@ public class NdkCxxPlatforms {
   }
 
   static int getNdkMinorVersion(String ndkVersion) {
-    return Integer.parseInt(NDK_MINOR_VERSION_PATTERN.matcher(ndkVersion).replaceAll("$1"));
+    String minorVersion = NDK_MINOR_VERSION_PATTERN.matcher(ndkVersion).replaceAll("$1");
+    if (minorVersion.startsWith("r") || minorVersion.startsWith("R")) {
+      // Failed to find a minor version, 0 is a safe fallback.
+      return 0;
+    }
+    return Integer.parseInt(minorVersion);
   }
 
   public static NdkCompilerType getDefaultCompilerTypeForNdk(String ndkVersion) {

--- a/src/com/facebook/buck/android/toolchain/ndk/impl/NdkCxxPlatforms.java
+++ b/src/com/facebook/buck/android/toolchain/ndk/impl/NdkCxxPlatforms.java
@@ -150,12 +150,17 @@ public class NdkCxxPlatforms {
           "-Wl,--as-needed");
 
   private static final Pattern NDK_MAJOR_VERSION_PATTERN = Pattern.compile("^[rR]?(\\d+).*");
+  private static final Pattern NDK_MINOR_VERSION_PATTERN = Pattern.compile("^[rR]?\\d+\\.(\\d+).*");
 
   // Utility class, do not instantiate.
   private NdkCxxPlatforms() {}
 
   static int getNdkMajorVersion(String ndkVersion) {
     return Integer.parseInt(NDK_MAJOR_VERSION_PATTERN.matcher(ndkVersion).replaceAll("$1"));
+  }
+
+  static int getNdkMinorVersion(String ndkVersion) {
+    return Integer.parseInt(NDK_MINOR_VERSION_PATTERN.matcher(ndkVersion).replaceAll("$1"));
   }
 
   public static NdkCompilerType getDefaultCompilerTypeForNdk(String ndkVersion) {
@@ -172,6 +177,8 @@ public class NdkCxxPlatforms {
 
   public static String getDefaultClangVersionForNdk(String ndkVersion) {
     int ndkMajorVersion = getNdkMajorVersion(ndkVersion);
+    int ndkMinorVersion = getNdkMinorVersion(ndkVersion);
+
     if (ndkMajorVersion < 11) {
       return "3.5";
     } else if (ndkMajorVersion < 15) {
@@ -186,8 +193,10 @@ public class NdkCxxPlatforms {
       return "8.0.2";
     } else if (ndkMajorVersion < 21) {
       return "8.0.7";
-    } else {
+    } else if (ndkMajorVersion == 21 && ndkMinorVersion <= 3) {
       return "9.0.8";
+    } else {
+      return "9.0.9";
     }
   }
 


### PR DESCRIPTION
Supersedes: https://github.com/facebook/buck/pull/2685

NDK up to 21.3 uses clang 9.0.8, for the rest of the r21 releases clang 9.0.9 is used.