### PR TITLE
allow buck to be built at newer version of Python

### DIFF
--- a/third-party/py/pathlib/pathlib.py
+++ b/third-party/py/pathlib/pathlib.py
@@ -7,7 +7,7 @@ import posixpath
 import re
 import sys
 import time
-from collections import Sequence
+from collections.abc import Sequence
 from contextlib import contextmanager
 from errno import EINVAL, ENOENT
 from operator import attrgetter


### PR DESCRIPTION
allow buck to be built at newer version of Python

Summary:
See #2696 for another example.

In Python 3.3 types like `Sequence` were moved to the
`collections.abc` submodule. The aforementioned PR fixed runtime
issues, but the bin/buck Python bootstrapping script still failed with
non-ancient versions of Python.

Test Plan: Built and ran buck1 successfully on my machine.
